### PR TITLE
feat: statements for degree sequences in triangle-free graphs

### DIFF
--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -53,12 +53,9 @@ lemma lemma1_a
     (h_pos : ∀ k, 0 < d k)
     (h_no_three : ∀ k, d (k + 2) ≠ d k) :
     1 ≤ d (k + 2) - d k := by
-  rw [Nat.one_le_iff_ne_zero]
-  intro h
-  rw [Nat.sub_eq_zero_iff_le] at h
-  have h' : d k ≤ d (k + 2) := h_mono (le_add_of_nonneg_right (Nat.zero_le 2))
-  have h_eq : d (k + 2) = d k := le_antisymm h h'
-  exact h_no_three k h_eq
+  have : d k ≤ d (k + 2) := h_mono (by omega)
+  have := h_no_three k
+  omega
 
 /-- **Lemma 1 (b)**
 If a sequence `d` is nondecreasing and no three terms are equal, then terms at distance `2 * r` differ by at least `r`. -/


### PR DESCRIPTION
This commit introduces the formal statements (definitions, lemmas, and theorems) from the paper "Degree sequences in triangle-free graphs" by P. Erdős, S. Fajtlowicz, and W. Staton.

The work was published in Discrete Mathematics, Volume 92, Issues 1–3, in November 1991, pages 85-88. 

The paper answers one of the Graffiti conjectures. Graffiti conjectures appeared in this repository in the directory FormalConjectures/WrittenOnTheWallII.