### PR TITLE
fix: maximality in `168.lean`

### DIFF
--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -66,8 +66,8 @@ Sanity check: if `S` is a maximal non ternary subset of `{1,..., N}` then `F N` 
 cardinality of `S`
 -/
 @[category API, AMS 5 11]
-lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N)
-    (hS' : NonTernary S) (hS'' : ∀ T, T ⊆ Finset.Icc 1 N → NonTernary T → S ⊆ T → T = S) :
+lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N) (hS' : NonTernary S)
+    (hS'' : ∀ T, T ⊆ Finset.Icc 1 N → NonTernary T → S.card ≤ T.card → T = S) :
     F N = S.card := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -67,7 +67,7 @@ cardinality of `S`
 -/
 @[category API, AMS 5 11]
 lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N) (hS' : NonTernary S)
-    (hS'' : ∀ T, T ⊆ Finset.Icc 1 N → NonTernary T → S.card ≤ T.card → T = S) :
+    (hS'' : ∀ T, T ⊆ Finset.Icc 1 N → NonTernary T → S.card ≤ T.card → T.card = S.card) :
     F N = S.card := by
   sorry
 


### PR DESCRIPTION
In `F_eq_card`, maximality is formalised with respect to inclusion but it should be formalised with respect to cardinality since `F` is defined as the max cardinality. In particular, `{1, 2, 5, 6, 7}` is a subset of `{1, ..., 7}` that is maximal with respect to inclusion, but `{1, 3, 4, 5, 6, 7}` is a larger set that contains no AP of the form `n, 2n, 3n` (disproof found by AlphaProof).