### PR TITLE
Beaver Math Olympiad problems

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,4 +17,5 @@ Mirek Olšák
 Paul Lezeau
 Salvatore Mercuri
 Seewoo Lee
+The bbchallenge Collaboration (bbchallenge.org)
 Thomas Hubert

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -86,7 +86,7 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
 
 [BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
-The machine was informally proven not to halt on [bbchallenge.org](bbchallenge.org) Discord's server, see [this discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
+The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org) contributor Daniel Yuan on June 18th 2024, see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_3

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -50,7 +50,7 @@ using `↔ answer(sorry)`.
 The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jason Yuen on
 June 25th 2024.
 -/
-@[category research open, AMS 5, AMS 11, AMS 68]
+@[category research open, AMS 5 11 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if (a n) ≥ (b n) then (a n) - (b n) else 2*(a n) + 1)
     (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)):
@@ -74,7 +74,7 @@ that the machine does not halt is based on [a probabilistic argument](https://wi
 This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org)
 contributors mxdys and Rachel Hunter on June 28th 2024.
 -/
-@[category research open, AMS 5, AMS 11, AMS 68]
+@[category research open, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_2_antihydra
     (a : ℕ → ℕ) (b : ℕ → ℤ)
     (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ))
@@ -88,7 +88,7 @@ theorem beaver_math_olympiad_problem_2_antihydra
 Alternative statement of beaver_math_olympiad_problem_2_antihydra
 using set size comparison instead of a recurrent sequence b.
 -/
-@[category research open, AMS 5, AMS 11, AMS 68]
+@[category research open, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_2_antihydra.variants.set
     (a : ℕ → ℕ)
     (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ)) :
@@ -104,7 +104,7 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
 The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org)
 contributor Daniel Yuan on June 18th 2024; see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
 -/
-@[category research solved, AMS 5, AMS 11, AMS 68]
+@[category research solved, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_3
     (a : ℕ → ℕ)
     (a_ini : a 0 = 2)
@@ -122,11 +122,11 @@ is equivalent to the non-termination of 2-state 5-symbol Turing machine
 The machine was informally proven not to halt [bbchallenge.org](bbchallenge.org)
 contributor Daniel Yuan on July 19th 2024; see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) and [Discord discussion](https://discord.com/channels/960643023006490684/960643023530762343/1263666591900631210).
 -/
-@[category research solved, AMS 5, AMS 11, AMS 68]
+@[category research solved, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_4
     (a : ℕ → ℕ)
     (a_ini : a 0 = 2)
-    (a_rec : ∀ n, a (n+1) 
+    (a_rec : ∀ n, a (n+1)
       = if (a n) % 3 = 0 then (a n) / 3 + 2^n + 1 else ((a n) - 2) / 3 + 2^n - 1) :
     ¬ (∃ n, (a n) % 3 = 1) :=
   sorry
@@ -149,10 +149,10 @@ in [Rocq](https://github.com/ccz181078/busycoq/blob/BB6/verify/1RB0LD_1LC0RA_1RA
 def f (x: ℕ) :=
   10*2^x - 1
 
-@[category research open, AMS 5, AMS 11, AMS 68]
+@[category research open, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_5 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 0) (a_rec : ∀ n, a (n+1) = if b n ≥ f (a n) then a n + 1 else a n)
-    (b_ini : b 0 = 5) 
+    (b_ini : b 0 = 5)
     (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n) else 3 * b n + a n + 5) :
     (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -46,7 +46,7 @@ The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jas
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if (a n) ≥ (b n) then (a n) - (b n) else 2*(a n) + 1)
     (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)) :
-    ∃ i, a i = b i ↔ answer(sorry) := by
+    (∃ i, a i = b i) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -133,5 +133,5 @@ def f (x: ℕ) :=
 theorem beaver_math_olympiad_problem_5 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 0) (a_rec : ∀ n, a (n+1) = if b n ≥ f (a n) then a n + 1 else a n)
     (b_ini : b 0 = 5) (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n) else 3*b n + a n + 5) :
