### PR TITLE
Replace lowerDensity with new one for Erdos 10

### DIFF
--- a/FormalConjectures/ErdosProblems/10.lean
+++ b/FormalConjectures/ErdosProblems/10.lean
@@ -21,12 +21,6 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/10](https://www.erdosproblems.com/10)
 -/
-/--
-The lower asymptotic density of a set $S$ is the $\liminf$ as $n → ∞$ of the
-ratio $\frac{|\{a ∈ S \mid  a < n\}|}{n}$.
--/
-noncomputable def lowerDensity (S : Set ℕ) : ℝ :=
-    Filter.atTop.liminf (fun n => (Set.Iio n ∩ S).ncard / n)
 
 /--
 The set of natural numbers that can be written as a sum
@@ -53,7 +47,7 @@ Ref: Gallagher, P. X., _Primes and powers of 2_.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_10.variants.gallagher (ε : ℝ)
-    (hε : 0 < ε) : ∃ k, 1 - ε ≤ lowerDensity (sumPrimeAndTwoPows k) := by
+    (hε : 0 < ε) : ∃ k, 1 - ε ≤ (sumPrimeAndTwoPows k).lowerDensity := by
   sorry
 
 /--


### PR DESCRIPTION
It seems that the definition of `lowerDensity` in Erdos 10 is added before more general definition is added to `ForMathlib/Data/Set/Density.lean`. Remove it and replace with new one. Let me know if this is wrong.