### PR TITLE
feat(Erdos/326): add Erdos 326 and abstract some API to ForMathlib

### DIFF
--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 Google LLC
+Copyright 2025 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -33,16 +33,16 @@ Must there exist $B = \{b_1 < b_2 < \dots\} \subseteq A$ which is also a basis s
 $\lim_{k\to\infty} \frac{b_k}{k^2}$ does not exist?
 -/
 @[category research open, AMS 5, AMS 11]
-theorem erdos_326 (A : Set ℕ) (hA₀ : A.IsAddBasisOfOrder 2) : ∃ (b : ℕ → ℕ),
-    StrictMono b ∧ ∀ n, b n ∈ A ∧ (Set.range b).IsAddBasis ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x) := by
+theorem erdos_326 : (∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
+    ∃ (b : ℕ → ℕ), StrictMono b ∧ ∀ n, b n ∈ A ∧ (Set.range b).IsAddBasis ∧
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x)) ↔ answer(sorry) := by
   sorry
 
 /--
 Erdős originally asked whether this was true with `A = B`, but this was disproved by Cassels.
 -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_326.variants.eq (A : Set ℕ) (hA₀ : A.IsAddBasisOfOrder 2) : ∃ (a : ℕ → ℕ),
-    StrictMono a ∧ Set.range a = A ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x) := by
+theorem erdos_326.variants.eq : (∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
+    ∃ (a : ℕ → ℕ), StrictMono a ∧ Set.range a = A ∧
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x)) ↔ answer(False) := by
   sorry

--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -1,0 +1,46 @@
+/-
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 326
+
+*Reference:* [erdosproblems.com/326](https://www.erdosproblems.com/326)
+-/
+
+open Filter
+
+open scoped Topology
+
+/--
+Let $A \subset \mathbb{N}$ be an additive basis of order 2.
+
+Must there exist $B = \{b_1 < b_2 < \dots\} \subseteq A$ which is also a basis such that
+$\lim_{k\to\infty} \frac{b_k}{k^2}$ does not exist?
+-/
+@[category research open, AMS 5, AMS 11]
+theorem erdos_326 (A : Set ℕ) (hA₀ : A.IsAddBasisOfOrder 2) : ∃ (b : ℕ → ℕ),
+    StrictMono b ∧ ∀ n, b n ∈ A ∧ (Set.range b).IsAddBasis ∧
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x) := sorry
+
+/--
+Erdős originally asked whether this was true with `A = B`, but this was disproved by Cassels.
+-/
+@[category research solved, AMS 5, AMS 11]
+theorem erdos_326.variants.eq (A : Set ℕ) (hA₀ : A.IsAddBasisOfOrder 2) : ∃ (a : ℕ → ℕ),
+    StrictMono a ∧ Set.range a = A ∧
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x) := sorry

--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -35,7 +35,8 @@ $\lim_{k\to\infty} \frac{b_k}{k^2}$ does not exist?
 @[category research open, AMS 5, AMS 11]
 theorem erdos_326 (A : Set ℕ) (hA₀ : A.IsAddBasisOfOrder 2) : ∃ (b : ℕ → ℕ),
     StrictMono b ∧ ∀ n, b n ∈ A ∧ (Set.range b).IsAddBasis ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x) := sorry
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x) := by
+  sorry
 
 /--
 Erdős originally asked whether this was true with `A = B`, but this was disproved by Cassels.
@@ -43,4 +44,5 @@ Erdős originally asked whether this was true with `A = B`, but this was disprov
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_326.variants.eq (A : Set ℕ) (hA₀ : A.IsAddBasisOfOrder 2) : ∃ (a : ℕ → ℕ),
     StrictMono a ∧ Set.range a = A ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x) := sorry
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x) := by
+  sorry

--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -33,7 +33,7 @@ must $A$ contain a minimal additive basis of order $2$? -/
 theorem erdos_868.parts.i {A : Set ℕ} (hA₁ : A.IsAsymptoticAddBasisOfOrder 2)
     (hA₂ : atTop.Tendsto (fun n => ncard_add_repr A 2 n) atTop) :
     ∃ B ⊆ A, B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B,
-      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 :=
+      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := by
   sorry
 
 /-- Let $A$ be an additive basis of order $2$, let $f(n)$ denote the number of ways in which
