### PR TITLE
feat: add answer(sorry) to all Erdos problems stated as questions.

### DIFF
--- a/FormalConjectures/ErdosProblems/10.lean
+++ b/FormalConjectures/ErdosProblems/10.lean
@@ -41,7 +41,7 @@ Is there some $k$ such that every integer is the sum of a prime and at most $k$
 powers of $2$?
 -/
 @[category research open, AMS 5,  AMS 11]
-theorem erdos_10 : ∃ k, sumPrimeAndTwoPows k = Set.univ \ {0, 1} := by
+theorem erdos_10 : (∃ k, sumPrimeAndTwoPows k = Set.univ \ {0, 1}) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/126.lean
+++ b/FormalConjectures/ErdosProblems/126.lean
@@ -35,8 +35,8 @@ $\prod_{a\neq b\in A}(a + b)$ has at least $f(n)$ distinct prime factors.
 Is it true that $\frac{f(n)}{\log n} \to\infty$?
 -/
 @[category research open, AMS 11]
-theorem erdos_126 (f : ℕ → ℕ) (hf : IsMaximalAddFactorsCard f) :
-    Tendsto (fun n => f n / Real.log n) atTop atTop ↔ answer(sorry) :=
+theorem erdos_126 : (∀ (f : ℕ → ℕ), IsMaximalAddFactorsCard f →
+    Tendsto (fun n => f n / Real.log n) atTop atTop) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/126.lean
+++ b/FormalConjectures/ErdosProblems/126.lean
@@ -35,10 +35,8 @@ $\prod_{a\neq b\in A}(a + b)$ has at least $f(n)$ distinct prime factors.
 Is it true that $\frac{f(n)}{\log n} \to\infty$?
 -/
 @[category research open, AMS 11]
-theorem erdos_126
-    (f : ℕ → ℕ)
-    (hf : IsMaximalAddFactorsCard f) :
-    Tendsto (fun n => f n / Real.log n) atTop atTop :=
+theorem erdos_126 (f : ℕ → ℕ) (hf : IsMaximalAddFactorsCard f) :
+    Tendsto (fun n => f n / Real.log n) atTop atTop ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/143.lean
+++ b/FormalConjectures/ErdosProblems/143.lean
@@ -39,8 +39,8 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_143.parts.i (A : Set ℝ) (h : WellSeparatedSet A):
-    liminf (fun x => (A ∩ (Set.Icc 1 x)).ncard / x) atTop = 0 ↔ answer(sorry) := by
+theorem erdos_143.parts.i : (∀ (A : Set ℝ), WellSeparatedSet A →
+    liminf (fun x => (A ∩ (Set.Icc 1 x)).ncard / x) atTop = 0) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/143.lean
+++ b/FormalConjectures/ErdosProblems/143.lean
@@ -40,7 +40,7 @@ $$
 -/
 @[category research open, AMS 11]
 theorem erdos_143.parts.i (A : Set ℝ) (h : WellSeparatedSet A):
-    liminf (fun x => (A ∩ (Set.Icc 1 x)).ncard / x) atTop = 0 := by
+    liminf (fun x => (A ∩ (Set.Icc 1 x)).ncard / x) atTop = 0 ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -68,19 +68,19 @@ lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N)
     F N = S.card := by
   sorry
 
-/--What is the limit `F(N)/N` as `N → ∞`? -/
+/--What is the limit $F(N)/N$ as $N \to \infty$? -/
 @[category research open, AMS 11]
 theorem erdos_168.parts.i :
     Filter.Tendsto (fun N => (F N / N : ℝ)) Filter.atTop (𝓝 answer(sorry)) := by
   sorry
 
-/--Is the limit `F(N)/N` as `N → ∞` irrational? -/
+/--Is the limit $F(N)/N$ as $N \to \infty$ irrational? -/
 @[category research open, AMS 5, AMS 11]
 theorem erdos_168.parts.ii :
-    Irrational <| Filter.atTop.limsup (fun N => (F N / N : ℝ)) := by
+    Irrational (Filter.atTop.limsup (fun N => (F N / N : ℝ))) ↔ answer(sorry):= by
   sorry
 
-/--The limit `F(N)/N` as `N → ∞` exists.
+/--The limit $F(N)/N$ as $N \to \infty$ exists.
 (proved by Graham, Spencer, and Witsenhausen)-/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_168.variants.limit_exists :

--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -49,7 +49,8 @@ lemma F_2 : F 2 = 2 := rfl
 lemma F_3 : F 3 = 2 := rfl
 
 /--
-Sanity check: elements of `IntervalNonTernarySets N` are precisely non ternary subsets of `{1,...,N}`
+Sanity check: elements of `IntervalNonTernarySets N` are precisely non ternary subsets of
+`{1,...,N}`
 -/
 @[category API, AMS 5, AMS 11]
 lemma mem_IntervalNonTernarySets_iff (N : ℕ) (S : Finset ℕ) :
@@ -60,7 +61,8 @@ lemma mem_IntervalNonTernarySets_iff (N : ℕ) (S : Finset ℕ) :
   exact fun n hn₁ hn₂ hn₃ => h.2 n (h.1 hn₁).1 (h.1 hn₃).2 hn₁ hn₂ hn₃
 
 /--
-Sanity check: if `S` is a maximal non ternary subset of `{1,..., N}` then `F N` is given by the cardinality of `S`
+Sanity check: if `S` is a maximal non ternary subset of `{1,..., N}` then `F N` is given by the
+cardinality of `S`
 -/
 @[category API, AMS 5, AMS 11]
 lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N)
@@ -68,20 +70,19 @@ lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N)
     F N = S.card := by
   sorry
 
-/--What is the limit $F(N)/N$ as $N \to \infty$? -/
+/-- What is the limit $F(N)/N$ as $N \to \infty$? -/
 @[category research open, AMS 11]
 theorem erdos_168.parts.i :
     Filter.Tendsto (fun N => (F N / N : ℝ)) Filter.atTop (𝓝 answer(sorry)) := by
   sorry
 
-/--Is the limit $F(N)/N$ as $N \to \infty$ irrational? -/
+/-- Is the limit $F(N)/N$ as $N \to \infty$ irrational? -/
 @[category research open, AMS 5, AMS 11]
 theorem erdos_168.parts.ii :
     Irrational (Filter.atTop.limsup (fun N => (F N / N : ℝ))) ↔ answer(sorry):= by
   sorry
 
-/--The limit $F(N)/N$ as $N \to \infty$ exists.
-(proved by Graham, Spencer, and Witsenhausen)-/
+/-- The limit $F(N)/N$ as $N \to \infty$ exists. (proved by Graham, Spencer, and Witsenhausen) -/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_168.variants.limit_exists :
     ∃ x, Filter.Tendsto (fun N => (F N / N : ℝ)) Filter.atTop (𝓝 x) := by

--- a/FormalConjectures/ErdosProblems/189.lean
+++ b/FormalConjectures/ErdosProblems/189.lean
@@ -32,8 +32,8 @@ def Erdos189For (P : ℝ² → ℝ² → ℝ² → ℝ² → Prop) (A : ℝ² �
       P a b c d
 
 /--
-If `ℝ²` is finitely coloured then must there exist some colour class which contains the vertices
-of a rectangle of every area?
+If $\mathbb{R}^2$ is finitely coloured then must there exist some colour class which contains the
+vertices of a rectangle of every area?
 
 Graham, "On Partitions of 𝔼ⁿ", Journal of Combinatorial Theory, Series A 28, 89-91 (1980).
 (See "Concluding Remarks" on page 96.)
@@ -45,12 +45,12 @@ In fact, Kovač's colouring is even Jordan measurable (the topological boundary 
 monochromatic region is Lebesgue measurable and has measure zero). -/
 @[category research solved, AMS 5, AMS 51]
 theorem erdos_189 :
-    ¬ Erdos189For
+    Erdos189For
       (fun a b c d ↦
         line[ℝ, a, b].direction ⟂ line[ℝ, b, c].direction ∧
         line[ℝ, b, c].direction ⟂ line[ℝ, c, d].direction)
-      (fun a b c d ↦ dist a b * dist b c) :=
-sorry
+      (fun a b c d ↦ dist a b * dist b c) ↔ answer(False) :=
+  sorry
 
 /-- Graham claims this is "easy to see". -/
 @[category research solved, AMS 5, AMS 51]

--- a/FormalConjectures/ErdosProblems/198.lean
+++ b/FormalConjectures/ErdosProblems/198.lean
@@ -57,14 +57,15 @@ Answer "yes" according to remark on page 23 of:
 - Erdös and Graham, "Old and new problems and results in combinatorial number theory", 1980.
 
 
-"Baumgartner also proved the conjecture of Erdös that if $A$ is a sequence of positive integers with all
-sums $a + a'$ distinct for $a, a' ∈ A$ then the complement of $A$ contains an
+"Baumgartner also proved the conjecture of Erdös that if $A$ is a sequence of positive integers with
+all sums $a + a'$ distinct for $a, a' ∈ A$ then the complement of $A$ contains an
 infinite A.P."
 
 
 But this seems to be a misprint, since the opposite is true:
-There is a sequence of positive integers with all $a + a'$ distinct for $a, a' ∈ A$ such that the complement of $A$ contains no
-infinite A.P., i.e. there is a Sidon set $A$ which intersects all arithmetic progressions.
+There is a sequence of positive integers with all $a + a'$ distinct for $a, a' ∈ A$ such that the
+complement of $A$ contains no infinite A.P., i.e. there is a Sidon set $A$ which intersects all
+arithmetic progressions.
 
 So the answer should be "no".
 
