### PR TITLE
AlphaProof solutions for `kurepa_conjecture.prime_reduction` and `kurepa_conjecture.gcd_reduction`

### DIFF
--- a/FormalConjectures/Paper/Kurepa.lean
+++ b/FormalConjectures/Paper/Kurepa.lean
@@ -22,7 +22,7 @@ import FormalConjectures.Util.ProblemImports
 
 -/
 
-open BigOperators Nat
+open BigOperators Nat Finset
 
 /--
 Left factorial of n
@@ -53,11 +53,30 @@ theorem kurepa_conjecture.variant.prime (p : ℕ) (h_p : 2 < p) :
     p.Prime → (!p : ℕ) % p ≠ 0 := by
   sorry
 
--- TODO(firsching): show equivalence
 @[category undergraduate, AMS 11]
-theorem kurepa_conjecture.prime_reduction  : (∀ n, ∀ h_n : 2 < n, (!n : ℕ) % n ≠ 0)
-    ↔ (∀ p, ∀ h_p : 2 < p, p.Prime → (!p : ℕ) % p ≠ 0) := by
-  sorry
+theorem kurepa_conjecture.prime_reduction  : (∀ n, 2 < n → (!n : ℕ) % n ≠ 0)
+    ↔ (∀ p, 2 < p → p.Prime → (!p : ℕ) % p ≠ 0) := by
+  refine ⟨fun h p hp hp_prime ↦ h p hp, fun h n hn h_mod ↦ ?_⟩
+  have : n.primeFactorsList.prod ≠ n := by
+    have (p : ℕ) (h_mem: p ∈ n.primeFactorsList) : p = 2 := by
+      have hp : p.Prime := prime_of_mem_primeFactorsList h_mem
+      refine hp.eq_two_or_odd.resolve_right fun _ ↦ ?_
+      have : p ∣ ∑ a ∈ range n, (a)! := .trans (by simp [left_factorial])
+        (dvd_of_mem_primeFactorsList h_mem |>.trans (dvd_of_mod_eq_zero h_mod))
+      rw [← CharP.cast_eq_zero_iff (ZMod p), cast_sum, ← sum_subset (range_subset.2
+        (le_of_mem_primeFactorsList h_mem)) (fun _ _ _ ↦ CharP.cast_eq_zero_iff _ p _ |>.2 <|
+        hp.dvd_factorial.2 <| by aesop), ← cast_sum, CharP.cast_eq_zero_iff _ p] at this
+      exact h p (hp.two_le.lt_of_ne (by omega)) hp <| mod_eq_zero_of_dvd this
+    rw [List.prod_eq_pow_card _ 2 this]
+    intro h
+    have : 4 ∣ n :=
+      h ▸ pow_dvd_pow 2 ((Nat.pow_lt_pow_iff_right (n := 1) one_lt_two).1 (by linarith))
+    have : 4 ∣ (!n : ℕ) := this.trans (dvd_of_mod_eq_zero h_mod)
+    match n with
+    | S + 4 =>
+      simp_arith [left_factorial, mod_eq_zero_of_dvd ∘ Nat.dvd_factorial _,
+        dvd_iff_mod_eq_zero,Nat.add_mod, Finset.sum_nat_mod, Finset.sum_range_succ'] at this
+  exact this <| prod_primeFactorsList hn.ne_bot
 
 /--
 An equivalent formulation in terms of the gcd of $n!$ and $!n$.
@@ -66,11 +85,29 @@ An equivalent formulation in terms of the gcd of $n!$ and $!n$.
 theorem kurepa_conjecture.variant.gcd (n : ℕ) : 2 < n → (n !).gcd (! n) = 2 := by
   sorry
 
--- TODO(firsching): show equivalence
 @[category undergraduate, AMS 11]
-theorem kurepa_conjecture.gcd_reduction : (∀ n, ∀ h_n : 2 < n, (!n : ℕ) % n ≠ 0)
-    ↔ (∀ n,  2 < n → (n !).gcd (! n) = 2) := by
-  sorry
+theorem kurepa_conjecture.gcd_reduction : (∀ n, 2 < n → (!n : ℕ) % n ≠ 0)
+    ↔ (∀ n, 2 < n → (n)!.gcd (!n) = 2) := by
+  refine ⟨fun h n hn ↦ match n with | S + 1 => gcd_eq_iff.2 ?_,
+    fun h n hn _ ↦ n.not_dvd_of_pos_of_lt (by omega) hn <| h n hn ▸ n.dvd_gcd
+      (n.dvd_factorial hn.pos le_rfl) (dvd_of_mod_eq_zero ‹_›)⟩
+  refine ⟨Nat.factorial_dvd_factorial hn.le, ?_, fun c hc h_dvd ↦ ?_⟩
+  · match S with
+    | S+1 => simp [mod_eq_zero_of_dvd ∘ dvd_factorial _, dvd_iff_mod_eq_zero, add_mod,
+        sum_nat_mod, sum_range_succ', left_factorial]
+  · have hc' : c ≤ S + 1 := by
+      by_contra
+      apply h c (by omega) (c.mod_eq_zero_of_dvd ?_)
+      exact (sum_range_add_sum_Ico _ (le_of_not_ge ‹_›)).subst
+        (h_dvd.add (dvd_sum fun _ h => hc.trans <| Nat.factorial_dvd_factorial (by aesop)))
+    rw [dvd_iff_mod_eq_zero, left_factorial, sum_nat_mod, ← sum_subset (range_mono hc')
+      (by simp_arith +contextual [mod_eq_zero_of_dvd, dvd_factorial,
+        pos_of_dvd_of_pos hc (factorial_pos _)])] at h_dvd
+    refine by_contra fun _ ↦ h c ?_ (sum_nat_mod _ _ _ ▸ h_dvd)
+    match c with
+    | 0 => field_simp [Ne.symm] at hc
+    | 1 => trivial
+    | S + 3 => omega
 
 /--
 Sanity check: for small values we can just compute that the conjecture is true


### PR DESCRIPTION
Proofs for API results in `Kurepa.lean`, adapted from AlphaProof.