### PR TITLE
Add Modularity Conjecture 

### DIFF
--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -39,6 +39,7 @@ open scoped UpperHalfPlane Real ModularForm CongruenceSubgroup
 
 noncomputable section
 
+/--Then `n`-th Fourier coefficient of a modular forms (around the cusp at infinity). -/
 def modularFormAn (n : ℕ) {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : ℂ :=
   (qExpansion N f).coeff ℂ n
 
@@ -49,6 +50,7 @@ conductor of the elliptic curve saves us.-/
 def ratRed (q : ℚ) (p : ℕ) : ZMod p :=
   (q.num : ZMod p) * (q.den : ZMod p)⁻¹
 
+/-- The set of points on an elliptic curve over `ZMod n`. -/
 def setOfPointsModN (E : WeierstrassCurve ℚ) [E.IsElliptic] (n : ℕ) :=
   {P : ZMod n × ZMod n |
     let ⟨x, y⟩ := P

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -1,0 +1,82 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Modularity conjecture
+
+The **Modularity conjecture** (also know as the Shimura--Taniyama--Weil conjecture) states that
+every rational elliptic curve is modular, meaning that it can be
+associated with a modular form. We state the `a_p` version of the conjecture, which relates the
+coefficients of the modular form to the number of points on the elliptic curve over finite fields.
+
+Since we don't have the conductor of the elliptic curve, our definition of `a_p(E)` differs from
+that in the literature at primes of bad reduction. For this reason, we state the conjecture with the
+assumption that `p ∤ N`, in order to give an equivalent statement.
+
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Modularity_theorem)
+-/
+
+
+open Complex CongruenceSubgroup ModularFormClass
+open scoped UpperHalfPlane Real ModularForm CongruenceSubgroup
+
+noncomputable section
+
+def modularFormAn (n : ℕ) {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : ℂ :=
+  (qExpansion N f).coeff ℂ n
+
+local notation:73 "a_[" n:0 "]" f:72 => modularFormAn n f
+
+/-We need to reduce a rational modulo `p`, in practice we wont be dividing by zero since the
+conductor of the elliptic curve saves us.-/
+def ratRed (q : ℚ) (p : ℕ) : ZMod p :=
+  (q.num : ZMod p) * (q.den : ZMod p)⁻¹
+
+def setOfPointsModN (E : WeierstrassCurve ℚ) [E.IsElliptic] (n : ℕ) :=
+  {P : ZMod n × ZMod n |
+    let ⟨x, y⟩ := P
+    y ^ 2 + ratRed E.a₁ n * x * y + ratRed E.a₃ n * y =
+      x ^ 3 + ratRed E.a₂ n * x ^ 2 + ratRed E.a₄ n * x + ratRed E.a₆ n}
+
+/-- The set of point `mod n` is finite.-/
+instance apFintype (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ+) :
+    Fintype (setOfPointsModN E p) := by
+  rw [setOfPointsModN]
+  apply Subtype.fintype _
+
+/-Note that normally this is written as `p + 1 - #E(𝔽ₚ)`, but since we don't have a point at infinty
+on this affine curve we only have `p` -/
+def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : ℕ :=
+  p - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
+
+/- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. -/
+def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop :=
+  a_[1]f = 1 ∧
+    ∀ (m n : ℕ), m.Coprime n →
+      a_[n * m]f = a_[n]f * a_[m]f ∧
+        ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) ≠ 0 →
+          a_[p ^ r]f = a_[p]f * a_[p ^ (r - 1)]f - p ^ (k - 1) * a_[p ^ (r - 2)]f ∧
+            ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) = 0 →
+              a_[p ^ r]f = (a_[p]f) ^ r
+
+def ModularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
+  ∃ (N : ℕ+) (f : CuspForm (Gamma0 N) 2), IsNormalisedEigenform f ∧
+    ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p
+
+@[category research solved, AMS 11]
+theorem modularity_conjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : ModularityConjecture E := sorry

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -29,6 +29,8 @@ that in the literature at primes of bad reduction. For this reason, we state the
 assumption that `p ∤ N`, in order to give an equivalent statement.
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Modularity_theorem)
+* [F. Diamond and J. Shurman, *A First Course in Modular Forms*][diamondshurman2005]
+
 -/
 
 
@@ -74,6 +76,7 @@ def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop
             ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) = 0 →
               a_[p ^ r]f = (a_[p]f) ^ r
 
+/--See [diamondshurman2005] theorem 8.8.1. -/
 def ModularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
   ∃ (N : ℕ+) (f : CuspForm (Gamma0 N) 2), IsNormalisedEigenform f ∧
     ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -76,7 +76,7 @@ def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop
             ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) = 0 →
               a_[p ^ r]f = (a_[p]f) ^ r
 
-/--See [diamondshurman2005] theorem 8.8.1. -/
+/-- See [diamondshurman2005] theorem 8.8.1. -/
 def ModularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
   ∃ (N : ℕ+) (f : CuspForm (Gamma0 N) 2), IsNormalisedEigenform f ∧
     ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -61,8 +61,8 @@ instance apFintype (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ+) :
   rw [setOfPointsModN]
   apply Subtype.fintype _
 
