### PR TITLE
Fix: AMS codes

### DIFF
--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -21,6 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/1](https://www.erdosproblems.com/1)
 -/
+
 open Filter
 
 open scoped Topology Real
@@ -39,7 +40,7 @@ $$
   N \gg 2 ^ n.
 $$
 -/
-@[category research open, AMS 5, AMS 11]
+@[category research open, AMS 5 11]
 theorem erdos_1 : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ) (_ : IsSumDistinctSet A N),
     N ≠ 0 → C * 2 ^ A.card < N := by
   sorry
@@ -47,7 +48,7 @@ theorem erdos_1 : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ) (_ : IsSumDi
 /--
 The trivial lower bound is $N \gg 2^n / n$.
 -/
-@[category undergraduate, AMS 5, AMS 11]
+@[category undergraduate, AMS 5 11]
 theorem erdos_1.variants.weaker : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ)
     (_ : IsSumDistinctSet A N), N ≠ 0 → C * 2 ^ A.card / A.card < N := by
   sorry
@@ -60,7 +61,7 @@ $$
 
 [Er56] Erdős, P., _Problems and results in additive number theory_. Colloque sur la Th\'{E}orie des Nombres, Bruxelles, 1955 (1956), 127-137.
 -/
-@[category research solved, AMS 5, AMS 11]
+@[category research solved, AMS 5 11]
 theorem erdos_1.variants.lb : ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
     ∀ (N : ℕ) (A : Finset ℕ) (h : IsSumDistinctSet A N),
       (1 / 4 - o A.card) * 2 ^ A.card / (A.card : ℝ).sqrt ≤ N := by
@@ -70,7 +71,7 @@ theorem erdos_1.variants.lb : ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0
 A number of improvements of the constant $\frac{1}{4}$ have been given, with the current
 record $\sqrt{2 / \pi}$ first provied in unpublished work of Elkies and Gleason.
 -/
-@[category research solved, AMS 5, AMS 11]
+@[category research solved, AMS 5 11]
 theorem erdos_1.variants.lb_strong : ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
     ∀ (N : ℕ) (A : Finset ℕ) (h : IsSumDistinctSet A N),
       (√(2 / π) - o A.card) * 2 ^ A.card / (A.card : ℝ).sqrt ≤ N := by
@@ -91,7 +92,7 @@ sums all differ by at least $1$ is proposed in [Er73] and [ErGr80].
 
 [ErGr80] Erdős, P. and Graham, R., _Old and new problems and results in combinatorial number theory_. Monographies de L'Enseignement Mathematique (1980).
 -/
-@[category research open]
+@[category research open, AMS 5 11]
 theorem erdos_1.variants.real : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℝ)
     (_ : IsSumDistinctRealSet A N), N ≠ 0 → C * 2 ^ A.card < N := by
   sorry
@@ -102,7 +103,7 @@ elements is $4$.
 
 https://oeis.org/A276661
 -/
-@[category undergraduate, AMS 5, AMS 11]
+@[category undergraduate, AMS 5 11]
 theorem erdos_1.variants.least_N_3 :
     IsLeast { N | ∃ A, IsSumDistinctSet A N ∧ A.card = 3 } 4 := by
   refine ⟨⟨{1, 2, 4}, ?_⟩, ?_⟩
@@ -133,7 +134,7 @@ elements is $13$.
 
 https://oeis.org/A276661
 -/
-@[category research solved, AMS 5, AMS 11]
+@[category research solved, AMS 5 11]
 theorem erdos_1.variants.least_N_5 :
     IsLeast { N | ∃ A, IsSumDistinctSet A N ∧ A.card = 5 } 13 := by
   sorry
@@ -144,7 +145,7 @@ elements is $161$.
 
 https://oeis.org/A276661
 -/
