### PR TITLE
chore(ErdosProblems/402): fix misformalisation

### DIFF
--- a/FormalConjectures/ErdosProblems/402.lean
+++ b/FormalConjectures/ErdosProblems/402.lean
@@ -46,11 +46,11 @@ an iff statement.
 -/
 @[category research solved, AMS 11]
 theorem erdos_402.variants.equality (A : Finset ℕ) (h₁ : 0 ∉ A) (h₂ : A.Nonempty)
-    (h₃ : 4 ≤ A.card)
-    (hA : ∀ n, A ≠ Finset.Icc 1 n ∧
-      A ≠ ((Finset.Icc 1 n).image fun i => ((Finset.Icc 1 n).lcm id) / i) ∧
-      A ≠ {2,3,4,6}) :
-    ∃ᵉ (a ∈ A) (b ∈ A), a.gcd b < (a / A.card : ℚ) := by
+    (h₃ : A.gcd id = 1)
+    (h : ∀ᵉ (a ∈ A) (b ∈ A), (a / A.card : ℚ) ≤ a.gcd b) :
+    A = Finset.Icc 1 A.card ∨
+    A = (Finset.Icc 1 A.card).image ((Finset.Icc 1 A.card).lcm id / ·) ∨
+    A = {2, 3, 4, 6} := by
   sorry
 
 /-- Proved for all sufficiently large sets (including the sharper version which


### PR DESCRIPTION
Reformulate the equality case.
- The equality case is intended to assert that the mutual gcd is 1: this is on the website and in the docstring already
- As a consequence, no assumption on the cardinality is needed (eg for singletons, we can only have the gcd being 1 if it's already {1}, and then we're in the first of the three cases, so the theorem holds).
- The equality case is stated here by saying that (a,b) >= a/|A| for all a,b, as written in the fourth paragraph of the introduction in [BaSo96].