### PR TITLE
chore: fix AMS linting errors

### DIFF
--- a/FormalConjectures/Arxiv/1601.03081/UniqueCrystalComponents.lean
+++ b/FormalConjectures/Arxiv/1601.03081/UniqueCrystalComponents.lean
@@ -31,7 +31,7 @@ and $B(a, b) ∈ ℕ$, where $B(a, b) := ((a + b)^2 + (a b + 1)^2) / (2 (a + 1) 
 def IsCrystalWithComponents (n a b : ℕ) : Prop :=
   Odd n ∧ 1 < a ∧ 1 < b ∧ n = a * b ∧ 2 * (a + 1) * (b + 1) ∣ (a + b)^2 + (a * b + 1)^2
 
-@[category test]
+@[category test, AMS 11]
 example : IsCrystalWithComponents 35 5 7 := by
   norm_num [IsCrystalWithComponents]
   decide

--- a/FormalConjectures/Arxiv/2107.12475/CollatzLike.lean
+++ b/FormalConjectures/Arxiv/2107.12475/CollatzLike.lean
@@ -42,5 +42,5 @@ theorem CollatzLike (n : ℕ) (hn : 8 < n) : 2 ∈ Nat.digits 3 (2^n) := by
 /--
 For $n = 8$, $2$ is not contained in the base $3$ digits of $n$.
 -/
-@[category test]
+@[category test, AMS 5 11]
 example : 2 ∉ Nat.digits 3 (2^8) := by norm_num

--- a/FormalConjectures/ErdosProblems/228.lean
+++ b/FormalConjectures/ErdosProblems/228.lean
@@ -30,7 +30,7 @@ The answer is yes, proved by Balister, Bollobás, Morris, Sahasrabudhe, and Tiba
 
 [BBMST19] Balister, P. and Bollob\'{A}s, B. and Morris, R. and Sahasrabudhe, J. and Tiba, M., _Flat Littlewood Polynomials Exist_. arXiv:907.09464 (2019).
 -/
-@[category research solved, AMS 5 12, AMS 41] --TODO(lezeau): I'm a little unhappy with the `41` tag
+@[category research solved, AMS 5 12 41] --TODO(lezeau): I'm a little unhappy with the `41` tag
 theorem erdos_228 :
     (∃ (c₁ : ℝ) (c₂ : ℝ), ∀ᶠ n : ℕ in Filter.atTop,
     ∃ p : Polynomial ℂ, p.degree = n ∧

--- a/FormalConjectures/ErdosProblems/304.lean
+++ b/FormalConjectures/ErdosProblems/304.lean
@@ -29,12 +29,12 @@ The set of `k` for which `a / b` can be expressed as a sum of `k` distinct unit 
 def unitFractionExpressible (a b : ℕ) : Set ℕ :=
   {k | ∃ s : Finset ℕ, s.card = k ∧ (∀ n ∈ s, n > 1) ∧ (a / b : ℚ) = ∑ n ∈ s, (n : ℚ)⁻¹}
 
-@[category API, simp]
+@[category API, simp, AMS 11]
 lemma zero_mem_unitFractionExpressible_iff {a b : ℕ} :
     0 ∈ unitFractionExpressible a b ↔ a = 0 ∨ b = 0 := by
   simp_all [unitFractionExpressible]
 
-@[category API]
+@[category API, AMS 11]
 lemma unitFractionExpressible_of_zero {a b : ℕ} (h : a = 0 ∨ b = 0) :
     unitFractionExpressible a b = {0} := by
   simp only [Set.eq_singleton_iff_unique_mem, zero_mem_unitFractionExpressible_iff, *]
@@ -48,20 +48,20 @@ lemma unitFractionExpressible_of_zero {a b : ℕ} (h : a = 0 ∨ b = 0) :
   intro i hi
   linarith [h i hi, hs i hi]
 
-@[category API]
+@[category API, AMS 11]
 lemma unitFractionExpressible_zero_left {b : ℕ} :
     unitFractionExpressible 0 b = {0} := unitFractionExpressible_of_zero (by simp)
 
-@[category API]
+@[category API, AMS 11]
 lemma unitFractionExpressible_zero_right {a : ℕ} :
     unitFractionExpressible a 0 = {0} := unitFractionExpressible_of_zero (by simp)
 
-@[category API]
+@[category API, AMS 11]
 lemma zero_notMem_unitFractionExpressible {a b : ℕ} :
     0 ∉ unitFractionExpressible a b ↔ a ≠ 0 ∧ b ≠ 0 := by
   simp_all [unitFractionExpressible]
 
-@[category API]
+@[category API, AMS 11]
 lemma eq_inv_of_one_mem_unitFractionExpressible {a b : ℕ}
     (h : 1 ∈ unitFractionExpressible a b) : ∃ m : ℕ, 1 < m ∧ (a / b : ℚ) = (m : ℚ)⁻¹ := by
   simp only [unitFractionExpressible, gt_iff_lt, Set.mem_setOf_eq, Finset.card_eq_one] at h
@@ -69,7 +69,7 @@ lemma eq_inv_of_one_mem_unitFractionExpressible {a b : ℕ}
   simp only [Finset.mem_singleton, forall_eq, Finset.sum_singleton] at h₁ h₂
   use m
 
-@[category API]
+@[category API, AMS 11]
 lemma dvd_of_one_mem_unitFractionExpressible {a b : ℕ}
     (h : 1 ∈ unitFractionExpressible a b) : a ∣ b := by
   obtain ⟨m, hm₁, hm⟩ := eq_inv_of_one_mem_unitFractionExpressible h
@@ -88,7 +88,7 @@ noncomputable def smallestCollection (a b : ℕ) : ℕ := sInf (unitFractionExpr
 
 -- in fact `(unitFractionExpressible a b).Nonempty` should always be true, but we do not prove it
 -- for now
-@[category API]
+@[category API, AMS 11]
 lemma smallestCollection_pos {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : (unitFractionExpressible a b).Nonempty) :
     0 < smallestCollection a b := by
@@ -97,7 +97,7 @@ lemma smallestCollection_pos {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
   have : 0 ∈ unitFractionExpressible a b := h' ▸ Nat.sInf_mem h
   simp_all
 
-@[category API]
+@[category API, AMS 11]
 lemma smallestCollection_left_one (b : ℕ) (hb : 1 < b) : smallestCollection 1 b = 1 := by
   have : 1 ∈ unitFractionExpressible 1 b := ⟨{b}, by simpa⟩
   have : smallestCollection 1 b ≤ 1 := Nat.sInf_le this
@@ -105,19 +105,19 @@ lemma smallestCollection_left_one (b : ℕ) (hb : 1 < b) : smallestCollection 1 
   have : smallestCollection 1 b ≠ 0 := ne_of_mem_of_not_mem (Nat.sInf_mem ⟨_, ‹_›⟩) this
   omega
 
-@[category API]
+@[category API, AMS 11]
 lemma eq_one_of_smallestCollection_eq_one {a b : ℕ}
     (h : smallestCollection a b = 1) : ∃ m : ℕ, 1 < m ∧ (a / b : ℚ) = (m : ℚ)⁻¹ := by
   have : 1 ∈ unitFractionExpressible a b := h ▸ Nat.sInf_mem (Nat.nonempty_of_sInf_eq_succ h)
   apply eq_inv_of_one_mem_unitFractionExpressible this
 
-@[category API]
+@[category API, AMS 11]
 lemma dvd_of_smallestCollection_eq_one {a b : ℕ}
     (h : smallestCollection a b = 1) : a ∣ b := by
   have : 1 ∈ unitFractionExpressible a b := h ▸ Nat.sInf_mem (Nat.nonempty_of_sInf_eq_succ h)
   apply dvd_of_one_mem_unitFractionExpressible this
 
-@[category test]
+@[category test, AMS 11]
 lemma smallestCollection_two_fifteen : smallestCollection 2 15 = 2 := by
   have h : 2 ∈ unitFractionExpressible 2 15 := by
     use {10, 30}

--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -38,7 +38,7 @@ theorem erdos_409.parts.i (n : ℕ) (hn : 0 < n) :
 
 /-- If $n > 0$, then the iteration $n\mapsto\phi(n) + 1$ necessarily
 reaches a prime. -/
-@[category test]
+@[category test, AMS 11]
 theorem erdos_409.termination (n : ℕ) (hn : 0 < n) :
     ∃ i, (φ · + 1)^[i] n |>.Prime := by
   sorry
@@ -107,7 +107,7 @@ theorem erdos_409.variants.sigma.parts.i (n : ℕ) (hn : n > 1) :
   sorry
 
 /-- If $n > 1$ then the iteration $n\mapsto\sigma(n) - 1$ necessarily reaches a prime. -/
-@[category test]
+@[category test, AMS 11]
 theorem erdos_409.variants.sigma.termination (n : ℕ) (hn : n > 1) :
     ∃ i, (σ 1 · - 1)^[i] n |>.Prime := by
   sorry

--- a/FormalConjectures/ErdosProblems/678.lean
+++ b/FormalConjectures/ErdosProblems/678.lean
@@ -34,7 +34,7 @@ The referee of [Er79] found the example $M(96, 7) > M(104, 8)$, showing that the
 $M(n, k) > M(m, k + 1)$ with $m \geq n + k$.
 [Er79] Erdős, Paul, Some unconventional problems in number theory. Math. Mag. (1979), 67-70.
 -/
-@[category test]
+@[category test, AMS 11]
 lemma lcmInterval_lt_example1 : lcmInterval 104 8 < lcmInterval 96 7 := by decide
 
 /--
@@ -42,21 +42,21 @@ The referee of [Er79] found the example $M(132, 7) > M(139, 8)$, showing that th
 $M(n, k) > M(m, k + 1)$ with $m \geq n + k$.
 [Er79] Erdős, Paul, Some unconventional problems in number theory. Math. Mag. (1979), 67-70.
 -/
-@[category test]
+@[category test, AMS 11]
 lemma lcmInterval_lt_example2 : lcmInterval 139 8 < lcmInterval 132 7 := by decide
 
 /--
 Cambie [Ca24] found the example $M(52, 7) > M(62, 8)$.
 [Ca24] S. Cambie, Resolution of an Erdős' problem on least common multiples. arXiv:2410.09138 (2024).
 -/
-@[category test]
+@[category test, AMS 11]
 lemma lcmInterval_lt_example3 : lcmInterval 62 8 < lcmInterval 52 7 := by decide
 
 /--
 Cambie [Ca24] found the example $M(36, 8) > M(48, 9)$.
 [Ca24] S. Cambie, Resolution of an Erdős' problem on least common multiples. arXiv:2410.09138 (2024).
 -/
-@[category test]
+@[category test, AMS 11]
 lemma lcmInterval_lt_example4 : lcmInterval 47 9 < lcmInterval 36 8 := by decide
 
 /--

--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -46,7 +46,7 @@ theorem erdos_730.variants.explicit_pairs :
 /--
 Show that for all $n$, the binomial coefficient $\binom{2n}{n}$ is even.
 -/
-@[category high_school]
+@[category high_school, AMS 11]
 theorem erdos_730.variants.two_div_forall (n : ℕ) (h : 0 < n) : 2 ∣ (2*n).choose n := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/9.lean
+++ b/FormalConjectures/ErdosProblems/9.lean
@@ -28,7 +28,7 @@ The set of odd numbers that cannot be expressed as a prime plus two powers of 2.
 def Erdos9A : Set ℕ := { n | Odd n ∧ ¬ ∃ (p k l : ℕ), (Nat.Prime p) ∧ n = p + 2 ^ k + 2 ^ l }
 
 
-@[category test, AMS 11]
+@[category test, AMS 5 11]
 example : 1 ∈ Erdos9A := by
   constructor
   · decide
@@ -36,7 +36,7 @@ example : 1 ∈ Erdos9A := by
     intro p k l hp
     linarith [Nat.Prime.two_le hp, @Nat.one_le_two_pow k, @Nat.one_le_two_pow l]
 
-@[category test, AMS 11]
+@[category test, AMS 5 11]
 example : 3 ∈ Erdos9A := by
   constructor
   · decide
@@ -44,7 +44,7 @@ example : 3 ∈ Erdos9A := by
     intro p k l hp
     linarith [Nat.Prime.two_le hp, @Nat.one_le_two_pow k, @Nat.one_le_two_pow l]
 
-@[category test, AMS 11]
+@[category test, AMS 5 11]
 example : 5 ∉ Erdos9A := by
   unfold Erdos9A
   simp only [exists_and_left, not_exists, not_and, Set.mem_setOf_eq, not_forall, Classical.not_imp,

--- a/FormalConjectures/ErdosProblems/9.lean
+++ b/FormalConjectures/ErdosProblems/9.lean
@@ -28,7 +28,7 @@ The set of odd numbers that cannot be expressed as a prime plus two powers of 2.
 def Erdos9A : Set ℕ := { n | Odd n ∧ ¬ ∃ (p k l : ℕ), (Nat.Prime p) ∧ n = p + 2 ^ k + 2 ^ l }
 
 
-@[category test]
+@[category test, AMS 11]
 example : 1 ∈ Erdos9A := by
   constructor
   · decide
@@ -36,7 +36,7 @@ example : 1 ∈ Erdos9A := by
     intro p k l hp
     linarith [Nat.Prime.two_le hp, @Nat.one_le_two_pow k, @Nat.one_le_two_pow l]
 
-@[category test]
+@[category test, AMS 11]
 example : 3 ∈ Erdos9A := by
   constructor
   · decide
@@ -44,7 +44,7 @@ example : 3 ∈ Erdos9A := by
     intro p k l hp
     linarith [Nat.Prime.two_le hp, @Nat.one_le_two_pow k, @Nat.one_le_two_pow l]
 
-@[category test]
+@[category test, AMS 11]
 example : 5 ∉ Erdos9A := by
   unfold Erdos9A
   simp only [exists_and_left, not_exists, not_and, Set.mem_setOf_eq, not_forall, Classical.not_imp,

--- a/FormalConjectures/Paper/Kurepa.lean
+++ b/FormalConjectures/Paper/Kurepa.lean
@@ -54,7 +54,7 @@ theorem kurepa_conjecture.variant.prime (p : ℕ) (h_p : 2 < p) :
   sorry
 
 -- TODO(firsching): show equivalence
-@[category undergraduate]
+@[category undergraduate, AMS 11]
 theorem kurepa_conjecture.prime_reduction  : (∀ n, ∀ h_n : 2 < n, (!n : ℕ) % n ≠ 0)
     ↔ (∀ p, ∀ h_p : 2 < p, p.Prime → (!p : ℕ) % p ≠ 0) := by
   sorry
@@ -67,7 +67,7 @@ theorem kurepa_conjecture.variant.gcd (n : ℕ) : 2 < n → (n !).gcd (! n) = 2 
   sorry
 
 -- TODO(firsching): show equivalence
-@[category undergraduate]
+@[category undergraduate, AMS 11]
 theorem kurepa_conjecture.gcd_reduction : (∀ n, ∀ h_n : 2 < n, (!n : ℕ) % n ≠ 0)
     ↔ (∀ n,  2 < n → (n !).gcd (! n) = 2) := by
   sorry

--- a/FormalConjectures/Wikipedia/ABC.lean
+++ b/FormalConjectures/Wikipedia/ABC.lean
@@ -26,7 +26,7 @@ The radical of `n` denoted is the product of the distinct prime factors of `n`.
 -/
 def radical (n : ℕ) : ℕ := n.primeFactors.prod id
 
-@[category test]
+@[category test, AMS 11]
 example : radical 16 = 2 := by
   have : Nat.primeFactors 16 = {2} := by
     rw [show 16 = 2 ^ 4 by decide, Nat.primeFactors_pow]
@@ -34,11 +34,11 @@ example : radical 16 = 2 := by
     · decide
   norm_num [radical, this]
 
-@[category test]
+@[category test, AMS 11]
 example : radical 17 = 17 := by
   rw [radical, Nat.Prime.primeFactors (by norm_num), Finset.prod_singleton, id]
 
-@[category test]
+@[category test, AMS 11]
 example : radical 12 = 6 := by
   rw [radical, show 12 = 2^2 * 3 by rfl, Nat.primeFactors_mul (by norm_num)
     (by norm_num), Nat.primeFactors_pow _ (by norm_num),

--- a/FormalConjectures/Wikipedia/CongruentNumber.lean
+++ b/FormalConjectures/Wikipedia/CongruentNumber.lean
@@ -31,28 +31,28 @@ def congruentNumber (n : ℕ) : Prop :=
   ∃ (a b c : ℚ), a ^ 2 + b ^ 2 = c ^ 2 ∧ n = (2⁻¹ : ℚ) * a * b
 
 /- 1 is not a congruent number. -/
-@[category test]
+@[category test, AMS 11]
 example : ¬ congruentNumber 1 := by
   sorry
 
 /- 5, 6, 7, and 157 are congruent numbers. -/
-@[category test]
+@[category test, AMS 11]
 example : congruentNumber 5 := by
   use 3 / 2, 20 / 3, 41 / 6
   norm_num
 
-@[category test]
+@[category test, AMS 11]
 example : congruentNumber 6 := by
   use 3, 4, 5
   norm_num
 
-@[category test]
+@[category test, AMS 11]
 example : congruentNumber 7 := by
   use 35 / 12, 24 / 5, 337 / 60
   norm_num
 
 /- Zagier's example -/
-@[category test]
+@[category test, AMS 11]
 example : congruentNumber 157 := by
   use 411340519227716149383203 / 21666555693714761309610,
     6803298487826435051217540 / 411340519227716149383203,

--- a/FormalConjectures/Wikipedia/Hadamard.lean
+++ b/FormalConjectures/Wikipedia/Hadamard.lean
@@ -44,7 +44,7 @@ Both definitions are equivalent.
 
 TOOD(firsching): complete and golf the proof
 -/
-@[category test]
+@[category test, AMS 15]
 example (n : ℕ) (M : Matrix (Fin n) (Fin n) ℝ) : IsHadamard' M ↔ IsHadamard M := by
   simp [IsHadamard, IsHadamard']
   intro h
@@ -85,7 +85,7 @@ There exists a Hadamard matrix for all $n = 4k$.
 theorem HadamardConjecture (k : ℕ) : ∃ M, IsHadamard (n := 4 * k) M := by
   sorry
 
-@[category test]
+@[category test, AMS 15]
 example : ∃ M, IsHadamard (n := 0) M := by
   use 0
   simp [IsHadamard]
@@ -109,7 +109,7 @@ def H12 : Matrix (Fin 12) (Fin 12) ℝ :=
 /--
 which satisifies the condition.
 -/
-@[category test]
+@[category test, AMS 15]
 example : IsHadamard H12 := by
   sorry
 

--- a/FormalConjectures/Wikipedia/Hall.lean
+++ b/FormalConjectures/Wikipedia/Hall.lean
@@ -46,7 +46,7 @@ theorem hall_conjecture : HallConjectureExp 2⁻¹ := by
 Elkies' example $(x, y) = (5853886516781223, 447884928428402042307918)$ shows that such $C$ must be
 less than $0.0215$. Note that simple `linarith` does not work here.
 -/
-@[category test]
+@[category test, AMS 11]
 theorem elkies_bound (C : ℝ) : HallIneq C 2⁻¹ → C < 0.0215 := by
   intro h
   by_cases hC : C ≤ 0

--- a/FormalConjectures/Wikipedia/Mandelbrot.lean
+++ b/FormalConjectures/Wikipedia/Mandelbrot.lean
@@ -45,7 +45,7 @@ abbrev mandelbrotSet := multibrotSet 2
 
 /-- The `multibrotSet n` is equivalently the set of all parameters `c` for which the orbit of `0`
 under `z ↦ z ^ n + c` does not leave the closed disk of radius `2 ^ (n - 1)⁻¹` around the origin. -/
-@[category API]
+@[category API, AMS 37]
 theorem multibrotSet_eq {n : ℕ} (hn : 2 ≤ n) :
     multibrotSet n = {c | ∀ k, ‖(fun z ↦ z ^ n + c)^[k] 0‖ ≤ 2 ^ (n - 1 : ℝ)⁻¹} := by
   replace hn := one_lt_two.trans_le hn
@@ -95,7 +95,7 @@ theorem multibrotSet_eq {n : ℕ} (hn : 2 ≤ n) :
 
 /-- The mandelbrot set is equivalently the set of all parameters `c` for which the orbit of `0`
 under `z ↦ z ^ 2 + c` does not leave the closed disk of radius two around the origin. -/
-@[category API]
+@[category API, AMS 37]
 theorem mandelbrotSet_eq : mandelbrotSet = {c | ∀ k, ‖(fun z ↦ z ^ 2 + c)^[k] 0‖ ≤ 2} := by
   simpa [show (2 - 1 : ℝ) = 1 by norm_num] using multibrotSet_eq le_rfl
 
@@ -118,19 +118,19 @@ def IsAttractingCycle (f : ℂ → ℂ) (n : ℕ) (z : ℂ) : Prop :=
   f.IsPeriodicPt n z ∧ DifferentiableAt ℂ f^[n] z ∧ ‖deriv f^[n] z‖ < 1
 
 /-- For example, `0` is part of an attracting `2`-cycle of `z ↦ z ^ 2 - 1`. -/
-@[category test]
+@[category test, AMS 37]
 example : IsAttractingCycle (fun z ↦ z ^ 2 - 1) 2 0 :=
   ⟨by simp [IsPeriodicPt, IsFixedPt], by fun_prop, by simp [deriv_comp]⟩
 
 /-- On the other hand, while `2` is part of a `1`-cycle of `z ↦ z ^ 2 - 2`, that cycle is not
 attracting. -/
-@[category test]
+@[category test, AMS 37]
 example : ¬ IsAttractingCycle (fun z ↦ z ^ 2 - 2) 1 2 := by
   simp [IsAttractingCycle, show (1 : ℝ) ≤ 2 * 2 by norm_num]
 
 /-- No function has an attracting cycle of period `0`. This is important in that it means we don't
 need to require `0 < n` in the conjectures below. -/
-@[category test]
+@[category test, AMS 37]
 example (f : ℂ → ℂ) (z : ℂ) : ¬ IsAttractingCycle f 0 z := by
   simp [IsAttractingCycle]
 
@@ -151,7 +151,7 @@ theorem density_of_hyperbolicity_general_exponent {n : ℕ} (hn : 2 ≤ n) :
 
 /-- The boundary of any Multibrot set is measurable because it is closed, so it makes sense to
 ask about its area. -/
-@[category test]
+@[category test, AMS 37]
 example {n : ℕ} : MeasurableSet (frontier (multibrotSet n)) := isClosed_frontier.measurableSet
 
 /-- The boundary of the Mandelbrot set is conjectured to have zero area. -/

--- a/FormalConjectures/Wikipedia/RamanujanTau.lean
+++ b/FormalConjectures/Wikipedia/RamanujanTau.lean
@@ -37,19 +37,19 @@ noncomputable def Δ : PowerSeries ℤ := X * ∏' (n : ℕ+), (1 - X ^ (n : ℕ
 noncomputable def τ (n : ℕ) : ℤ := PowerSeries.coeff ℤ n Δ
 
 
-@[category API]
+@[category API, AMS 11]
 lemma multipliable : Multipliable fun n : ℕ+ ↦ ((1 - X ^ (n : ℕ)) ^ 24 : PowerSeries ℤ) := by
   sorry
 
-@[category test]
+@[category test, AMS 11]
 lemma τ_zero : τ 0 = 0 := by simp [τ, Δ]
 
-@[category test]
+@[category test, AMS 11]
 lemma τ_one : τ 1 = 1 := by
   obtain ⟨i, hi⟩ := by simpa using ((continuous_constantCoeff ℤ).tendsto _).comp multipliable.hasProd
   simp [τ, Δ, hi i]
 
-@[category test]
+@[category test, AMS 11]
 lemma τ_two : τ 2 = -24 := by
   sorry
 

--- a/FormalConjectures/Wikipedia/WolstenholmePrime.lean
+++ b/FormalConjectures/Wikipedia/WolstenholmePrime.lean
@@ -43,18 +43,18 @@ def IsWolstenholmePrime (p : ℕ) : Prop :=
 /--
 Two known Wolstenholme primes: 16843 and 2124679.
 -/
-@[category test]
+@[category test, AMS 11]
 theorem wolstenholme_prime_16483 : IsWolstenholmePrime 16843 := by
   sorry
 
-@[category test]
+@[category test, AMS 11]
 theorem wolstenholme_prime_2124679 : IsWolstenholmePrime 2124679 := by
   sorry
 
 /--
 Equivalently, a prime $p > 7$ is a Wolstenholme prime if it divides the numerator of the Bernoulli number $B_{p-3}$.
 -/
-@[category API]
+@[category API, AMS 11]
 theorem wolstenholme_bernoulli (p : ℕ) : IsWolstenholmePrime p ↔
     (p > 7) ∧ Nat.Prime p ∧ ↑p ∣ (bernoulli' (p - 3)).num := by
   sorry
@@ -63,7 +63,7 @@ theorem wolstenholme_bernoulli (p : ℕ) : IsWolstenholmePrime p ↔
 Another equivalent definition is that a prime $p > 7$ is a Wolstenholme prime
 if it $p^3$ divides the numerator of the harmonic number $H_{p-1}$.
 -/
-@[category test]
+@[category test, AMS 11]
 theorem wolstenholme_harmonic (p : ℕ) : IsWolstenholmePrime p ↔
     (p > 7) ∧ Nat.Prime p ∧ ↑(p ^ 3) ∣ (harmonic (p - 1)).num := by
   sorry


### PR DESCRIPTION
This PR cleans up the build warnings arising from the AMS tag linter (#516)