-@[category research solved, AMS 5, AMS 11]
+@[category research solved, AMS 5 11]
 theorem erdos_1.variants.least_N_9 :
     IsLeast { N | ∃ A, IsSumDistinctSet A N ∧ A.card = 9 } 161 := by
   sorry

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -21,6 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/257](https://www.erdosproblems.com/257)
 -/
+
 /--
 Let $A\subseteq\mathbb{N}$ be an infinite set. Is
 $$
@@ -40,7 +41,7 @@ $$
 $$
 where $d(n)$ is the number of divisors of $n$.
 -/
-@[category undergraduate]
+@[category undergraduate, AMS 11]
 theorem erdos_257.variants.tsum_top_eq :
     ∑' n, 1 / (2 ^ n - 1 : ℝ) = ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
   sorry
@@ -54,7 +55,7 @@ is irrational.
 
 [Er48] Erdős, P., _On arithmetical properties of Lambert series_. J. Indian Math. Soc. (N.S.) (1948), 63-66.
 -/
-@[category research solved]
+@[category research solved, AMS 11]
 theorem erdos_257.variants.tsum_top :
     Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
   sorry

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -21,6 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/786](https://www.erdosproblems.com/786)
 -/
+
 open Filter
 
 open scoped Topology
@@ -82,7 +83,7 @@ the set $A$ of all naturals divisible by exactly one of $p_1, ..., p_k$ has
 density $1 / e - \epsilon$ and has the property that $a_1\cdots a_r = b_1\cdots b_s$
 with $a_i, b_j\in A$ can only hold when $r = s$.
 -/
-@[category research solved]
+@[category research solved, AMS 11]
 theorem erdos_786.parts.i.selfridge (ε : ℝ) (hε : 0 < ε ∧ ε ≤ 1) :
     -- TODO(mercuris) : I think we want `k` to be allowed to vary somehow as well, but maybe the exists is sufficient
     ∃ (k : ℕ),

--- a/FormalConjectures/Mathoverflow/347178.lean
+++ b/FormalConjectures/Mathoverflow/347178.lean
@@ -17,6 +17,7 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 open Real Set
+
 /-!
 # Mathoverflow 347178
 
@@ -25,10 +26,10 @@ asked by user [*Biagio Ricceri*](https://mathoverflow.net/users/149235/biagio-ri
 -/
 
 /--
-Let $f\colon ℝ^n → ℝ,  n ≥ 2$ be a $C^1$ function. Is it true that
-$$\sup_{x\in {\bf R}^n}f(x)=\sup_{x\in {\bf R}^n}f(x+\nabla f(x))$$?
+Let $f : \mathbb R^n \to \mathbb R,  n \geq 2$ be a $C^1$ function. Is it true that
+$$\sup_{x \in \mathbb R^n}f(x) = \sup_{x\in \mathbb R^n} f(x+\nabla f(x))$$?
 -/
-@[category research open]
+@[category research open, AMS 26]
 theorem mathoverflow_347178 :
     (∀ᵉ (n ≥ 2) (f : EuclideanSpace ℝ (Fin n) → ℝ) (hf : ContDiff ℝ 1 f),
         (BddAbove (range f) ↔ BddAbove (range (fun x ↦ f (x + gradient f x)))) ∧
@@ -36,14 +37,23 @@ theorem mathoverflow_347178 :
       ↔ answer(sorry) := by
   sorry
 
-@[category research open]
+/--
+Let $f : \mathbb R^n \to \mathbb R,  n \geq 2$ be a $C^1$ function. Is the boundedness of
+$\sup_{x \in \mathbb R^n}f(x)$ and $\sup_{x\in \mathbb R^n} f(x+\nabla f(x))$ equivalent?
+-/
+@[category research open, AMS 26]
 theorem mathoverflow_347178.variants.bounded_iff :
     (∀ᵉ (n ≥ 2) (f : EuclideanSpace ℝ (Fin n) → ℝ) (hf : ContDiff ℝ 1 f),
         (BddAbove (range f) ↔ BddAbove (range (fun x ↦ f (x + gradient f x)))))
       ↔ answer(sorry) := by
   sorry
 
-@[category research open]
+/--
+Let $f : \mathbb R^n \to \mathbb R,  n \geq 2$ be a $C^1$ function. Does the equality
+$$\sup_{x \in \mathbb R^n}f(x) = \sup_{x\in \mathbb R^n} f(x+\nabla f(x))$$
+hold when both suprema are finite?
+-/
+@[category research open, AMS 26]
 theorem mathoverflow_347178.variants.bounded_only :
     (∀ᵉ (n ≥ 2) (f : EuclideanSpace ℝ (Fin n) → ℝ) (hf : ContDiff ℝ 1 f)
         (h : BddAbove (range f)) (h' : BddAbove (range (fun x ↦ f (x + gradient f x)))),


### PR DESCRIPTION
While working on #151, I noticed that not all theorems had AMS code. Fixed.
`SchanuelsConjecture.lean` will be fixed along with the rest of its changes.