@@ -44,7 +44,8 @@ basis of order $2$? -/
 theorem erdos_868.parts.ii {A : Set ℕ} (hA₁ : A.IsAsymptoticAddBasisOfOrder 2) {ε : ℝ} (hε : 0 < ε)
     (hA₂ : ∀ᶠ (n : ℕ) in atTop, ε * Real.log n < ncard_add_repr A 2 n) :
     ∃ B ⊆ A, B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B,
-      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := sorry
+      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := by
+  sorry
 
 /-- Erdős and Nathanson proved that this is true if $f(n) > (\log\frac{4}{3})^{-1}\log n$ for
 all large $n$. -/
@@ -52,12 +53,13 @@ all large $n$. -/
 theorem erdos_868.variants.fixed_ε {A : Set ℕ} (hA₁ : A.IsAsymptoticAddBasisOfOrder 2)
     (hA₂ : ∀ᶠ (n : ℕ) in atTop, (Real.log (4 / 3))⁻¹ * Real.log n < ncard_add_repr A 2 n) :
     ∃ B ⊆ A, B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B,
-      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := sorry
+      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := by
+  sorry
 
 /-- Härtter and Nathanson proved that there exist additive bases which do not contain
 any minimal additive bases. -/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_868.variants.Hartter_Nathanson : ∃ (A : Set ℕ), ∃ o > 1,
     A.IsAsymptoticAddBasisOfOrder o ∧ ∀ B ⊆ A, B.IsAsymptoticAddBasisOfOrder o →
-    ∃ b ∈ B, (B \ {b}).IsAsymptoticAddBasisOfOrder o :=
+    ∃ b ∈ B, (B \ {b}).IsAsymptoticAddBasisOfOrder o := by
   sorry

--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -16,51 +16,9 @@ limitations under the License.
 
 import FormalConjectures.Util.ProblemImports
 
