### PR TITLE
chore: various style fixes in Wikipedia subdirectory

### DIFF
--- a/FormalConjectures/Wikipedia/BoundedBurnsideProblem.lean
+++ b/FormalConjectures/Wikipedia/BoundedBurnsideProblem.lean
@@ -21,11 +21,14 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Burnside_problem#Bounded_Burnside_problem)
 -/
+
 /--
 Let $G$ be a finitely generated group, and assume there exists $n$ such that for every $g$ in $G$,
 $g^n = 1$. Is $G$ necessarily finite?
 -/
 @[category research open, AMS 20]
-theorem bounded_burnside_problem (G : Type) [Group G] (fin_gen : Group.FG G)
-    (n : ℕ) (hn : n > 0) (bounded : ∀ g : G, g^n = 1) : Finite G := by
+theorem bounded_burnside_problem :
+    (∀ (G : Type) [Group G] (fin_gen : Group.FG G)
+      (n : ℕ) (hn : n > 0) (bounded : ∀ g : G, g^n = 1), Finite G) ↔
+    answer(sorry) := by
   sorry

--- a/FormalConjectures/Wikipedia/Conway99Graph.lean
+++ b/FormalConjectures/Wikipedia/Conway99Graph.lean
@@ -55,8 +55,8 @@ one of the two diagonals of a unique 4-cycle.
 The first condition is equivalent to being locally linear.
 -/
 @[category research open, AMS 5]
-theorem Conway99Graph : ∃ G : SimpleGraph (Fin 99),
-    G.LocallyLinear ∧ NonEdgesAreDiagonals G := by
+theorem Conway99Graph : (∃ G : SimpleGraph (Fin 99),
+    G.LocallyLinear ∧ NonEdgesAreDiagonals G) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/DeterminantalConjecture.lean
+++ b/FormalConjectures/Wikipedia/DeterminantalConjecture.lean
@@ -21,20 +21,21 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Determinantal_conjecture)
 -/
-/--
-Determinantal Conjecture asks whether the determinant of a sum $A + B$
-of two $n$ by $n$ normal complex matrices A and B lies in the convex hull
-of the n! points $\prod i (\lambda(A)_i + \lambda(B)_{σ(i)})$,
-where the numbers $\lambda (A)_i$ and $\lambda (B)_i$ are
-the eigenvalues of $A$ and $B$, and $\sigma$ is an element of the symmetric
-group $S_n$.
 
-Here, we represent the two normal matrices as $U_1 D_1 U_1^*$ and
+/- Formalisation note: Here, we represent the two normal matrices as $U_1 D_1 U_1^*$ and
 $U_2 D_2 U_2^*$ respectively, where $U_1, U_2$ are unitary and $D_1, D_2$
 are diagonal. This is an universal form of a normal matrix,
 allowing to retrieve $\lambda (A)_i$ as ${D_1}_{i,i}$, whereas the current mathlib
 doesn't support obtaining the vector of eigenvalues from a general normal
-non-Hermitian matrix.
+non-Hermitian matrix. -/
+
+/--
+Does the determinant of the sum $A + B$ of two $n \times n$ normal
+complex matrices A and B always lie in the convex hull
+of the $n!$ points $\prod i (\lambda(A)_i + \lambda(B)_{σ(i)})$?
+Here the numbers $\lambda (A)_i$ and $\lambda (B)_i$ are
+the eigenvalues of $A$ and $B$, and $\sigma$ is an element of the symmetric
+group $S_n$.
 -/
 @[category research open, AMS 15]
 theorem determinantal_conjecture

--- a/FormalConjectures/Wikipedia/GaussCircleProblem.lean
+++ b/FormalConjectures/Wikipedia/GaussCircleProblem.lean
@@ -41,8 +41,8 @@ noncomputable section
 namespace GaussCircleProblem
 
 /--
-Let $N(r)$ be thenumber of points $(m, n)$ within a circle of radius $r$, where $m$ and $n$ are both
-integers.
+Let $N(r)$ be the number of points $(m, n)$ within a circle of radius $r$,
+where $m$ and $n$ are both integers.
 -/
 private abbrev N (r : ℝ) : ℕ :=
   { (m, n) : ℤ × ℤ | !₂[↑m, ↑n] ∈ Metric.closedBall (0 : ℝ²) r }.ncard

