### PR TITLE
Add cardinality assumption to `erdos_402.variants.equality`

### DIFF
--- a/FormalConjectures/ErdosProblems/402.lean
+++ b/FormalConjectures/ErdosProblems/402.lean
@@ -45,9 +45,10 @@ an iff statement.
 -/
 @[category research solved, AMS 11]
 theorem erdos_402.variants.equality (A : Finset ℕ) (h₁ : 0 ∉ A) (h₂ : A.Nonempty)
+    (h₃ : 4 ≤ A.card)
     (hA : ∀ n, A ≠ Finset.Icc 1 n ∧
-    A ≠ ((Finset.Icc 1 n).image fun i => ((Finset.Icc 1 n).lcm id) / i) ∧
-    A ≠ {2,3,4,6}) :
+      A ≠ ((Finset.Icc 1 n).image fun i => ((Finset.Icc 1 n).lcm id) / i) ∧
+      A ≠ {2,3,4,6}) :
     ∃ᵉ (a ∈ A) (b ∈ A), a.gcd b < (a / A.card : ℚ) := by
   sorry
 


### PR DESCRIPTION
AlphaProof showed that equality also holds for `{12}`, as it does for any singleton.

Digging into the references [[Sz86]](https://link.springer.com/article/10.1007/BF02579410) sounds like it expects `4 ≤ A.card`, while [[BaSo96]](https://eudml.org/doc/206861) explicitly asserts `5 ≤ A.card` (but this latter would mean `{2, 3, 4, 6}` should also be removed). Going with `4` for now.