-    ∃ i, b i = (f (a i)) - 1 ↔ answer(sorry) :=
+    (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -35,6 +35,8 @@ BMO#1
 
 BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
+There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
+
 The machine was discovered by Jason Yuen on June 25th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -33,7 +33,7 @@ Among these problems is the Collatz-like *Antihydra* problem which is open and c
 /--
 BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
-The machine was discovered by Jason Yuen in June 2024.
+The machine was discovered by Jason Yuen on June 25th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
@@ -49,10 +49,10 @@ The conjecture states that the cumulative number of odd values in this sequence
 is never more than twice the cumulative number of even values
 
 It is a relatively new open problem with, so it might be solvable, although
-seems quite hard. It is equivalent to non-termination of the `1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA` 6-state
+seems quite hard. It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state
 Turing machine.
 
-This machine and its mathematical reformulations were found by bbchallenge.org contributors mxdys and Rachel Hunter.
+This machine and its mathematical reformulations were found by bbchallenge.org contributors mxdys and Rachel Hunter on June 28th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -152,7 +152,7 @@ def f (x: ℕ) :=
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_5 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 0) (a_rec : ∀ n, a (n+1) = if b n ≥ f (a n) then a n + 1 else a n)
-    (b_ini : b 0 = 5) (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n)
-                                                               else 3*b n + a n + 5) :
+    (b_ini : b 0 = 5) 
+    (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n) else 3 * b n + a n + 5) :
     (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -37,7 +37,7 @@ BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
 
-The machine was discovered by bbchallenge.org contributor Jason Yuen on June 25th 2024.
+The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jason Yuen on June 25th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
@@ -58,7 +58,7 @@ It is a relatively new open problem with, so it might be solvable, although
 seems quite hard. It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state
 Turing machine.
 
-This machine and its mathematical reformulations were found by bbchallenge.org contributors mxdys and Rachel Hunter on June 28th 2024.
+This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org) contributors mxdys and Rachel Hunter on June 28th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra
@@ -88,7 +88,7 @@ BMO#3
 
 BMO#3 is equivalent to saying that the 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) does not halt.
 
-The machine was informally proven not to halt on bbchallenge.org Discord's server:
+The machine was informally proven not to halt on [bbchallenge.org](bbchallenge.org) Discord's server:
 https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -112,3 +112,24 @@ theorem beaver_math_olympiad_problem_4
                                            else ((a n) - 2)/3 + 2^n - 1) :
     ¬ (∃ n, (a n) % 3 = 1) :=
   sorry