--- a/FormalConjectures/Wikipedia/Hadamard.lean
+++ b/FormalConjectures/Wikipedia/Hadamard.lean
@@ -72,6 +72,11 @@ example (n : ℕ) (M : Matrix (Fin n) (Fin n) ℝ) : IsHadamard' M ↔ IsHadamar
       norm_num
   · sorry
 
+/- Note: the conjecture was originally formulated by
+Hadamard as a question: "For which values of $n=4k$ does
+a Hadamard matrix exist." However the expectation seems
+to be that all such matrices are Hadamard, and the
+formalisation has been written with this in mind. -/
 
 /--
 There exists a Hadamard matrix for all $n = 4k$.

--- a/FormalConjectures/Wikipedia/Hadamard.lean
+++ b/FormalConjectures/Wikipedia/Hadamard.lean
@@ -74,11 +74,16 @@ example (n : ℕ) (M : Matrix (Fin n) (Fin n) ℝ) : IsHadamard' M ↔ IsHadamar
 
 
 /--
-Hadamard asks for which values of $n = 4k$ exists such a Matrix.
+There exists a Hadamard matrix for all $n = 4k$.
 -/
 @[category research open, AMS 15]
 theorem HadamardConjecture (k : ℕ) : ∃ M, IsHadamard (n := 4 * k) M := by
   sorry
+
+@[category test]
+example : ∃ M, IsHadamard (n := 0) M := by
+  use 0
+  simp [IsHadamard]
 
 /--
 Hadamard constructs a 12 x 12 matrix ...

--- a/FormalConjectures/Wikipedia/InverseGalois.lean
+++ b/FormalConjectures/Wikipedia/InverseGalois.lean
@@ -46,7 +46,6 @@ theorem inverse_galois_problem {G : Type*} [Fintype G] [Group G] :
     IsRealizable ℚ G := by
   sorry
 
-
 /--
 Every finite cyclic group is realizable.
 -/
@@ -55,7 +54,6 @@ theorem inverse_galois_problem.variants.cyclic
     {G : Type*} [Fintype G] [Group G] [IsCyclic G] :
     IsRealizable ℚ G := by
   sorry
-
 
 /--
 Every finite abelian group is realizable.
@@ -66,7 +64,6 @@ theorem inverse_galois_problem.variants.abelian
     IsRealizable ℚ G := by
   sorry
 
-
 /--
 Every finite symmetric group is realizable.
 -/
@@ -75,7 +72,6 @@ theorem inverse_galois_problem.variants.symmetric_group
     {S : Type*} [Fintype S] :
     IsRealizable ℚ (S ≃ S) := by
   sorry
-
 
 /--
 Every finite group is realisable over the field of rational functions
@@ -86,7 +82,6 @@ theorem inverse_galois_problem.variants.complex_rational_functions
     {G : Type*} [Fintype G] [Group G] :
     IsRealizable (RatFunc ℂ) G := by
   sorry
-
 
 /--
 Every finite group is realisable over the field of rational functions

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -79,8 +79,8 @@ open RegularFunction
 
 variable {σ τ ι : Type*} [Fintype σ]
 
-/--The evaluation of a regular function `f` over `k` at some point `a` with coordinates
-in some algebra over `k`-/
+/--The evaluation of a regular function `f` over `k` at some point `a`
+with coordinates in some algebra over `k`-/
 noncomputable def RegularFunction.aeval {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
     (F : RegularFunction k σ τ) : (σ → S₁) → τ → S₁ :=
   fun a t ↦ MvPolynomial.aeval a (F t)
@@ -108,7 +108,8 @@ lemma sanity_check_condition_1 (F : RegularFunction k σ σ) :
   sorry
 
 
--- Let's apply the conjecture to a trivial case to make sure things are working as expected.
+-- Let's apply the conjecture to a trivial case to make sure things
+-- are working as expected.
 @[category test, AMS 14]
 example :
     ∃ (G : RegularFunction k σ σ), G.comp (id k σ) = id k σ ∧

--- a/FormalConjectures/Wikipedia/LonelyRunnerConjecture.lean
+++ b/FormalConjectures/Wikipedia/LonelyRunnerConjecture.lean
@@ -35,7 +35,6 @@ theorem lonely_runner_conjecture (n : ℕ)
     (lonely_def :
       ∀ r t, lonely r t ↔
         ∀ r2 : Fin n, r2 ≠ r →
-        dist (t * speed r : UnitAddCircle) (t * speed r2) ≥ 1 / n
-    ) :
-    ∀ r : Fin n, ∃ t ≥ 0, lonely r t := by
+        dist (t * speed r : UnitAddCircle) (t * speed r2) ≥ 1 / n)
+    (r : Fin n) : ∃ t ≥ 0, lonely r t := by
   sorry

