### PR TITLE
Abstract `IsSidon` 

### DIFF
--- a/FormalConjectures/ErdosProblems/155.lean
+++ b/FormalConjectures/ErdosProblems/155.lean
@@ -29,7 +29,7 @@ namespace Erdos155
 /--
 Let $F(N)$ be the size of the largest Sidon subset of $\{1, \dots, N\}$.
 -/
-noncomputable abbrev F := maxSidonSetSize
+noncomputable abbrev F := Finset.maxSidonSetSize
 
 /--
 Is it true that for every $k \geq 1$ we have

--- a/FormalConjectures/ErdosProblems/155.lean
+++ b/FormalConjectures/ErdosProblems/155.lean
@@ -29,7 +29,7 @@ namespace Erdos155
 /--
 Let $F(N)$ be the size of the largest Sidon subset of $\{1, \dots, N\}$.
 -/
-noncomputable abbrev F := Finset.maxSidonSetSize
+noncomputable abbrev F (N : ℕ) : ℕ := Finset.IsSidon.maxSubsetCard (Finset.Icc 1 N)
 
 /--
 Is it true that for every $k \geq 1$ we have

--- a/FormalConjectures/ErdosProblems/155.lean
+++ b/FormalConjectures/ErdosProblems/155.lean
@@ -29,7 +29,7 @@ namespace Erdos155
 /--
 Let $F(N)$ be the size of the largest Sidon subset of $\{1, \dots, N\}$.
 -/
-noncomputable abbrev F (N : ℕ) : ℕ := Finset.IsSidon.maxSubsetCard (Finset.Icc 1 N)
+noncomputable abbrev F (N : ℕ) : ℕ := Finset.maxSidonSubsetCard (Finset.Icc 1 N)
 
 /--
 Is it true that for every $k \geq 1$ we have

--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 /--
 Let $h(N)$ be the maximum size of a Sidon set in $\{1, \dots, N\}$.
 -/
-noncomputable abbrev h := Finset.maxSidonSetSize
+noncomputable abbrev h (N : ℕ) : ℕ := Finset.IsSidon.maxSubsetCard (Finset.Icc 1 N)
 
 
 open Filter

--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 /--
 Let $h(N)$ be the maximum size of a Sidon set in $\{1, \dots, N\}$.
 -/
-noncomputable abbrev h := maxSidonSetSize
+noncomputable abbrev h := Finset.maxSidonSetSize
 
 
 open Filter

--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 /--
 Let $h(N)$ be the maximum size of a Sidon set in $\{1, \dots, N\}$.
 -/
-noncomputable abbrev h (N : ℕ) : ℕ := Finset.IsSidon.maxSubsetCard (Finset.Icc 1 N)
+noncomputable abbrev h (N : ℕ) : ℕ := Finset.maxSidonSubsetCard (Finset.Icc 1 N)
 
 
 open Filter

--- a/FormalConjectures/ErdosProblems/329.lean
+++ b/FormalConjectures/ErdosProblems/329.lean
@@ -90,7 +90,7 @@ then the maximum density would be 1.
 -/
 @[category research open, AMS 5 11]
 theorem erdos_329.of_sub_perfectDifferenceSet :
-    (∀ (A : Finset ℕ), IsSidon A.toSet → ∃ (D : Set ℕ) (n : ℕ),
+    (∀ (A : Finset ℕ), IsSidon A → ∃ (D : Set ℕ) (n : ℕ),
       ↑A ⊆ D ∧ IsPerfectDifferenceSet D n) →
     sSup {sidonUpperDensity A | (A : Set ℕ) (_ : IsSidon A)} = 1 := by
   sorry
@@ -102,7 +102,7 @@ can be embedded in a perfect difference set.
 @[category research open, AMS 5 11]
 theorem erdos_329.converse_implication :
     (sSup {sidonUpperDensity A | (A : Set ℕ) (_ : IsSidon A)} = 1) →
-    (∀ (A : Finset ℕ), IsSidon A.toSet → ∃ (D : Set ℕ) (n : ℕ),
+    (∀ (A : Finset ℕ), IsSidon A → ∃ (D : Set ℕ) (n : ℕ),
       ↑A ⊆ D ∧ IsPerfectDifferenceSet D n) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/340.lean
+++ b/FormalConjectures/ErdosProblems/340.lean
@@ -22,19 +22,16 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/340](https://www.erdosproblems.com/340)
 -/
 
-open Filter
+open Filter Finset
 open scoped Real Pointwise
-
-local instance (A : Finset ℕ) : Decidable (IsSidon A.toSet) :=
-  decidable_of_iff (∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A) (j₂ ∈ A), _) <| by rfl
 
 /-- Given a finite Sidon set `A` and a lower bound `m`, `go` finds the smallest number `m' ≥ m`
 such that `A ∪ {m'}` is Sidon. If `A` is empty then this returns the value `m`. Note that
 the lower bound is required to avoid `0` being a contender in some cases. -/
-private def greedySidon.go (A : Finset ℕ) (hA : IsSidon A.toSet) (m : ℕ) :
-    {m' : ℕ // m' ≥ m ∧ m' ∉ A ∧ IsSidon (A ∪ {m'}).toSet} :=
+private def greedySidon.go (A : Finset ℕ) (hA : IsSidon A) (m : ℕ) :
+    {m' : ℕ // m' ≥ m ∧ m' ∉ A ∧ IsSidon (A ∪ {m'})} :=
   if h : A.Nonempty then