+
+/--
+[BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch))
+
+[BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) is equivalent to asking whether the 6-state Turing machine [`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.
+
+There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
+
+The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor mxdys on August 7th 2024.
+
+The correspondence between the machine's halting problem and the below reformulation has been proven in [Rocq](https://github.com/ccz181078/busycoq/blob/BB6/verify/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE.v).
+-/
+def f (x: ℕ) :=
+  10*2^x - 1
+
+@[category research open, AMS 5, AMS 11, AMS 68]
+theorem beaver_math_olympiad_problem_5 (a : ℕ → ℕ) (b : ℕ → ℕ)
+    (a_ini : a 0 = 0) (a_rec : ∀ n, a (n+1) = if b n ≥ f (a n) then a n + 1 else a n)
+    (b_ini : b 0 = 5) (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n) else 3*b n + a n + 5) :
+    ∃ i, b i = (f (a i)) - 1 ↔ answer(sorry) :=
+  sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -53,10 +53,9 @@ theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
 Antihydra is a sequence starting at 8, and iterating the function
 $$H(n) = \left\lfloor \frac {3n}2 \right\rfloor.$$
 The conjecture states that the cumulative number of odd values in this sequence
-is never more than twice the cumulative number of even values
+is never more than twice the cumulative number of even values. It is a relatively new open problem with, so it might be solvable, although seems quite hard because of its Collatz-like flavor. The underlying Collatz-like map has been studied independently in the past, see doi:[10.1017/S0017089508004655](https://doi.org/10.1017/S0017089508004655) (Corollary 4).
 
-It is a relatively new open problem with, so it might be solvable, although
-seems quite hard. It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape).
+It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape). Note that the conjecture that the machine does not halt is based on [a probabilistic argument](https://wiki.bbchallenge.org/wiki/Antihydra#Trajectory).
 
 This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org) contributors mxdys and Rachel Hunter on June 28th 2024.
 -/

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -23,6 +23,8 @@ The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the ha
 
 Among these problems is the Collatz-like *Antihydra* problem which is open and coming from a 6-state Turing machine, and a testament to the difficulty of knowing the sixth Busy Beaver value.
 
+For some BMO problem, the equivalence between the mathematical formulation and the corresponding Turing machine non-termination has been formally proved in Rocq, we indicate it when done.
+
 *References:*
 
 - [bbchallenge.org](https://bbchallenge.org)

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -25,6 +25,7 @@ Among these problems is the Collatz-like *Antihydra* problem which is open and c
 
 *References:*
 
+- [bbchallenge.org](https://bbchallenge.org)
 - [Beaver Math Olympiad wiki page](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad)
 - [Antihydra web page](https://bbchallenge.org/antihydra)
 - [Antihydra wiki page](https://wiki.bbchallenge.org/wiki/Antihydra)

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -95,3 +95,19 @@ theorem beaver_math_olympiad_problem_3
     (a_rec : ∀ n, a (n+1) = (a n) + 2 ^ ((padicValNat 2 (a n)) + 2) - 1) :
     ¬ (∃ n k, a n = 4 ^ k) :=
   sorry
+
+/--
+BMO#4
+
+BMO#4 is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
+
+The machine was informally proven not to halt, see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB).
+-/
+@[category research solved, AMS 5, AMS 11, AMS 68]
+theorem beaver_math_olympiad_problem_4
+    (a : ℕ → ℕ)
+    (a_ini : a 0 = 2)
+    (a_rec : ∀ n, a (n+1) = if (a n)%3 = 0 then (a n)/3 + 2^n + 1
+                                           else ((a n) - 2)/3 + 2^n - 1) :
+    ¬ (∃ n, (a n) % 3 = 1) :=
+  sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -37,9 +37,9 @@ The machine was discovered by Jason Yuen in June 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
-    (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if a n ≥ b n then a n - b n else 2*a n + 1)
-    (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if a n ≥ b n then 4*b n + 2 else b n - a n) :
-    ∃ i, a i = b i ↔ answer(sorry) := by
+    (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if (a n) ≥ (b n) then (a n) - (b n) else 2*(a n) + 1)
+    (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)) :
+    ∃ i, (a i) = (b i) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -57,9 +57,9 @@ This machine and its mathematical reformulations were found by bbchallenge.org c
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra
     (a : ℕ → ℕ) (b : ℕ → ℤ)
-    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ))
-    (b_ini : b 0 = 0) (b_rec : ∀ n, b (n+1) = if a n % 2 = 0 then b n + 2 else b n - 1) :
-    ∀ n, b n ≥ 0 := by
+    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ))
+    (b_ini : b 0 = 0) (b_rec : ∀ n, b (n+1) = if (a n) % 2 = 0 then (b n) + 2 else (b n) - 1) :
+    ∀ n, (b n) ≥ 0 := by
   sorry
 
 /--
@@ -69,7 +69,7 @@ using set size comparison instead of a recurrent sequence b.
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra.variants.set
     (a : ℕ → ℕ)
-    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ)) :
+    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ)) :
     ∀ n, ((Finset.Ico 0 n).filter fun x ↦ Odd (a x)).card ≤
         2*((Finset.Ico 0 n).filter fun x ↦ Even (a x)).card := by
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -43,7 +43,7 @@ The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jas
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if (a n) ≥ (b n) then (a n) - (b n) else 2*(a n) + 1)
     (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)) :
-    ∃ i, (a i) = (b i) ↔ answer(sorry) := by
+    ∃ i, a i = b i ↔ answer(sorry) := by
   sorry
 
 /--
@@ -65,7 +65,7 @@ theorem beaver_math_olympiad_problem_2_antihydra
     (a : ℕ → ℕ) (b : ℕ → ℤ)
     (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ))
     (b_ini : b 0 = 0) (b_rec : ∀ n, b (n+1) = if (a n) % 2 = 0 then (b n) + 2 else (b n) - 1) :
-    ∀ n, (b n) ≥ 0 := by
+    ∀ n, b n ≥ 0 := by
   sorry
 
 /--

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -126,8 +126,8 @@ contributor Daniel Yuan on July 19th 2024; see [sketched proof](https://wiki.bbc
 theorem beaver_math_olympiad_problem_4
     (a : ℕ → ℕ)
     (a_ini : a 0 = 2)
-    (a_rec : ∀ n, a (n+1) = if (a n)%3 = 0 then (a n)/3 + 2^n + 1
-                                           else ((a n) - 2)/3 + 2^n - 1) :
+    (a_rec : ∀ n, a (n+1) 
+      = if (a n) % 3 = 0 then (a n) / 3 + 2^n + 1 else ((a n) - 2) / 3 + 2^n - 1) :
     ¬ (∃ n, (a n) % 3 = 1) :=
   sorry
 

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -86,7 +86,7 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
 
 [BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
-The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org) contributor Daniel Yuan on June 18th 2024, see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
+The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org) contributor Daniel Yuan on June 18th 2024; see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_3
@@ -102,7 +102,7 @@ theorem beaver_math_olympiad_problem_3
 [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
  is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
 
-The machine was informally proven not to halt, see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB).
+The machine was informally proven not to halt [bbchallenge.org](bbchallenge.org) contributor Daniel Yuan on July 19th 2024; see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) and [Discord discussion](https://discord.com/channels/960643023006490684/960643023530762343/1263666591900631210).
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_4

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -81,19 +81,17 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
         2*((Finset.Ico 0 n).filter fun x ↦ Even (a x)).card := by
   sorry
 
-
 /--
 BMO#3
 
 BMO#3 is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
 The machine was informally proven not to halt on [bbchallenge.org](bbchallenge.org) Discord's server, see [this discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
-
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_3
     (a : ℕ → ℕ)
     (a_ini : a 0 = 2)
     (a_rec : ∀ n, a (n+1) = (a n) + 2 ^ ((padicValNat 2 (a n)) + 2) - 1) :
-    ∃ n k, a n = 4 ^ k :=
+    ¬ (∃ n k, a n = 4 ^ k) :=
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -55,8 +55,7 @@ The conjecture states that the cumulative number of odd values in this sequence
 is never more than twice the cumulative number of even values
 
 It is a relatively new open problem with, so it might be solvable, although
-seems quite hard. It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state
-Turing machine.
+seems quite hard. It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape).
 
 This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org) contributors mxdys and Rachel Hunter on June 28th 2024.
 -/
@@ -86,10 +85,10 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
 /--
 BMO#3
 
-BMO#3 is equivalent to saying that the 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) does not halt.
+BMO#3 is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
-The machine was informally proven not to halt on [bbchallenge.org](bbchallenge.org) Discord's server:
-https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728
+The machine was informally proven not to halt on [bbchallenge.org](bbchallenge.org) Discord's server, see [this discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
+
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_3

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -31,9 +31,9 @@ Among these problems is the Collatz-like *Antihydra* problem which is open and c
 -/
 
 /--
-BMO#1
+[BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch))
 
-BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
+[BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch)) is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
 
@@ -47,7 +47,7 @@ theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
   sorry
 
 /--
-BMO#2
+[BMO#2](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#2._Hydra_and_Antihydra)
 
 Antihydra is a sequence starting at 8, and iterating the function
 $$H(n) = \left\lfloor \frac {3n}2 \right\rfloor.$$
@@ -68,7 +68,7 @@ theorem beaver_math_olympiad_problem_2_antihydra
   sorry
 
 /--
-BMO#2 formulation variant
+[BMO#2](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#2._Hydra_and_Antihydra) formulation variant
 
 Alternative statement of beaver_math_olympiad_problem_2_antihydra
 using set size comparison instead of a recurrent sequence b.
@@ -82,9 +82,9 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
   sorry
 
 /--
-BMO#3
+[BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)]
 
-BMO#3 is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
+[BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
 The machine was informally proven not to halt on [bbchallenge.org](bbchallenge.org) Discord's server, see [this discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
 -/
@@ -97,9 +97,10 @@ theorem beaver_math_olympiad_problem_3
   sorry
 
 /--
-BMO#4
+[BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
 
-BMO#4 is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
+[BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
+ is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
 
 The machine was informally proven not to halt, see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB).
 -/

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -41,6 +41,18 @@ Turing machine non-termination has been formally proved in Rocq, we indicate it 
 /--
 [BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch))
 
+Let $(a_n)_{n \ge 1}$ and $(b_n)_{n \ge 1}$ be two sequences such that $(a_1, b_1) = (1, 2)$ and
+
+$$(a_{n+1}, b_{n+1}) = \begin{cases}
+(a_n-b_n, 4b_n+2) & \text{if }a_n \ge b_n \\
+(2a_n+1, b_n-a_n) & \text{if }a_n < b_n
+\end{cases}$$
+
+for all positive integers $n$. Does there exist a positive integer $i$ such that $a_i = b_i$?
+
+The first 10 values of $(a_n, b_n)$ are $(1, 2), (3, 1), (2, 6), (5, 4), (1, 18), (3, 17),
+(7, 14), (15, 7), (8, 30), (17, 22)$.
+
 [BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch)) is equivalent to asking whether the 6-state Turing machine
 [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
@@ -99,6 +111,17 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
 /--
 [BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)]
 
+Let $v_2(n)$ be the largest integer $k$ such that $2^k$ divides $n$.
+Let $(a_n)_{n \ge 0}$ be a sequence such that
+
+$$a_n = \begin{cases}
+2 & \text{if } n=0 \\
+a_{n-1}+2^{v_2(a_{n-1})+2}-1 & \text{if } n \ge 1
+\end{cases}$$
+
+for all non-negative integers $n$. Is there an integer $n$ such that $a_n=4^k$ for
+some positive integer $k$?
+
 [BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
 The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org)
@@ -114,6 +137,17 @@ theorem beaver_math_olympiad_problem_3
 
 /--
 [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
+
+Bonnie the beaver was bored, so she tried to construct a sequence of integers $\{a_n\}_{n \ge 0}$.
+She first defined $a_0=2$, then defined $a_{n+1}$ depending on $a_n$ and $n$
+using the following rules:
+
+* If $a_n \equiv 0\text{ (mod 3)}$, then $a_{n+1}=\frac{a_n}{3}+2^n+1$.
+* If $a_n \equiv 2\text{ (mod 3)}$, then $a_{n+1}=\frac{a_n-2}{3}+2^n-1$.
+
+With these two rules alone, Bonnie calculates the first few terms in the sequence: $2, 0, 3, 6, 11,
+18, 39, 78, 155, 306, \dots$. At this point, Bonnie plans to continue writing terms until a term
+becomes $1\text{ (mod 3)}$. If Bonnie sticks to her plan, will she ever finish?
 
 [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
 is equivalent to the non-termination of 2-state 5-symbol Turing machine
@@ -133,6 +167,17 @@ theorem beaver_math_olympiad_problem_4
 
 /--
 [BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch))
+
+Let $(a_n)_{n \ge 1}$ and $(b_n)_{n \ge 1}$ be two sequences such that $(a_1, b_1) = (0, 5)$ and
+
+$$(a_{n+1}, b_{n+1}) = \begin{cases}
+(a_n+1, b_n-f(a_n)) & \text{if } b_n \ge f(a_n) \\
+(a_n, 3b_n+a_n+5) & \text{if } b_n < f(a_n)
+\end{cases}$$
+
+where $f(x)=10\cdot 2^x-1$
+
+for all positive integers $n$. Does there exist a positive integer $i$ such that $b_i = f(a_i)-1$?
 
 [BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) is equivalent to asking whether the 6-state Turing machine
 [`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -31,6 +31,8 @@ Among these problems is the Collatz-like *Antihydra* problem which is open and c
 -/
 
 /--
+BMO#1
+
 BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
 The machine was discovered by Jason Yuen on June 25th 2024.
@@ -43,6 +45,8 @@ theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
   sorry
 
 /--
+BMO#2
+
 Antihydra is a sequence starting at 8, and iterating the function
 $$H(n) = \left\lfloor \frac {3n}2 \right\rfloor.$$
 The conjecture states that the cumulative number of odd values in this sequence
@@ -63,6 +67,8 @@ theorem beaver_math_olympiad_problem_2_antihydra
   sorry
 
 /--
+BMO#2 formulation variant
+
 Alternative statement of beaver_math_olympiad_problem_2_antihydra
 using set size comparison instead of a recurrent sequence b.
 -/

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -17,9 +17,15 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Busy Beaver Challenge: Antihydra
+# Beaver Math Olympiad (BMO)
 
-*Reference:* [bbchallenge](https://wiki.bbchallenge.org/wiki/Antihydra)
+The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the halting/nonhalting problem of specific Turing machines from all-0 tape. These problems came from studying small Busy Beaver values. Among these problems is the Collatz-like *Antihydra* problem which is open and coming from a 6-state Turing machine, and a testament to the difficulty of knowing the sixth Busy Beaver value.
+
+*References:*
+
+- [Beaver Math Olympiad wiki page](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad)
+- [Antihydra web page](https://bbchallenge.org/antihydra)
+- [Antihydra wiki page](https://wiki.bbchallenge.org/wiki/Antihydra)
 -/
 
 /--
@@ -29,22 +35,24 @@ The conjecture states that the cumulative number of odd values in this sequence
 is never more than twice the cumulative number of even values
 
 It is a relatively new open problem with, so it might be solvable, although
-seems quite hard. It is equivalent to non-termination of a particular 6-state
-turing machine.
+seems quite hard. It is equivalent to non-termination of the `1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA` 6-state
+Turing machine.
 -/
 @[category research open, AMS 5, AMS 11]
-theorem busy_beaver_antihydra (a : ℕ → ℕ) (b : ℕ → ℤ)
-    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ)) (b_ini : b 0 = 0)
-    (b_rec : ∀ n, b (n+1) = if a n % 2 = 0 then b n + 2 else b n - 1) :
+theorem beaver_math_olympiad_problem_2_antihydra
+    (a : ℕ → ℕ) (b : ℕ → ℤ)
+    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ))
+    (b_ini : b 0 = 0) (b_rec : ∀ n, b (n+1) = if a n % 2 = 0 then b n + 2 else b n - 1) :
     ∀ n, b n ≥ 0 := by
   sorry
 
 /--
