### PR TITLE
Standardize use of Landau notation

### DIFF
--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -62,7 +62,7 @@ $$
 [Er56] Erdős, P., _Problems and results in additive number theory_. Colloque sur la Th\'{E}orie des Nombres, Bruxelles, 1955 (1956), 127-137.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_1.variants.lb : ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+theorem erdos_1.variants.lb : ∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
     ∀ (N : ℕ) (A : Finset ℕ) (h : IsSumDistinctSet A N),
       (1 / 4 - o A.card) * 2 ^ A.card / (A.card : ℝ).sqrt ≤ N := by
   sorry
@@ -72,7 +72,7 @@ A number of improvements of the constant $\frac{1}{4}$ have been given, with the
 record $\sqrt{2 / \pi}$ first provied in unpublished work of Elkies and Gleason.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_1.variants.lb_strong : ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+theorem erdos_1.variants.lb_strong : ∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
     ∀ (N : ℕ) (A : Finset ℕ) (h : IsSumDistinctSet A N),
       (√(2 / π) - o A.card) * 2 ^ A.card / (A.card : ℝ).sqrt ≤ N := by
   sorry

--- a/FormalConjectures/ErdosProblems/285.lean
+++ b/FormalConjectures/ErdosProblems/285.lean
@@ -51,7 +51,7 @@ theorem erdos_285
         { n (Fin.last k) | (n : Fin k.succ → ℕ) (_ : StrictMono n) (_ : 0 ∉ Set.range n)
           (_ : 1 = ∑ i, (1 : ℝ) / n i) }
         (f k)) :
-    (∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+    (∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
       ∀ k ∈ S, f k = (1 + o k) * rexp 1 / (rexp 1 - 1) * (k + 1)) ↔ answer(True) := by
   sorry
 
@@ -68,6 +68,6 @@ theorem erdos_285.variants.lb (f : ℕ → ℕ)
         { n (Fin.last k) | (n : Fin k.succ → ℕ) (_ : StrictMono n) (_ : 0 ∉ Set.range n)
           (_ : 1 = ∑ i, (1 : ℝ) / n i) }
         (f k)) :
-    ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+    ∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
       ∀ k ∈ S, (1 + o k) * rexp 1 / (rexp 1 - 1) * (k + 1) ≤ f k := by
   sorry

--- a/FormalConjectures/ErdosProblems/319.lean
+++ b/FormalConjectures/ErdosProblems/319.lean
@@ -117,7 +117,7 @@ follows from the main result of Croot [Cr01]
 Acta Arith. (2001), 99-114.
 -/
 @[category research solved, AMS 5]
-theorem erdos_319.variants.lb : ∃ o, (o =o[atTop] fun n => (1 : ℝ)) ∧
+theorem erdos_319.variants.lb : ∃ o, (o =o[atTop] (1 : ℕ → ℝ)) ∧
     ∀ {N : ℕ} {A : Finset ℕ} (hA : A ⊆ Finset.Icc 1 N) (h_nonempty : A.Nonempty)
     {δ : ℕ → ℤˣ} (hδ₁ : ∑ n ∈ A, (δ n : ℚ) / n = 0)
     (hδ₂ : ∀ A' ⊂ A, A'.Nonempty → ∑ n ∈ A', (δ n : ℚ) / n ≠ 0),

--- a/FormalConjectures/ErdosProblems/442.lean
+++ b/FormalConjectures/ErdosProblems/442.lean
@@ -112,7 +112,7 @@ $$
 -/
 @[category research solved, AMS 11]
 theorem erdos_442.variants.tao :
-    ∃ (A : Set ℕ) (f : ℝ → ℝ) (C: ℝ) (hC : 0 < C) (hf : Tendsto f atTop (𝓝 0)),
+    ∃ (A : Set ℕ) (f : ℝ → ℝ) (C: ℝ) (hC : 0 < C) (hf : f =o[atTop] (1 : ℝ → ℝ)),
       ∀ (x : ℝ),
         ∑ n ∈ A.bdd x, (1 : ℝ) / n =
           Real.exp ((1 / 2 + f x) * √x.maxLogOne.maxLogOne * x.maxLogOne.maxLogOne.maxLogOne) ∧

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -51,7 +51,7 @@ $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold when
 $r = s$?
 -/
 @[category research open, AMS 11]
-theorem erdos_786.parts.ii : (∃ (A : ℕ → Set ℕ) (f : ℕ → ℝ) (_ : Tendsto f atTop (𝓝 0)),
+theorem erdos_786.parts.ii : (∃ (A : ℕ → Set ℕ) (f : ℕ → ℝ) (_ : f =o[atTop] (1 : ℕ → ℝ)),
     ∀ N, A N ⊆ Set.Icc 1 (N + 1) ∧ (1 - f N) * N ≤ (A N).ncard ∧ (A N).IsMulCardSet) ↔
     answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/897.lean
+++ b/FormalConjectures/ErdosProblems/897.lean
@@ -62,7 +62,8 @@ theorem erdos_897.variants.log_growth
     (f : ℕ → ℝ)
     (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
     (C : ℝ) (hf' : ∀ n, |f (n+1) - f n| ≤ C) :
-    ∃ c O, ∀ n, |f n - c*Real.log n| ≤ O := by
+    ∃ c, ∃ (O : ℕ → ℝ), O =O[Filter.atTop] (1 : ℕ → ℝ) ∧
+      ∀ n, f n ≤ c*Real.log n + O n := by
   sorry
 
 
@@ -78,7 +79,8 @@ theorem erdos_897.variants.parts.i : (∀ (f : ℕ → ℝ),
     ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
       (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
     (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤) ↔ answer(sorry) := by
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤) ↔
+      answer(sorry) := by
   sorry
 
 /--


### PR DESCRIPTION
This PR standardizes the use of Landau notation for functions that are `o(1)` or `O(1)`. 