### PR TITLE
AlphaProof's counterexample  erdos_730.variants.delta_one

### DIFF
--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -53,7 +53,7 @@ theorem erdos_730.variants.two_div_forall (n : ℕ) (h : 0 < n) : 2 ∣ (2*n).ch
   sorry
 
 /--
-There are examples where $(n, m) ∈ S$, we have $m ≠ n + 1$.
+There are examples where $(n, m) ∈ S$ with $m ≠ n + 1$.
 
 (Found by AlphaProof, although it was implicit already in [A129515])
 -/


### PR DESCRIPTION
AlphaProof found a counterexample to what we had in `erdos_730.variants.delta_one`: 10003 and 10005.

We adapt the disproof and change the negated statement's name to `erdos_730.variants.delta_ne_one.

A numerical search for more counterexamples is implemented here: https://github.com/mo271/kummer