### PR TITLE
fix: take `k` sufficiently large in `erdos_678`

### DIFF
--- a/FormalConjectures/ErdosProblems/678.lean
+++ b/FormalConjectures/ErdosProblems/678.lean
@@ -64,7 +64,7 @@ Write $M(n, k)$ be the least common multiple of ${n+1, \dotsc, n+k}$.
 Let $k$ be sufficiently large. Are there infinitely many $m, n$ with $m \geq n + k$ such that
 $$
 M(n, k) > M(m, k + 1)
-$$?s
+$$?
 The answer is yes, as proved in a strong form by Cambie [Ca24].
 [Ca24] S. Cambie, Resolution of an Erdős' problem on least common multiples. arXiv:2410.09138 (2024).
 -/

--- a/FormalConjectures/ErdosProblems/678.lean
+++ b/FormalConjectures/ErdosProblems/678.lean
@@ -61,15 +61,15 @@ lemma lcmInterval_lt_example4 : lcmInterval 47 9 < lcmInterval 36 8 := by decide
 
 /--
 Write $M(n, k)$ be the least common multiple of ${n+1, \dotsc, n+k}$.
-Let $k \geq 3$. Are there infinitely many $m, n$ with $m \geq n + k$ such that
+Let $k$ be sufficiently large. Are there infinitely many $m, n$ with $m \geq n + k$ such that
 $$
 M(n, k) > M(m, k + 1)
-$$?
+$$?s
 The answer is yes, as proved in a strong form by Cambie [Ca24].
 [Ca24] S. Cambie, Resolution of an Erdős' problem on least common multiples. arXiv:2410.09138 (2024).
 -/
 @[category research solved, AMS 11]
 theorem erdos_678 :
-    (∀ k, 3 ≤ k → {(m, n) | n + k ≤ m ∧ lcmInterval m (k + 1) < lcmInterval n k}.Infinite) ↔
+    (∀ᶠ k in atTop, {(m, n) | n + k ≤ m ∧ lcmInterval m (k + 1) < lcmInterval n k}.Infinite) ↔
       answer(True) := by
   sorry


### PR DESCRIPTION
The claim is false for `k = 3`. For `k = 3` one can show that we must always have 
`lcm {n + 1, n + 2, n + 3} ≤ lcm {m + 1, m + 2, m + 3, m + 4}` if `n + 3 ≤ m` -- this was shown by AlphaProof using elementary methods.

The [solution paper](https://arxiv.org/pdf/2410.09138) states this only for sufficiently large `k`. In particular the proof there requires the existence of three primes in some open interval `((1 − ε)k, k)`, so this proof fails for `k = 3` as well.
