### PR TITLE
style(Arxiv): make proofs start with `:= by`

### DIFF
--- a/FormalConjectures/Arxiv/0911.2077/Conjecture6_3.lean
+++ b/FormalConjectures/Arxiv/0911.2077/Conjecture6_3.lean
@@ -45,6 +45,7 @@ theorem arxiv.id0911_2077.conjecture6_3
   (σ : ℝ) (h_σ : σ = (p * (1 - p)).sqrt) :
   letI hp' : (.ofReal p : ℝ≥0∞) ≤ 1 := ENNReal.ofReal_le_one.mpr <|
     le_trans (le_of_lt (Set.mem_Ioo.mp h_p).right) (by linarith)
-  ((PMF.binomial (.ofReal p : ℝ≥0∞) hp' (2 * k)).toMeasure (Set.Ici k)).toReal
- ≥ 1 - Φ ((1 / 2 - p) * sqrt (2 * k : ℝ≥0) / σ)
-    + (1 / 2) * ((2 * k).choose k) * σ ^ (2 * k) := sorry
+  1 - Φ ((1 / 2 - p) * sqrt (2 * k : ℝ≥0) / σ)
+    + (1 / 2) * ((2 * k).choose k) * σ ^ (2 * k)
+    ≤ ((PMF.binomial (.ofReal p : ℝ≥0∞) hp' (2 * k)).toMeasure (Set.Ici k)).toReal := by
+  sorry

--- a/FormalConjectures/Arxiv/0912.2382/CurlingNumberConjecture.lean
+++ b/FormalConjectures/Arxiv/0912.2382/CurlingNumberConjecture.lean
@@ -48,4 +48,5 @@ private noncomputable def S (S₀ : List ℤ) (n : ℕ) : List ℤ :=
 The sequence will eventually reach $1$.
 -/
 @[category research open, AMS 11]
-theorem curling_number_conjecture (S₀ : List ℤ) (h : S₀ ≠ []) : ∃ m, k (S S₀ m) = 1 := sorry
+theorem curling_number_conjecture (S₀ : List ℤ) (h : S₀ ≠ []) : ∃ m, k (S S₀ m) = 1 := by
+  sorry

--- a/FormalConjectures/Arxiv/1601.03081/UniqueCrystalComponents.lean
+++ b/FormalConjectures/Arxiv/1601.03081/UniqueCrystalComponents.lean
@@ -46,4 +46,5 @@ $B(c, d) ∈ ℕ$, i.e., the components of the crystals are unique.
 @[category research open, AMS 11, AMS 26]
 theorem crystals_components_unique (n a b c d : ℕ)
     (hab : IsCrystalWithComponents n a b) (hcd : IsCrystalWithComponents n c d) :
-  ({a, b} : Finset ℕ) = {c, d} := sorry
+    ({a, b} : Finset ℕ) = {c, d} := by
+  sorry

--- a/FormalConjectures/Arxiv/1609.08688/sIncreasingrTuples.lean
+++ b/FormalConjectures/Arxiv/1609.08688/sIncreasingrTuples.lean
@@ -149,24 +149,26 @@ example : maximalLength 1 = 1 := by
   exact ⟨1, ⟨[fun _ => 1], by simp⟩, one_ne_zero⟩
 
 @[category test, AMS 5]
-example : maximalLength 4 = 8 := sorry
+example : maximalLength 4 = 8 := by
+  sorry
 
 /-- In a set of more than $n^2$ triples with coordinates from $\{1, ..., n\}$ we must
 have two triples that are equal in their first two coordinates. -/
 @[category API, AMS 5]
 lemma exists_pair_of_mem_Icc {s : List (Fin 3 → ℕ)} {n : ℕ} (hn : 2 ≤ n)
     (hs₁ : ∀ a ∈ s, Set.range a ⊆ Set.Icc 1 n) (hs₂ : s.length > n ^ 2) :
-    ∃ (i j : Fin s.length), i ≠ j ∧ s[i] 0 = s[j] 0 ∧ s[i] 1 = s[j] 1 :=
+    ∃ (i j : Fin s.length), i ≠ j ∧ s[i] 0 = s[j] 0 ∧ s[i] 1 = s[j] 1 := by
   sorry
 
 /-- For all $n$ we have $F(n) \leq n^2$. -/
 @[category research solved, AMS 5]
-theorem maximalLength_le (n : ℕ) : F n ≤ n ^ 2 := sorry
+theorem maximalLength_le (n : ℕ) : F n ≤ n ^ 2 := by
+  sorry
 
 /-- Moreover, whenever $n$ is a perfect square we have $F(n) \geq n^{3/2}$. -/
 @[category research solved, AMS 5]
 theorem maximalLength_ge_of_isSquare {n : ℕ} (h : IsSquare n) :
-    n.sqrt ^ 3 ≤ F n :=
+    n.sqrt ^ 3 ≤ F n := by
   sorry
 
 /-- Two triples $t_1$ and $t_2$ are $2$-comparable if one of them is $2$-less
@@ -183,7 +185,7 @@ open Filter in
 @[category research solved, AMS 5]
 theorem maximalLength_le_isBigO : ∃ Ω : ℕ → ℝ,
     (fun (n : ℕ) => (Real.iteratedLog n : ℝ)) =O[atTop] Ω ∧
-      ∀ n, F n ≤ n ^ 2 / Real.exp (Ω n) :=
+      ∀ n, F n ≤ n ^ 2 / Real.exp (Ω n) := by
   sorry
 
 /-- We define the product of two triples $(a, b, c)$ and $(d, e, f)$ by
@@ -223,6 +225,7 @@ theorem maximalLength_pow {n : ℕ} {e : ℝ} (hn : 1 < n) (h : F n = (n : ℝ) 
 
 /-- $F(n) \leq n^{3/2}$. -/
 @[category research open, AMS 5]
-theorem maximalLength_le_strong (n : ℕ) : F n ≤ Real.sqrt n ^ 3 := sorry
+theorem maximalLength_le_strong (n : ℕ) : F n ≤ Real.sqrt n ^ 3 := by
+  sorry
 
 end Arxiv.id160908688


### PR DESCRIPTION
And other minor style tweaks.

See #79 