### PR TITLE
fix: `conjecture6_3` distribution function -> density function

### DIFF
--- a/FormalConjectures/Arxiv/0911.2077/Conjecture6_3.lean
+++ b/FormalConjectures/Arxiv/0911.2077/Conjecture6_3.lean
@@ -28,7 +28,7 @@ open NNReal ENNReal ProbabilityTheory
 
 
 /-- As usual, let $\Phi$ and $\phi$ be the distribution function and density of the standard normal. -/
-local notation "Φ" => gaussianPDFReal 0 1
+local notation "Φ" => cdf (gaussianReal 0 1)
 
 /--
 Empirical evidence seems to suggest that Slud's bound does not hold for all $p$, and in fact, as $n\to\infty$,
@@ -42,11 +42,11 @@ $$
 -/
 @[category research open, AMS 60]
 theorem arxiv.id0911_2077.conjecture6_3
-  (p : ℝ) (h_p : p ∈ Set.Ioo 0 (1 / 2)) (k : ℕ) (hk : 0 < k)
-  (σ : ℝ) (h_σ : σ = (p * (1 - p)).sqrt) :
-  letI hp' : (.ofReal p : ℝ≥0∞) ≤ 1 := ENNReal.ofReal_le_one.mpr <|
-    le_trans (le_of_lt (Set.mem_Ioo.mp h_p).right) (by linarith)
-  1 - Φ ((1 / 2 - p) * sqrt (2 * k : ℝ≥0) / σ)
-    + (1 / 2) * ((2 * k).choose k) * σ ^ (2 * k)
-    ≤ ((PMF.binomial (.ofReal p : ℝ≥0∞) hp' (2 * k)).toMeasure (Set.Ici k)).toReal := by
+    (p : ℝ) (h_p : p ∈ Set.Ioo 0 (1 / 2)) (k : ℕ) (hk : 0 < k)
+    (σ : ℝ) (h_σ : σ = (p * (1 - p)).sqrt) :
+    letI hp' : (.ofReal p : ℝ≥0∞) ≤ 1 := ENNReal.ofReal_le_one.mpr <|
+      le_trans (le_of_lt (Set.mem_Ioo.mp h_p).right) (by linarith)
+    1 - Φ ((1 / 2 - p) * sqrt (2 * k : ℝ≥0) / σ)
+      + (1 / 2) * ((2 * k).choose k) * σ ^ (2 * k)
+      ≤ ((PMF.binomial (.ofReal p : ℝ≥0∞) hp' (2 * k)).toMeasure (Set.Ici k)).toReal := by
   sorry


### PR DESCRIPTION
Conjecture 6.3 in https://arxiv.org/pdf/0911.2077 is stated using the distribution function rather than the density function