### PR TITLE
chore: add `letI` statements in favor of hypothesis

### DIFF
--- a/FormalConjectures/ErdosProblems/248.lean
+++ b/FormalConjectures/ErdosProblems/248.lean
@@ -32,5 +32,5 @@ Here $\omega(n)$ is the number of distinct prime divisors
 of $n$.
 -/
 @[category research open, AMS 11]
-theorem erdos_248 : ∃ C > (0 : ℝ), { n | ∀ k ≥ 1, ω (n + k) ≤ C * k }.Infinite :=
+theorem erdos_248 : { n | ∃ C > (0 : ℝ), ∀ k ≥ 1, ω (n + k) ≤ C * k }.Infinite ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/248.lean
+++ b/FormalConjectures/ErdosProblems/248.lean
@@ -32,5 +32,5 @@ Here $\omega(n)$ is the number of distinct prime divisors
 of $n$.
 -/
 @[category research open, AMS 11]
-theorem erdos_248 : { n | ∃ C > (0 : ℝ), ∀ k ≥ 1, ω (n + k) ≤ C * k }.Infinite ↔ answer(sorry) :=
+theorem erdos_248 : (∃ C > (0 : ℝ), { n | ∀ k ≥ 1, ω (n + k) ≤ C * k }.Infinite) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/672.lean
+++ b/FormalConjectures/ErdosProblems/672.lean
@@ -26,12 +26,14 @@ def Erdos672With (k l : ℕ) [NeZero k] : Prop :=
   ∀ᵉ (s : Fin k → ℕ), 0 < s 0 → (∃ d > 0, Nat.gcd (s 0) d = 1 ∧ ∀ i, s i = s 0 + i * d) →
   ¬ ∃ q, ∏ i, s i = q ^ l
 
-/-- Can the product of an arithmetic progression of positive integers of length ≥ 4 be a perfect power? -/
+/--
+Can the product of an arithmetic progression of positive integers of length ≥ 4 be a perfect power?
+-/
 @[category research open, AMS 11]
-theorem erdos_672
-    (k l : ℕ) (hk : 4 ≤ k) (hl : 1 < l)
-    (hk' : NeZero k := ⟨Nat.not_eq_zero_of_lt hk⟩) :
-    Erdos672With k l :=
+theorem erdos_672 :
+    (∀ᵉ (k) (l > 1), (hk : k ≥ 4) →
+    letI : NeZero k := ⟨Nat.not_eq_zero_of_lt hk⟩
+    Erdos672With k l) ↔ answer(sorry) :=
   sorry
 
 /-- According to https://www.erdosproblems.com/672, Euler proved this. -/

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -27,10 +27,8 @@ open scoped Nat
 Let $k ≥ 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_727
-    (k : ℕ)
-    (hk : k > 1) :
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} :=
+theorem erdos_727 (k : ℕ) (hk : 2 ≤ k) : (∀ᵉ (k ≥ 2),
+    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)}) ↔ answer(sorry) :=
   sorry
 
 /--
@@ -38,10 +36,9 @@ It is open even for $k = 2$.
 Let $k = 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many n?
 -/
 @[category research open, AMS 11]
-theorem erdos_727_variants.k_2
-    (k : ℕ)
-    (hk : k = 2) :
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} :=
+theorem erdos_727_variants.k_2 :
+    let k := 2
+    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} ↔ answer(sorry) :=
   sorry
 
 /--
@@ -50,20 +47,16 @@ Balakran proved this holds for $k = 1$.
 Let $k = 1$. Does $((n+k)!)^2∣(2n)!$ for infinitely many $n$?
 -/
 @[category research solved, AMS 11]
-theorem erdos_727_variants.k_1
-    (k : ℕ)
-    (hk : k = 1) :
+theorem erdos_727_variants.k_1 :
+    let k := 1
     Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} :=
   sorry
 
 /--
-Erdős, Graham, Ruzsa, and Straus observe that the method of Balakran can be further used to prove that there are infinitely many $n$
- such that
-$(n+k)!(n+1)!∣(2n)!$
+Erdős, Graham, Ruzsa, and Straus observe that the method of Balakran can be further used to prove
+that there are infinitely many $n$ such that $(n+k)!(n+1)!∣(2n)!$
 -/
 @[category research solved, AMS 11]
-theorem erdos_727_variants.k_1_2
-    (k : ℕ)
-    (hk : k > 1) :
+theorem erdos_727_variants.k_1_2 (k : ℕ) (hk : 2 ≤ k) :
     Set.Infinite {n : ℕ | (Nat.factorial (n + k)) * (Nat.factorial (n + 1)) ∣ Nat.factorial (2 * n)} :=
   sorry

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -37,7 +37,7 @@ Let $k = 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many n?
 -/
 @[category research open, AMS 11]
 theorem erdos_727_variants.k_2 :
-    let k := 2
+    letI k := 2
     Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} ↔ answer(sorry) :=
   sorry
 
@@ -48,7 +48,7 @@ Let $k = 1$. Does $((n+k)!)^2∣(2n)!$ for infinitely many $n$?
 -/
 @[category research solved, AMS 11]
 theorem erdos_727_variants.k_1 :
-    let k := 1
+    letI k := 1
     Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} ↔ answer(True) :=
   sorry
 

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -49,7 +49,7 @@ Let $k = 1$. Does $((n+k)!)^2∣(2n)!$ for infinitely many $n$?
 @[category research solved, AMS 11]
 theorem erdos_727_variants.k_1 :
     let k := 1
-    Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} :=
+    Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} ↔ answer(True) :=
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -27,7 +27,7 @@ open scoped Nat
 Let $k ≥ 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_727 (k : ℕ) (hk : 2 ≤ k) : (∀ᵉ (k ≥ 2),
+theorem erdos_727 : (∀ᵉ (k ≥ 2),
     Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)}) ↔ answer(sorry) :=
   sorry
 
@@ -58,5 +58,6 @@ that there are infinitely many $n$ such that $(n+k)!(n+1)!∣(2n)!$
 -/
 @[category research solved, AMS 11]
 theorem erdos_727_variants.k_1_2 (k : ℕ) (hk : 2 ≤ k) :
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) * (Nat.factorial (n + 1)) ∣ Nat.factorial (2 * n)} :=
+    Set.Infinite {n : ℕ |
+      (Nat.factorial (n + k)) * (Nat.factorial (n + 1)) ∣ Nat.factorial (2 * n)} :=
   sorry

--- a/FormalConjectures/ErdosProblems/826.lean
+++ b/FormalConjectures/ErdosProblems/826.lean
@@ -30,5 +30,5 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_826 : { n | ∃ᵉ (C > 0), ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite ↔ answer(sorry) :=
+theorem erdos_826 : (∃ C > (0 : ℝ), { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/ErdosProblems/826.lean
+++ b/FormalConjectures/ErdosProblems/826.lean
@@ -30,6 +30,5 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_826 : ∃ C > (0 : ℝ),
-    { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite :=
+theorem erdos_826 : { n | ∃ᵉ (C > 0), ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite ↔ answer(sorry) :=
   sorry


### PR DESCRIPTION
Fix 2 misformalizations (turned out to not be misformalizations in the end!), and 2 problems where a hypothesis can be stated using `letI` instead.
Also change a few statements to the answer(sorry) convention.