### PR TITLE
Erdős Problem 30

### DIFF
--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -31,7 +31,7 @@ noncomputable abbrev h := maxSidonSetSize
 open Filter
 
 /--
-Is it true that, for every $\varepsilon > 0$, $h(N) = \sqrt N + O_{\varespilon}(N_{\varespilon})
+Is it true that, for every $\varepsilon > 0$, $h(N) = \sqrt N + O_{\varespilon}(N^\varespilon)
 -/
 @[category research open, AMS 11]
 theorem erdos_30 :

--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 30
+
+*Reference:* [erdosproblems.com/30](https://www.erdosproblems.com/30)
+-/
+
+/--
+Let $h(N)$ be the maximum size of a Sidon set in $\{1, \dots, N\}$.
+-/
+noncomputable abbrev h := maxSidonSetSize
+
+
+open Filter
+
+/--
+Is it true that, for every $\varepsilon > 0$, $h(N) = \sqrt N + O_{\varespilon}(N_{\varespilon})
+-/
+@[category research open, AMS 11]
+theorem erdos_30 :
+    (∀ᵉ (ε > 0), (fun N => h N - (N : Real).sqrt) =O[atTop] fun N => (N : ℝ)^(ε : ℝ))
+    ↔ answer(sorry) := by
+  sorry
+
+-- TODO(firsching): add the various known bounds as variants.

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -24,16 +24,6 @@ import FormalConjectures.Util.ProblemImports
 
 open Function Set
 
-/-- The maximum size of a Sidon set in `{1, ..., N}`. -/
-noncomputable def maxSidonSetSize (N : ℕ) : ℕ :=
-  sSup {(A.card) | (A : Finset ℕ) (_ : A ⊆ Finset.Icc 1 N) (_ : IsSidon A.toSet)}
-
-/-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `√N + 1`. -/
-@[category undergraduate, AMS 5 11]
-theorem maxSidonSetSize_bound (N : ℕ) (hN : 1 ≤ N) :
-    maxSidonSetSize N ≤ N.sqrt + 1 := by
-  sorry
-
 /--
 **Erdős Problem 44:** Let N ≥ 1 and `A ⊆ {1,…,N}` be a Sidon set. Is it true that, for any ε > 0,
 there exist M = M(ε) and `B ⊆ {N+1,…,M}` such that `A ∪ B ⊆ {1,…,M}` is a Sidon set

--- a/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjectures.ForMathlib.Combinatorics.AP.Basic
+import Mathlib.Data.Nat.Lattice
 
 open Function Set
 
@@ -28,3 +29,8 @@ def IsSidon (A : Set α) : Prop := ∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A)
 lemma IsSidon.avoids_isAPOfLength_three {α : Type*} [AddCommMonoid α] (A : Set ℕ) (hA : IsSidon A) :
     (∀ Y, IsAPOfLength Y 3 → (A ∩ Y).ncard ≤ 2) := by
   sorry
+
+/-- The maximum size of a Sidon set in `{1, ..., N}`. -/
+noncomputable def maxSidonSetSize (N : ℕ) : ℕ :=
+  sSup {(A.card) | (A : Finset ℕ) (_ : A ⊆ Finset.Icc 1 N) (_ : IsSidon A.toSet)}
+


### PR DESCRIPTION
closes #205 

deleting `maxSidonSetSize_bound`, since this seems to be 
 - not used anywhere
 -  wrong