### PR TITLE
feat: formalise Lehmer totient

### DIFF
--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 Google LLC
+Copyright 2025 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -1,0 +1,32 @@
+/-
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Lehmer's totient problem
+
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Lehmer%27s_totient_problem)
+-/
+
+
+/--
+Does there exist a composite number $n > 1$ such that Euler’s totient function $\varphi(n)$ divides $n - 1$?
+-/
+@[category research open, AMS 11]
+theorem lehmer_totient :
+    (∃ n > 1, ¬Prime n ∧ Nat.totient n ∣ n - 1) ↔ answer(sorry) := by
+  sorry

--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -23,7 +23,8 @@ import FormalConjectures.Util.ProblemImports
 -/
 
 /--
-Does there exist a composite number $n > 1$ such that Euler’s totient function $\varphi(n)$ divides $n - 1$?
+Does there exist a composite number $n > 1$ such that Euler’s totient function
+$\varphi(n)$ divides $n - 1$?
 -/
 @[category research open, AMS 11]
 theorem lehmer_totient :

--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -22,7 +22,6 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Lehmer%27s_totient_problem)
 -/
 
-
 /--
 Does there exist a composite number $n > 1$ such that Euler’s totient function $\varphi(n)$ divides $n - 1$?
 -/

--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -28,5 +28,5 @@ $\varphi(n)$ divides $n - 1$?
 -/
 @[category research open, AMS 11]
 theorem lehmer_totient :
-    (∃ n > 1, ¬Prime n ∧ φ n ∣ n - 1) ↔ answer(sorry) := by
+    (∃ n > 1, ¬Prime n ∧ Nat.totient n ∣ n - 1) ↔ answer(sorry) := by
   sorry

--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -28,5 +28,5 @@ Does there exist a composite number $n > 1$ such that Euler’s totient function
 -/
 @[category research open, AMS 11]
 theorem lehmer_totient :
-    (∃ n > 1, ¬Prime n ∧ Nat.totient n ∣ n - 1) ↔ answer(sorry) := by
+    (∃ n > 1, ¬Prime n ∧ φ n ∣ n - 1) ↔ answer(sorry) := by
   sorry


### PR DESCRIPTION
hello! this PR adds the [Lehmer totient problem](https://en.wikipedia.org/wiki/Lehmer%27s_totient_problem) under `formal-conjectures/FormalConjectures/Wikipedia/LehmerTotient.lean` (closes issue #90), theorem uses sorry (unsolved question for benchmarking), included license header, import, docstrings, and @[category research open, AMS 11]. Builds with `lake build`. Please take a loot at the last commit: `feat: formalise Lehmer totient` :)