-Alternative statement of busy_beaver_antihydra
+Alternative statement of beaver_math_olympiad_problem_2_antihydra
 using set size comparison instead of a recurrent sequence b.
 -/
 @[category research open, AMS 5, AMS 11]
-theorem busy_beaver_antihydra.variants.set (a : ℕ → ℕ)
+theorem beaver_math_olympiad_problem_2_antihydra.variants.set
+    (a : ℕ → ℕ)
     (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ)) :
     ∀ n, ((Finset.Ico 0 n).filter fun x ↦ Odd (a x)).card ≤
         2*((Finset.Ico 0 n).filter fun x ↦ Even (a x)).card := by

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -19,11 +19,16 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Beaver Math Olympiad (BMO)
 
-The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the halting/nonhalting problem of specific Turing machines from all-0 tape. These problems came from studying small Busy Beaver values. Some problems are open and have a conjectured answer, some are open and don't have a conjectured answer, and, some are solved.
+The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the halting/nonhalting
+problem of specific Turing machines from all-0 tape. These problems came from studying small Busy
+Beaver values. Some problems are open and have a conjectured answer, some are open and don't have a
+conjectured answer, and, some are solved.
 
-Among these problems is the Collatz-like *Antihydra* problem which is open and coming from a 6-state Turing machine, and a testament to the difficulty of knowing the sixth Busy Beaver value.
+Among these problems is the Collatz-like *Antihydra* problem which is open and coming from a 6-state
+Turing machine, and a testament to the difficulty of knowing the sixth Busy Beaver value.
 