-    ⟨Nat.find (IsSidon.exists_insert_ge h hA m), Nat.find_spec (IsSidon.exists_insert_ge h hA m)⟩
+    ⟨Nat.find (hA.exists_insert_ge h m), Nat.find_spec (hA.exists_insert_ge h m)⟩
   else ⟨m, by simp_all [IsSidon]⟩
 
 @[category test, AMS 5]
@@ -50,7 +47,7 @@ finite set of numbers generated so far, a proof that it is Sidon, and the greate
 the finite set at that point. This is initialised at `{1}`, then `greedySidon.go` is
 called iteratively using the lower bound `max + 1` to find the next smallest Sidon preserving
 number. -/
-private def greedySidon.aux (n : ℕ) : ({A : Finset ℕ // IsSidon A.toSet} × ℕ) :=
+private def greedySidon.aux (n : ℕ) : ({A : Finset ℕ // IsSidon A} × ℕ) :=
   match n with
   | 0 => (⟨{1}, by simp [IsSidon]⟩, 1)
   | k + 1 =>

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -29,7 +29,7 @@ namespace Erdos44
 -- Reference: https://arxiv.org/pdf/2103.15850
 /-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `2 * √N`. -/
 @[category undergraduate, AMS 5 11]
-theorem maxSidonSetSize_bound (N : ℕ) (hN : 1 ≤ N) :
+theorem maxSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) :
     IsSidon.maxSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -22,7 +22,7 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/44](https://www.erdosproblems.com/44)
 -/
 
-open Function Set
+open Function Set Finset
 
 namespace Erdos44
 
@@ -42,18 +42,18 @@ This problem asks whether any Sidon set can be extended to achieve a density
 arbitrarily close to the optimal density for Sidon sets.
 -/
 @[category undergraduate, AMS 5 11]
-theorem erdos_44 : (∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N), IsSidon A.toSet →
+theorem erdos_44 : (∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N), IsSidon A →
     ∀ᵉ (ε > (0 : ℝ)), ∃ᵉ (M > N) (B ⊆ Finset.Icc (N + 1) M),
-      IsSidon (A ∪ B).toSet ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
+      IsSidon (A ∪ B) ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
   sorry
 
 /--
 A variant considering the extension to any larger range.
 -/
 @[category undergraduate, AMS 5 11]
-theorem erdos_44.variant : (∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N), IsSidon A.toSet →
+theorem erdos_44.variant : (∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N), IsSidon A →
     ∀ᵉ (ε > (0 : ℝ)) (M ≥ N), ∃ᵉ (B ⊆ Finset.Icc (N + 1) M),
-      IsSidon (A ∪ B).toSet ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
+      IsSidon (A ∪ B) ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -61,7 +61,7 @@ The case where we start with an empty set (constructing large Sidon sets).
 -/
 @[category research open, AMS 5 11]
 theorem erdos_44.empty_start : (∀ᵉ (ε > (0 : ℝ)), ∃ᵉ (M : ℕ) (A ⊆ Finset.Icc 1 M),
-    IsSidon A.toSet ∧ (1 - ε) * Real.sqrt M ≤ A.card) ↔ answer(sorry) := by
+    IsSidon A ∧ (1 - ε) * Real.sqrt M ≤ A.card) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -69,8 +69,8 @@ A constructive version asking for explicit bounds on M in terms of ε.
 -/
 @[category research open, AMS 5 11]
 theorem erdos_44.constructive : (∃ (f : ℝ → ℕ), ∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N),
-    IsSidon A.toSet → ∀ᵉ (ε > (0 : ℝ)), ∃ᵉ (M ≤ f ε) (B ⊆ Finset.Icc (N + 1) M),
-      N < M ∧ IsSidon (A ∪ B).toSet ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
+    IsSidon A → ∀ᵉ (ε > (0 : ℝ)), ∃ᵉ (M ≤ f ε) (B ⊆ Finset.Icc (N + 1) M),
+      N < M ∧ IsSidon (A ∪ B) ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
   sorry
 
 /-! ## Related results and examples -/
@@ -79,7 +79,7 @@ theorem erdos_44.constructive : (∃ (f : ℝ → ℕ), ∀ᵉ (N ≥ (1 : ℕ))
 The set `{1, 2, 4, 8, 13}` is a Sidon set in `{1, ..., 13}`.
 -/
 @[category undergraduate, AMS 5 11]
-theorem example_sidon_set : IsSidon {1, 2, 4, 8, 13} := by
+theorem example_sidon_set : IsSidon ({1, 2, 4, 8, 13} : Set ℕ) := by
   sorry
 
 /--
@@ -87,7 +87,7 @@ For any `N`, there exists a Sidon set of size at least `√N/2`.
 -/
 @[category undergraduate, AMS 5 11]
 theorem sidon_set_lower_bound (N : ℕ) (hN : 1 ≤ N) :
-    ∃ᵉ (A ⊆ Finset.Icc 1 N), IsSidon A.toSet ∧ N.sqrt / 2 ≤ A.card := by
+    ∃ᵉ (A ⊆ Finset.Icc 1 N), IsSidon A ∧ N.sqrt / 2 ≤ A.card := by
   sorry
 
 /--
@@ -95,7 +95,7 @@ The greedy construction gives a Sidon set of size approximately `√N`.
 -/
 @[category undergraduate, AMS 5 11]
 theorem greedy_sidon_construction (N : ℕ) (hN : 1 ≤ N) :
-    ∃ᵉ (A ⊆ Finset.Icc 1 N), IsSidon A.toSet ∧ A.card ≥ N.sqrt := by
+    ∃ᵉ (A ⊆ Finset.Icc 1 N), IsSidon A ∧ A.card ≥ N.sqrt := by
   sorry
 
 end Erdos44

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -29,8 +29,8 @@ namespace Erdos44
 -- Reference: https://arxiv.org/pdf/2103.15850
 /-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `2 * √N`. -/
 @[category undergraduate, AMS 5 11]
-theorem maxSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) :
-    IsSidon.maxSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
+theorem maxSidonSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) :
+    maxSidonSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -30,7 +30,7 @@ namespace Erdos44
 /-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `2 * √N`. -/
 @[category undergraduate, AMS 5 11]
 theorem maxSidonSetSize_bound (N : ℕ) (hN : 1 ≤ N) :
-    maxSidonSetSize N ≤ 2 * Real.sqrt N := by
+    IsSidon.maxSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/707.lean
+++ b/FormalConjectures/ErdosProblems/707.lean
@@ -100,7 +100,7 @@ theorem erdos_707.variants.singer_construction (p : ℕ) (hp : IsPrimePow p) :
 The set `{1, 2, 4}` is a Sidon set.
 -/
 @[category undergraduate, AMS 5 11]
-theorem erdos_707.variants.example_sidon_set : IsSidon {1, 2, 4} := by
+theorem erdos_707.variants.example_sidon_set : IsSidon ({1, 2, 4} : Set ℕ) := by
   sorry
 
 /--

--- a/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
@@ -94,12 +94,12 @@ namespace Finset
 theorem isSidon_toSet {A : Finset α} : IsSidon A.toSet ↔ IsSidon A := by
   simp [IsSidon]
 
-instance (A : Finset ℕ) : Decidable (IsSidon A) :=
+instance (A : Finset α) [DecidableEq α] : Decidable (IsSidon A) :=
   decidable_of_iff (∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A) (j₂ ∈ A), _) <| by rfl
 