-/-!
-# Erdős Problem 868
-
-*Reference:* [erdosproblems.com/868](https://www.erdosproblems.com/868)
--/
 open Filter
 
 open scoped Pointwise
-
-/-- A set `A : Set ℕ` is an additive basis of order `o` if every large
-enough `n : ℕ` belongs to the o-fold addition of `A`. In other words,
-`n` can be written as `n = a₁ + ... + aₒ`, where each `aᵢ ∈ A`. -/
-def IsAddBasis (A : Set ℕ) (o : ℕ) : Prop := ∀ᶠ n in atTop, n ∈ o • A
-
-/-- A set `A : Set ℕ` is an additive basis of order `o` if every large
-enough `n : ℕ` can be written as `n = a₁ + ... + aₒ`, where each `aᵢ ∈ A`. -/
-@[category API, AMS 5, AMS 11]
-theorem isAddBasis_iff (A : Set ℕ) (o : ℕ) :
-    IsAddBasis A o ↔ ∀ᶠ n in atTop, ∃ (f : Fin o → ℕ) (_ : ∀ i, f i ∈ A), ∑ i, f i = n := by
-  have := Set.mem_finset_sum (t := .univ) (f := fun _ : Fin o ↦ A)
-  simp_all [IsAddBasis]
-
-/-- A set `A : Set ℕ` is an additive basis of order `2` if every large enough
-`n` belongs to `A + A`. -/
-@[category API, AMS 5, AMS 11]
-theorem isAddBasis_order_two_iff (A : Set ℕ) :
-    IsAddBasis A 2 ↔ ∀ᶠ n in atTop, n ∈ A + A := by
-  simp [isAddBasis_iff, Set.mem_add, Fin.forall_fin_two]
-  refine ⟨fun ⟨a, h⟩ => ⟨a, fun b hb => ?_⟩, fun ⟨a, h⟩ => ⟨a, fun b hb => ?_⟩⟩
-  · let ⟨f, hf⟩ := h b hb
-    exact ⟨f 0, ⟨hf.1.1, ⟨f 1, ⟨hf.1.2, hf.2⟩⟩⟩⟩
-  · let ⟨x, ⟨hx, ⟨y, ⟨hy, hxy⟩⟩⟩⟩ := h b hb
-    exact ⟨![x, y], by simp [hx, hy, hxy]⟩
-
-/-- No set is an additive basis of order `0`. -/
-@[category API, AMS 5, AMS 11]
-theorem not_isAddBasis_zero (A : Set ℕ) : ¬IsAddBasis A 0 := by
-  simpa [isAddBasis_iff] using fun n => ⟨n.succ, by simp⟩
-
-/-- A set is an additive basis of order `1` if it contains an infinite tail
-of consecutive naturals. -/
-@[category API, AMS 5, AMS 11]
-theorem isAddBasis_one_iff (A : Set ℕ) :
-    IsAddBasis A 1 ↔ ∃ n, Set.Ici n ⊆ A := by
-  simp [IsAddBasis, Set.subset_def]
 
 /-- The number of ways in which a natural `n` can be written as the sum of
 `o` members of the set `A`. -/
@@ -72,9 +30,10 @@ def ncard_add_repr (A : Set ℕ) (o : ℕ) (n : ℕ) : ℕ :=
 $n$ can be written as the sum of two elements from $A$. If $f(n)\to\infty$ as $n\to\infty$, then
 must $A$ contain a minimal additive basis of order $2$? -/
 @[category research open, AMS 5, AMS 11]
-theorem erdos_868.parts.i {A : Set ℕ} (hA₁ : IsAddBasis A 2)
+theorem erdos_868.parts.i {A : Set ℕ} (hA₁ : A.IsAsymptoticAddBasisOfOrder 2)
     (hA₂ : atTop.Tendsto (fun n => ncard_add_repr A 2 n) atTop) :
-    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2 :=
+    ∃ B ⊆ A, B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B,
+      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 :=
   sorry
 
 /-- Let $A$ be an additive basis of order $2$, let $f(n)$ denote the number of ways in which
@@ -82,20 +41,23 @@ $n$ can be written as the sum of two elements from $A$. If $f(n)>\epsilon\log n$
 and an arbitrary fixed $\epsilon > 0$, then must $A$ contain a minimal additive
 basis of order $2$? -/
 @[category research open, AMS 5, AMS 11]
-theorem erdos_868.parts.ii {A : Set ℕ} (hA₁ : IsAddBasis A 2) {ε : ℝ} (hε : 0 < ε)
+theorem erdos_868.parts.ii {A : Set ℕ} (hA₁ : A.IsAsymptoticAddBasisOfOrder 2) {ε : ℝ} (hε : 0 < ε)
     (hA₂ : ∀ᶠ (n : ℕ) in atTop, ε * Real.log n < ncard_add_repr A 2 n) :
-    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2 := sorry
+    ∃ B ⊆ A, B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B,
+      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := sorry
 
 /-- Erdős and Nathanson proved that this is true if $f(n) > (\log\frac{4}{3})^{-1}\log n$ for
 all large $n$. -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_868.variants.fixed_ε {A : Set ℕ} (hA₁ : IsAddBasis A 2)
+theorem erdos_868.variants.fixed_ε {A : Set ℕ} (hA₁ : A.IsAsymptoticAddBasisOfOrder 2)
     (hA₂ : ∀ᶠ (n : ℕ) in atTop, (Real.log (4 / 3))⁻¹ * Real.log n < ncard_add_repr A 2 n) :
-    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2 := sorry
+    ∃ B ⊆ A, B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B,
+      ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := sorry
 
 /-- Härtter and Nathanson proved that there exist additive bases which do not contain
 any minimal additive bases. -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_868.variants.Hartter_Nathanson : ∃ A, ∃ o > 1, IsAddBasis A o ∧
-    ∀ B ⊆ A, IsAddBasis B o → ∃ b ∈ B, IsAddBasis (B \ {b}) o :=
+theorem erdos_868.variants.Hartter_Nathanson : ∃ (A : Set ℕ), ∃ o > 1,
+    A.IsAsymptoticAddBasisOfOrder o ∧ ∀ B ⊆ A, B.IsAsymptoticAddBasisOfOrder o →
+    ∃ b ∈ B, (B \ {b}).IsAsymptoticAddBasisOfOrder o :=
   sorry

--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -16,6 +16,11 @@ limitations under the License.
 
 import FormalConjectures.Util.ProblemImports
 
+/-!
+# Erdős Problem 868
+
+*Reference:* [erdosproblems.com/868](https://www.erdosproblems.com/868)
+-/
 open Filter
 
 open scoped Pointwise

--- a/FormalConjectures/ForMathlib/Combinatorics/Additive/Basis.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Additive/Basis.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 Google LLC
+Copyright 2025 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjectures/ForMathlib/Combinatorics/Additive/Basis.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Additive/Basis.lean
@@ -1,0 +1,179 @@
+/-
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import Mathlib.Algebra.Group.Pointwise.Set.BigOperators
+import FormalConjectures.ForMathlib.Order.Filter.Cofinite
+
+open Filter
+
+open scoped Pointwise
+
+namespace Set
+
+variable {α} [CommMonoid α]
+
+section MulBasis
+
+/--
+A set `A : Set α` is a multiplicative basis of order `n` if for any element
+`a : α`, it can be expressed as a product of `n` elements lying in `A`.
+-/
+@[to_additive "A set `A : Set α` is an additive basis of order `n` if for any element
+`a : α`, it can be expressed as a sum of `n` elements lying in `A`."]
+abbrev IsMulBasisOfOrder (A : Set α) (n : ℕ) : Prop :=
+    ∀ a, a ∈ A ^ n
+
+/--
+A multiplicative basis of some order.
+-/
+@[to_additive "An additive basis of some order"]
+abbrev IsMulBasis (A : Set α) : Prop :=
+    ∃ n, A.IsMulBasisOfOrder n
+
+@[to_additive]
+theorem IsMulBasisOfOrder.toMulBasis {A : Set α} {n : ℕ} (hA : A.IsMulBasisOfOrder n) :
+    A.IsMulBasis := ⟨n, hA⟩
+
+@[to_additive]
+theorem isMulBasisOfOrder_iff (A : Set α) (n : ℕ) : A.IsMulBasisOfOrder n ↔
+    ∀ a, ∃ (f : Fin n → α) (_ : ∀ i, f i ∈ A), ∏ i, f i = a := by
+  have := Set.mem_finset_prod (t := .univ) (f := fun _ : Fin n ↦ A)
+  simp_all [IsMulBasisOfOrder]
+
+/-- A set `A : Set α` is a multiplicative basis of order `2` if every `a : α` belongs to `A + A`. -/
+@[to_additive "A set `A : Set α` is an additive basis of order `2` if every `a : α` belongs to
+`A + A`."]
+theorem isMulBasisOfOrder_two_iff (A : Set α) :
+    A.IsMulBasisOfOrder 2 ↔ ∀ a, a ∈ A * A := by
+  simp [IsMulBasisOfOrder, pow_two]
+
+/-- No set is a multiplicative basis of order `0`. -/
+@[to_additive "No set is an additive basis of order `0`."]
+theorem not_isMulBasisOfOrder_zero [Nontrivial α] [DecidableEq α] (A : Set α) :
+    ¬A.IsMulBasisOfOrder 0 := by
+  simp [isMulBasisOfOrder_iff, eq_comm]
+  apply Decidable.exists_ne
+
+@[to_additive]
+theorem isMulBasisOfOrder_one_iff (A : Set α) :
+    A.IsMulBasisOfOrder 1 ↔ A = univ := by
+  simp [IsMulBasisOfOrder, eq_univ_iff_forall]
+
+end MulBasis
+
+section AsymptoticMulBasis
+
+/--
+A set `A : Set α` is an asymptotic multiplicative basis of order `n` if the elements that can
+be expressed as a product of `n` elements lying in `A` is cofinite.
+-/
+@[to_additive "A set `A : Set α` is an asymptotic additive basis of order `n` if the elements that
+can be expressed as a sum of `n` elements lying in `A` is cofinite."]
+abbrev IsAsymptoticMulBasisOfOrder (A : Set α) (n : ℕ) : Prop :=
+    ∀ᶠ a in cofinite, a ∈ A ^ n
+
+/--
+An asymptotic multiplicative basis of some order.
+-/
+@[to_additive "An asymptotic additive basis of some order"]
+abbrev IsAsymptoticMulBasis (A : Set α) : Prop :=
+    ∃ n, A.IsAsymptoticMulBasisOfOrder n
+
+@[to_additive]
+theorem IsAsymptoticMulBasisOfOrder.toIsAsymptoticMulBasis {A : Set α} {n : ℕ}
+    (hA : A.IsAsymptoticMulBasisOfOrder n) : A.IsAsymptoticMulBasis :=
+  ⟨n, hA⟩
+
+@[to_additive]
+theorem IsMulBasisOfOrder.toIsAsymptoticMulBasisOfOrder {A : Set α} {n : ℕ}
+    (hA : IsMulBasisOfOrder A n) : A.IsAsymptoticMulBasisOfOrder n :=
+  Eventually.of_forall hA
+
+@[to_additive]
+theorem IsMulBasis.toIsAsymptoticMulBasis {A : Set α} (hA : IsMulBasis A) :
+    A.IsAsymptoticMulBasis := by
+  obtain ⟨n, hn⟩ := hA
+  exact ⟨n, Eventually.of_forall hn⟩
+
+/-- A set `A : Set α` is an asymptotic multiplicative basis of order `n` if a cofinite set of
+`a : α` can be written as `a = a₁ * ... * aₙ`, where each `aᵢ ∈ A`. -/
+@[to_additive "A set `A : Set α` is an asymptotic additive basis of order `n` if a cofinite set of
+`a : α` can be written as `a = a₁ + ... + aₙ`, where each `aᵢ ∈ A`."]
+theorem isAsymptoticMulBasisOfOrder_iff_prod (A : Set α) (n : ℕ) :
+    IsAsymptoticMulBasisOfOrder A n ↔ ∀ᶠ a in cofinite, ∃ (f : Fin n → α) (_ : ∀ i, f i ∈ A),
+      ∏ i, f i = a := by
+  have := Set.mem_finset_prod (t := .univ) (f := fun _ : Fin n ↦ A)
+  simp_all [IsAsymptoticMulBasisOfOrder]
+
+/-- A set `A : Set α` is an asymptotic multiplicative basis of order `2` if a cofinite set of
+`a : α` belongs to `A * A`. -/
+@[to_additive "A set `A : Set α` is an asymptotic additive basis of order `2` if a cofinite set of
+`a : α` belongs to `A + A`."]
+theorem isAsymptoticMulBasisOfOrder_two_iff (A : Set α) :
+    IsAsymptoticMulBasisOfOrder A 2 ↔ ∀ᶠ a in cofinite, a ∈ A * A := by
+  simp [pow_two]
+
+/-- If `α` is infinite, then no set `A` is an asymptotic multiplicative basis of order `0`. -/
+@[to_additive "If `α` is infinite, then no set `A` is an asymptotic additive basis of order `0`."]
+theorem not_isAsymptoticMulBasisOfOrder_zero [Infinite α] (A : Set α) :
+    ¬IsAsymptoticMulBasisOfOrder A 0 := by
+  simp only [eventually_cofinite, pow_zero, mem_one, ← not_infinite, not_not]
+  apply Set.infinite_of_finite_compl
+  simp
+
+
+/-- `A : Set α` is an asymptotic basis of order one iff it is cofinite. -/
+@[to_additive "`A : Set α` is an asymptotic basis of order one iff it is cofinite."]
+theorem isAsymptoticMulBasisOfOrder_one_iff (A : Set α) :
+    IsAsymptoticMulBasisOfOrder A 1 ↔ Aᶜ.Finite := by
+  simp only [eventually_cofinite, pow_one]
+  rfl
+
+/-- For `α` equipped with a directed order, a set is an asymptotic multiplicative basis of order `1`
+if it contains an infinite tail of elements.
+-/
+@[to_additive "A set is an asymptotic additive basis of order `1` if it contains an infinite tail
+of consecutive naturals."]
+theorem isAsymptoticMulBasisOfOrder_one_iff_Ioi [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]
+    (A : Set α) : IsAsymptoticMulBasisOfOrder A 1 ↔ ∃ a, Set.Ioi a ⊆ A := by
+  simp [Filter.HasBasis.eventually_iff cofinite_hasBasis_Ioi, Set.subset_def]
+
+/-- For `α` equipped with a directed order, a set is an asymptotic multiplicative basis of order `1`
+if it contains an infinite tail of elements.
+-/
+@[to_additive "A set is an asymptotic additive basis of order `1` if it contains an infinite tail
+of consecutive naturals."]
+theorem isAsymptoticMulBasisOfOrder_one_iff_Ici [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]
+    [SuccOrder α] [NoMaxOrder α] (A : Set α) :
+      IsAsymptoticMulBasisOfOrder A 1 ↔ ∃ a, Set.Ici a ⊆ A := by
+  simp [Filter.HasBasis.eventually_iff cofinite_hasBasis_Ici, Set.subset_def]
+
+@[to_additive]
+lemma isAsymptoticMulBasisOfOrder_iff_atTop [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]
+    [SuccOrder α] [NoMaxOrder α] (A : Set α) (n : ℕ) :
+      IsAsymptoticMulBasisOfOrder A n ↔ ∀ᶠ a in atTop, a ∈ A ^ n := by
+  rw [IsAsymptoticMulBasisOfOrder, cofinite_eq_atTop]
+
+@[to_additive]
+lemma isAsymptoticMulBasisOfOrder_iff_prod_atTop [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]
+    [SuccOrder α] [NoMaxOrder α] (A : Set α) (n : ℕ) :
+      IsAsymptoticMulBasisOfOrder A n ↔ ∀ᶠ a in atTop, ∃ (f : Fin n → α) (_ : ∀ i, f i ∈ A),
+        ∏ i, f i = a := by
+  rw [isAsymptoticMulBasisOfOrder_iff_prod, cofinite_eq_atTop]
+
+end AsymptoticMulBasis
+
+end Set

--- a/FormalConjectures/ForMathlib/Order/Filter/Cofinite.lean
+++ b/FormalConjectures/ForMathlib/Order/Filter/Cofinite.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 Google LLC
+Copyright 2025 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjectures/ForMathlib/Order/Filter/Cofinite.lean
+++ b/FormalConjectures/ForMathlib/Order/Filter/Cofinite.lean
@@ -1,0 +1,68 @@
+/-
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import Mathlib.Order.Filter.Cofinite
+import Mathlib.Order.Interval.Finset.Defs
+import Mathlib.Order.SuccPred.Basic
+
+open Set
+
+namespace Filter
+
+lemma cofinite_hasBasis_Ioi {α : Type*} [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α] :
+    cofinite.HasBasis (fun (_ : α) ↦ True) (Set.Ioi ·) := by
+  constructor
+  intro A
+  simp only [mem_cofinite, true_and]
+  constructor
+  · intro hA
+    obtain ⟨a, ha⟩ := Set.Finite.bddAbove hA
+    use a
+    rw [← Set.compl_subset_compl, compl_Ioi]
+    exact ha
+  · rintro ⟨a, ha⟩
+    rw [← Set.compl_subset_compl, compl_Ioi] at ha
+    apply Set.Finite.subset _ ha
+    exact finite_Iic a
+
+/--
+Note(csonne): According to a TODO in `Mathlib.Order.Interval.Finset.Defs`, Assuming `SuccOrder α`
+should not be necessary as an instance should follow from `[LocallyFiniteOrder α] [OrderBot α]`.
+This has not been implemented in mathlib however.
+-/
+lemma cofinite_hasBasis_Ici {α : Type*} [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]
+    [SuccOrder α] [NoMaxOrder α] : cofinite.HasBasis (fun (_ : α) ↦ True) (Set.Ici ·) := by
+  constructor
+  intro A
+  simp only [mem_cofinite, true_and]
+  constructor
+  · intro hA
+    obtain ⟨a, ha⟩ := Set.Finite.bddAbove hA
+    use Order.succ a
+    rw [← Set.compl_subset_compl, compl_Ici]
+    exact Set.Subset.trans ha (Order.Iic_subset_Iio_succ a)
+  · rintro ⟨a, ha⟩
+    rw [← Set.compl_subset_compl, compl_Ici] at ha
+    apply Set.Finite.subset _ ha
+    exact finite_Iio a
+
+theorem cofinite_eq_atTop {α : Type*} [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]
+  [SuccOrder α] [NoMaxOrder α] :
+    @cofinite α = atTop := by
+  simp only [atTop_eq_generate_Ici, HasBasis.eq_generate cofinite_hasBasis_Ici, true_and]
+  rfl
+
+end Filter

--- a/FormalConjectures/Util/ForMathlib.lean
+++ b/FormalConjectures/Util/ForMathlib.lean
@@ -16,11 +16,13 @@ limitations under the License.
 
 import FormalConjectures.ForMathlib.Algebra.Order.Group.Pointwise.Interval
 import FormalConjectures.ForMathlib.Analysis.SpecialFunctions.Log.Basic
+import FormalConjectures.ForMathlib.Combinatorics.Additive.Basis
 import FormalConjectures.ForMathlib.Combinatorics.Basic
 import FormalConjectures.ForMathlib.Data.Nat.MaxPrimeFac
 import FormalConjectures.ForMathlib.Data.Nat.Prime.Defs
 import FormalConjectures.ForMathlib.Data.Set.Density
 import FormalConjectures.ForMathlib.Geometry.«2d»
 import FormalConjectures.ForMathlib.Logic.Equiv.Fin
+import FormalConjectures.ForMathlib.Order.Filter.Cofinite
 import FormalConjectures.ForMathlib.Order.Interval.Finset.Basic
 import FormalConjectures.ForMathlib.Order.Interval.Finset.Nat


### PR DESCRIPTION
Adding `Erdos 326`. After formalizing, it was pointed out to me that `Erdos 868` also develops similar API, so this has been abstracted and put into `ForMathlib`.