### PR TITLE
feat: add answer(sorry) to all solved problems from 442 onwards

### DIFF
--- a/FormalConjectures/ErdosProblems/480.lean
+++ b/FormalConjectures/ErdosProblems/480.lean
@@ -25,11 +25,13 @@ import FormalConjectures.Util.ProblemImports
 /--
 Let $x_1,x_2,...∈[0, 1]$ be an infinite sequence. Is it true that there are infinitely many $m, n$
 such that $|x_{m+n} - x_n| ≤ \frac 1 {\sqrt 5 n}$?
+
+This was proved Chung and Graham.
 -/
 @[category research solved, AMS 11]
-theorem erdos_480
-    (x : ℕ → ℝ) (hx : ∀ n, x n ∈ Set.Icc 0 1) :
-    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite := by
+theorem erdos_480 : (∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
+    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x n| ≤ 1 / (√5 * n))}.Infinite) ↔
+    answer(True) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/509.lean
+++ b/FormalConjectures/ErdosProblems/509.lean
@@ -91,9 +91,8 @@ lacunaires et leurs applications*, Henri Cartan,
 http://www.numdam.org/article/ASENS_1928_3_45__255_0.pdf
 -/
 @[category research solved, AMS 30]
-theorem erdos_509.variants.Cartan_bound
-    (f : ℂ[X]) (hf : f.Monic) (hf' : f.natDegree ≠ 0) : ∃ (ι : Type),
-    Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} (2*rexp 1) ι) := by
+theorem erdos_509.variants.Cartan_bound : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} (2*rexp 1) ι)) ↔ answer(True) := by
   sorry
 
 /--
@@ -103,9 +102,8 @@ be covered by a set of closed discs the sum of whose radii is $≤ 2.59$?
 Solution: True. This is due to Pommerenke.
 -/
 @[category research solved, AMS 30]
-theorem erdos_509.variants.Pommerenke_bound
-    (f : ℂ[X]) (hf : f.Monic) (hf' : f.natDegree ≠ 0) : ∃ (ι : Type),
-    Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2.59 ι) := by
+theorem erdos_509.variants.Pommerenke_bound : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2.59 ι)) ↔ answer(True) := by
   sorry
 
 /--
@@ -115,8 +113,7 @@ be covered by a set of circles the sum of whose radii is $≤ 2$?
 Solution: True. This is due to Pommerenke.
 -/
 @[category research solved, AMS 30]
-theorem erdos_509.variants.Pommerenke_connected
-    (f : ℂ[X]) (hf : f.Monic) (hf' : f.natDegree ≠ 0)
-    (hf'' : IsConnected {z | ‖f.eval z‖ ≤ 1}) : ∃ (ι : Type),
-    Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι) := by
+theorem erdos_509.variants.Pommerenke_connected : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    IsConnected {z | ‖f.eval z‖ ≤ 1} →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι)) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ErdosProblems/899.lean
+++ b/FormalConjectures/ErdosProblems/899.lean
@@ -35,9 +35,14 @@ Is it true that
 $$
 \limsup_{N\to\infty}\frac{|(A - A)\cap \{1, ..., N\}|}{|A \cap \{1, ..., N\}|} = \infty?
 $$
+
+The answer is yes, proved by Ruzsa [Ru78].
+
+[Ru78] Ruzsa, I. Z., _On the cardinality of {$A+A$}\ and {$A-A$}_. (1978), 933--938.
 -/
 @[category research solved, AMS 5]
-theorem erdos_899 (A : Set ℕ) (h_inf : A.Infinite)
-    (hf : Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0)) :
-    Tendsto (fun N => ((A - A : Set ℕ).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop atTop :=
+theorem erdos_899 : (∀ (A : Set ℕ), A.Infinite →
+    Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0) →
+    Tendsto (fun N => ((A - A : Set ℕ).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop atTop) ↔
+    answer(True) :=
   sorry

--- a/FormalConjectures/ErdosProblems/932.lean
+++ b/FormalConjectures/ErdosProblems/932.lean
@@ -32,8 +32,7 @@ theorem erdos_932 :
   sorry
 
 /--
-Erdős could show that the density of $r$ such that at least one such $n$
-exist is $0$.
+Erdős could show that the density of $r$ such that at least one such $n$ exist is $0$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_932.variants.one_le :


### PR DESCRIPTION
Adding `answer(sorry)` to all other problems is #68. It also adds `answer(sorry)` to solved problems before 442, as I did not know how big of a task this would be then. Also, I think it will take more time to manually separate that PR into solved / unsolved than is saved by having smaller PRs to review (but let me know if you disagree). Especially since some files contain both solved and unsolved problems, and that PR changes both in that case (if the problem is before 442).