--- a/FormalConjectures/Wikipedia/NoetherProblem.lean
+++ b/FormalConjectures/Wikipedia/NoetherProblem.lean
@@ -43,7 +43,6 @@ example (K L ι : Type*) [Field K] [Field L] [Algebra K L] [IsEmpty ι]
     IsFractionRing.fieldEquivOfAlgEquiv K (FractionRing (MvPolynomial ι K)) K b
   apply Nonempty.intro (a.trans c)
 
-
 /--
 We say that a rational extension `L` of `K` has the _Noether Property_
 if for any finite subgroup `H` of the Galois group of `L`, the fixed field
@@ -60,16 +59,16 @@ indeterminates over `K`. Is it true that `L/K` has the Noether property?
 
 Solution: False.
 -/
-@[category research solved, AMS 12, AMS 14]
-theorem noether_problem : ∃ (K L ι G : Type)
-    (_ : Field K) (_ : Field L) (_ : Fintype ι) (_ : Algebra K L) (_ : IsRationalExtension K L ι),
-    ¬ HasNoetherProperty K L ι := by
+@[category research solved, AMS 12 14]
+theorem noether_problem : (∀ (K L ι G : Type)
+    [Field K] [Field L] [Fintype ι] [Algebra K L] [IsRationalExtension K L ι],
+    HasNoetherProperty K L ι) ↔ answer(False) := by
   sorry
 
 /--
 The Noether problem has a positive solution in the two indeterminate case.
 -/
-@[category research solved, AMS 12, AMS 14]
+@[category research solved, AMS 12 14]
 theorem noether_problem.variants.two {K L ι G : Type}
     [Field K] [Field L] [Fintype ι] [Algebra K L]
     [IsRationalExtension K L ι] (hι : Fintype.card ι = 2) :
@@ -79,7 +78,7 @@ theorem noether_problem.variants.two {K L ι G : Type}
 /--
 The Noether problem has a positive solution in the three indeterminate case.
 -/
-@[category research solved, AMS 12, AMS 14]
+@[category research solved, AMS 12 14]
 theorem noether_problem.variants.three {K L ι G : Type}
     [Field K] [Field L] [Fintype ι] [Algebra K L]
     [IsRationalExtension K L ι] (hι : Fintype.card ι = 3) :
@@ -89,7 +88,7 @@ theorem noether_problem.variants.three {K L ι G : Type}
 /--
 The Noether problem has a positive solution in the four indeterminate case.
 -/
-@[category research solved, AMS 12, AMS 14]
+@[category research solved, AMS 12 14]
 theorem noether_problem.variants.four {K L ι G : Type}
     [Field K] [Field L] [Fintype ι] [Algebra K L]
     [IsRationalExtension K L ι] (hι : Fintype.card ι = 4) :
@@ -100,7 +99,7 @@ theorem noether_problem.variants.four {K L ι G : Type}
 One can find a counterexample to the Noether Problem's claim by considering a
 rational function field in 47 indeterminates.
 -/
-@[category research solved, AMS 12, AMS 14]
+@[category research solved, AMS 12 14]
 theorem noether_problem.variants.forty_seven :
     ∃ (K L ι G : Type)
     (_ :  Field K) (_ : Field L) (_ : Fintype ι) (_ : Algebra K L)

--- a/FormalConjectures/Wikipedia/SchanuelsConjecture.lean
+++ b/FormalConjectures/Wikipedia/SchanuelsConjecture.lean
@@ -37,7 +37,7 @@ abbrev transcendenceDegree (R : Type*) {A : Type*} [CommRing R] [CommRing A]
 /--
 The transcendence degree is independent of the choice of a transcendence basis.
 -/
-@[category graduate, AMS 12, AMS 13, AMS 14]
+@[category graduate, AMS 12 13 14]
 theorem isTranscendenceBasis_ncard_eq_transcendenceDegree (R : Type*) {A ι : Type*}
     [CommRing R] [CommRing A] [Algebra R A] (h : Function.Injective (algebraMap R A))
     (𝒷 : ι → A) (hS : IsTranscendenceBasis R 𝒷) :
@@ -48,7 +48,7 @@ open IntermediateField in
 /--
 The transcendence degree of $A$ adjoined $\{x_1, ..., x_n\}$ is $\leq n$.
 -/