@@ -72,8 +73,8 @@ This can be seen, as pointed out by Thomas Bloom [erdosproblems.com/198](https:/
 by an elementary argument.
 -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_198 : ∃ A : ℕ →o ℕ,
-    IsSidon A ∧ (∀ Y, IsAPOfLength Y ⊤ → ((range A) ∩ Y).Nonempty) := by
+theorem erdos_198 : (∀ A : ℕ →o ℕ,
+    IsSidon A → (∀ Y, IsAPOfLength Y ⊤ → ((range A) ∩ Y).Nonempty)) ↔ answer(False) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/198.lean
+++ b/FormalConjectures/ErdosProblems/198.lean
@@ -73,8 +73,8 @@ This can be seen, as pointed out by Thomas Bloom [erdosproblems.com/198](https:/
 by an elementary argument.
 -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_198 : (∀ A : ℕ →o ℕ,
-    IsSidon A → (∀ Y, IsAPOfLength Y ⊤ → ((range A) ∩ Y).Nonempty)) ↔ answer(False) := by
+theorem erdos_198 : (∀ A : ℕ →o ℕ, IsSidon A → (∃ Y, IsAPOfLength Y ⊤ ∧ Y ⊆ (range A)ᶜ)) ↔
+    answer(False) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/219.lean
+++ b/FormalConjectures/ErdosProblems/219.lean
@@ -60,5 +60,5 @@ Solution: yes.
 Ref: Green, Ben and Tao, Terence, _The primes contain arbitrarily long arithmetic progressions_
 -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_219 : ∀ N, ∃ l ∈ primeArithmeticProgressions, N ≤ l.length := by
+theorem erdos_219 : (∀ N, ∃ l ∈ primeArithmeticProgressions, N ≤ l.length) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/228.lean
+++ b/FormalConjectures/ErdosProblems/228.lean
@@ -22,16 +22,18 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/228](https://www.erdosproblems.com/228)
 -/
 /--
-Does there exist, for all large $n$, a polynomial $P$
-of degree $n$, with coefficients $\pm1$, such that
-$$\sqrt n \ll |P(z)| \ll \sqrt n$$
-for all $|z|=1$,
-with the implied constants independent of $z$ and $n$?
+Does there exist, for all large $n$, a polynomial $P$ of degree $n$, with coefficients $\pm1$, such
+that $$\sqrt n \ll |P(z)| \ll \sqrt n$$ for all $|z|=1$, with the implied constants independent of
+$z$ and $n$?
+
+The answer is yes, proved by Balister, Bollobás, Morris, Sahasrabudhe, and Tiba [BBMST19].
+
+[BBMST19] Balister, P. and Bollob\'{A}s, B. and Morris, R. and Sahasrabudhe, J. and Tiba, M., _Flat Littlewood Polynomials Exist_. arXiv:907.09464 (2019).
 -/
 @[category research solved, AMS 5, AMS 12, AMS 41] --TODO(lezeau): I'm a little unhappy with the `41` tag
 theorem erdos_228 :
-    ∃ (c₁ : ℝ) (c₂ : ℝ), ∀ᶠ n : ℕ in Filter.atTop,
+    (∃ (c₁ : ℝ) (c₂ : ℝ), ∀ᶠ n : ℕ in Filter.atTop,
     ∃ p : Polynomial ℂ, p.degree = n ∧
     (∀ i ≤ n, p.coeff i = 1 ∨ p.coeff i = -1) ∧
     ∀ z : ℂ, ‖z‖ = 1 →
-    ( √n < c₁ * ‖p.eval z‖ ∧ ‖p.eval z‖ < c₂ * √n ) := sorry
+    ( √n < c₁ * ‖p.eval z‖ ∧ ‖p.eval z‖ < c₂ * √n )) ↔ answer(True) := sorry

--- a/FormalConjectures/ErdosProblems/229.lean
+++ b/FormalConjectures/ErdosProblems/229.lean
@@ -38,7 +38,7 @@ theorem erdos_229 :
     letI := Polynomial.algebraPi ℂ ℂ ℂ
     (∀ (S : ℕ → Set ℂ), (∀ (n), derivedSet (S n) = ∅) →
     ∃ (f : ℂ → ℂ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ n ≥ 1,
-      ∃ k, ∀ᵉ (z ∈ S n), iteratedDeriv k f z = 0) ↔ answer(True) :=
+      ∃ k, ∀ z ∈ S n, iteratedDeriv k f z = 0) ↔ answer(True) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/229.lean
+++ b/FormalConjectures/ErdosProblems/229.lean
@@ -28,14 +28,18 @@ exists some $k_n \geq 0$ such that
 $$
   f^{(k_n)}(z) = 0\quad\text{for all $z\in S_n$?}
 $$
--/
+
+Solved in the affirmative by Barth and Schneider [BaSc72].
+
+[BaSc72] Barth, K. F. and Schneider, W. J., _On a problem of Erdős concerning the zeros of_
+_the derivatives of an entire function_. Proc. Amer. Math. Soc. (1972), 229--232.-/
 @[category research solved, AMS 30]
 theorem erdos_229
     (S : ℕ → Set ℂ)
     (h : ∀ (n), derivedSet (S n) = ∅) :
     letI := Polynomial.algebraPi ℂ ℂ ℂ
-    ∃ (f : ℂ → ℂ) (k : ℕ → ℕ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ (n) (z) (_ : z ∈ S n),
-      iteratedDeriv (k n) f z = 0 :=
+    (∃ (f : ℂ → ℂ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ᵉ (n ≥ 1),
+      ∃ (k : ℕ → ℕ), ∀ᵉ (z ∈ S n), iteratedDeriv (k n) f z = 0) ↔ answer(True) :=
   sorry
 
 /--
@@ -44,9 +48,6 @@ Solved in the affirmative by Barth and Schneider [BaSc72], who proved the follow
 Let $\{S_k\}$ be any sequence of sets in the complex plane, each of which has no finite
 limit point. Then there exists a sequence $\{n_k\}$ of positive integers and a
 transcendental entire function $f(z)$ such that $f^{(n_k)}(z) = 0$ if $z \in S_k$.
-
-[BaSc72] Barth, K. F. and Schneider, W. J., _On a problem of Erdős concerning the zeros of_
-_the derivatives of an entire function_. Proc. Amer. Math. Soc. (1972), 229--232.
 -/
 @[category research solved, AMS 30]
 theorem theorem_1

--- a/FormalConjectures/ErdosProblems/229.lean
+++ b/FormalConjectures/ErdosProblems/229.lean
@@ -36,7 +36,7 @@ _the derivatives of an entire function_. Proc. Amer. Math. Soc. (1972), 229--232
 @[category research solved, AMS 30]
 theorem erdos_229 :
     letI := Polynomial.algebraPi ℂ ℂ ℂ
-    (∀ (S : ℕ → Set ℂ), (∀ (n), derivedSet (S n) = ∅) →
+    (∀ (S : ℕ → Set ℂ), (∀ n, derivedSet (S n) = ∅) →
     ∃ (f : ℂ → ℂ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ n ≥ 1,
       ∃ k, ∀ z ∈ S n, iteratedDeriv k f z = 0) ↔ answer(True) :=
   sorry

--- a/FormalConjectures/ErdosProblems/229.lean
+++ b/FormalConjectures/ErdosProblems/229.lean
@@ -34,17 +34,14 @@ Solved in the affirmative by Barth and Schneider [BaSc72].
 [BaSc72] Barth, K. F. and Schneider, W. J., _On a problem of Erdős concerning the zeros of_
 _the derivatives of an entire function_. Proc. Amer. Math. Soc. (1972), 229--232.-/
 @[category research solved, AMS 30]
-theorem erdos_229
-    (S : ℕ → Set ℂ)
-    (h : ∀ (n), derivedSet (S n) = ∅) :
+theorem erdos_229 :
     letI := Polynomial.algebraPi ℂ ℂ ℂ
-    (∃ (f : ℂ → ℂ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ᵉ (n ≥ 1),
-      ∃ (k : ℕ → ℕ), ∀ᵉ (z ∈ S n), iteratedDeriv (k n) f z = 0) ↔ answer(True) :=
+    (∀ (S : ℕ → Set ℂ), (∀ (n), derivedSet (S n) = ∅) →
+    ∃ (f : ℂ → ℂ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ n ≥ 1,
+      ∃ k, ∀ᵉ (z ∈ S n), iteratedDeriv k f z = 0) ↔ answer(True) :=
   sorry
 
 /--
-Solved in the affirmative by Barth and Schneider [BaSc72], who proved the following.
-
 Let $\{S_k\}$ be any sequence of sets in the complex plane, each of which has no finite
 limit point. Then there exists a sequence $\{n_k\}$ of positive integers and a
 transcendental entire function $f(z)$ such that $f^{(n_k)}(z) = 0$ if $z \in S_k$.

--- a/FormalConjectures/ErdosProblems/243.lean
+++ b/FormalConjectures/ErdosProblems/243.lean
@@ -27,7 +27,8 @@ open Filter
 open scoped Topology
 
 /--
-Let $a_1 < a_2 < \dots$ be a sequence of integers such that $\lim_{n\to\infty} \frac{a_n}{a_{n-1}^2} = 1$ and $\sum \frac{1}{a_n} \in \mathbb{Q}$.
+Let $a_1 < a_2 < \dots$ be a sequence of integers such that
+$\lim_{n\to\infty} \frac{a_n}{a_{n-1}^2} = 1$ and $\sum \frac{1}{a_n} \in \mathbb{Q}$.
 
 Then, for all sufficiently large $n \ge 1$, $a_n = a_{n-1}^2 - a_{n-1} + 1$.
 -/

--- a/FormalConjectures/ErdosProblems/244.lean
+++ b/FormalConjectures/ErdosProblems/244.lean
@@ -24,7 +24,7 @@ import FormalConjectures.Util.ProblemImports
 /-- Let $C > 1$. Does the set of integers of the form $p + \lfloor C^k \rfloor$,
 for some prime $p$ and $k\geq 0$, have density $>0$? -/
 @[category research open, AMS 11]
-theorem erdos_244 : (∀ C > 1, { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasPosDensity) ↔
+theorem erdos_244 : (∀ C > (1 : ℝ), { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasPosDensity) ↔
     answer(sorry) :=
   sorry
 

--- a/FormalConjectures/ErdosProblems/244.lean
+++ b/FormalConjectures/ErdosProblems/244.lean
@@ -24,7 +24,7 @@ import FormalConjectures.Util.ProblemImports
 /-- Let $C > 1$. Does the set of integers of the form $p + \lfloor C^k \rfloor$,
 for some prime $p$ and $k\geq 0$, have density $>0$? -/
 @[category research open, AMS 11]
-theorem erdos_244 : (∀ᵉ (C > 1), (∃ α > 0, { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasDensity α)) ↔
+theorem erdos_244 : (∀ C > 1, { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasPosDensity) ↔
     answer(sorry) :=
   sorry
 

--- a/FormalConjectures/ErdosProblems/244.lean
+++ b/FormalConjectures/ErdosProblems/244.lean
@@ -24,8 +24,8 @@ import FormalConjectures.Util.ProblemImports
 /-- Let $C > 1$. Does the set of integers of the form $p + \lfloor C^k \rfloor$,
 for some prime $p$ and $k\geq 0$, have density $>0$? -/
 @[category research open, AMS 11]
-theorem erdos_244 {C : ℝ} (hC : 1 < C) :
-    (∃ α > 0, { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasDensity α) ↔ answer(sorry) :=
+theorem erdos_244 : (∀ᵉ (C > 1), (∃ α > 0, { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasDensity α)) ↔
+    answer(sorry) :=
   sorry
 
 /-- Romanoff [Ro34] proved that the answer is yes if $C$ is an integer.

--- a/FormalConjectures/ErdosProblems/244.lean
+++ b/FormalConjectures/ErdosProblems/244.lean
@@ -24,9 +24,8 @@ import FormalConjectures.Util.ProblemImports
 /-- Let $C > 1$. Does the set of integers of the form $p + \lfloor C^k \rfloor$,
 for some prime $p$ and $k\geq 0$, have density $>0$? -/
 @[category research open, AMS 11]
-theorem erdos_244 {C : ℝ} (hC : 1 < C) {α : ℝ}
-    (h : { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasDensity α) :
-    0 < α :=
+theorem erdos_244 {C : ℝ} (hC : 1 < C) :
+    (∃ α > 0, { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasDensity α) ↔ answer(sorry) :=
   sorry
 
 /-- Romanoff [Ro34] proved that the answer is yes if $C$ is an integer.

--- a/FormalConjectures/ErdosProblems/245.lean
+++ b/FormalConjectures/ErdosProblems/245.lean
@@ -41,9 +41,9 @@ The answer is yes, proved by Freiman [Fr73].
 [Fr73] Fre\u{\i}man, G. A., _Foundations of a structural theory of set addition_. (1973), vii+108.
 -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_245 (A : Set ℕ) (h_inf : A.Infinite)
-    (hf : Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0)) :
-    3 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop ↔ answer(True) :=
+theorem erdos_245 :
+    (∀ (A : Set ℕ), A.Infinite → Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0) →
+    3 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop) ↔ answer(True) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/245.lean
+++ b/FormalConjectures/ErdosProblems/245.lean
@@ -35,11 +35,15 @@ Is it true that
 $$
 \limsup_{N\to\infty}\frac{|(A + A)\cap \{1, ..., N\}|}{|A \cap \{1, ..., N\}|} \geq 3?
 $$
+
+The answer is yes, proved by Freiman [Fr73].
+
+[Fr73] Fre\u{\i}man, G. A., _Foundations of a structural theory of set addition_. (1973), vii+108.
 -/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_245 (A : Set ℕ) (h_inf : A.Infinite)
     (hf : Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0)) :
-    3 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop :=
+    3 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop ↔ answer(True) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/247.lean
+++ b/FormalConjectures/ErdosProblems/247.lean
@@ -39,7 +39,7 @@ transcendental?
 theorem erdos_247 (n : ℕ → ℕ)
     (hn : StrictMono n)
     (h : atTop.limsup (fun k => (n k / k.succ : EReal)) = ⊤) :
-    Transcendental ℚ (∑' k, (1 : ℝ) / 2 ^ n k) :=
+    Transcendental ℚ (∑' k, (1 : ℝ) / 2 ^ n k) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/247.lean
+++ b/FormalConjectures/ErdosProblems/247.lean
@@ -36,17 +36,18 @@ $$
 transcendental?
 -/
 @[category research open, AMS 11]
-theorem erdos_247 (n : ℕ → ℕ)
-    (hn : StrictMono n)
-    (h : atTop.limsup (fun k => (n k / k.succ : EReal)) = ⊤) :
-    Transcendental ℚ (∑' k, (1 : ℝ) / 2 ^ n k) ↔ answer(sorry) :=
+theorem erdos_247 : (∀ (n : ℕ → ℕ), (StrictMono n) →
+    atTop.limsup (fun k => (n k / k.succ : EReal)) = ⊤ →
+    Transcendental ℚ (∑' k, (1 : ℝ) / 2 ^ n k)) ↔ answer(sorry) :=
   sorry
 
 /--
 Erdős proved the answer is yes under the stronger condition that
 $\limsup \frac{n_k}{k^t} = \infty$ for all $t\geq 1$.
 
-[ErGr80] Erdős, P. and Graham, R., _Old and new problems and results in combinatorial number theory_. Monographies de L'Enseignement Mathematique (1980).
+[ErGr80] Erdős, P. and Graham, R.,
+_Old and new problems and results in combinatorial number theory_.
+Monographies de L'Enseignement Mathematique (1980).
 -/
 @[category research solved, AMS 11]
 theorem erdos_247.variants.strong_condition (n : ℕ → ℕ)

--- a/FormalConjectures/ErdosProblems/248.lean
+++ b/FormalConjectures/ErdosProblems/248.lean
@@ -32,5 +32,5 @@ Here $\omega(n)$ is the number of distinct prime divisors
 of $n$.
 -/
 @[category research open, AMS 11]
-theorem erdos_248 : ∃ C > (0 : ℝ), { n | ∀ k ≥ 1, ω (n + k) ≤ C * k }.Infinite :=
+theorem erdos_248 : { n | ∃ C > (0 : ℝ), ∀ k ≥ 1, ω (n + k) ≤ C * k }.Infinite ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/250.lean
+++ b/FormalConjectures/ErdosProblems/250.lean
@@ -36,7 +36,6 @@ The answer is yes, as shown by Nesterenko [Ne96].
 Mat. Sb. 187 *9* (1996), 1319--1348.
 -/
 @[category research solved, AMS 11]
-theorem erdos_250 (x : ℝ)
-    (h : HasSum (fun (n : ℕ) => σ 1 n / (2 : ℝ) ^ n) x) :
-    Irrational x ↔ answer(True):=
+theorem erdos_250  : (∀ x,  HasSum (fun (n : ℕ) => σ 1 n / (2 : ℝ) ^ n) x → Irrational x) ↔
+    answer(True):=
   sorry

--- a/FormalConjectures/ErdosProblems/250.lean
+++ b/FormalConjectures/ErdosProblems/250.lean
@@ -30,7 +30,7 @@ $$
 $$
 irrational? Here $\sigma(n)$ is the sum of divisors function.
 
-Solved by Nesterenko in [Ne96]
+The answer is yes, as shown by Nesterenko [Ne96].
 
 [Ne96] Nesterenko, Yu V., _Modular functions and transcendence questions_,
 Mat. Sb. 187 *9* (1996), 1319--1348.
@@ -38,5 +38,5 @@ Mat. Sb. 187 *9* (1996), 1319--1348.
 @[category research solved, AMS 11]
 theorem erdos_250 (x : ℝ)
     (h : HasSum (fun (n : ℕ) => σ 1 n / (2 : ℝ) ^ n) x) :
-    Irrational x :=
+    Irrational x ↔ answer(True):=
   sorry

--- a/FormalConjectures/ErdosProblems/250.lean
+++ b/FormalConjectures/ErdosProblems/250.lean
@@ -36,6 +36,6 @@ The answer is yes, as shown by Nesterenko [Ne96].
 Mat. Sb. 187 *9* (1996), 1319--1348.
 -/
 @[category research solved, AMS 11]
-theorem erdos_250  : (∀ x,  HasSum (fun (n : ℕ) => σ 1 n / (2 : ℝ) ^ n) x → Irrational x) ↔
+theorem erdos_250  : (∀ x, HasSum (fun (n : ℕ) => σ 1 n / (2 : ℝ) ^ n) x → Irrational x) ↔
     answer(True):=
   sorry

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -29,8 +29,8 @@ $$
 irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_257 (A : Set ℕ) (h : A.Infinite) :
-    Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1)) ↔ answer(sorry) :=
+theorem erdos_257 : (∀ (A : Set ℕ), A.Infinite →
+    Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1))) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -30,7 +30,7 @@ irrational?
 -/
 @[category research open, AMS 11]
 theorem erdos_257 (A : Set ℕ) (h : A.Infinite) :
-    Irrational <| ∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1) :=
+    Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1)) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -22,14 +22,13 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/258](https://www.erdosproblems.com/258)
 -/
 /--
-Let $a_n → ∞$ be a sequence of non-zero natural numbers. Is $\sum_n \frac{d(n)}{(a_1 ... a_n)}$
-irrational, where $d(n)$ is the number of divisors of $n$?
+Let $a_n \to \infty$ be a sequence of non-zero natural numbers. Is
+$\sum_n \frac{d(n)}{(a_1 ... a_n)}$ irrational, where $d(n)$ is the number of divisors of $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_258
-    (a : ℕ → ℕ) (ha : ∀ n, a n ≠ 0)
-    (ha : Filter.Tendsto a Filter.atTop Filter.atTop) :
-    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) ↔
+theorem erdos_258 : (∀ (a : ℕ → ℕ), (∀ n, a n ≠ 0) →
+    Filter.Tendsto a Filter.atTop Filter.atTop →
+    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i))) ↔
     answer(sorry) := by
   sorry
 
@@ -41,10 +40,9 @@ Is $\sum_n \frac{d(n)}{(a_1 ... a_n)}$ irrational, where $d(n)$ is the number of
 Solution: True (proved by Erdős and Straus, see Erdős Problems website).
 -/
 @[category research solved, AMS 11]
-theorem erdos_258.variants.Monotone
-    (a : ℕ → ℤ) (ha : ∀ n, a n ≠ 0) (ha : Monotone a)
-    (ha : Filter.Tendsto a Filter.atTop Filter.atTop) :
-    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) ↔ answer(True) := by
+theorem erdos_258.variants.Monotone : (∀ (a : ℕ → ℤ), ∀ n, a n ≠ 0 → Monotone a →
+    Filter.Tendsto a Filter.atTop Filter.atTop →
+    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i))) ↔ answer(True) := by
   sorry
 
 
@@ -54,6 +52,6 @@ Is $\sum_n \frac{d(n)}{t^n}$ irrational, where $t ≥ 2$ is an integer.
 Solution: True (proved by Erdős, see Erdős Problems website)
 -/
 @[category research solved, AMS 11]
-theorem erdos_258.variants.Constant (t : ℕ) (ht : 2 ≤ t):
-    Irrational (∑' (n : ℕ), ((n+1).divisors.card / t^n)) ↔ answer(True) := by
+theorem erdos_258.variants.Constant : (∀ᵉ (t ≥ 2),
+    Irrational (∑' (n : ℕ), ((n+1).divisors.card / t^n))) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -29,7 +29,8 @@ irrational, where $d(n)$ is the number of divisors of $n$?
 theorem erdos_258
     (a : ℕ → ℕ) (ha : ∀ n, a n ≠ 0)
     (ha : Filter.Tendsto a Filter.atTop Filter.atTop) :
-    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) := by
+    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) ↔
+    answer(sorry) := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -52,6 +52,6 @@ Is $\sum_n \frac{d(n)}{t^n}$ irrational, where $t ≥ 2$ is an integer.
 Solution: True (proved by Erdős, see Erdős Problems website)
 -/
 @[category research solved, AMS 11]
-theorem erdos_258.variants.Constant : (∀ᵉ (t ≥ 2),
+theorem erdos_258.variants.Constant : (∀ t ≥ 2,
     Irrational (∑' (n : ℕ), ((n+1).divisors.card / t^n))) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -35,7 +35,7 @@ theorem erdos_258
 
 
 /--
-Let $a_n → ∞$ be a monotone sequence of non-zero natural numbers.
+Let $a_n \to \infty$ be a monotone sequence of non-zero natural numbers.
 Is $\sum_n \frac{d(n)}{(a_1 ... a_n)}$ irrational, where $d(n)$ is the number of divisors of $n$?
 
 Solution: True (proved by Erdős and Straus, see Erdős Problems website).
@@ -44,7 +44,7 @@ Solution: True (proved by Erdős and Straus, see Erdős Problems website).
 theorem erdos_258.variants.Monotone
     (a : ℕ → ℤ) (ha : ∀ n, a n ≠ 0) (ha : Monotone a)
     (ha : Filter.Tendsto a Filter.atTop Filter.atTop) :
-    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) := by
+    Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) ↔ answer(True) := by
   sorry
 
 
@@ -55,5 +55,5 @@ Solution: True (proved by Erdős, see Erdős Problems website)
 -/
 @[category research solved, AMS 11]
 theorem erdos_258.variants.Constant (t : ℕ) (ht : 2 ≤ t):
-    Irrational (∑' (n : ℕ), ((n+1).divisors.card / t^n)) := by
+    Irrational (∑' (n : ℕ), ((n+1).divisors.card / t^n)) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -40,7 +40,7 @@ Is $\sum_n \frac{d(n)}{(a_1 ... a_n)}$ irrational, where $d(n)$ is the number of
 Solution: True (proved by Erdős and Straus, see Erdős Problems website).
 -/
 @[category research solved, AMS 11]
-theorem erdos_258.variants.Monotone : (∀ (a : ℕ → ℤ), ∀ n, a n ≠ 0 → Monotone a →
+theorem erdos_258.variants.Monotone : (∀ (a : ℕ → ℤ), (∀ n, a n ≠ 0) → Monotone a →
     Filter.Tendsto a Filter.atTop Filter.atTop →
     Irrational (∑' (n : ℕ), ((n+1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i))) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/267.lean
+++ b/FormalConjectures/ErdosProblems/267.lean
@@ -30,7 +30,7 @@ $\sum_k \frac 1 {F_{n_k}}$ be irrational?
 theorem erdos_267 (n : ℕ → ℕ)
     (hn : StrictMono n) (c : ℚ) (hc : 1 < c)
     (hnc : ∀ k, c ≤ n (k+1) / n k) :
-    Irrational <| ∑' k, 1 / (Nat.fib <| n k) :=
+    Irrational (∑' k, 1 / (Nat.fib <| n k) ) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -42,7 +42,7 @@ $\sum_k \frac 1 {F_{n_k}}$ be irrational?
 theorem erdos_267.variants.generalisation_ratio_limit_to_infinity (n : ℕ → ℕ)
     (hn : StrictMono n)
     (hnc : Filter.Tendsto (fun k => (n (k+1) / k.succ : ℝ)) Filter.atTop Filter.atTop) :
-    Irrational <| ∑' k, 1 / (Nat.fib <| n k) :=
+    Irrational (∑' k, 1 / (Nat.fib <| n k)) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/267.lean
+++ b/FormalConjectures/ErdosProblems/267.lean
@@ -27,10 +27,8 @@ Let $n_1 < n_2 < ...$ be an infinite sequence with $\frac{n_{k+1}}{n_k} ≥ c > 
 $\sum_k \frac 1 {F_{n_k}}$ be irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_267 (n : ℕ → ℕ)
-    (hn : StrictMono n) (c : ℚ) (hc : 1 < c)
-    (hnc : ∀ k, c ≤ n (k+1) / n k) :
-    Irrational (∑' k, 1 / (Nat.fib <| n k) ) ↔ answer(sorry) :=
+theorem erdos_267 : (∀ᵉ (n : ℕ → ℕ) (c > (1 : ℚ)), StrictMono n → (∀ k, c ≤ n (k+1) / n k) →
+    Irrational (∑' k, 1 / (Nat.fib <| n k))) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -39,10 +37,9 @@ Let $n_1 < n_2 < ...$ be an infinite sequence with $\frac {n_k}{k} → ∞$. Mus
 $\sum_k \frac 1 {F_{n_k}}$ be irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_267.variants.generalisation_ratio_limit_to_infinity (n : ℕ → ℕ)
-    (hn : StrictMono n)
-    (hnc : Filter.Tendsto (fun k => (n (k+1) / k.succ : ℝ)) Filter.atTop Filter.atTop) :
-    Irrational (∑' k, 1 / (Nat.fib <| n k)) ↔ answer(sorry) :=
+theorem erdos_267.variants.generalisation_ratio_limit_to_infinity : (∀ (n : ℕ → ℕ),
+    StrictMono n → Filter.Tendsto (fun k => (n (k+1) / k.succ : ℝ)) Filter.atTop Filter.atTop →
+    Irrational (∑' k, 1 / (Nat.fib <| n k))) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/285.lean
+++ b/FormalConjectures/ErdosProblems/285.lean
@@ -34,6 +34,10 @@ Is it true that
 $$
   f(k) = (1 + o(1)) \frac{e}{e - 1} k ?
 $$
+
+Proved by Martin [Ma00].
+
+[Ma00] Martin, Greg, _Denser Egyptian fractions_. Acta Arith. (2000), 231-260.
 -/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_285
@@ -46,14 +50,12 @@ theorem erdos_285
         { n (Fin.last k) | (n : Fin k.succ → ℕ) (_ : StrictMono n) (_ : 0 ∉ Set.range n)
           (_ : 1 = ∑ i, (1 : ℝ) / n i) }
         (f k)) :
-    ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
-      ∀ k ∈ S, f k = (1 + o k) * rexp 1 / (rexp 1 - 1) * (k + 1) := by
+    (∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+      ∀ k ∈ S, f k = (1 + o k) * rexp 1 / (rexp 1 - 1) * (k + 1)) ↔ answer(True) := by
   sorry
 
 /--
 It is trivial that $f(k)\geq (1 + o(1)) \frac{e}{e - 1}k$.
-
-[Ma00] Martin, Greg, _Denser Egyptian fractions_. Acta Arith. (2000), 231-260.
 -/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_285.variants.lb (f : ℕ → ℕ)

--- a/FormalConjectures/ErdosProblems/295.lean
+++ b/FormalConjectures/ErdosProblems/295.lean
@@ -48,7 +48,7 @@ Is it true that $\lim_{N→∞} k(N) - (e - 1)N = ∞$?
 -/
 @[category research open, AMS 5, AMS 11]
 theorem erdos_295 :
-    Filter.atTop.Tendsto (fun N => k N - (rexp 1 - 1)*N) Filter.atTop := by
+    Filter.atTop.Tendsto (fun N => k N - (rexp 1 - 1)*N) Filter.atTop ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/298.lean
+++ b/FormalConjectures/ErdosProblems/298.lean
@@ -21,9 +21,13 @@ import FormalConjectures.Util.ProblemImports
 Does every set $A \subseteq \mathbb{N}$ of positive density contain some finite $S \subset A$ such
 that $\sum_{n \in S} \frac{1}{n} = 1$?
 
+The answer is yes, proved by Bloom [Bl21].
+
+[Bl21] Bloom, T. F., _On a density conjecture about unit fractions_. arXiv:2112.03726 (2021).
+
 Note: The solution to this problem has been formalized in Lean 3 by T. Bloom and B. Mehta, see
 https://github.com/b-mehta/unit-fractions -/
 @[category research solved, AMS 11]
-theorem erdos_298 (A : Set ℕ) (hA : 0 ∉ A) (hA : A.HasPosDensity) :
-    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1 := by
+theorem erdos_298 : (∀ (A : Set ℕ), 0 ∉ A → A.HasPosDensity →
+    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/298.lean
+++ b/FormalConjectures/ErdosProblems/298.lean
@@ -17,9 +17,12 @@ limitations under the License.
 -- Erdős Problems URL: https://www.erdosproblems.com/298
 import FormalConjectures.Util.ProblemImports
 
-/--Does every set `A ⊆ N` of positive density contain some finite `S ⊂ A` such that `∑ n ∈ S, 1 / n = 1`?
+/--
+Does every set $A \subseteq \mathbb{N}$ of positive density contain some finite $S \subset A$ such
+that $\sum_{n \in S} \frac{1}{n} = 1$?
 
-Note: The solution to this problem has been formalized in Lean 3 by T. Bloom and B. Mehta, see https://github.com/b-mehta/unit-fractions -/
+Note: The solution to this problem has been formalized in Lean 3 by T. Bloom and B. Mehta, see
+https://github.com/b-mehta/unit-fractions -/
 @[category research solved, AMS 11]
 theorem erdos_298 (A : Set ℕ) (hA : 0 ∉ A) (hA : A.HasPosDensity) :
     ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1 := by

--- a/FormalConjectures/ErdosProblems/303.lean
+++ b/FormalConjectures/ErdosProblems/303.lean
@@ -21,12 +21,19 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/303](https://www.erdosproblems.com/303)
 -/
-/--Is it true that in any finite colouring of the integers there exists a monochromatic solution
-to $\frac 1 a = \frac 1 b + \frac 1 c$ with distinct $a, b, c$?-/
+/-- Is it true that in any finite colouring of the integers there exists a monochromatic solution
+to $\frac 1 a = \frac 1 b + \frac 1 c$ with distinct $a, b, c$?
+
+This is true, as proved by Brown and Rödl [BrRo91].
+
+[BrRo91] Brown, Tom C. and Rödl, Voijtech,
+_Monochromatic solutions to equations with unit fractions_.
+Bull. Austral. Math. Soc. (1991), 387-392.
+-/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_303 :
     --For any finite colouring of the integers
-    ∀ (𝓒 : ℤ → ℤ), (Set.range 𝓒).Finite →
+    (∀ (𝓒 : ℤ → ℤ), (Set.range 𝓒).Finite →
       --There exists integers `a, b, c`
       ∃ (a b c : ℤ),
       --that are non-zero and distinct.
@@ -34,5 +41,5 @@ theorem erdos_303 :
       --`a, b, c` satisfy the equation
       (1/a : ℝ) = 1/b + 1/c ∧
       --`a, b, c` have the same color
-      (𝓒 '' {a, b, c}).Subsingleton := by
+      (𝓒 '' {a, b, c}).Subsingleton) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/316.lean
+++ b/FormalConjectures/ErdosProblems/316.lean
@@ -25,12 +25,15 @@ import FormalConjectures.Util.ProblemImports
 $\sum_{n \in A} \frac{1}{n} < 2$ then there is a partition $A=A_1 \sqcup A_2$
 such that $\sum_{n \in A_i} \frac{1}{n} < 1$ for $i=1,2$?
 
-Solution: False. -/
+This is not true in general, as shown by Sándor [Sa97].
+
+[Sa97] S\'{A}ndor, Csaba, _On a problem of Erdős_. J. Number Theory (1997), 203-210.
+-/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_316 : ∃ A : Finset ℕ, 0 ∉ A ∧ 1 ∉ A ∧
-  ∑ n ∈ A, (1 / n : ℚ) < 2 ∧ ∀ (A₁ A₂ : Finset ℕ),
-    Disjoint A₁ A₂ → A = A₁ ∪ A₂ →
-    1 ≤ ∑ n ∈ A₁, (1 / n : ℚ) ∨ 1 ≤ ∑ n ∈ A₂, (1 / n : ℚ) := by
+theorem erdos_316 : (∀ A : Finset ℕ, 0 ∉ A → 1 ∉ A →
+    ∑ n ∈ A, (1 / n : ℚ) < 2 → ∃ (A₁ A₂ : Finset ℕ),
+      Disjoint A₁ A₂ ∧ A = A₁ ∪ A₂ ∧
+      (1 ≤ ∑ n ∈ A₁, (1 / n : ℚ) ∨ 1 ≤ ∑ n ∈ A₂, (1 / n : ℚ))) ↔ answer(False) := by
   sorry
 
 /-- It is not true if `A` is a multiset (easier) -/

--- a/FormalConjectures/ErdosProblems/370.lean
+++ b/FormalConjectures/ErdosProblems/370.lean
@@ -22,10 +22,12 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/370](https://www.erdosproblems.com/370)
 -/
 /--
-Are there infinitely many $n$ such that the largest prime factor of $n$ is $< n^{\frac 1 2}$ and
-the largest prime factor of $n + 1$ is $< (n + 1)^{\frac 1 2}$.
+Are there infinitely many $n$ such that the largest prime factor of $n$ is $< n^{\frac{1}{2}}$ and
+the largest prime factor of $n + 1$ is $< (n + 1)^{\frac{1}{2}}$.
+
+Steinerberger has pointed out this problem has a trivial solution.
 -/
 @[category research solved, AMS 11]
 theorem erdos_370 :
-    { n | Nat.maxPrimeFac n < √n ∧ Nat.maxPrimeFac (n + 1) < √(n + 1) }.Infinite :=
+    { n | Nat.maxPrimeFac n < √n ∧ Nat.maxPrimeFac (n + 1) < √(n + 1) }.Infinite ↔ answer(True) :=
   sorry

--- a/FormalConjectures/ErdosProblems/376.lean
+++ b/FormalConjectures/ErdosProblems/376.lean
@@ -26,8 +26,7 @@ Are there infinitely many $n$ such that ${2n\choose n}$ is
 coprime to $105$?
 -/
 @[category research open, AMS 11]
-theorem erdos_376 :
-    { n | ((2 * n).choose n).Coprime 105 }.Infinite :=
+theorem erdos_376 : { n | ((2 * n).choose n).Coprime 105 }.Infinite ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/376.lean
+++ b/FormalConjectures/ErdosProblems/376.lean
@@ -22,16 +22,15 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/376](https://www.erdosproblems.com/376)
 -/
 /--
-Are there infinitely many $n$ such that ${2n\choose n}$ is
-coprime to $105$?
+Are there infinitely many $n$ such that ${2n\choose n}$ is coprime to $105$?
 -/
 @[category research open, AMS 11]
 theorem erdos_376 : { n | ((2 * n).choose n).Coprime 105 }.Infinite ↔ answer(sorry) :=
   sorry
 
 /--
-Erdős, Graham, Ruzsa, and Straus [EGRS75] have shown that, for any two odd primes $p$ and $q$, there are infinite many $n$ such
-that ${2n\choose n}$ is coprime to $pq$.
+Erdős, Graham, Ruzsa, and Straus [EGRS75] have shown that, for any two odd primes $p$ and $q$,
+there are infinite many $n$ such that ${2n\choose n}$ is coprime to $pq$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_376.variants.prime {p q : ℕ} (h₁ : p.Prime)

--- a/FormalConjectures/ErdosProblems/377.lean
+++ b/FormalConjectures/ErdosProblems/377.lean
@@ -40,8 +40,8 @@ $$
 for all $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_377 : ∃ C > (0 : ℝ),
-    ∀ (n : ℕ), sumInvPrimesNotDvdCentralBinom n ≤ C :=
+theorem erdos_377 : (∃ C > (0 : ℝ), ∀ (n : ℕ), sumInvPrimesNotDvdCentralBinom n ≤ C) ↔
+    answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/383.lean
+++ b/FormalConjectures/ErdosProblems/383.lean
@@ -30,6 +30,7 @@ $$
 is $p$?
 -/
 @[category research open, AMS 11]
-theorem erdos_383 (k : ℕ) :
-    {p : ℕ | p.Prime ∧ Nat.maxPrimeFac (∏ i ∈ Finset.Icc 0 k, (p ^ 2 + i)) = p}.Infinite := by
+theorem erdos_383 :
+    (∀ k, {p : ℕ | p.Prime ∧ Nat.maxPrimeFac (∏ i ∈ Finset.Icc 0 k, (p ^ 2 + i)) = p}.Infinite) ↔
+    answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/389.lean
+++ b/FormalConjectures/ErdosProblems/389.lean
@@ -29,7 +29,7 @@ $$
 -/
 @[category research open, AMS 11]
 theorem erdos_389 :
-    (∀ᵉ (n ≥ 1), ∃ k ≥ 1, ∏ i ∈ Finset.range k, (n + i) ∣ ∏ i ∈ Finset.range k, (n + k + i)) ↔
+    (∀ n ≥ 1, ∃ k ≥ 1, ∏ i ∈ Finset.range k, (n + i) ∣ ∏ i ∈ Finset.range k, (n + k + i)) ↔
     answer(sorry) :=
   sorry
 

--- a/FormalConjectures/ErdosProblems/389.lean
+++ b/FormalConjectures/ErdosProblems/389.lean
@@ -28,9 +28,9 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_389 (n : ℕ) (h : 1 ≤ n) :
-    ∃ k ≥ 1,
-      ∏ i ∈ Finset.range k, (n + i) ∣ ∏ i ∈ Finset.range k, (n + k + i) :=
+theorem erdos_389 :
+    (∀ᵉ (n ≥ 1), ∃ k ≥ 1, ∏ i ∈ Finset.range k, (n + i) ∣ ∏ i ∈ Finset.range k, (n + k + i)) ↔
+    answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/392.lean
+++ b/FormalConjectures/ErdosProblems/392.lean
@@ -40,7 +40,8 @@ theorem erdos_392 (A : ℕ → ℕ)
     (hA : ∀ n > 0, IsLeast
       { t + 1 | (t) (_ : ∃ a : Fin (t + 1) → ℕ, (n)! = ∏ i, a i ∧ Monotone a ∧ a t ≤ n ^ 2) }
       (A n)) :
-    (fun (n : ℕ) => (A n - n / 2 + n / (2 * Real.log n) : ℝ)) =o[atTop] fun n => n / Real.log n :=
+    ((fun (n : ℕ) => (A n - n / 2 + n / (2 * Real.log n) : ℝ)) =o[atTop] fun n => n / Real.log n) ↔
+    answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/392.lean
+++ b/FormalConjectures/ErdosProblems/392.lean
@@ -36,12 +36,11 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_392 (A : ℕ → ℕ)
-    (hA : ∀ n > 0, IsLeast
-      { t + 1 | (t) (_ : ∃ a : Fin (t + 1) → ℕ, (n)! = ∏ i, a i ∧ Monotone a ∧ a t ≤ n ^ 2) }
-      (A n)) :
-    ((fun (n : ℕ) => (A n - n / 2 + n / (2 * Real.log n) : ℝ)) =o[atTop] fun n => n / Real.log n) ↔
-    answer(sorry) :=
+theorem erdos_392 : (∀ (A : ℕ → ℕ), (∀ n > 0,
+    IsLeast { t + 1 | (t) (_ : ∃ a : Fin (t + 1) → ℕ, (n)! = ∏ i, a i ∧ Monotone a ∧ a t ≤ n ^ 2) }
+      (A n)) →
+    ((fun (n : ℕ) => (A n - n / 2 + n / (2 * Real.log n) : ℝ)) =o[atTop] fun n => n / Real.log n))
+    ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/4.lean
+++ b/FormalConjectures/ErdosProblems/4.lean
@@ -34,7 +34,7 @@ $$
 $$
 -/
 @[category research solved, AMS 11]
-theorem erdos_4 : (∀ᵉ (C > 0), Erdos4For C) ↔ answer(True) :=
+theorem erdos_4 : (∀ C > 0, Erdos4For C) ↔ answer(True) :=
   sorry
 
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/4.lean
+++ b/FormalConjectures/ErdosProblems/4.lean
@@ -34,8 +34,7 @@ $$
 $$
 -/
 @[category research solved, AMS 11]
-theorem erdos_4 (C : ℝ) (hC : 0 < C) :
-    Erdos4For C :=
+theorem erdos_4 : (∀ᵉ (C > 0), Erdos4For C) ↔ answer(True) :=
   sorry
 
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/406.lean
+++ b/FormalConjectures/ErdosProblems/406.lean
@@ -26,7 +26,7 @@ Is it true that there are only finitely many powers of $2$ which have only the d
 and $1$ when written in base $3$?
 -/
 @[category research open, AMS 11]
-theorem erdos_406 : { n | n.isPowerOfTwo ∧ Nat.digits 3 n ⊆ [0, 1] }.Finite :=
+theorem erdos_406 : { n | n.isPowerOfTwo ∧ Nat.digits 3 n ⊆ [0, 1] }.Finite ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -83,7 +83,7 @@ Can infinitely many $n$ reach the same prime under the iteration $n\mapsto\phi(n
 -/
 @[category research open, AMS 11]
 theorem erdos_409.parts.ii :
-    ∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (φ · + 1)^[i] n = p }.Infinite :=
+    (∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (φ · + 1)^[i] n = p }.Infinite) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -148,7 +148,7 @@ Can infinitely many $n$ reach the same prime under the iteration $n\mapsto\sigma
 -/
 @[category research open, AMS 11]
 theorem erdos_409.variants.sigma.parts.ii :
-    ∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (σ 1 · - 1)^[i] n = p }.Infinite :=
+    (∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (σ 1 · - 1)^[i] n = p }.Infinite) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/410.lean
+++ b/FormalConjectures/ErdosProblems/410.lean
@@ -34,6 +34,6 @@ Erdos, Granville, Pomerance, Spiro
 (page 169 of the book "Analytic Number Theory", 1990).
 -/
 @[category research open, AMS 11]
-theorem erdos_410 (n : ℕ) (hn : 1 < n) :
-    Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop ↔ answer(sorry) :=
+theorem erdos_410 : (∀ᵉ (n > 1),
+    Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/410.lean
+++ b/FormalConjectures/ErdosProblems/410.lean
@@ -35,5 +35,5 @@ Erdos, Granville, Pomerance, Spiro
 -/
 @[category research open, AMS 11]
 theorem erdos_410 (n : ℕ) (hn : 1 < n) :
-    Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop :=
+    Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/412.lean
+++ b/FormalConjectures/ErdosProblems/412.lean
@@ -31,6 +31,5 @@ Let $σ_1(n)=σ(n)$, the sum of divisors function, and $σ_k(n) = σ(σ_{k−1}(
 Is it true that, for every $m, n ≥ 2$, there exist some $i, j$ such that $σ_i(m) = σ_j(n)$?
 -/
 @[category research open, AMS 11]
-theorem erdos_412 (m n : ℕ) (hm : 2 ≤ m) (hn : 2 ≤ n) :
-    ∃ i j, (σ 1)^[i] m = (σ 1)^[j] n := by
+theorem erdos_412 : (∀ᵉ (m ≥ 2) (n ≥ 2), ∃ i j, (σ 1)^[i] m = (σ 1)^[j] n) ↔ answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/418.lean
+++ b/FormalConjectures/ErdosProblems/418.lean
@@ -27,9 +27,14 @@ open scoped ArithmeticFunction
 
 /--
 Are there infinitely many integers not of the form $n - \phi(n)$?
+
+This is true, as shown by Browkin and Schinzel [BrSc95].
+
+[BrSc95] Browkin, J. and Schinzel, A., _On integers not of the form {$n-\phi(n)$}_.
+Colloq. Math. (1995), 55-58.
 -/
 @[category research solved, AMS 11]
-theorem erdos_418 : { (n - n.totient : ℕ) | n }ᶜ.Infinite :=
+theorem erdos_418 : { (n - n.totient : ℕ) | n }ᶜ.Infinite ↔ answer(True) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/418.lean
+++ b/FormalConjectures/ErdosProblems/418.lean
@@ -73,6 +73,5 @@ not of the form $n - \phi(n)$.
 -/
 @[category research open, AMS 11]
 theorem erdos_418.variants.density :
-    ∃ (S : Set ℕ) (hS : S.HasPosDensity),
-      S ⊆ { (n - n.totient : ℕ) | n }ᶜ :=
+    (∃ (S : Set ℕ) (hS : S.HasPosDensity), S ⊆ { (n - n.totient : ℕ) | n }ᶜ) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/421.lean
+++ b/FormalConjectures/ErdosProblems/421.lean
@@ -25,7 +25,9 @@ import FormalConjectures.Util.ProblemImports
 open Set
 
 /--
-Is there a sequence $1 \le d_1 < d_2 < \dots$ with density 1 such that all products $\prod_{u \le i \le v} d_i$ are distinct? -/
+Is there a sequence $1 \le d_1 < d_2 < \dots$ with density 1 such that all products
+$\prod_{u \le i \le v} d_i$ are distinct? -/
 @[category research open, AMS 11]
-theorem erdos_421 : ∃ (d : ℕ → ℕ), StrictMono d ∧ 1 ≤ d 0 ∧ HasDensity (Set.range d) 1 ∧
-    {(u, v) : ℕ × ℕ | u ≤ v}.InjOn fun (u, v) => ∏ i ∈ Finset.Icc u v, d i := by sorry
+theorem erdos_421 : (∃ (d : ℕ → ℕ), StrictMono d ∧ 1 ≤ d 0 ∧ HasDensity (Set.range d) 1 ∧
+    {(u, v) : ℕ × ℕ | u ≤ v}.InjOn fun (u, v) => ∏ i ∈ Finset.Icc u v, d i) ↔ answer(sorry) := by
+  sorry

--- a/FormalConjectures/ErdosProblems/427.lean
+++ b/FormalConjectures/ErdosProblems/427.lean
@@ -42,7 +42,7 @@ $$
 where $p_r$ denotes the $r$th prime?
 -/
 @[category research solved, AMS 11]
-theorem erdos_427 : Erdos427 := by
+theorem erdos_427 : Erdos427 ↔ answer(True) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/434.lean
+++ b/FormalConjectures/ErdosProblems/434.lean
@@ -55,8 +55,8 @@ does $A = \{n, n - 1, ..., n - k + 1\}$ maximise the number of integers
 not representable as the sum of finitely many elements from $A$ (with repetitions allowed)?
 -/
 @[category research open, AMS 11]
-theorem erdos_434.parts.ii (n k : ℕ) (hn : 1 ≤ n) (hk : 1 ≤ k) (h : k ≤ n) :
+theorem erdos_434.parts.ii : (∀ᵉ (n ≥ 1) (k ≥ 1), k ≤ n →
     IsGreatest
       { Nat.NcardUnrepresentable S | (S : Set ℕ) (_ : S ⊆ Set.Icc 1 n) (_ : S.ncard = k) }
-      (Nat.NcardUnrepresentable <| Set.Icc (n - k + 1 : ℕ) n) ↔ answer(sorry) :=
+      (Nat.NcardUnrepresentable <| Set.Icc (n - k + 1 : ℕ) n)) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/434.lean
+++ b/FormalConjectures/ErdosProblems/434.lean
@@ -58,5 +58,5 @@ not representable as the sum of finitely many elements from $A$ (with repetition
 theorem erdos_434.parts.ii (n k : ℕ) (hn : 1 ≤ n) (hk : 1 ≤ k) (h : k ≤ n) :
     IsGreatest
       { Nat.NcardUnrepresentable S | (S : Set ℕ) (_ : S ⊆ Set.Icc 1 n) (_ : S.ncard = k) }
-      (Nat.NcardUnrepresentable <| Set.Icc (n - k + 1 : ℕ) n) :=
+      (Nat.NcardUnrepresentable <| Set.Icc (n - k + 1 : ℕ) n) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/442.lean
+++ b/FormalConjectures/ErdosProblems/442.lean
@@ -78,16 +78,19 @@ $$
 $$
 as $x\to\infty$?
 
-Note: the informal and formal statements follow the solution paper
-https://arxiv.org/pdf/2407.04226
+Tao [Ta24b] has shown this is false.
+
+[Ta24b] Tao, T., _Dense sets of natural numbers with unusually large least common multiples_.
+arXiv:2407.04226 (2024).
+
+Note: the informal and formal statements follow the solution paper https://arxiv.org/pdf/2407.04226
 -/
 @[category research solved, AMS 11]
-theorem erdos_442
-    (A : Set ℕ)
-    (hA : Tendsto (fun (x : ℝ) =>
-      1 / x.maxLogOne.maxLogOne * ∑ n ∈ A.bdd x, (1 : ℝ) / n) atTop atTop) :
+theorem erdos_442 : (∀ (A : Set ℕ),
+    Tendsto (fun (x : ℝ) =>
+      1 / x.maxLogOne.maxLogOne * ∑ n ∈ A.bdd x, (1 : ℝ) / n) atTop atTop →
     Tendsto (fun (x : ℝ) => 1 / (∑ n ∈ A.bdd x, (1 : ℝ) / n) ^ 2 *
-      ∑ nm ∈ A.bddProdUpper x, (1 : ℝ) / nm.1.lcm nm.2) atTop atTop :=
+      ∑ nm ∈ A.bddProdUpper x, (1 : ℝ) / nm.1.lcm nm.2) atTop atTop) ↔ answer(True) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/457.lean
+++ b/FormalConjectures/ErdosProblems/457.lean
@@ -29,9 +29,9 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_457 : ∃ ε > (0 : ℝ),
+theorem erdos_457 : (∃ ε > (0 : ℝ),
     { (n : ℕ) | ∀ (p : ℕ), p ≤ (2 + ε) * Real.log n → p.Prime →
-      p ∣ ∏ i ∈ Finset.Icc 1 ⌊Real.log n⌋₊, (n + i) }.Infinite :=
+      p ∣ ∏ i ∈ Finset.Icc 1 ⌊Real.log n⌋₊, (n + i) }.Infinite) ↔ answer(sorry) :=
   sorry
 
 /-- Let $q(n, k)$ denote the least prime which does not divide
@@ -47,8 +47,8 @@ problem asks whether $q(n,\log n)\geq(2+\epsilon)\log n$
 infinitely often.
 -/
 @[category research open, AMS 11]
-theorem erdos_457.variants.qnk : ∃ ε > (0 : ℝ),
-    { (n : ℕ) | (2 + ε) * Real.log n ≤ q n (Real.log n) }.Infinite :=
+theorem erdos_457.variants.qnk : (∃ ε > (0 : ℝ),
+    { (n : ℕ) | (2 + ε) * Real.log n ≤ q n (Real.log n) }.Infinite) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -61,6 +61,6 @@ Can one prove that $q(n,\log n)<(1−\epsilon)(\log n)^2$
 for all large $n$ and some $\epsilon > 0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_457.variants.one_sub : ∃ ε > (0 : ℝ),
-    ∀ᶠ n in Filter.atTop, q n (Real.log n) < (1 - ε) * Real.log n ^ 2 :=
+theorem erdos_457.variants.one_sub : (∃ ε > (0 : ℝ),
+    ∀ᶠ n in Filter.atTop, q n (Real.log n) < (1 - ε) * Real.log n ^ 2) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/463.lean
+++ b/FormalConjectures/ErdosProblems/463.lean
@@ -32,8 +32,8 @@ $$
 Here $p(m)$ is the least prime factor of $m$.
 -/
 @[category research open, AMS 11]
-theorem erdos_463 : ∃ (f : ℕ → ℕ) (_ : Tendsto f atTop atTop),
+theorem erdos_463 : (∃ (f : ℕ → ℕ) (_ : Tendsto f atTop atTop),
     ∀ᶠ n in atTop,
       ∃ m, ¬m.Prime ∧
-        n + f n < m ∧ m < n + m.minFac :=
+        n + f n < m ∧ m < n + m.minFac) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/469.lean
+++ b/FormalConjectures/ErdosProblems/469.lean
@@ -36,5 +36,5 @@ converge?
 @[category research open, AMS 11]
 theorem erdos_469 :
     letI A := {n : ℕ | 0 < n ∧ n.IsSumDivisors ∧ ∀ m < n, m ∣ n → ¬ m.IsSumDivisors}
-    Summable fun n : A ↦ 1 / (n : ℝ) :=
+    (Summable fun n : A ↦ 1 / (n : ℝ)) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -28,8 +28,8 @@ Let $f: \mathbb{Z} \rightarrow \mathbb{Z}$ be a polynomial of degree at least $2
 Is there a set $A$ such that every $z \in \mathbb{Z}$ has exactly one representation as $z = a + f(n)$ for some $a \in A$ and $n \in \mathbb{Z}$?
 -/
 @[category research open, AMS 12]
-theorem erdos_477 (f : Polynomial ℤ) (hf₀ : 2 ≤ f.degree) : (∃ (A : Set ℤ),
-    ∀ z, ∃! a ∈ A ×ˢ Set.range f.eval, z = a.1 + a.2) ↔ answer(sorry) := sorry
+theorem erdos_477 : (∀ (f : Polynomial ℤ), 2 ≤ f.degree →
+    (∃ (A : Set ℤ), ∀ z, ∃! a ∈ A ×ˢ Set.range f.eval, z = a.1 + a.2)) ↔ answer(sorry) := sorry
 
 /--
 Probably there is no such $A$ for any polynomial $f$.

--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -28,8 +28,8 @@ Let $f: \mathbb{Z} \rightarrow \mathbb{Z}$ be a polynomial of degree at least $2
 Is there a set $A$ such that every $z \in \mathbb{Z}$ has exactly one representation as $z = a + f(n)$ for some $a \in A$ and $n \in \mathbb{Z}$?
 -/
 @[category research open, AMS 12]
-theorem erdos_477 (f : Polynomial ℤ) (hf₀ : 2 ≤ f.degree) : ∃ (A : Set ℤ),
-    ∀ z, ∃! a ∈ A ×ˢ Set.range f.eval, z = a.1 + a.2 := sorry
+theorem erdos_477 (f : Polynomial ℤ) (hf₀ : 2 ≤ f.degree) : (∃ (A : Set ℤ),
+    ∀ z, ∃! a ∈ A ×ˢ Set.range f.eval, z = a.1 + a.2) ↔ answer(sorry) := sorry
 
 /--
 Probably there is no such $A$ for any polynomial $f$.

--- a/FormalConjectures/ErdosProblems/479.lean
+++ b/FormalConjectures/ErdosProblems/479.lean
@@ -26,5 +26,5 @@ Is it true that, for all $k\neq 1$, there are infinitely many $n$ such that
 $2^n\equiv k\pmod{n}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_479 (k : ℕ) (h : 1 < k) : { n | 2 ^ n ≡ k [MOD n]}.Infinite :=
+theorem erdos_479 : (∀ᵉ (k > 1), { n | 2 ^ n ≡ k [MOD n]}.Infinite) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/48.lean
+++ b/FormalConjectures/ErdosProblems/48.lean
@@ -28,5 +28,5 @@ Are there infinitely many integers $n, m$ such that $ϕ(n) = σ(m)$?
 -/
 @[category research solved, AMS 11]
 theorem erdos_48 :
-    {(n, m) : ℕ × ℕ | n.totient = σ 1 m}.Infinite := by
+    {(n, m) : ℕ × ℕ | n.totient = σ 1 m}.Infinite ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/480.lean
+++ b/FormalConjectures/ErdosProblems/480.lean
@@ -29,7 +29,7 @@ such that $|x_{m+n} - x_n| ≤ \frac 1 {\sqrt 5 n}$?
 @[category research solved, AMS 11]
 theorem erdos_480
     (x : ℕ → ℝ) (hx : ∀ n, x n ∈ Set.Icc 0 1) :
-    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite := by
+    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/480.lean
+++ b/FormalConjectures/ErdosProblems/480.lean
@@ -28,8 +28,9 @@ such that $|x_{m+n} - x_n| ≤ \frac 1 {\sqrt 5 n}$?
 -/
 @[category research solved, AMS 11]
 theorem erdos_480
-    (x : ℕ → ℝ) (hx : ∀ n, x n ∈ Set.Icc 0 1) :
-    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite ↔ answer(sorry) := by
+    (x : ℕ → ℝ) (hx : ∀ n, x n ∈ Set.Icc 0 1) : (∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
+    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite) ↔
+    answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/480.lean
+++ b/FormalConjectures/ErdosProblems/480.lean
@@ -26,8 +26,7 @@ Let $x_1,x_2,...∈[0, 1]$ be an infinite sequence. Is it true that there are in
 such that $|x_{m+n} - x_n| ≤ \frac 1 {\sqrt 5 n}$?
 -/
 @[category research solved, AMS 11]
-theorem erdos_480
-    (x : ℕ → ℝ) (hx : ∀ n, x n ∈ Set.Icc 0 1) : (∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
+theorem erdos_480 : (∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
     {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite) ↔
     answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/509.lean
+++ b/FormalConjectures/ErdosProblems/509.lean
@@ -76,9 +76,8 @@ $\{z ∈ ℂ : |f(z)| ≤ 1\}$
 be covered by a set of closed discs the sum of whose radii is $≤ 2$?
 -/
 @[category research open, AMS 30]
-theorem erdos_509
-    (f : ℂ[X]) (hf : f.Monic) (hf' : f.natDegree ≠ 0) : (∃ (ι : Type),
-    Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι)) ↔ answer(sorry) := by
+theorem erdos_509 : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι)) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/509.lean
+++ b/FormalConjectures/ErdosProblems/509.lean
@@ -77,8 +77,8 @@ be covered by a set of closed discs the sum of whose radii is $≤ 2$?
 -/
 @[category research open, AMS 30]
 theorem erdos_509
-    (f : ℂ[X]) (hf : f.Monic) (hf' : f.natDegree ≠ 0) : ∃ (ι : Type),
-    Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι) := by
+    (f : ℂ[X]) (hf : f.Monic) (hf' : f.natDegree ≠ 0) : (∃ (ι : Type),
+    Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι)) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/56.lean
+++ b/FormalConjectures/ErdosProblems/56.lean
@@ -97,6 +97,6 @@ relatively prime. An example is the set of all multiples of the first $k$ primes
 Is this the largest such set?
 -/
 @[category research solved, AMS 11]
-theorem erdos_56 (N : ℕ) (hN : 2 ≤ N)
-    (k : ℕ) : (MaxWeaklyDivisible N k = (FirstPrimesMultiples N k).card) ↔ answer(False) := by
+theorem erdos_56 : ∀ᵉ (N ≥ 2) (k), (MaxWeaklyDivisible N k = (FirstPrimesMultiples N k).card) ↔
+    answer(False) := by
   sorry

--- a/FormalConjectures/ErdosProblems/56.lean
+++ b/FormalConjectures/ErdosProblems/56.lean
@@ -92,11 +92,11 @@ lemma weaklyDivisible_firstPrimesMultiples (N k : ℕ) (hN : 1 ≤ N) :
   sorry
 
 /--
-Suppose `A ⊆ {1,…,N}` is such that there are no `k+1` elements of `A`
-which are relatively prime. An example is the set of all multiples of
-the first `k` primes. Is this the largest such set?
+Suppose $A \subseteq \{1,\dots,N\}$ is such that there are no $k+1$ elements of $A$ which are
+relatively prime. An example is the set of all multiples of the first $k$ primes.
+Is this the largest such set?
 -/
 @[category research solved, AMS 11]
 theorem erdos_56 (N : ℕ) (hN : 2 ≤ N)
-    (k : ℕ) : MaxWeaklyDivisible N k = (FirstPrimesMultiples N k).card := by
+    (k : ℕ) : (MaxWeaklyDivisible N k = (FirstPrimesMultiples N k).card) ↔ answer(False) := by
   sorry

--- a/FormalConjectures/ErdosProblems/587.lean
+++ b/FormalConjectures/ErdosProblems/587.lean
@@ -31,7 +31,7 @@ def MaxNotSqSum (N : ℕ) : ℕ :=
       ¬ IsSquare (∑ n ∈ S, n)).sup Finset.card
 
 /--
-Nguyen and Vu proved that `|A|≪N^(1/3) * (log N)^O(1)`
+Nguyen and Vu proved that $|A| \ll N^{1/3} (\log N)^{O(1)}$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_587.variants.nguyen_vu : ∃ᵉ (O > 0) (O' > 0),

--- a/FormalConjectures/ErdosProblems/672.lean
+++ b/FormalConjectures/ErdosProblems/672.lean
@@ -21,17 +21,19 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/672](https://www.erdosproblems.com/672)
 -/
-/-- Erdős problem 672 conjectures the below holds for all $k ≥ 4$ and $l > 1$. -/
+/-- Erdős problem 672 conjectures that the below holds for any $k ≥ 4$ and $l > 1$. -/
 def Erdos672With (k l : ℕ) [NeZero k] : Prop :=
   ∀ᵉ (s : Fin k → ℕ), 0 < s 0 → (∃ d > 0, Nat.gcd (s 0) d = 1 ∧ ∀ i, s i = s 0 + i * d) →
   ¬ ∃ q, ∏ i, s i = q ^ l
 
-/-- Can the product of an arithmetic progression of positive integers of length ≥ 4 be a perfect power? -/
+/--
+Can the product of an arithmetic progression of positive integers of length ≥ 4 be a perfect power?
+-/
 @[category research open, AMS 11]
-theorem erdos_672
-    (k l : ℕ) (hk : 4 ≤ k) (hl : 1 < l)
-    (hk' : NeZero k := ⟨Nat.not_eq_zero_of_lt hk⟩) :
-    Erdos672With k l :=
+theorem erdos_672 :
+    (∀ᵉ (k) (l > 1), (hk : k ≥ 4) →
+    letI : NeZero k := ⟨Nat.not_eq_zero_of_lt hk⟩
+    Erdos672With k l) ↔ answer(sorry) :=
   sorry
 
 /-- According to https://www.erdosproblems.com/672, Euler proved this. -/

--- a/FormalConjectures/ErdosProblems/694.lean
+++ b/FormalConjectures/ErdosProblems/694.lean
@@ -45,7 +45,7 @@ exactly one solution, that is $\frac{f_{\max}(n)}{f_{\min}(n)} = 1$.
 -/
 @[category research open, AMS 11]
 theorem erdos_694.variants.carmichael :
-    ∃ n > 0, ∃! m, Nat.totient m = n :=
+    (∃ n > 0, ∃! m, Nat.totient m = n) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -27,7 +27,7 @@ open scoped Nat
 Let $k ≥ 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_727 : (∀ᵉ (k ≥ 2),
+theorem erdos_727 : (∀ k ≥ 2,
     Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)}) ↔ answer(sorry) :=
   sorry
 

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -27,10 +27,8 @@ open scoped Nat
 Let $k ≥ 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_727
-    (k : ℕ)
-    (hk : k > 1) :
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} :=
+theorem erdos_727 (k : ℕ) (hk : 2 ≤ k) :
+    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} ↔ answer(sorry) :=
   sorry
 
 /--
@@ -38,10 +36,8 @@ It is open even for $k = 2$.
 Let $k = 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many n?
 -/
 @[category research open, AMS 11]
-theorem erdos_727_variants.k_2
-    (k : ℕ)
-    (hk : k = 2) :
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} :=
+theorem erdos_727_variants.k_2 (k : ℕ) (hk : k = 2) :
+    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} ↔ answer(sorry) :=
   sorry
 
 /--
@@ -50,20 +46,15 @@ Balakran proved this holds for $k = 1$.
 Let $k = 1$. Does $((n+k)!)^2∣(2n)!$ for infinitely many $n$?
 -/
 @[category research solved, AMS 11]
-theorem erdos_727_variants.k_1
-    (k : ℕ)
-    (hk : k = 1) :
-    Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} :=
+theorem erdos_727_variants.k_1 (k : ℕ) (hk : k = 1) :
+    Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} ↔ answer(sorry) :=
   sorry
 
 /--
-Erdős, Graham, Ruzsa, and Straus observe that the method of Balakran can be further used to prove that there are infinitely many $n$
- such that
-$(n+k)!(n+1)!∣(2n)!$
+Erdős, Graham, Ruzsa, and Straus observe that the method of Balakran can be further used to prove
+that there are infinitely many $n$ such that $(n+k)!(n+1)!∣(2n)!$
 -/
 @[category research solved, AMS 11]
-theorem erdos_727_variants.k_1_2
-    (k : ℕ)
-    (hk : k > 1) :
+theorem erdos_727_variants.k_1_2 (k : ℕ) (hk : k > 1) :
     Set.Infinite {n : ℕ | (Nat.factorial (n + k)) * (Nat.factorial (n + 1)) ∣ Nat.factorial (2 * n)} :=
   sorry

--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -30,7 +30,7 @@ Are there infinitely many pairs of integers $n ≠ m$ such that $\binom{2n}{n}$
 and $\binom{2m}{m}$ have the same set of prime divisors?
 -/
 @[category research open, AMS 11]
-theorem erdos_730 : S.Infinite := by
+theorem erdos_730 : S.Infinite ↔ answer(sorry) := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -40,8 +40,8 @@ such that $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold whe
 $r = s$?
 -/
 @[category research open, AMS 11]
-theorem erdos_786.parts.i (ε : ℝ) (hε : 0 < ε ∧ ε ≤ 1) :
-    (∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet) ↔ answer(sorry) :=
+theorem erdos_786.parts.i : (∀ᵉ (ε > 0), ε ≤ 1 →
+    ∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -40,7 +40,7 @@ such that $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold whe
 $r = s$?
 -/
 @[category research open, AMS 11]
-theorem erdos_786.parts.i : (∀ᵉ (ε > 0), ε ≤ 1 →
+theorem erdos_786.parts.i : (∀ ε > 0, ε ≤ 1 →
     ∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet) ↔ answer(sorry) :=
   sorry
 

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -41,8 +41,7 @@ $r = s$?
 -/
 @[category research open, AMS 11]
 theorem erdos_786.parts.i (ε : ℝ) (hε : 0 < ε ∧ ε ≤ 1) :
-    ∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧
-      A.IsMulCardSet :=
+    (∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -51,8 +50,9 @@ $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold when
 $r = s$?
 -/
 @[category research open, AMS 11]
-theorem erdos_786.parts.ii : ∃ (A : ℕ → Set ℕ) (f : ℕ → ℝ) (_ : Tendsto f atTop (𝓝 0)),
-      ∀ N, A N ⊆ Set.Icc 1 (N + 1) ∧ (1 - f N) * N ≤ (A N).ncard ∧ (A N).IsMulCardSet :=
+theorem erdos_786.parts.ii : (∃ (A : ℕ → Set ℕ) (f : ℕ → ℝ) (_ : Tendsto f atTop (𝓝 0)),
+    ∀ N, A N ⊆ Set.Icc 1 (N + 1) ∧ (1 - f N) * N ≤ (A N).ncard ∧ (A N).IsMulCardSet) ↔
+    answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/817.lean
+++ b/FormalConjectures/ErdosProblems/817.lean
@@ -76,7 +76,7 @@ $$ -/
 -- Formalisation note : only formalising the "In particular" part
 @[category research open, AMS 5, AMS 11]
 theorem erdos_817 :
-    (fun n => (3 ^ n : ℝ)) =O[atTop] fun n => (g 3 n : ℝ) :=
+    ((fun n => (3 ^ n : ℝ)) =O[atTop] fun n => (g 3 n : ℝ)) ↔ answer(sorry) :=
   sorry
 
 /-- A problem of Erdős and Sárközy who proved

--- a/FormalConjectures/ErdosProblems/825.lean
+++ b/FormalConjectures/ErdosProblems/825.lean
@@ -29,9 +29,9 @@ $\sigma(n) > Cn$ is the distinct sum of proper divisors of $n$?
 -/
 @[category research open, AMS 11]
 theorem erdos_825 :
-    ∃ (C : ℝ) (_ : C > 0),
+    (∃ (C : ℝ) (_ : C > 0),
       ∀ (n) (_ : σ 1 n > C * n),
-        ∃ s ⊆ n.properDivisors, n = s.sum id :=
+        ∃ s ⊆ n.properDivisors, n = s.sum id) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/826.lean
+++ b/FormalConjectures/ErdosProblems/826.lean
@@ -30,5 +30,6 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_826 : (∃ C > (0 : ℝ), { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite) ↔ answer(sorry) :=
+theorem erdos_826 : (∃ C > (0 : ℝ), { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite) ↔
+    answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/826.lean
+++ b/FormalConjectures/ErdosProblems/826.lean
@@ -30,6 +30,5 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_826 : ∃ C > (0 : ℝ),
-    { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite :=
+theorem erdos_826 : { n | ∃ᵉ (C > 0), ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/846.lean
+++ b/FormalConjectures/ErdosProblems/846.lean
@@ -59,6 +59,6 @@ In other words, prove or disprove the following statement: every infinite `ε`-n
 plane is weakly non-trilinar.
 -/
 @[category research open, AMS 11]
-theorem erdos_846 (A : Set ℝ²) (ε : ℝ) (hε : 0 < ε) (hA : NonTrilinearFor A ε)
-    (hA' : A.Infinite) : WeaklyNonTrilinear A ↔ answer(sorry) :=
+theorem erdos_846 : (∀ᵉ (A : Set ℝ²) (ε > 0), A.Infinite → NonTrilinearFor A ε →
+    WeaklyNonTrilinear A) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/846.lean
+++ b/FormalConjectures/ErdosProblems/846.lean
@@ -60,5 +60,5 @@ plane is weakly non-trilinar.
 -/
 @[category research open, AMS 11]
 theorem erdos_846 (A : Set ℝ²) (ε : ℝ) (hε : 0 < ε) (hA : NonTrilinearFor A ε)
-    (hA' : A.Infinite) : WeaklyNonTrilinear A :=
+    (hA' : A.Infinite) : WeaklyNonTrilinear A ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -74,7 +74,7 @@ must $A$ contain a minimal additive basis of order $2$? -/
 @[category research open, AMS 5, AMS 11]
 theorem erdos_868.parts.i {A : Set ℕ} (hA₁ : IsAddBasis A 2)
     (hA₂ : atTop.Tendsto (fun n => ncard_add_repr A 2 n) atTop) :
-    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2 :=
+    (∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(sorry) :=
   sorry
 
 /-- Let $A$ be an additive basis of order $2$, let $f(n)$ denote the number of ways in which
@@ -84,14 +84,14 @@ basis of order $2$? -/
 @[category research open, AMS 5, AMS 11]
 theorem erdos_868.parts.ii {A : Set ℕ} (hA₁ : IsAddBasis A 2) {ε : ℝ} (hε : 0 < ε)
     (hA₂ : ∀ᶠ (n : ℕ) in atTop, ε * Real.log n < ncard_add_repr A 2 n) :
-    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2 := sorry
+    (∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(sorry) := sorry
 
 /-- Erdős and Nathanson proved that this is true if $f(n) > (\log\frac{4}{3})^{-1}\log n$ for
 all large $n$. -/
 @[category research solved, AMS 5, AMS 11]
 theorem erdos_868.variants.fixed_ε {A : Set ℕ} (hA₁ : IsAddBasis A 2)
     (hA₂ : ∀ᶠ (n : ℕ) in atTop, (Real.log (4 / 3))⁻¹ * Real.log n < ncard_add_repr A 2 n) :
-    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2 := sorry
+    (∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(True) := sorry
 
 /-- Härtter and Nathanson proved that there exist additive bases which do not contain
 any minimal additive bases. -/

--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -72,9 +72,9 @@ def ncard_add_repr (A : Set ℕ) (o : ℕ) (n : ℕ) : ℕ :=
 $n$ can be written as the sum of two elements from $A$. If $f(n)\to\infty$ as $n\to\infty$, then
 must $A$ contain a minimal additive basis of order $2$? -/
 @[category research open, AMS 5, AMS 11]
-theorem erdos_868.parts.i {A : Set ℕ} (hA₁ : IsAddBasis A 2)
-    (hA₂ : atTop.Tendsto (fun n => ncard_add_repr A 2 n) atTop) :
-    (∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(sorry) :=
+theorem erdos_868.parts.i :
+    (∀ (A : Set ℕ), IsAddBasis A 2 → atTop.Tendsto (fun n => ncard_add_repr A 2 n) atTop →
+      ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(sorry) :=
   sorry
 
 /-- Let $A$ be an additive basis of order $2$, let $f(n)$ denote the number of ways in which
@@ -82,16 +82,18 @@ $n$ can be written as the sum of two elements from $A$. If $f(n)>\epsilon\log n$
 and an arbitrary fixed $\epsilon > 0$, then must $A$ contain a minimal additive
 basis of order $2$? -/
 @[category research open, AMS 5, AMS 11]
-theorem erdos_868.parts.ii {A : Set ℕ} (hA₁ : IsAddBasis A 2) {ε : ℝ} (hε : 0 < ε)
-    (hA₂ : ∀ᶠ (n : ℕ) in atTop, ε * Real.log n < ncard_add_repr A 2 n) :
-    (∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(sorry) := sorry
+theorem erdos_868.parts.ii :
+    (∀ᵉ (A : Set ℕ) (ε > 0), IsAddBasis A 2 →
+    (∀ᶠ (n : ℕ) in atTop, ε * Real.log n < ncard_add_repr A 2 n) →
+    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(sorry) := sorry
 
 /-- Erdős and Nathanson proved that this is true if $f(n) > (\log\frac{4}{3})^{-1}\log n$ for
 all large $n$. -/
 @[category research solved, AMS 5, AMS 11]
-theorem erdos_868.variants.fixed_ε {A : Set ℕ} (hA₁ : IsAddBasis A 2)
-    (hA₂ : ∀ᶠ (n : ℕ) in atTop, (Real.log (4 / 3))⁻¹ * Real.log n < ncard_add_repr A 2 n) :
-    (∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(True) := sorry
+theorem erdos_868.variants.fixed_ε :
+    (∀ (A : Set ℕ), IsAddBasis A 2 →
+    (∀ᶠ (n : ℕ) in atTop, (Real.log (4 / 3))⁻¹ * Real.log n < ncard_add_repr A 2 n) →
+    ∃ B ⊆ A, IsAddBasis B 2 ∧ ∀ b ∈ B, ¬IsAddBasis (B \ {b}) 2) ↔ answer(True) := sorry
 
 /-- Härtter and Nathanson proved that there exist additive bases which do not contain
 any minimal additive bases. -/

--- a/FormalConjectures/ErdosProblems/873.lean
+++ b/FormalConjectures/ErdosProblems/873.lean
@@ -31,6 +31,6 @@ private noncomputable abbrev F (a : ℕ → ℕ) (X : ℝ) (k : ℕ) : ℕ∞ :=
 $[a_i,a_{i+1}, … ,a_{i+k−1}] < X$, where the left-hand side is the least common multiple.
 Is it true that, for every $ϵ > 0$, there exists some $k$ such that $F(A,X,k) < X^ϵ$?-/
 @[category research open, AMS 11]
-theorem erdos_873 (a : ℕ → ℕ) (hapos : 0 < a 0) (ha : StrictMono a) (ε : ℝ) (hε : 0 < ε):
-    ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal :=
+theorem erdos_873 (a : ℕ → ℕ) (hapos : 0 < a 0) (ha : StrictMono a) : (∀ᵉ (ε > (0 : ℝ)),
+    ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/873.lean
+++ b/FormalConjectures/ErdosProblems/873.lean
@@ -31,6 +31,6 @@ private noncomputable abbrev F (a : ℕ → ℕ) (X : ℝ) (k : ℕ) : ℕ∞ :=
 $[a_i,a_{i+1}, … ,a_{i+k−1}] < X$, where the left-hand side is the least common multiple.
 Is it true that, for every $ϵ > 0$, there exists some $k$ such that $F(A,X,k) < X^ϵ$?-/
 @[category research open, AMS 11]
-theorem erdos_873 (a : ℕ → ℕ) (hapos : 0 < a 0) (ha : StrictMono a) : (∀ᵉ (ε > (0 : ℝ)),
+theorem erdos_873 : (∀ᵉ (a : ℕ → ℕ) (ε > (0 : ℝ)), 0 < a 0 → StrictMono a →
     ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/897.lean
+++ b/FormalConjectures/ErdosProblems/897.lean
@@ -29,11 +29,11 @@ if $(a,b)=1$ such that $\limsup_{p,k} f(p^k) \log(p^k) = ∞$.
 Is it true that $\limsup_n (f(n+1)−f(n))/ \log n = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.parts.i
-    (f : ℕ → ℝ)
-    (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
-    (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) :
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ ↔
+theorem erdos_897.parts.i : (∀ (f : ℕ → ℝ),
+    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
+    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
+      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤) ↔
     answer(sorry) := by
   sorry
 
@@ -43,12 +43,11 @@ if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) \log(p^k) = ∞$.
 Is it true that $\limsup_n f(n+1)/ f(n) = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.parts.ii
-    (f : ℕ → ℝ)
-    (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
-    (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
-      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) :
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ ↔ answer(sorry) := by
+theorem erdos_897.parts.ii : (∀ (f : ℕ → ℝ),
+    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
+    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
+      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
+    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -71,12 +70,12 @@ or $f(p^k) = kf(p)$.
 Is it true that $\limsup_n (f(n+1)−f(n))/ \log n = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.variants.parts.i
-    (f : ℕ → ℝ)
-    (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
-    (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤)
-    (hf'' : (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p)) :
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ ↔ answer(sorry) := by
+theorem erdos_897.variants.parts.i : (∀ (f : ℕ → ℝ),
+    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
+    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
+      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
+    (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -86,10 +85,10 @@ or $f(p^k) = kf(p)$.
 Is it true that $\limsup_n f(n+1)/f(n) = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.variants.parts.ii
-    (f : ℕ → ℝ)
-    (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
-    (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤)
-    (hf'' : (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p)) :
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ ↔ answer(sorry) := by
+theorem erdos_897.variants.parts.ii : (∀ (f : ℕ → ℝ),
+    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
+    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
+      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
+    (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
+    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤) ↔ answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/897.lean
+++ b/FormalConjectures/ErdosProblems/897.lean
@@ -33,7 +33,8 @@ theorem erdos_897.parts.i
     (f : ℕ → ℝ)
     (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
     (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) :
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ ↔
+    answer(sorry) := by
   sorry
 
 /--
@@ -47,7 +48,7 @@ theorem erdos_897.parts.ii
     (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
     (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
       (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) :
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
+    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ ↔ answer(sorry) := by
   sorry
 
 /--
@@ -75,7 +76,7 @@ theorem erdos_897.variants.parts.i
     (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
     (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤)
     (hf'' : (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p)) :
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ ↔ answer(sorry) := by
   sorry
 
 /--
@@ -90,5 +91,5 @@ theorem erdos_897.variants.parts.ii
     (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
     (hf' : (Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤)
     (hf'' : (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p)) :
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
+    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ ↔ answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/899.lean
+++ b/FormalConjectures/ErdosProblems/899.lean
@@ -37,8 +37,8 @@ $$
 $$
 -/
 @[category research solved, AMS 5]
-theorem erdos_899 (A : Set ℕ) (h_inf : A.Infinite)
-    (hf : Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0)) :
-    Tendsto (fun N => ((A - A : Set ℕ).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop atTop ↔
+theorem erdos_899 : (∀ (A : Set ℕ), A.Infinite →
+    Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0) →
+    Tendsto (fun N => ((A - A : Set ℕ).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop atTop) ↔
     answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/899.lean
+++ b/FormalConjectures/ErdosProblems/899.lean
@@ -39,5 +39,6 @@ $$
 @[category research solved, AMS 5]
 theorem erdos_899 (A : Set ℕ) (h_inf : A.Infinite)
     (hf : Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0)) :
-    Tendsto (fun N => ((A - A : Set ℕ).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop atTop :=
+    Tendsto (fun N => ((A - A : Set ℕ).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop atTop ↔
+    answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/913.lean
+++ b/FormalConjectures/ErdosProblems/913.lean
@@ -30,7 +30,8 @@ is the factorisation into distinct primes then all exponents $k_i$ are distinct?
 -/
 @[category research open, AMS 11]
 theorem erdos_913 :
-    { n | Set.InjOn (n * (n + 1)).factorization (n * (n + 1)).primeFactors }.Infinite :=
+    { n | Set.InjOn (n * (n + 1)).factorization (n * (n + 1)).primeFactors }.Infinite ↔
+    answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/931.lean
+++ b/FormalConjectures/ErdosProblems/931.lean
@@ -30,10 +30,10 @@ $$
 have the same prime factors?
 -/
 @[category research open, AMS 11]
-theorem erdos_931 (k₁ k₂ : ℕ) (h₁ : k₂ ≤ k₁) (h₂ : 3 ≤ k₂) :
+theorem erdos_931 : (∀ᵉ (k₁ : ℕ) (k₂ ≥ 3), k₂ ≤ k₁ →
     { (n₁, n₂) | n₁ + k₁ ≤ n₂ ∧
       (∏ i ∈ Finset.Icc 1 k₁, (n₁ + i)).primeFactors =
-      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors }.Finite ↔ answer(sorry) :=
+      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors }.Finite) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -42,10 +42,10 @@ $n_2 > 2(n_1 + k_1)$.
 It is an open question whether this is true when allowing a finite number of counterexamples.
 -/
 @[category research open, AMS 11]
-theorem erdos_931.variants.additional_condition (k₁ k₂ : ℕ) (h₁ : k₂ ≤ k₁) (h₂ : 3 ≤ k₂):
+theorem erdos_931.variants.additional_condition : (∀ᵉ (k₁ : ℕ) (k₂ ≥ 3), k₂ ≤ k₁ →
     {(n₁, n₂) | n₁ + k₁ ≤ n₂ ∧ n₂ ≤ 2 * (n₁ + k₁) ∧
       (∏ i ∈ Finset.Icc 1 k₁, (n₁ + i)).primeFactors =
-      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors}.Finite ↔ answer(sorry) :=
+      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors}.Finite) ↔ answer(sorry) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/931.lean
+++ b/FormalConjectures/ErdosProblems/931.lean
@@ -33,7 +33,7 @@ have the same prime factors?
 theorem erdos_931 (k₁ k₂ : ℕ) (h₁ : k₂ ≤ k₁) (h₂ : 3 ≤ k₂) :
     { (n₁, n₂) | n₁ + k₁ ≤ n₂ ∧
       (∏ i ∈ Finset.Icc 1 k₁, (n₁ + i)).primeFactors =
-      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors }.Finite :=
+      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors }.Finite ↔ answer(sorry) :=
   sorry
 
 /--
@@ -45,7 +45,7 @@ It is an open question whether this is true when allowing a finite number of cou
 theorem erdos_931.variants.additional_condition (k₁ k₂ : ℕ) (h₁ : k₂ ≤ k₁) (h₂ : 3 ≤ k₂):
     {(n₁, n₂) | n₁ + k₁ ≤ n₂ ∧ n₂ ≤ 2 * (n₁ + k₁) ∧
       (∏ i ∈ Finset.Icc 1 k₁, (n₁ + i)).primeFactors =
-      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors}.Finite :=
+      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors}.Finite ↔ answer(sorry) :=
   sorry
 
 /--


### PR DESCRIPTION
See #29.

This fixes this for all open Erdos problems, and also for the solved ones up to 442.

Also fixes a potential misformalization / issue with 244, where previously it was assumed that the set had some density (which does not seem clear from the problem statement).

Also, when creating this branch I by accident also had some work in converting (a few) docstrings into Latex. I have not bothered to remove this, as this is a (very minor) good thing to do anyways. 