### PR TITLE
fix: typing in `erdos_245`  to `EReal`.

### DIFF
--- a/FormalConjectures/ErdosProblems/245.lean
+++ b/FormalConjectures/ErdosProblems/245.lean
@@ -44,7 +44,7 @@ The answer is yes, proved by Freiman [Fr73].
 @[category research solved, AMS 5 11]
 theorem erdos_245 :
     (∀ (A : Set ℕ), A.Infinite → Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0) →
-    3 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop) ↔ answer(True) := by
+    3 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : EReal) / (A.bdd N).ncard) atTop) ↔ answer(True) := by
   sorry
 
 /--
@@ -73,5 +73,5 @@ $$
 @[category research solved, AMS 5 11]
 theorem erdos_245.variants.two (A : Set ℕ) (h_inf : A.Infinite)
     (hf : Tendsto (fun N => (A.bdd N |>.ncard : ℝ) / N) atTop (𝓝 0)) :
-    2 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : ℝ) / (A.bdd N).ncard) atTop := by
+    2 ≤ limsup (fun N => ((A + A).bdd N |>.ncard : EReal) / (A.bdd N).ncard) atTop := by
   sorry


### PR DESCRIPTION
`limsup` returns `0` for unbounded sequences when the type of the sequence is `Real`, which leads to false counterexamples in `erdos_245`. AlphaProof found a disproof using the set `S = {2^n}` which is sparse enough to satisfy the conditions of the problem, but `|(S + S) ∩ [1, n] |/|S ∩ [1, n]|` is unbounded. 