-For some BMO problem, the equivalence between the mathematical formulation and the corresponding Turing machine non-termination has been formally proved in Rocq, we indicate it when done.
+For some BMO problem, the equivalence between the mathematical formulation and the corresponding
+Turing machine non-termination has been formally proved in Rocq, we indicate it when done.
 
 *References:*
 
@@ -36,16 +41,19 @@ For some BMO problem, the equivalence between the mathematical formulation and t
 /--
 [BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch))
 
-[BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch)) is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
+[BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch)) is equivalent to asking whether the 6-state Turing machine
+[`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
-There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
+There is presently no consensus on whether the machine halts or not, hence the problem is formulated
+using `↔ answer(sorry)`.
 
-The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jason Yuen on June 25th 2024.
+The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jason Yuen on
+June 25th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if (a n) ≥ (b n) then (a n) - (b n) else 2*(a n) + 1)
-    (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)) :
+    (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)):
     (∃ i, a i = b i) ↔ answer(sorry) := by
   sorry
 
@@ -55,11 +63,16 @@ theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
 Antihydra is a sequence starting at 8, and iterating the function
 $$H(n) = \left\lfloor \frac {3n}2 \right\rfloor.$$
 The conjecture states that the cumulative number of odd values in this sequence
-is never more than twice the cumulative number of even values. It is a relatively new open problem with, so it might be solvable, although seems quite hard because of its Collatz-like flavor. The underlying Collatz-like map has been studied independently in the past, see doi:[10.1017/S0017089508004655](https://doi.org/10.1017/S0017089508004655) (Corollary 4).
+is never more than twice the cumulative number of even values. It is a relatively new open problem
+with, so it might be solvable, although seems quite hard because of its Collatz-like flavor.
+The underlying Collatz-like map has been studied independently in the past,
+see doi:[10.1017/S0017089508004655](https://doi.org/10.1017/S0017089508004655) (Corollary 4).
 
-It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape). Note that the conjecture that the machine does not halt is based on [a probabilistic argument](https://wiki.bbchallenge.org/wiki/Antihydra#Trajectory).
+It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape). Note that the conjecture
+that the machine does not halt is based on [a probabilistic argument](https://wiki.bbchallenge.org/wiki/Antihydra#Trajectory).
 
-This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org) contributors mxdys and Rachel Hunter on June 28th 2024.
+This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org)
+contributors mxdys and Rachel Hunter on June 28th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra
@@ -88,7 +101,8 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
 
 [BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
-The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org) contributor Daniel Yuan on June 18th 2024; see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
+The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org)
+contributor Daniel Yuan on June 18th 2024; see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_3
@@ -102,9 +116,11 @@ theorem beaver_math_olympiad_problem_3
 [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
 
 [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
- is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
+is equivalent to the non-termination of 2-state 5-symbol Turing machine
+[`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
 
-The machine was informally proven not to halt [bbchallenge.org](bbchallenge.org) contributor Daniel Yuan on July 19th 2024; see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) and [Discord discussion](https://discord.com/channels/960643023006490684/960643023530762343/1263666591900631210).
+The machine was informally proven not to halt [bbchallenge.org](bbchallenge.org)
+contributor Daniel Yuan on July 19th 2024; see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) and [Discord discussion](https://discord.com/channels/960643023006490684/960643023530762343/1263666591900631210).
 -/
 @[category research solved, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_4
@@ -118,13 +134,17 @@ theorem beaver_math_olympiad_problem_4
 /--
 [BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch))
 
-[BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) is equivalent to asking whether the 6-state Turing machine [`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.
+[BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) is equivalent to asking whether the 6-state Turing machine
+[`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.
 
-There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
+There is presently no consensus on whether the machine halts or not, hence the problem is formulated
+using `↔ answer(sorry)`.
 
-The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor mxdys on August 7th 2024.
+The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor mxdys
+on August 7th 2024.
 
-The correspondence between the machine's halting problem and the below reformulation has been proven in [Rocq](https://github.com/ccz181078/busycoq/blob/BB6/verify/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE.v).
+The correspondence between the machine's halting problem and the below reformulation has been proven
+in [Rocq](https://github.com/ccz181078/busycoq/blob/BB6/verify/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE.v).
 -/
 def f (x: ℕ) :=
   10*2^x - 1
@@ -132,6 +152,7 @@ def f (x: ℕ) :=
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_5 (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 0) (a_rec : ∀ n, a (n+1) = if b n ≥ f (a n) then a n + 1 else a n)
-    (b_ini : b 0 = 5) (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n) else 3*b n + a n + 5) :
+    (b_ini : b 0 = 5) (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n)
+                                                               else 3*b n + a n + 5) :
     (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) :=
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -175,9 +175,9 @@ $$(a_{n+1}, b_{n+1}) = \begin{cases}
 (a_n, 3b_n+a_n+5) & \text{if } b_n < f(a_n)
 \end{cases}$$
 
-where $f(x)=10\cdot 2^x-1$
+where $f(x)=10\cdot 2^x-1$ for all non-negative integers $x$.
 
-for all positive integers $n$. Does there exist a positive integer $i$ such that $b_i = f(a_i)-1$?
+Does there exist a positive integer $i$ such that $b_i = f(a_i)-1$?
 
 [BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) is equivalent to asking whether the 6-state Turing machine
 [`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -64,8 +64,10 @@ June 25th 2024.
 -/
 @[category research open, AMS 5 11 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
-    (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if (a n) ≥ (b n) then (a n) - (b n) else 2*(a n) + 1)
-    (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if (a n) ≥ (b n) then 4*(b n) + 2 else (b n) - (a n)):
+    (a_ini : a 0 = 1)
+    (a_rec : ∀ n, a (n + 1) = if b n ≤ a n then a n - b n else 2 * a n + 1)
+    (b_ini : b 0 = 2)
+    (b_rec : ∀ n, b (n + 1) = if b n ≤ a n then 4 * b n + 2 else b n - a n):
     (∃ i, a i = b i) ↔ answer(sorry) := by
   sorry
 
@@ -89,8 +91,10 @@ contributors mxdys and Rachel Hunter on June 28th 2024.
 @[category research open, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_2_antihydra
     (a : ℕ → ℕ) (b : ℕ → ℤ)
-    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ))
-    (b_ini : b 0 = 0) (b_rec : ∀ n, b (n+1) = if (a n) % 2 = 0 then (b n) + 2 else (b n) - 1) :
+    (a_ini : a 0 = 8)
+    (a_rec : ∀ n, a (n + 1) = (3 * a n) / 2)
+    (b_ini : b 0 = 0)
+    (b_rec : ∀ n, b (n + 1) = if a n % 2 = 0 then b n + 2 else b n - 1) :
     ∀ n, b n ≥ 0 := by
   sorry
 
@@ -102,10 +106,10 @@ using set size comparison instead of a recurrent sequence b.
 -/
 @[category research open, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_2_antihydra.variants.set
-    (a : ℕ → ℕ)
-    (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*(a n)/2 : ℕ)) :
-    ∀ n, ((Finset.Ico 0 n).filter fun x ↦ Odd (a x)).card ≤
-        2*((Finset.Ico 0 n).filter fun x ↦ Even (a x)).card := by
+    (a : ℕ → ℕ) (a_ini : a 0 = 8)
+    (a_rec : ∀ n, a (n + 1) = (3 * a n) / 2) (n : ℕ) :
+    ((Finset.Ico 0 n).filter fun x ↦ Odd (a x)).card ≤
+      2 * ((Finset.Ico 0 n).filter fun x ↦ Even (a x)).card := by
   sorry
 
 /--
@@ -131,8 +135,8 @@ contributor Daniel Yuan on June 18th 2024; see [Discord discussion](https://disc
 theorem beaver_math_olympiad_problem_3
     (a : ℕ → ℕ)
     (a_ini : a 0 = 2)
-    (a_rec : ∀ n, a (n+1) = (a n) + 2 ^ ((padicValNat 2 (a n)) + 2) - 1) :
-    ¬ (∃ n k, a n = 4 ^ k) :=
+    (a_rec : ∀ n, a (n + 1) = (a n) + 2 ^ ((padicValNat 2 (a n)) + 2) - 1) :
+    ¬ (∃ n k, a n = 4 ^ k) := by
   sorry
 
 /--
@@ -161,8 +165,8 @@ theorem beaver_math_olympiad_problem_4
     (a : ℕ → ℕ)
     (a_ini : a 0 = 2)
     (a_rec : ∀ n, a (n+1)
-      = if (a n) % 3 = 0 then (a n) / 3 + 2^n + 1 else ((a n) - 2) / 3 + 2^n - 1) :
-    ¬ (∃ n, (a n) % 3 = 1) :=
+      = if a n % 3 = 0 then a n / 3 + 2 ^ n + 1 else (a n - 2) / 3 + 2 ^ n - 1) :
+    ¬ (∃ n, a n % 3 = 1) := by
   sorry
 
 /--
@@ -191,13 +195,11 @@ on August 7th 2024.
 The correspondence between the machine's halting problem and the below reformulation has been proven
 in [Rocq](https://github.com/ccz181078/busycoq/blob/BB6/verify/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE.v).
 -/
-def f (x: ℕ) :=
-  10*2^x - 1
-
 @[category research open, AMS 5 11 68]
-theorem beaver_math_olympiad_problem_5 (a : ℕ → ℕ) (b : ℕ → ℕ)
-    (a_ini : a 0 = 0) (a_rec : ∀ n, a (n+1) = if b n ≥ f (a n) then a n + 1 else a n)
-    (b_ini : b 0 = 5)
-    (b_rec : ∀ n, b (n+1) = if b n ≥ f (a n) then b n - f (a n) else 3 * b n + a n + 5) :
-    (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) :=
+theorem beaver_math_olympiad_problem_5
+    (a b f : ℕ → ℕ) (hf : f = fun x ↦ 10 * 2 ^ x - 1)
+    (a_ini : a 0 = 0) (b_ini : b 0 = 5)
+    (a_rec : ∀ n, a (n + 1) = if f (a n) ≤ b n then a n + 1 else a n)
+    (b_rec : ∀ n, b (n+1) = if f (a n) ≤ b n then b n - f (a n) else 3 * b n + a n + 5) :
+    (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) := by
   sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -37,8 +37,10 @@ is never more than twice the cumulative number of even values
 It is a relatively new open problem with, so it might be solvable, although
 seems quite hard. It is equivalent to non-termination of the `1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA` 6-state
 Turing machine.
+
+This machine and its mathematical reformulations were found by bbchallenge.org contributors mxdys and Rachel Hunter.
 -/
-@[category research open, AMS 5, AMS 11]
+@[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra
     (a : ℕ → ℕ) (b : ℕ → ℤ)
     (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ))
@@ -50,7 +52,7 @@ theorem beaver_math_olympiad_problem_2_antihydra
 Alternative statement of beaver_math_olympiad_problem_2_antihydra
 using set size comparison instead of a recurrent sequence b.
 -/
-@[category research open, AMS 5, AMS 11]
+@[category research open, AMS 5, AMS 11, AMS 68]
 theorem beaver_math_olympiad_problem_2_antihydra.variants.set
     (a : ℕ → ℕ)
     (a_ini : a 0 = 8) (a_rec : ∀ n, a (n+1) = (3*a n/2 : ℕ)) :

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -37,7 +37,7 @@ BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated using `↔ answer(sorry)`.
 
-The machine was discovered by Jason Yuen on June 25th 2024.
+The machine was discovered by bbchallenge.org contributor Jason Yuen on June 25th 2024.
 -/
 @[category research open, AMS 5, AMS 11, AMS 68]
 theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -81,3 +81,20 @@ theorem beaver_math_olympiad_problem_2_antihydra.variants.set
     ∀ n, ((Finset.Ico 0 n).filter fun x ↦ Odd (a x)).card ≤
         2*((Finset.Ico 0 n).filter fun x ↦ Even (a x)).card := by
   sorry
+
+
+/--
+BMO#3
+
+BMO#3 is equivalent to saying that the 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) does not halt.
+
+The machine was informally proven not to halt on bbchallenge.org Discord's server:
+https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728
+-/
+@[category research solved, AMS 5, AMS 11, AMS 68]
+theorem beaver_math_olympiad_problem_3
+    (a : ℕ → ℕ)
+    (a_ini : a 0 = 2)
+    (a_rec : ∀ n, a (n+1) = (a n) + 2 ^ ((padicValNat 2 (a n)) + 2) - 1) :
+    ∃ n k, a n = 4 ^ k :=
+  sorry

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -19,7 +19,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Beaver Math Olympiad (BMO)
 
-The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the halting/nonhalting problem of specific Turing machines from all-0 tape. These problems came from studying small Busy Beaver values. Among these problems is the Collatz-like *Antihydra* problem which is open and coming from a 6-state Turing machine, and a testament to the difficulty of knowing the sixth Busy Beaver value.
+The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the halting/nonhalting problem of specific Turing machines from all-0 tape. These problems came from studying small Busy Beaver values. Some problems are open and have a conjectured answer, some are open and don't have a conjectured answer, and, some are solved.
+
+Among these problems is the Collatz-like *Antihydra* problem which is open and coming from a 6-state Turing machine, and a testament to the difficulty of knowing the sixth Busy Beaver value.
 
 *References:*
 
@@ -27,6 +29,18 @@ The Beaver Math Olympiad (BMO) is a set of mathematical reformulations of the ha
 - [Antihydra web page](https://bbchallenge.org/antihydra)
 - [Antihydra wiki page](https://wiki.bbchallenge.org/wiki/Antihydra)
 -/
+
+/--
+BMO#1 is equivalent to asking whether the 6-state Turing machine [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
+
+The machine was discovered by Jason Yuen in June 2024.
+-/
+@[category research open, AMS 5, AMS 11, AMS 68]
+theorem busy_beaver_math_olympiad_problem_1 (a : ℕ → ℕ) (b : ℕ → ℕ)
+    (a_ini : a 0 = 1) (a_rec : ∀ n, a (n+1) = if a n ≥ b n then a n - b n else 2*a n + 1)
+    (b_ini : b 0 = 2) (b_rec : ∀ n, b (n+1) = if a n ≥ b n then 4*b n + 2 else b n - a n) :
+    ∃ i, a i = b i ↔ answer(sorry) := by
+  sorry
 
 /--
 Antihydra is a sequence starting at 8, and iterating the function


### PR DESCRIPTION
This PR adds the current [Beaver Math Olympiad problems](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) to the project (see #230).

A few notes:

- I have added verbose comments documenting each problem and crediting the bbchallenge contributors who found the associated TMs and mathematical reformulations
- I have used a lean parenthesisation style that is slightly more verbose than was originally done to help non-native lean speakers
- [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch)) original formulation is based on a partial definition of `a` I have taken the liberty of making it total through the `else` branch
- In BMO#5 statement, I've used [global definition of function "f"](https://github.com/tcosmo/formal-conjectures/blob/579d1ba125ce8b61a4f20b5085af36ccc07f33b5/FormalConjectures/Other/BeaverMathOlympiad.lean#L128), I don't know if it is compatible with your preferred good practice, I will inline it if you prefer
- I added "The bbchallenge Collaboration (bbchallenge.org)" in the AUTHORS, let me know if this is against your authoring guidelines and what we should do instead