-/-Note that normally this is written as `p + 1 - #E(𝔽ₚ)`, but since we don't have a point at infinty
-on this affine curve we only have `p` -/
+/-- Note that normally this is written as `p + 1 - #E(𝔽ₚ)`, but since we don't have a point at
+infinty on this affine curve we only have `p` -/
 def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : ℕ :=
   p - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
 

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -68,7 +68,7 @@ def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : �
 
 /-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. -/
 def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop :=
- a_[1]f = 1 ∧
+  a_[1]f = 1 ∧
   (∀ (m n : ℕ), m.Coprime n → a_[n * m]f = a_[n]f * a_[m]f) ∧
   (∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) ≠ 0 →
     a_[p ^ r]f = a_[p]f * a_[p ^ (r - 1)]f - p ^ (k - 1) * a_[p ^ (r - 2)]f) ∧

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -44,7 +44,7 @@ def modularFormAn (n : ℕ) {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : �
 
 local notation:73 "a_[" n:0 "]" f:72 => modularFormAn n f
 
-/-We need to reduce a rational modulo `p`, in practice we wont be dividing by zero since the
+/-- We need to reduce a rational modulo `p`, in practice we wont be dividing by zero since the
 conductor of the elliptic curve saves us.-/
 def ratRed (q : ℚ) (p : ℕ) : ZMod p :=
   (q.num : ZMod p) * (q.den : ZMod p)⁻¹

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -39,7 +39,7 @@ open scoped UpperHalfPlane Real ModularForm CongruenceSubgroup
 
 noncomputable section
 
-/--Then `n`-th Fourier coefficient of a modular forms (around the cusp at infinity). -/
+/-- The `n`-th Fourier coefficient of a modular forms (around the cusp at infinity). -/
 def modularFormAn (n : ℕ) {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : ℂ :=
   (qExpansion N f).coeff ℂ n
 

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -66,7 +66,8 @@ infinty on this affine curve we only have `p` -/
 def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : ℕ :=
   p - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
 
-/-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. -/
+/-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. See
+ Propositing 5.8.5 of [diamondshurman2005]. -/
 def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop :=
   a_[1]f = 1 ∧
   (∀ (m n : ℕ), m.Coprime n → a_[n * m]f = a_[n]f * a_[m]f) ∧
@@ -74,7 +75,7 @@ def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop
     a_[p ^ r]f = a_[p]f * a_[p ^ (r - 1)]f - p ^ (k - 1) * a_[p ^ (r - 2)]f) ∧
   ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) = 0 → a_[p ^ r]f = (a_[p]f) ^ r
 
-/-- See [diamondshurman2005] theorem 8.8.1. -/
+/-- See  theorem 8.8.1 of [diamondshurman2005]. -/
 def ModularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
   ∃ (N : ℕ+) (f : CuspForm (Gamma0 N) 2), IsNormalisedEigenform f ∧
     ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -67,7 +67,7 @@ def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : �
   p - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
 
 /-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. See
- Propositing 5.8.5 of [diamondshurman2005]. -/
+ Proposition 5.8.5 of [diamondshurman2005]. -/
 def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop :=
   a_[1]f = 1 ∧
   (∀ (m n : ℕ), m.Coprime n → a_[n * m]f = a_[n]f * a_[m]f) ∧

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -66,7 +66,7 @@ infinty on this affine curve we only have `p` -/
 def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : ℕ :=
   p - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
 
-/- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. -/
+/-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. -/
 def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop :=
   a_[1]f = 1 ∧
     ∀ (m n : ℕ), m.Coprime n →

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -68,13 +68,11 @@ def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : �
 
 /-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. -/
 def IsNormalisedEigenform {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : Prop :=
-  a_[1]f = 1 ∧
-    ∀ (m n : ℕ), m.Coprime n →
-      a_[n * m]f = a_[n]f * a_[m]f ∧
-        ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) ≠ 0 →
-          a_[p ^ r]f = a_[p]f * a_[p ^ (r - 1)]f - p ^ (k - 1) * a_[p ^ (r - 2)]f ∧
-            ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) = 0 →
-              a_[p ^ r]f = (a_[p]f) ^ r
+ a_[1]f = 1 ∧
+  (∀ (m n : ℕ), m.Coprime n → a_[n * m]f = a_[n]f * a_[m]f) ∧
+  (∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) ≠ 0 →
+    a_[p ^ r]f = a_[p]f * a_[p ^ (r - 1)]f - p ^ (k - 1) * a_[p ^ (r - 2)]f) ∧
+  ∀ (p r : ℕ), p.Prime → 2 ≤ r → (N : ZMod p) = 0 → a_[p ^ r]f = (a_[p]f) ^ r
 
 /-- See [diamondshurman2005] theorem 8.8.1. -/
 def ModularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -82,4 +82,5 @@ def ModularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
     ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p
 
 @[category research solved, AMS 11]
-theorem modularity_conjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : ModularityConjecture E := sorry
+theorem modularity_conjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : ModularityConjecture E := by
+  sorry


### PR DESCRIPTION
### What is the conjecture
State the Shimura--Taniyama--Weil conjecture  (also known as the modularity conjecture/theorem) for elliptic curves over the rational numbers. 

https://en.wikipedia.org/wiki/Modularity_theorem

This is a very hard, known theorem in the case of the rational number and many  other cases, but open in general (and much harder to state!). The version we state is stronger than what is needed for FLT.

### [AMS categories](https://github.com/google-deepmind/formal-conjectures/labels?q=ams-)

* ams-11