### PR TITLE
Avoid trivial edge cases in Erdos 488

### DIFF
--- a/FormalConjectures/ErdosProblems/488.lean
+++ b/FormalConjectures/ErdosProblems/488.lean
@@ -31,7 +31,7 @@ Is it true that, for every $m > n \ge \max(A)$,
 $$\frac{|B \cap [1, m]|}{m} < 2 \frac{|B \cap [1, n]|}{n}?$$
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_488 : (∀ (A : Finset ℕ),
+theorem erdos_488 : (∀ (A : Finset ℕ), A.Nonempty → 0 ∉ A → 1 ∉ A →
     letI B := {n ≥ 1 | ∀ a ∈ A, ¬ a ∣ n}
     ∀ᵉ (n : ℕ) (m > n), A.max ≤ n →
       ((Finset.Icc 1 m).filter (· ∈ B)).card / (m : ℚ) <


### PR DESCRIPTION
The [original statement](https://www.erdosproblems.com/488) was solved in the negative. A counterexample is the set of primes bounded by `n`.

As formalised, AlphaProof found a trivial counterexample of this problem by taking `A = ∅`, `n = 0`, `m = 1` from which `B = {n | n ≥ 1}` and the final assertion yields `1 < 0`. So we assert `A.Nonempty` now.

Modifying the same proof with `A = {0}`, `n = 0`, `m = 1` leads to a similar trivial counterexample. It seems to be OK for `0 ∈ A` so long as it's not a singleton, but the original problem probably intends `ℕ = {1, 2, ...}` anyway, so exclude `0` from `A`.

We also exclude `1` from `A`, because otherwise `B` is empty and we get the `0 < 0` in the final claim.

