### PR TITLE
fix: add positivity to `erdos_326.variants.eq`

### DIFF
--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -41,8 +41,10 @@ theorem erdos_326 : (∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
 /--
 Erdős originally asked whether this was true with `A = B`, but this was disproved by Cassels.
 -/
+-- Formalisation note: This is trivially true for `x = 0` by taking `a = id`. Cassels' proof
+-- shows it for `0 < x` which is more interesting.
 @[category research solved, AMS 5 11]
-theorem erdos_326.variants.eq : (∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
-    ∃ (a : ℕ → ℕ), StrictMono a ∧ Set.range a = A ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x)) ↔ answer(False) := by
+theorem erdos_326.variants.eq :
+    ∃ (a : ℕ → ℕ) (_ : StrictMono a) (_ : Set.range a |>.IsAddBasisOfOrder 2) (x : ℝ) (_ : 0 < x),
+      Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 x) :=
   sorry


### PR DESCRIPTION
Prior formalisation admits a trivial proof using all of `ℕ` as the additive basis, for which $a_n/n^2$ converges to `0` . In the reference, Cassels constructs an additive basis $a_n$ satisfying $a_n \sim \beta n^2$, for $\beta > 0$, which is the more interesting case.