### PR TITLE
fix(EllipticCurveRank): corner cases and a sanity check

### DIFF
--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -76,6 +76,14 @@ def heightLE (H : ℕ) : Set RatEllipticCurve := {E : RatEllipticCurve | E.naive
 open scoped Topology
 open Filter (atTop)
 
+/-- Formula (5.1.1) of [PPVW2016]: The number of elliptic curves over ℚ with naïve height at most
+`H` is asymptotically `2^(4/3)*3^(-3/2)/ζ(10) * H^(5/6)`. -/
+@[category graduate, AMS 11 14]
+theorem card_heightLE_div_pow_five_div_six_tensto :
+    atTop.Tendsto (fun H ↦ (heightLE H).ncard / (H : ℝ) ^ (5 / 6 : ℝ))
+      (𝓝 (2 ^ (4 / 3 : ℝ) * 3 ^ (-3 / 2 : ℝ) / (riemannZeta 10).re)) := by
+  sorry
+
 /-- Conjecture by Goldfeld and Katz–Sarnak: if elliptic curves over ℚ are ordered by their
 heights, then 50% of the curves have rank 0 and 50% have rank 1.
 See p. 28 of https://people.maths.bris.ac.uk/~matyd/BSD2011/bsd2011-Bhargava.pdf. -/
@@ -108,7 +116,7 @@ theorem _02062_le_density_rank_zero : 0.2062 ≤ atTop.liminf
   sorry
 
 /-- From [PPVW2016], Section 3.1: "from the mid-1960s to the present,
-it seems that most experts conjectured unboundedness". -/
+it seems that most experts conjectured unboundedness." -/
 @[category research open, AMS 11 14]
 theorem unbounded_rank_conjecture (n : ℕ) : ∃ E : RatEllipticCurve, n ≤ E.rank := by
   sorry
@@ -124,19 +132,22 @@ theorem finite_twentyone_lt_finrank : {E : RatEllipticCurve | 21 < E.rank}.Finit
 
 /-- [PPVW2016] 8.2(b): for 1 ≤ r ≤ 20, the number of elliptic curves over ℚ with rank `r` and
 naïve height at most `H` is asymptotically `H ^ ((21 - r) / 24 + o(1))`.
-Note: ℰ_H in 8.2(b) should be ℰ_{≤H}, see the statement of Theorem 7.3.3. -/
+Note: ℰ_H in 8.2(b) should be ℰ_{≤H}, see the statement of Theorem 7.3.3.
+When `r = 1`, the exponent is `20 / 24 = 5 / 6`, which agrees with the exponent in
+`card_heightLE_div_pow_five_div_six_tensto` and is consistent with
+`half_rank_zero_and_half_rank_one`. -/
 @[category research open, AMS 11 14]
 theorem rank_height_count_asymptotic (r : ℕ) (h₁ : 1 ≤ r) (h₂ : r ≤ 20) :
-    ∃ f : ℕ+ → ℝ, atTop.Tendsto f (𝓝 0) ∧
-      ∀ H : ℕ+, {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H) := by
+    ∃ f : ℕ → ℝ, atTop.Tendsto f (𝓝 0) ∧
+      ∀ H : ℕ, 1 < H → {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H) := by
   sorry
 
 /-- [PPVW2016] 8.2(c): the number of elliptic curves over ℚ with rank ≥ 21 and naïve height
-at most `H` is asymptotically `H ^ o(1)`. -/
+at most `H` is asymptotically at most `H ^ o(1)`. -/
 @[category research open, AMS 11 14]
 theorem twentyone_le_rank_height_count_asymptotic :
-    ∃ f : ℕ+ → ℝ, atTop.Tendsto f (𝓝 0) ∧
-      ∀ H : ℕ+, {E ∈ heightLE H | 21 ≤ E.rank}.ncard ≤ (H : ℝ) ^ f H := by
+    ∃ f : ℕ → ℝ, atTop.Tendsto f (𝓝 0) ∧
+      ∀ H : ℕ, 1 < H → {E ∈ heightLE H | 21 ≤ E.rank}.ncard ≤ (H : ℝ) ^ f H := by
   sorry
 
 end RatEllipticCurve


### PR DESCRIPTION
+ Fix a potential issue when the height bound `H` is 1 in which case `H ^ _` is always 1.
+ Add the asymptotics of `(heightLE H).ncard` as a sanity check.