### PR TITLE
Fix 339137.lean

### DIFF
--- a/FormalConjectures/Mathoverflow/339137.lean
+++ b/FormalConjectures/Mathoverflow/339137.lean
@@ -31,7 +31,7 @@ asked by user [*Sil*](https://mathoverflow.net/users/136794/sil)
 /--
 The predicate that all coefficients of a polynomial are either zero or one.
 -/
-def IsZeroOne (P : ℝ[X]) := P.coeffs ⊆ {1}
+def IsZeroOne (P : ℝ[X]) := P.coeffs ⊆ {0, 1}
 
 -- TODO(lezeau): add probabilistic reformulation and statement
 -- that coefficients must at least lie in `[0, 1]`


### PR DESCRIPTION
## Description  
This fixes a mistake in the `IsZeroOne` definition for the MathOverflow 339137 conjecture. The original code required *all coefficients to be 1*, which is incorrect. The intended meaning is that coefficients should be either 0 or 1.
rankaiyx-patch-fix-339137-lean

### What was wrong?  
```lean
def IsZeroOne (P : ℝ[X]) := P.coeffs ⊆ {1}
```
This means every nonzero coefficient equals 1, disallowing zeros. For example, polynomials like `x + 1` would not satisfy this.

### What is the fix?  
Change it to:
```lean
def IsZeroOne (P : ℝ[X]) := P.coeffs ⊆ {0, 1}
```
Now all coefficients (including zeros) are either 0 or 1, matching the original conjecture.

### Other notes  
- The rest of the theorem remains unchanged.  
- This correction is crucial for the formalization to reflect the actual open problem from MathOverflow.  
