### PR TITLE
clean up imports for WrittenOnTheWallII

### DIFF
--- a/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Definitions.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Definitions.lean
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
 import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.Util.ProblemImports
+import Mathlib.Combinatorics.SimpleGraph.Acyclic
+import Mathlib.Combinatorics.SimpleGraph.Clique
+import Mathlib.Combinatorics.SimpleGraph.Matching
+import Mathlib.Data.Real.Archimedean
 
 namespace SimpleGraph
 

--- a/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Domination.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Domination.lean
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
+import Mathlib.Combinatorics.SimpleGraph.Clique
 
 /-
 Dominating sets and domination numbers

--- a/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
@@ -15,7 +15,9 @@ limitations under the License.
 -/
 
 import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.Util.ProblemImports
+import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
+import Mathlib.Combinatorics.SimpleGraph.Metric
+import Mathlib.Order.CompletePartialOrder
 
 namespace SimpleGraph
 

--- a/FormalConjectures/Util/ForMathlib.lean
+++ b/FormalConjectures/Util/ForMathlib.lean
@@ -19,6 +19,11 @@ import FormalConjectures.ForMathlib.Algebra.Polynomial.Basic
 import FormalConjectures.ForMathlib.Analysis.SpecialFunctions.Log.Basic
 import FormalConjectures.ForMathlib.Combinatorics.Additive.Basis
 import FormalConjectures.ForMathlib.Combinatorics.Basic
+import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
+import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
+import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
+import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
+import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 import FormalConjectures.ForMathlib.Computability.TuringMachine
 import FormalConjectures.ForMathlib.Data.Nat.MaxPrimeFac
 import FormalConjectures.ForMathlib.Data.Nat.Prime.Defs

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture1.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture1.lean
@@ -15,11 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 open SimpleGraph
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 import FormalConjectures.Util.ProblemImports
 
 open Classical

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
@@ -16,11 +16,6 @@ limitations under the License.
 
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 open Classical
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture3.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture3.lean
@@ -15,11 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 universe u
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -16,11 +16,6 @@ limitations under the License.
 
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 open Finset
 open scoped Classical

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture4.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture4.lean
@@ -15,11 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 namespace SimpleGraph
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture40.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture40.lean
@@ -15,11 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 namespace SimpleGraph
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
@@ -14,38 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 import FormalConjectures.Util.ProblemImports
-import Mathlib.Algebra.BigOperators.Module
-import Mathlib.Combinatorics.SimpleGraph.Acyclic
-import Mathlib.Combinatorics.SimpleGraph.Matching
-import Mathlib.Combinatorics.SimpleGraph.Subgraph
-import Mathlib.Combinatorics.SimpleGraph.Path
-import Mathlib.Combinatorics.SimpleGraph.Clique
-import Mathlib.Combinatorics.SimpleGraph.Finite
-import Mathlib.Combinatorics.SimpleGraph.Basic
-import Mathlib.Combinatorics.SimpleGraph.Metric
-import Mathlib.Combinatorics.SimpleGraph.Coloring
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Archimedean
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.Fintype.Card
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Finset.Image
-import Mathlib.Data.Finset.Powerset
-import Mathlib.Data.Nat.Lattice
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Set.Lattice
-import Mathlib.Data.Int.Basic
-import Mathlib.Data.Multiset.Sort
-import Mathlib.Data.ENat.Basic
-import Mathlib.Algebra.Order.Floor
-import Mathlib.Order.ConditionallyCompleteLattice.Basic
-
 namespace SimpleGraph
 
 variable {V : Type*} [Fintype V] [DecidableEq V]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture58.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture58.lean
@@ -15,11 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 namespace SimpleGraph
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture6.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture6.lean
@@ -16,11 +16,6 @@ limitations under the License.
 
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.DiamExtra
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.Bipartite
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
-import FormalConjectures.ForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 
 open Classical
 


### PR DESCRIPTION
We never want to include `FormalConjectures.Util.ProblemImports` inside of `ForMathlib`, but rather the other way around.