### PR TITLE
Erdős Problem 723

### DIFF
--- a/FormalConjectures/ErdosProblems/723.lean
+++ b/FormalConjectures/ErdosProblems/723.lean
@@ -1,0 +1,55 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 723
+
+Also known as the prime power conjecture.
+
+*Reference:* [erdosproblems.com/723](https://www.erdosproblems.com/723)
+-/
+
+open Configuration
+
+namespace Erdos723
+
+variable {P L : Type} [Membership P L]
+
+/--
+If there is a finite projective plane of order $n$ then must $n$ be a prime power?
+-/
+@[category research open, AMS 5]
+theorem erdos_732 : (∀ pp : ProjectivePlane P L, IsPrimePow pp.order) ↔ answer(sorry) := by
+  sorry
+
+/--
+These always exist if $n$ is a prime power.
+-/
+@[category research solved, AMS 5]
+theorem erdos_732.prime_pow_is_projplane_order :
+    ∀ n, IsPrimePow n → ∃ pp : ProjectivePlane P L, pp.order = n := by
+  sorry
+
+/--
+This conjecture has been proved for $n \leq 11$.
+-/
+@[category research solved, AMS 5]
+theorem erdos_732.leq_11 : ∀ pp : ProjectivePlane P L, pp.order ≤ 11 → IsPrimePow pp.order := by
+  sorry
+
+end Erdos723


### PR DESCRIPTION
Adds [Erdős Problem 723](https://www.erdosproblems.com/723).

I'm not sure if this is actually due to Erdős. This seems to be the Prime Power Conjecture. I looked through the linked paper and I couldn't find it. I think it might be better to move the contents to `FormalConjectures/Other/PrimePower.lean` and import it into `FormalConjectures/ErdosProblems/723.lean`, similar to the Brocard Problem.