### PR TITLE
fix: `k` should be non-zero in `conjecture_3_4`

### DIFF
--- a/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
+++ b/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
@@ -24,7 +24,7 @@ _On the Approximation of Quantum Gates using Lattices_
 by *Alec Greene and Steven Damelin*
 -/
 
-open scoped EuclideanSpace
+open scoped EuclideanSpace RealInnerProductSpace
 
 /-- The integer lattice ℤ⁴ as the ℤ-span of the standard basis in 4-dimensional Euclidean space. -/
 scoped[EuclideanSpace] notation "ℤ⁴" => Submodule.span ℤ (Set.range (PiLp.basisFun 2 ℝ (Fin 4)))
@@ -37,8 +37,8 @@ There exists $0 < \delta < 1$ such that for any $a \in \mathbb{S}^3$,
 there exists $b \in \mathbb{Z}^4$ and $k \in \mathbb{Z}$ such that $\|b\| = 5^k$ and
 $\langle a, \frac{b}{\|b\|} \rangle \geq 1 - 5^{-\frac{k}{2 - \delta}}.$
 -/
-@[category research open, AMS 81 11]
+@[category research open, AMS 11 81]
 theorem conjecture_3_4 : ∃ δ ∈ Set.Ioo (0 : ℝ) 1,
     ∀ (a : EuclideanSpace ℝ (Fin 4)) (ha : ‖a‖ = 1), ∃ (b : ℤ⁴) (k : ℕ), k > 0 ∧ ‖b‖ = 5 ^ k ∧
-      inner a (‖b‖⁻¹ • b) ≥ 1 - (5 : ℝ) ^ (-k / (2 - δ)) := by
+      1 - 5 ^ (-k / (2 - δ)) ≤ ⟪a, (‖b‖⁻¹ • b)⟫ := by
   sorry

--- a/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
+++ b/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
@@ -29,8 +29,6 @@ open scoped EuclideanSpace RealInnerProductSpace
 /-- The integer lattice ℤ⁴ as the ℤ-span of the standard basis in 4-dimensional Euclidean space. -/
 scoped[EuclideanSpace] notation "ℤ⁴" => Submodule.span ℤ (Set.range (PiLp.basisFun 2 ℝ (Fin 4)))
 
-instance : IsZLattice ℝ ℤ⁴ := ZSpan.isZLattice _
-
 /--
 *Conjecture 3.4*
 There exists $0 < \delta < 1$ such that for any $a \in \mathbb{S}^3$,

--- a/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
+++ b/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
@@ -38,7 +38,7 @@ there exists $b \in \mathbb{Z}^4$ and $k \in \mathbb{Z}$ such that $\|b\| = 5^k$
 $\langle a, \frac{b}{\|b\|} \rangle \geq 1 - 5^{-\frac{k}{2 - \delta}}.$
 -/
 @[category research open, AMS 81 11]
-theorem conjecture_3_4 : ∃ (δ : ℝ), 0 < δ ∧ δ < 1 ∧
-    ∀ (a : EuclideanSpace ℝ (Fin 4)) (ha : ‖a‖ = 1), ∃ (b : ℤ⁴) (k : ℤ), ‖b‖ = 5 ^ k ∧
+theorem conjecture_3_4 : ∃ δ ∈ Set.Ioo (0 : ℝ) 1,
+    ∀ (a : EuclideanSpace ℝ (Fin 4)) (ha : ‖a‖ = 1), ∃ (b : ℤ⁴) (k : ℕ), k > 0 ∧ ‖b‖ = 5 ^ k ∧
       inner a (‖b‖⁻¹ • b) ≥ 1 - (5 : ℝ) ^ (-k / (2 - δ)) := by
   sorry

--- a/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
+++ b/FormalConjectures/Arxiv/1506.05785/MaximumAngle.lean
@@ -38,5 +38,5 @@ $\langle a, \frac{b}{\|b\|} \rangle \geq 1 - 5^{-\frac{k}{2 - \delta}}.$
 @[category research open, AMS 11 81]
 theorem conjecture_3_4 : ∃ δ ∈ Set.Ioo (0 : ℝ) 1,
     ∀ (a : EuclideanSpace ℝ (Fin 4)) (ha : ‖a‖ = 1), ∃ (b : ℤ⁴) (k : ℕ), k > 0 ∧ ‖b‖ = 5 ^ k ∧
-      1 - 5 ^ (-k / (2 - δ)) ≤ ⟪a, (‖b‖⁻¹ • b)⟫ := by
+      1 - 5 ^ (-k / (2 - δ)) ≤ ⟪a, ‖b‖⁻¹ • b⟫ := by
   sorry


### PR DESCRIPTION
- If we allow `k = 0` this gives an easy solution of `conjecture_3_4` because then we only have to find a unit vector `b` with `⟪a, b⟫ ≥ 0`.
- The `IsZLattice` instance does not seem to be needed.
- Styling fixes.