### PR TITLE
feat: Improve linter warnings 

### DIFF
--- a/FormalConjectures/Util/Linters/AMSLinter.lean
+++ b/FormalConjectures/Util/Linters/AMSLinter.lean
@@ -51,25 +51,28 @@ def AMSLinter : Linter where
       | `(command| $a:declModifiers lemma $_ $_:bracketedBinder* : $_ := $_)
       | `(command| $a:declModifiers example $_:bracketedBinder* : $_ := $_) =>
         let ams ← toAMS a
+        let outStx := match a with
+        | `(declModifiers| $(_)? $atts $(_)? $(_)? $(_)? $(_)?) => atts.raw
+        | _ => stx
         if ams.size > 1 then
           let numerals := ams.flatten
           let outCorrect := m!"{← mkAMSSyntax numerals}"
           let currentOut := m!", ".joinSep (← ams.mapM fun nums ↦ do return m!"{← mkAMSSyntax nums}").toList
-          logWarningAt stx m!"The AMS tag should be formatted as {outCorrect} rather than {currentOut}"
+          logWarningAt outStx m!"The AMS tag should be formatted as {outCorrect} rather than {currentOut}"
           return
         if ams.size == 0 then
-          logWarningAt stx "Missing AMS attribute."
+          logWarningAt outStx "Missing AMS attribute."
           return
         if ams.flatten.isEmpty then
           -- If we're here then there is at least one AMS tag, but it doesn't have any number.
-          logWarningAt stx "The AMS tag should have at least one subject number."
+          logWarningAt outStx "The AMS tag should have at least one subject number."
         -- Check there the AMS tags are sorted and do not contain duplicates
         let ams_sorted := ams.flatten.qsort (fun n m => n.getNat < m.getNat)
         if ams_sorted != ams.flatten then
-          logWarningAt stx m!"The AMS tags should be ordered as {← mkAMSSyntax ams_sorted}"
+          logWarningAt outStx m!"The AMS tags should be ordered as {← mkAMSSyntax ams_sorted}"
           return
         if ams_sorted.dedupSorted != ams_sorted then
-          logWarningAt stx m!"AMS tags contain duplicates. This should be {← mkAMSSyntax ams_sorted.dedupSorted}"
+          logWarningAt outStx m!"AMS tags contain duplicates. This should be {← mkAMSSyntax ams_sorted.dedupSorted}"
       | _ => return
 
 initialize do

--- a/FormalConjectures/Util/Linters/CategoryLinter.lean
+++ b/FormalConjectures/Util/Linters/CategoryLinter.lean
@@ -40,6 +40,7 @@ private def toCategory
       | _ => return false
   | _ => return #[]
 
+#check Command.declModifiers
 
 /-- The problem category linter checks that every theorem/lemma/example
 has been given a problem category attribute. -/
@@ -50,7 +51,11 @@ def problemStatusLinter : Linter where
       | `(command| $a:declModifiers lemma $_ $_:bracketedBinder* : $_ := $_)
       | `(command| $a:declModifiers example $_:bracketedBinder* : $_ := $_) =>
         let prob_status ← toCategory a
-        if prob_status.size == 0 then logWarningAt stx "Missing problem category attribute"
+        if prob_status.size == 0 then
+          let outStx := match a with
+          | `(declModifiers| $(_)? $atts $(_)? $(_)? $(_)? $(_)?) => atts.raw
+          | _ => stx
+          logWarningAt outStx "Missing problem category attribute"
       | _ => return
 
 initialize do

--- a/FormalConjectures/Util/Linters/CategoryLinterTest.lean
+++ b/FormalConjectures/Util/Linters/CategoryLinterTest.lean
@@ -70,3 +70,4 @@ theorem test_1 : 1 + 1 = 2 := by
 @[category research open, simp]
 theorem test_3 : 1 + 1 = 2 := by
   rfl
+

--- a/FormalConjectures/Util/Linters/CopyrightLinter.lean
+++ b/FormalConjectures/Util/Linters/CopyrightLinter.lean
@@ -48,7 +48,8 @@ def copyrightLinter : Linter where run := withSetOptionIn fun stx ↦ do
   -- Get the syntax corresponding to the first character in the file since that's where the warning
   -- message will be logged.
   let startingStx : Syntax := .atom (.synthetic ⟨0⟩ ⟨1⟩) <| source.extract ⟨0⟩ ⟨1⟩
-  unless correctCopyrightHeader.data.IsPrefix source.data do
+  -- We don't want to output an error message when building `FormalConjectures.All`
+  unless (← getFileName) == "FormalConjectures.All" || correctCopyrightHeader.data.IsPrefix source.data do
     Lean.Linter.logLint linter.style.copyright startingStx <|
     "The copyright header is incorrect. Please copy and paste the following one:\n"
       ++ correctCopyrightHeader


### PR DESCRIPTION
This PR improves the warning messages from the category and AMS tag linters and prevents the header linter from firing on the file `FormalConjectures.All`.