### PR TITLE
Strengthen `erdos_868.variants.Hartter_Nathanson`

### DIFF
--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -68,7 +68,7 @@ theorem erdos_868.variants.fixed_ε :
 /-- Härtter and Nathanson proved that there exist additive bases which do not contain
 any minimal additive bases. -/
 @[category research solved, AMS 5 11]
-theorem erdos_868.variants.Hartter_Nathanson : ∃ᵉ (A : Set ℕ) (o > 1),
+theorem erdos_868.variants.Hartter_Nathanson (o : ℕ) (ho : 1 < o) : ∃ (A : Set ℕ),
     A.IsAsymptoticAddBasisOfOrder o ∧ ∀ B ⊆ A, B.IsAsymptoticAddBasisOfOrder o →
     ∃ b ∈ B, (B \ {b}).IsAsymptoticAddBasisOfOrder o := by
   sorry


### PR DESCRIPTION
While the current formalisation is valid, [one of the referenced papers](https://www.sciencedirect.com/science/article/pii/0022314X74900286) for this variant shows that the result holds for all orders `> 1` so we may as well strengthen our formalisation to match. 