### PR TITLE
Fix caching issues with the doc build

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -113,10 +113,10 @@ jobs:
           rsync -a --files-from=out-files.txt --relative .lake/build/doc ./out
 
       - name: Inject stats into index.html
+        shell: bash
         run: |
-          set -o pipefail
           cd docbuild
-          lake exe overwrite_index ./.lake/build/doc/index.html | tee -a "$GITHUB_STEP_SUMMARY"
+          lake exe overwrite_index ./out/index.html | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload docs
         id: deployment

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -121,7 +121,7 @@ jobs:
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          path: out
+          path: docbuild/out
 
   # Deployment job
   deploy:

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -106,6 +106,7 @@ jobs:
           cd docbuild
           mkdir out
           lake query FormalConjectures:docs > out-files.txt
+          sed -i 's|^.*\.lake/build/doc/||' out-files.txt
           echo "::group::Generated files" 
           cat out-files.txt
           echo "::endgroup::"

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -44,6 +44,10 @@ jobs:
           ./elan-init -y --default-toolchain none
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
+      - name: Install rsync
+        run: |
+          sudo apt-get install rsync
+
       - name: Generate All.lean
         run: |
           lake exe mk_all --lib FormalConjectures || true

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -44,10 +44,6 @@ jobs:
           ./elan-init -y --default-toolchain none
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
-      - name: Install rsync
-        run: |
-          sudo apt-get install rsync
-
       - name: Generate All.lean
         run: |
           lake exe mk_all --lib FormalConjectures || true

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -101,6 +101,16 @@ jobs:
           cd docbuild
           lake build FormalConjectures:docs
 
+      - name: Extract documentation
+        run: |
+          cd docbuild
+          mkdir out
+          lake query FormalConjectures:docs > out-files.txt
+          echo "::group::Generated files" 
+          cat out-files.txt
+          echo "::endgroup::"
+          rsync -a --files-from=out-files.txt --relative .lake/build/doc ./out
+
       - name: Inject stats into index.html
         run: |
           set -o pipefail
@@ -111,7 +121,7 @@ jobs:
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docbuild/.lake/build/doc
+          path: out
 
   # Deployment job
   deploy:

--- a/docbuild/lakefile.toml
+++ b/docbuild/lakefile.toml
@@ -11,7 +11,7 @@ path = "../"
 [[require]]
 name = "doc-gen4"
 git = "https://github.com/eric-wieser/doc-gen4"
-rev = "for-formal-conjectures"
+rev = "3502f05c27ca650492c945307874755a8c2b42e3"
 
 [[lean_exe]]
 name = "overwrite_index"

--- a/docbuild/lakefile.toml
+++ b/docbuild/lakefile.toml
@@ -10,8 +10,8 @@ path = "../"
 # using fork here, because it contains a backported fix. Can be dropped after bump to v4.20.0
 [[require]]
 name = "doc-gen4"
-git = "https://github.com/mo271/doc-gen4"
-rev = "04bbe873ae3ffc0f5e62dfa3982600f2e4bc1569"
+git = "https://github.com/eric-wieser/doc-gen4"
+rev = "for-formal-conjectures"
 
 [[lean_exe]]
 name = "overwrite_index"


### PR DESCRIPTION
Currently, doc pages for deleted Lean files remain in the build directory, and so get uploaded anyway.

This is using a backport of https://github.com/leanprover/doc-gen4/pull/286