-/-- The maximum size of a Sidon set in `{1, ..., N}`. -/
-noncomputable def maxSidonSetSize (N : ℕ) : ℕ :=
-  sSup {(A.card) | (A : Finset ℕ) (_ : A ⊆ Finset.Icc 1 N) (_ : IsSidon A)}
+/-- The maximum size of a Sidon set in the supplied `Finset`. -/
+def IsSidon.maxSubsetCard (A : Finset α) [DecidableEq α] : ℕ :=
+  (A.powerset.filter IsSidon).sup Finset.card
 
 theorem IsSidon.insert {A : Finset α} {m : α} [DecidableEq α] [IsRightCancelAdd α]
     [IsLeftCancelAdd α] (hA : IsSidon A) :

--- a/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
@@ -33,20 +33,20 @@ namespace Set
 lemma IsSidon.avoids_isAPOfLength_three {A : Set ℕ} (hA : IsSidon A)
     {Y : Set ℕ} (hY : Y.IsAPOfLength 3) :
     (A ∩ Y).ncard ≤ 2 := by
-  simp [Set.IsAPOfLength, Set.IsAPOfLengthWith] at hY
+  simp [IsAPOfLength, IsAPOfLengthWith] at hY
   obtain ⟨hc, ⟨a, d, hY⟩⟩ := hY
