### PR TITLE
ci: use the full set of lean files to compute the hash

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           path: ~/.cache/mathlib
           key: oleans-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.lean') }}
+          restore-keys: |
+            oleans-${{ hashFiles('lake-manifest.json') }}-
+            oleans-
 
       - name: Get olean cache
         run: |
@@ -75,7 +78,9 @@ jobs:
         with:
           path: docbuild/.lake/build/doc
           key: MathlibDoc-${{ hashFiles('docbuild/lake-manifest.json') }}-${{ hashFiles('**/*.lean') }}
-          restore-keys: MathlibDoc-
+          restore-keys: |
+            MathlibDoc-${{ hashFiles('docbuild/lake-manifest.json') }}-
+            MathlibDoc-
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
We keep the hash of the manifest as a prefix, since github falls back on prefix-matching in the case of a cache miss; and so can reuse the existing caches.