### PR TITLE
feat: add upper density to `ForMathlib` and fix Erdos 244

### DIFF
--- a/FormalConjectures/ErdosProblems/244.lean
+++ b/FormalConjectures/ErdosProblems/244.lean
@@ -24,7 +24,7 @@ import FormalConjectures.Util.ProblemImports
 /-- Let $C > 1$. Does the set of integers of the form $p + \lfloor C^k \rfloor$,
 for some prime $p$ and $k\geq 0$, have density $>0$? -/
 @[category research open, AMS 11]
-theorem erdos_244 : (∀ C > (1 : ℝ), { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.HasPosDensity) ↔
+theorem erdos_244 : (∀ C > (1 : ℝ), 0 < { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.LowerDensity) ↔
     answer(sorry) := by
   sorry
 
@@ -33,7 +33,6 @@ theorem erdos_244 : (∀ C > (1 : ℝ), { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Pr
 [Ro34] Romanoff, N. P., _Über einige Sätze der additiven Zahlentheorie_.
 Math. Ann. (1934), 668-678.-/
 @[category research solved, AMS 11]
-theorem erdos_244.variants.Romanoff {C : ℕ} (hC : 1 < C) {α : ℝ}
-    (h : { p + C ^ k | (p) (k) (_ : p.Prime) }.HasDensity α) :
-    0 < α := by
+theorem erdos_244.variants.Romanoff {C : ℕ} (hC : 1 < C) :
+    0 < { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.LowerDensity := by
   sorry

--- a/FormalConjectures/ErdosProblems/298.lean
+++ b/FormalConjectures/ErdosProblems/298.lean
@@ -21,7 +21,8 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/298](https://www.erdosproblems.com/298)
 -/
-/--Does every set `A ⊆ N` of positive density contain some finite `S ⊂ A` such that `∑ n ∈ S, 1 / n = 1`?
+/-- Does every set `A ⊆ N` of positive density contain some finite `S ⊂ A` such that
+`∑ n ∈ S, 1 / n = 1`?
 
 The answer is yes, proved by Bloom [Bl21].
 
@@ -31,5 +32,13 @@ Note: The solution to this problem has been formalized in Lean 3 by T. Bloom and
 https://github.com/b-mehta/unit-fractions -/
 @[category research solved, AMS 11]
 theorem erdos_298 : (∀ (A : Set ℕ), 0 ∉ A → A.HasPosDensity →
+    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) ↔ answer(True) := by
+  sorry
+
+/--
+In [Bl21] it is proved under the weaker assumption that `A` onlu has positive upper density.
+-/
+@[category research solved, AMS 11]
+theorem erdos_298.variants.upper_density : (∀ (A : Set ℕ), 0 < A.UpperDensity →
     ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) ↔ answer(True) := by
   sorry

--- a/FormalConjectures/ForMathlib/Data/Set/Density.lean
+++ b/FormalConjectures/ForMathlib/Data/Set/Density.lean
@@ -29,6 +29,8 @@ namespace Set
 Given a set `S` and an element `b` in an order `β`, where all intervals bounded above are finite,
 we define the partial density of `S` (relative to a set `A`) to be the proportion of elements in
 `{x ∈ A | x < b}` that lie in `S ∩ A`.
+
+This definition was inspired from https://github.com/b-mehta/unit-fractions
 -/
 noncomputable abbrev PartialDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) (b : β) : ℝ :=

--- a/FormalConjectures/ForMathlib/Data/Set/Density.lean
+++ b/FormalConjectures/ForMathlib/Data/Set/Density.lean
@@ -26,6 +26,33 @@ open scoped Topology
 namespace Set
 
 /--
+Given a set `S` and an element `b` in an order `β`, where all intervals bounded above are finite,
+we define the partial density of `S` (relative to a set `A`) to be the proportion of elements in
+`{x ∈ A | x < b}` that lie in `S ∩ A`.
+-/
+noncomputable def PartialDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) (b : β) : ℝ :=
+  (S ∩ A ∩ Set.Iio b).ncard / (A ∩ Set.Iio b).ncard
+
+/--
+Given a set `S` in an order `β`, where all intervals bounded above are finite, we define the upper
+density of `S` (relative to a set `A`) to be the limsup of the partial densities of `S`
+(relative to `A`) for `b → ∞`.
+-/
+noncomputable def UpperDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) : ℝ :=
+  atTop.limsup (fun (b : β) ↦ S.PartialDensity A b)
+
+/--
+Given a set `S` in an order `β`, where all intervals bounded above are finite, we define the upper
+density of `S` (relative to a set `A`) to be the liminf of the partial densities of `S`
+(relative to `A`) for `b → ∞`.
+-/
+noncomputable def LowerDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) : ℝ :=
+  atTop.liminf (fun (b : β) ↦ S.PartialDensity A b)
+
+/--
 A set `S` in an order `β` where all intervals bounded above are finite is said to have
 density `α : ℝ` (relative to a set `A`) if the proportion of `x ∈ S` such that `x < n`
 in `A` tends to `α` as `n → ∞`.
@@ -35,8 +62,7 @@ When `β = ℕ` this by default defines the natural density of a set
 -/
 def HasDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (α : ℝ) (A : Set β := Set.univ) : Prop :=
-  Tendsto (fun (b : β) => ((S ∩ A ∩ Set.Iio b).ncard : ℝ) / (A ∩ Set.Iio b).ncard)
-    atTop (𝓝 α)
+  Tendsto (fun (b : β) => S.PartialDensity A b) atTop (𝓝 α)
 
 /--
 A set `S` in an order `β` where all intervals bounded above are finite is said to have

--- a/FormalConjectures/ForMathlib/Data/Set/Density.lean
+++ b/FormalConjectures/ForMathlib/Data/Set/Density.lean
@@ -30,7 +30,7 @@ Given a set `S` and an element `b` in an order `β`, where all intervals bounded
 we define the partial density of `S` (relative to a set `A`) to be the proportion of elements in
 `{x ∈ A | x < b}` that lie in `S ∩ A`.
 -/
-noncomputable def PartialDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+noncomputable abbrev PartialDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) (b : β) : ℝ :=
   (S ∩ A ∩ Set.Iio b).ncard / (A ∩ Set.Iio b).ncard
 