-  have hY_card : Y.ncard = 3 := by simp [Set.ncard, Set.encard, hc]
+  have hY_card : Y.ncard = 3 := by simp [ncard, encard, hc]
   by_contra! h
   have hss : Y ⊆ A ∩ Y := by
-    have hY_fin : Finite Y := Set.finite_of_ncard_ne_zero (by linarith)
+    have hY_fin : Finite Y := finite_of_ncard_ne_zero (by linarith)
     rw [Set.eq_of_subset_of_ncard_le (Set.inter_subset_right) (by linarith)]
-  have ha : a ∈ A := Set.mem_of_mem_inter_left <| hss (hY ▸ ⟨0, by norm_num, by simp⟩)
-  have ha₁ : a + d ∈ A := Set.mem_of_mem_inter_left <| hss (hY ▸ ⟨1, by norm_num, by simp⟩)
-  have ha₂ : a + 2 • d ∈ A := Set.mem_of_mem_inter_left <| hss (hY ▸ ⟨2, by norm_num, by simp⟩)
+  have ha : a ∈ A := mem_of_mem_inter_left <| hss (hY ▸ ⟨0, by norm_num, by simp⟩)
+  have ha₁ : a + d ∈ A := mem_of_mem_inter_left <| hss (hY ▸ ⟨1, by norm_num, by simp⟩)
+  have ha₂ : a + 2 • d ∈ A := mem_of_mem_inter_left <| hss (hY ▸ ⟨2, by norm_num, by simp⟩)
   have := hA _ ha _ ha₁ _ ha₂ _ ha₁ (by simp; omega)
   simp at this
-  simp [hY, this.1, Set.setOf_and] at hY_card
-  linarith [Set.ncard_singleton _ ▸ Set.ncard_inter_le_ncard_right {a | ∃ x, x < 3} {a}]
+  simp [hY, this.1, setOf_and] at hY_card
+  linarith [ncard_singleton _ ▸ ncard_inter_le_ncard_right {a | ∃ x, x < 3} {a}]
 
 theorem IsSidon.subset {A B : Set α} (hB : IsSidon B) (hAB : A ⊆ B) : IsSidon A :=
   fun _ _ _ _ _ _ _ _ _ ↦ hB _ (hAB ‹_›) _ (hAB ‹_›) _ (hAB ‹_›) _ (hAB ‹_›) ‹_›
@@ -87,7 +87,7 @@ namespace Finset
 
 @[simp, push_cast]
 theorem isSidon_toSet {A : Finset α} : IsSidon A.toSet ↔ IsSidon A := by
-  simp [_root_.IsSidon]
+  simp [IsSidon]
 
 instance (A : Finset ℕ) : Decidable (IsSidon A) :=
   decidable_of_iff (∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A) (j₂ ∈ A), _) <| by rfl

--- a/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
@@ -28,6 +28,10 @@ coincidences forced by the commutativity of addition. -/
 def IsSidon {S : Type*} [Membership α S] (A : S) : Prop := ∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A) (j₂ ∈ A),
   i₁ + i₂ = j₁ + j₂ → (i₁ = j₁ ∧ i₂ = j₂) ∨ (i₁ = j₂ ∧ i₂ = j₁)
 
+@[simp, push_cast]
+theorem coe {S : Type*} [SetLike S α] {A : S} : IsSidon (A : Set α) ↔ IsSidon A := by
+  simp [IsSidon]
+
 namespace Set
 
 lemma IsSidon.avoids_isAPOfLength_three {A : Set ℕ} (hA : IsSidon A)
@@ -85,6 +89,7 @@ end Set
 
 namespace Finset
 
+-- TODO: remove once https://github.com/leanprover-community/mathlib4/pull/28241 is merged
 @[simp, push_cast]
 theorem isSidon_toSet {A : Finset α} : IsSidon A.toSet ↔ IsSidon A := by
   simp [IsSidon]

--- a/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/Basic.lean
@@ -98,7 +98,7 @@ instance (A : Finset α) [DecidableEq α] : Decidable (IsSidon A) :=
   decidable_of_iff (∀ᵉ (i₁ ∈ A) (j₁ ∈ A) (i₂ ∈ A) (j₂ ∈ A), _) <| by rfl
 
 /-- The maximum size of a Sidon set in the supplied `Finset`. -/
-def IsSidon.maxSubsetCard (A : Finset α) [DecidableEq α] : ℕ :=
+def maxSidonSubsetCard (A : Finset α) [DecidableEq α] : ℕ :=
   (A.powerset.filter IsSidon).sup Finset.card
 
 theorem IsSidon.insert {A : Finset α} {m : α} [DecidableEq α] [IsRightCancelAdd α]


### PR DESCRIPTION
Redefine `IsSidon` for any type `S` with the membership property. This allows `IsSidon A` to work when `A` is a `Finset` without having to write `A.toSet`.