### PR TITLE
chore: Move `GoldbachConjecture.lean` to the `Wikipedia` subdirectory

### DIFF
--- a/FormalConjectures/Wikipedia/CollatzConjecture.lean
+++ b/FormalConjectures/Wikipedia/CollatzConjecture.lean
@@ -1,0 +1,35 @@
+/-
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Collatz Conjecture
+
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Collatz_conjecture)
+-/
+
+/--
+The Collatz step => if `n` is even, halve it, otherwise multiply by three and add one.
+-/
+def collatz_fn : ℕ → ℕ
+| n =>
+  match n % 2 with
+  | 0   => n / 2
+  | _   => 3 * n + 1
+
+@[category research open, AMS 11]
+theorem collatz_conjecture (n : ℕ) : ∃ m, Nat.iterate collatz_fn m n = 1 := sorry

--- a/FormalConjectures/Wikipedia/CollatzConjecture.lean
+++ b/FormalConjectures/Wikipedia/CollatzConjecture.lean
@@ -25,11 +25,9 @@ import FormalConjectures.Util.ProblemImports
 /--
 The Collatz step => if `n` is even, halve it, otherwise multiply by three and add one.
 -/
-def collatz_fn : ℕ → ℕ
-| n =>
-  match n % 2 with
-  | 0   => n / 2
-  | _   => 3 * n + 1
+def collatz_fn (n : ℕ) : ℕ :=
+  if Even n then n / 2 else 3 * n + 1
 
 @[category research open, AMS 11]
-theorem collatz_conjecture (n : ℕ) : ∃ m, Nat.iterate collatz_fn m n = 1 := sorry
+theorem collatz_conjecture (n : ℕ) : ∃ m, collatz_fn^[m] n = 1 := by
+  sorry

--- a/FormalConjectures/Wikipedia/GoldbachConjecture.lean
+++ b/FormalConjectures/Wikipedia/GoldbachConjecture.lean
@@ -1,0 +1,32 @@
+/-
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Goldbach’s Conjecture
+
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Goldbach%27s_conjecture)
+-/
+
+/--
+Goldbach’s conjecture: every even integer greater than 2 can be written
+as the sum of two prime numbers.
+-/
+@[category research open, AMS 11]
+theorem goldbach (n : ℕ) (h₁: 2 < n) (h₂ : n % 2 = 0) :
+  ∃ p q, p.Prime ∧ q.Prime ∧ p + q = n := by
+  sorry


### PR DESCRIPTION
This PR moves `GoldbachConjecture.lean` to the `Wikipedia` subdirectory to make it more visible and to stay consistent with convention of structuring the repo by problem source. 

~~hello! this PR adds Collatz conjecture stmt to Wikipedia/CollatzConjecture.lean (closes issue #83 ) with collatz_fn, the conjecture theorem (uses sorry ofc), license header, import, docstrings, and @[category research open, AMS 11]. Builds with `lake build` PTAL! :)~~