-@[category graduate, AMS 12, AMS 13, AMS 14]
+@[category graduate, AMS 12 13 14]
 theorem adjoin_transcendenceDegree_le_of_finite {A ι : Type*} [Field A] {S : Set A}
     (hS : S.Finite) :
     transcendenceDegree A (algebraMap A (adjoin A S)).injective ≤ S.ncard := by
@@ -78,7 +78,7 @@ $$
   e^{z_1w_1}, e^{z_1w_2}, e^{z_2w_1}, e^{z_2w_2}.
 $$
 -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem four_exponentials {z₁ z₂ w₁ w₂ : ℂ} (hz : LinearIndependent ℚ ![z₁, z₂])
     (hw : LinearIndependent ℚ ![w₁, w₂]) :
     ∃ z ∈ ({cexp (z₁ * w₁), cexp (z₁ * w₂),
@@ -98,57 +98,57 @@ theorem exists_transcendental_of_two_pow_irrat_three_pow_irrat
 also be proven to the transcendental should Schanuel's conjecture hold. -/
 
 /-- $e + \pi$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem exp_add_pi_transcendental : Transcendental ℚ (rexp 1 + π) := by
   sorry
 
 /-- $e\pi$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem exp_mul_pi_transcendental : Transcendental ℚ (rexp 1 * π) := by
   sorry
 
 /-- $e^{\pi^2}$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem exp_pow_pi_sq_transcendental : Transcendental ℚ (rexp (π ^ 2)) := by
   sorry
 
 /-- $e^e$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem exp_exp_transcendental : Transcendental ℚ (rexp (rexp 1)) := by
   sorry
 
 /-- $\pi^e$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem pi_pow_exp_transcendental : Transcendental ℚ (π ^ (rexp 1)) := by
   sorry
 
 /-- $\pi^{\sqrt{2}}$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem pi_pow_sqrt_two_transcendental : Transcendental ℚ (π ^ √2) := by
   sorry
 
 /-- $\pi^{\pi}$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem pi_pow_pi_transcendental : Transcendental ℚ (π ^ π) := by
   sorry
 
 /-- $\pi^{\pi^{\pi}}$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem pi_pow_pi_pow_pi_transcendental : Transcendental ℚ (π ^ (π ^ π)) := by
   sorry
 
 /-- $\log(\pi)$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem rlog_pi_transcendental : Transcendental ℚ (Real.log π) := by
   sorry
 
 /-- $\log(\log(2))$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem rlog_rlog_two_transcendental : Transcendental ℚ ((2 : ℝ).log.log) := by
   sorry
 
 /-- $\sin(e)$ is transcendental. -/
-@[category research open, AMS 11, AMS 33]
+@[category research open, AMS 11 33]
 theorem sin_exp_transcendental : Transcendental ℚ (Real.sin (rexp 1)) := by
   sorry
 

--- a/FormalConjectures/Wikipedia/conjecture_1_3_to_2_3.lean
+++ b/FormalConjectures/Wikipedia/conjecture_1_3_to_2_3.lean
@@ -21,6 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/1/3%E2%80%932/3_conjecture)
 -/
+
 /--
 Does every finite partially ordered set that is not totally ordered
 contain two elements $x$ and $y$ such that the probability that
@@ -30,9 +31,10 @@ The set of all total order extensions is represented as order preserving
 bijections $P$ of $1, ..., n$.
 -/
 @[category research open, AMS 6]
-theorem conjecture_1_3_to_2_3 (P : Type) [Finite P] [PartialOrder P]
+theorem conjecture_1_3_to_2_3 : (∀ (P : Type) [Finite P] [PartialOrder P]
     (not_total : ¬ IsTotal P (· ≤ ·)) (total_ext : Set <| OrderHom P ℕ)
-    (total_ext_def : ∀ σ, σ ∈ total_ext ↔ Set.range σ = Set.Icc 1 (Nat.card P)) :
+    (total_ext_def : ∀ σ, σ ∈ total_ext ↔ Set.range σ = Set.Icc 1 (Nat.card P)),
     ∃ x y : P, ({σ ∈ total_ext | σ x < σ y}.ncard / total_ext.ncard : ℚ)
-      ∈ Set.Icc (1/3) (2/3) := by
+      ∈ Set.Icc (1/3) (2/3)) ↔
+    answer(sorry ) := by
   sorry


### PR DESCRIPTION
This PR does the following
- Use  the `answer(sorry)` convention when relevant
- Reword certain docstrings/theorem statements
- A few other drive-by style fixes