### PR TITLE
fix: misformalisations in `GaussCircleProblem.lean`

### DIFF
--- a/FormalConjectures/Wikipedia/GaussCircleProblem.lean
+++ b/FormalConjectures/Wikipedia/GaussCircleProblem.lean
@@ -63,7 +63,7 @@ $$
 [Ha59]  Hardy, G. H. (1959). _Ramanujan: Twelve Lectures on Subjects Suggested by His Life and Work_(3rd ed.). New York: Chelsea Publishing Company. p. 67
 -/
 @[category research solved, AMS 11]
-theorem error_le (r : ℝ) (hr : 0 ≤ r) : |E r| ≤ 2 * √2 * π * r := by
+theorem error_le (r : ℝ) (hr : 0 < r) : |E r| ≤ 2 * √2 * π * r := by
   sorry
 
 /--
@@ -73,8 +73,7 @@ $$
 $$
 -/
 @[category research solved, AMS 11]
-theorem error_not_isLittleO (r : ℝ) (hr : 0 ≤ r) :
-    ¬E =o[atTop] (fun r => √r * √√r.log) := by
+theorem error_not_isLittleO : ¬E =o[atTop] (fun r => √r * √√r.log) := by
   sorry
 
 /--
@@ -101,7 +100,7 @@ $$
 -/
 @[category research solved, AMS 11]
 theorem exact_form_floor (r : ℝ) (hr : 0 ≤ r) :
-    N r = 1 + 4 * ∑' i, (⌊r ^ 2 / (4 * i + 1)⌋ - ⌊r ^ 2 / (4 * i + 3)⌋) := by
+    N r = 1 + 4 * ∑' (i : ℕ), (⌊r ^ 2 / (4 * i + 1)⌋ - ⌊r ^ 2 / (4 * i + 3)⌋) := by
   sorry
 
 end GaussCircleProblem


### PR DESCRIPTION
- `error_le` is false for `r = 0`, because `E 0 = 1`
- `exact_form_floor` should sum over `Nat`, rather than `Real`
- Also remove unnecessary hypotheses in `error_not_isLittleO`

The first two follow disproofs found by AlphaProof.