### PR TITLE
Reformulate Erdos 412

### DIFF
--- a/FormalConjectures/ErdosProblems/412.lean
+++ b/FormalConjectures/ErdosProblems/412.lean
@@ -20,18 +20,17 @@ import FormalConjectures.Util.ProblemImports
 # Erdős Problem 412
 
 *Reference:* [erdosproblems.com/412](https://www.erdosproblems.com/412)
+
+Reviewed by @b-mehta on 2025-05-27
 -/
-/--Let $σ_1(n)=σ(n)$, the sum of divisors function, and $σ_k(n) = σ(σ_{k−1}(n))$-/
-abbrev σ (k : ℕ) : ℕ → ℕ := (ArithmeticFunction.sigma 1)^[k]
 
-@[category API, AMS 11]
-lemma sigma_0 : σ 0 = id := rfl
+open ArithmeticFunction
 
-@[category API, AMS 11]
-lemma sigma_1 : σ 1 = ArithmeticFunction.sigma 1 := rfl
-
-/--Is it true that, for every $m, n ≥ 2$, there exist some $i, j$ such that $σ_i(m) = σ_j(n)$?-/
+/--
+Let $σ_1(n)=σ(n)$, the sum of divisors function, and $σ_k(n) = σ(σ_{k−1}(n))$.
+Is it true that, for every $m, n ≥ 2$, there exist some $i, j$ such that $σ_i(m) = σ_j(n)$?
+-/
 @[category research open, AMS 11]
 theorem erdos_412 (m n : ℕ) (hm : 2 ≤ m) (hn : 2 ≤ n) :
-    ∃ i j, σ i m = σ j n := by
+    ∃ i j, (σ 1)^[i] m = (σ 1)^[j] n := by
   sorry


### PR DESCRIPTION
Use ArithmeticFunction notation rather than redefining it locally, for consistency with Erdos 410 and with mathlib analytic number theory in general.