@@ -62,7 +62,8 @@ When `β = ℕ` this by default defines the natural density of a set
 -/
 def HasDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (α : ℝ) (A : Set β := Set.univ) : Prop :=
-  Tendsto (fun (b : β) => S.PartialDensity A b) atTop (𝓝 α)
+  Tendsto (fun (b : β) => S.PartialDensity A b)
+    atTop (𝓝 α)
 
 /--
 A set `S` in an order `β` where all intervals bounded above are finite is said to have
@@ -94,7 +95,7 @@ example : (@Set.univ ℕ).HasDensity 1 := univ
 @[simp]
 theorem empty {β : Type*} [Preorder β] [LocallyFiniteOrderBot β] (A : Set β := Set.univ) :
     Set.HasDensity (∅ : Set β) 0 A := by
-  simpa [HasDensity] using tendsto_const_nhds
+  simpa [HasDensity, PartialDensity] using tendsto_const_nhds
 
 theorem mono {β : Type*} [PartialOrder β] [LocallyFiniteOrder β] [OrderBot β]
     {S T : Set β} {αS αT : ℝ} [(atTop : Filter β).NeBot] [IsDirected β fun x1 x2 ↦ x1 ≤ x2]
@@ -110,7 +111,7 @@ theorem mono {β : Type*} [PartialOrder β] [LocallyFiniteOrder β] [OrderBot β
 theorem nonneg {β : Type*} [Preorder β] [LocallyFiniteOrderBot β] [(atTop : Filter β).NeBot]
     {S : Set β} {α : ℝ}  (h : S.HasDensity α) :
     0 ≤ α :=
-  le_of_tendsto_of_tendsto' empty h fun b => by simp [div_nonneg]
+  le_of_tendsto_of_tendsto' empty h fun b => by simp [div_nonneg, PartialDensity]
 
 end Set.HasDensity
 

--- a/FormalConjectures/ForMathlib/Data/Set/Density.lean
+++ b/FormalConjectures/ForMathlib/Data/Set/Density.lean
@@ -62,8 +62,7 @@ When `β = ℕ` this by default defines the natural density of a set
 -/
 def HasDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (α : ℝ) (A : Set β := Set.univ) : Prop :=
-  Tendsto (fun (b : β) => S.PartialDensity A b)
-    atTop (𝓝 α)
+  Tendsto (fun (b : β) => S.PartialDensity A b) atTop (𝓝 α)
 
 /--
 A set `S` in an order `β` where all intervals bounded above are finite is said to have
@@ -84,7 +83,7 @@ elements has density one. -/
 theorem univ {β : Type*} [PartialOrder β] [LocallyFiniteOrder β]
     [OrderBot β] [Nontrivial β] [IsDirected β fun x1 x2 ↦ x1 ≤ x2] :
     (@Set.univ β).HasDensity 1 := by
-  simp [HasDensity]
+  simp [HasDensity, PartialDensity]
   let ⟨b, hb⟩ := Set.Iio_eventually_ncard_ne_zero β
   exact Tendsto.congr'
     (eventually_atTop.2 ⟨b, fun n hn => (div_self <| Nat.cast_ne_zero.2 (hb n hn)).symm⟩)
@@ -123,7 +122,7 @@ open Set
 The natural density of the set of even numbers is `1 / 2`.
 -/
 theorem hasDensity_even : {n : ℕ | Even n}.HasDensity (1 / 2) := by
-  simp [HasDensity]
+  simp [HasDensity, PartialDensity]
   have h {n : ℕ} (hn : 1 ≤ n) : (({n : ℕ | Even n} ∩ Iio n).ncard : ℝ) / n =
       if Even n then 2⁻¹ else (n + 1 : ℝ) /  n * 2⁻¹ := by
     split_ifs with h
@@ -145,7 +144,7 @@ theorem hasDensity_even : {n : ℕ | Even n}.HasDensity (1 / 2) := by
 /-- A finite set has natural density zero. -/
 theorem hasDensity_zero_of_finite {S : Set ℕ} (h : S.Finite) :
     S.HasDensity 0 := by
-  simp [HasDensity]
+  simp [HasDensity, PartialDensity]
   have (n : ℕ) : ((S ∩ Set.Iio n).ncard : ℝ) / n ≤ S.ncard / n := by
     by_cases h₀ : n = 0; simp [← Ico_bot, h₀]
     exact div_le_div₀ (by simp) (by simpa using Set.ncard_inter_le_ncard_left _ _ h)


### PR DESCRIPTION
This PR adds upper (and lower) density to `ForMathlib` to resolve #59. Doing this we are also able to add a variant to 298 that is more faithful to the statement in the paper solving the problem.