### PR TITLE
feat: add theorem for $\pi^{\pi^{\pi^\pi}}$ an integer

### DIFF
--- a/FormalConjectures/Wikipedia/Transcendental.lean
+++ b/FormalConjectures/Wikipedia/Transcendental.lean
@@ -81,6 +81,13 @@ theorem pi_pow_pi_pow_pi_transcendental : Transcendental ℚ (π ^ (π ^ π)) :=
   sorry
 
 /--
+$\pi^{\pi^{\pi^\pi}}$ is transcendental.
+-/
+@[category research open, AMS 11 33]
+theorem pi_pow_pi_pow_pi_pow_pi_transcendental : Transcendental ℚ (π ^ (π ^ (π ^ π))) := by
+  sorry
+
+/--
 $\pi^{\pi^{\pi^\pi}}$ is not an integer.
 
 This would follow from $\pi^{\pi^{\pi^\pi}}$ being transcendental,

--- a/FormalConjectures/Wikipedia/Transcendental.lean
+++ b/FormalConjectures/Wikipedia/Transcendental.lean
@@ -96,7 +96,7 @@ as it could in principle be proven by direct computation.
 
 *Reference:* [YouTube](https://www.youtube.com/watch?v=BdHFLfv-ThQ)
 -/
-@[category research open, AMS 11]
+@[category research open, AMS 11 33]
 theorem pi_pow_pi_pow_pi_pow_pi_not_integer : ¬ ∃ (n : ℤ), π ^ π ^ π ^ π = n :=
   sorry
 

--- a/FormalConjectures/Wikipedia/Transcendental.lean
+++ b/FormalConjectures/Wikipedia/Transcendental.lean
@@ -81,6 +81,19 @@ theorem pi_pow_pi_pow_pi_transcendental : Transcendental ℚ (π ^ (π ^ π)) :=
   sorry
 
 /--
+$\pi^{\pi^{\pi^\pi}}$ is not an integer.
+
+This would follow from $\pi^{\pi^{\pi^\pi}}$ being transcendental,
+but this formulation is of interest in its own right,
+as it could in principle be proven by direct computation.
+
+*Reference:* [YouTube](https://www.youtube.com/watch?v=BdHFLfv-ThQ)
+-/
+@[category research open, AMS 11]
+theorem pi_pow_pi_pow_pi_pow_pi_not_integer : ¬ ∃ (n : ℤ), π ^ π ^ π ^ π = n :=
+  sorry
+
+/--
 $\log(\pi)$ is transcendental.
 -/
 @[category research open, AMS 11 33]


### PR DESCRIPTION
This PR fixes #592.

It adds the conjecture that $\pi^{\pi^{\pi^\pi}}$ is not an integer.

This is similar to questions already in the `Transcendental` file, and would follow from $\pi^{\pi^{\pi^\pi}}$ being transcendental (which I have taken the liberty of adding as well), so we include it there.

But this formulation about being an integer is of interest in its own right, as it could in principle be proven by direct computation. See this [YouTube Video](https://www.youtube.com/watch?v=BdHFLfv-ThQ) for more discussion.
