### PR TITLE
Erdős Problem 470

### DIFF
--- a/FormalConjectures/ErdosProblems/218.lean
+++ b/FormalConjectures/ErdosProblems/218.lean
@@ -25,11 +25,6 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos218
 
 /--
-The prime gap: the difference between the $n+1$-th and $n$-th prime.
--/
-noncomputable def primeGap (n : ℕ) : ℕ := (n + 1).nth Nat.Prime - n.nth Nat.Prime
-
-/--
 The set of indices $n$ for which a prime gap is followed by a larger or equal prime gap has a
 natural density of $\frac 1 2$.
 -/

--- a/FormalConjectures/ErdosProblems/233.lean
+++ b/FormalConjectures/ErdosProblems/233.lean
@@ -25,13 +25,6 @@ import FormalConjectures.Util.ProblemImports
   - [Wikipedia](https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_conjecture)
 -/
 
--- TODO(firsching): This definition is also used in 218.lean, let's move it to a better place.
-/--
-The prime gap: the difference between the $n+1$-th and $n$-th prime.
--/
-noncomputable def primeGap (n : ℕ) : ℕ := (n + 1).nth Nat.Prime - n.nth Nat.Prime
-
-
 open Filter Real
 /--
 The prime number theorem immediately implies a lower bound of $\gg N(\log N)^2$ for the sum of

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -45,7 +45,7 @@ theorem erdos_470.part1 : (∃ n : ℕ, n.Weird ∧ Odd n) ↔ answer(sorry) := 
 Are there infinitely many primitive weird numbers?
 -/
 @[category research open, AMS 11]
-theorem erdos_470.part2 : (Set.Infinite {n : ℕ | PrimitiveWeird n}) ↔ answer(sorry) := by
+theorem erdos_470.part2 : (Set.Infinite PrimitiveWeird) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -88,7 +88,7 @@ that an odd weird number must have at least 6 prime divisors.
 -/
 @[category research solved, AMS 11]
 theorem erdos_470.variants.odd_weird_prime_div :
-    ∀ n : ℕ, n.Weird → {m | m ∈ n.divisors ∧ m.Prime}.ncard > 6 := by
+    ∀ n : ℕ, Odd n → n.Weird → {m | m ∈ n.divisors ∧ m.Prime}.ncard > 6 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -1,0 +1,102 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 470
+
+*Reference:* [erdosproblems.com/470](https://www.erdosproblems.com/470)
+-/
+
+namespace Erdos470
+
+/--
+Primitive weird numbers are weird numbers such that no proper divisor of $n$ are weird.
+-/
+def PrimitiveWeird (n : ℕ) := n.Weird ∧ ∀ d ∈ n.properDivisors, ¬d.Weird
+
+/--
+The abundancy index is the sum of the divisors of $n$ divided by $n$.
+-/
+def AbundancyIndex (n : ℕ) : ℚ := (∑ d ∈ n.divisors, d) / n
+
+/--
+Are there any odd weird numbers?
+-/
+@[category research open, AMS 11]
+theorem erdos_470.part1 : (∃ n : ℕ, n.Weird ∧ Odd n) ↔ answer(sorry) := by
+  sorry
+
+/--
+Are there infinitely many primitive weird numbers?
+-/
+@[category research open, AMS 11]
+theorem erdos_470.part2 : (Set.Infinite {n : ℕ | PrimitiveWeird n}) ↔ answer(sorry) := by
+  sorry
+
+/--
+Benkoski and Erdős [BeEr74](https://mathscinet.ams.org/mathscinet/relay-station?mr=347726) proved
+that the set of weird numbers has positive density.
+-/
+@[category research solved, AMS 11]
+theorem erdos_470.variants.weird_pos_density : {n : ℕ | n.Weird}.HasPosDensity := by
+  sorry
+
+/--
+The smallest weird number is 70.
+-/
+@[category high_school, AMS 11]
+theorem erdos_470.variants.smallest_weird_eq_70 : (∀ n < 70, ¬n.Weird) ∧ (70).Weird := by
+  sorry
+
+/--
+Melfi [Me15](https://mathscinet.ams.org/mathscinet/relay-station?mr=3276337) has proved that there
+are infinitely many primitive weird numbers, conditional on the fact that
+$p_{n+1} - p_n < \frac{1}{10} p_n^{1/2}$ for all large $n$, which in turn would follow from
+well-known conjectures concerning prime gaps.
+-/
+@[category research solved, AMS 11]
+theorem erdos_470.variants.prime_gap_imp_inf_prim_weird :
+    ∀ᶠ n in Filter.atTop, primeGap n < √ (n.nth Nat.Prime) / 10 →
+      Set.Infinite {n : ℕ | PrimitiveWeird n} := by
+  sorry
+
+/--
+Fang [Fa22](https://arxiv.org/abs/2207.12906) has shown there are no odd weird numbers below $10^21$.
+-/
+@[category research solved, AMS 11]
+theorem erdos_470.variants.odd_weird_1021 : ∀ n < 10 ^ 21, Odd n → ¬n.Weird := by
+  sorry
+
+/--
+Liddy and Riedl [LiRi18](https://ideaexchange.uakron.edu/honors_research_projects/728/) have shown
+that an odd weird number must have at least 6 prime divisors.
+-/
+@[category research solved, AMS 11]
+theorem erdos_470.variants.odd_weird_prime_div :
+    ∀ n : ℕ, n.Weird → {m | m ∈ n.divisors ∧ m.Prime}.ncard > 6 := by
+  sorry
+
+/--
+If there are no odd weird numbers then every weird number has abundancy index < 4.
+-/
+@[category research solved, AMS 11]
+theorem erdos_470.variants.abundancy_index :
+    (∀ n : ℕ, n.Weird → ¬Odd n) → ∀ n, n.Weird → AbundancyIndex n < 4 := by
+  sorry
+
+end Erdos470

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -72,7 +72,7 @@ well-known conjectures concerning prime gaps.
 @[category research solved, AMS 11]
 theorem erdos_470.variants.prime_gap_imp_inf_prim_weird :
     ∀ᶠ n in Filter.atTop, primeGap n < √ (n.nth Nat.Prime) / 10 →
-      Set.Infinite {n : ℕ | PrimitiveWeird n} := by
+      Set.Infinite PrimitiveWeird  := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -79,7 +79,7 @@ theorem erdos_470.variants.prime_gap_imp_inf_prim_weird :
 Fang [Fa22](https://arxiv.org/abs/2207.12906) has shown there are no odd weird numbers below $10^21$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_470.variants.odd_weird_1021 : ∀ n < 10 ^ 21, Odd n → ¬n.Weird := by
+theorem erdos_470.variants.odd_weird_10_pow_21 : ∀ n < 10 ^ 21, Odd n → ¬n.Weird := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -88,7 +88,7 @@ that an odd weird number must have at least 6 prime divisors.
 -/
 @[category research solved, AMS 11]
 theorem erdos_470.variants.odd_weird_prime_div :
-    ∀ n : ℕ, Odd n → n.Weird → {m | m ∈ n.divisors ∧ m.Prime}.ncard > 6 := by
+    ∀ n : ℕ, Odd n → n.Weird → 6 ≤ {m | m ∈ n.divisors ∧ m.Prime}.ncard := by
   sorry
 
 /--

--- a/FormalConjectures/ForMathlib/NumberTheory/PrimeGap.lean
+++ b/FormalConjectures/ForMathlib/NumberTheory/PrimeGap.lean
@@ -1,0 +1,23 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Data.Nat.Nth
+
+/--
+The prime gap: the difference between the $n+1$-th and $n$-th prime.
+-/
+noncomputable def primeGap (n : ℕ) : ℕ := (n + 1).nth Nat.Prime - n.nth Nat.Prime

--- a/FormalConjectures/Util/ForMathlib.lean
+++ b/FormalConjectures/Util/ForMathlib.lean
@@ -50,6 +50,7 @@ import FormalConjectures.ForMathlib.Logic.Equiv.Fin
 import FormalConjectures.ForMathlib.NumberTheory.AdditivelyComplete
 import FormalConjectures.ForMathlib.NumberTheory.CoveringSystem
 import FormalConjectures.ForMathlib.NumberTheory.Lacunary
+import FormalConjectures.ForMathlib.NumberTheory.PrimeGap
 import FormalConjectures.ForMathlib.NumberTheory.WallSunSunPrimes
 import FormalConjectures.ForMathlib.Order.Filter.Cofinite
 import FormalConjectures.ForMathlib.Order.Interval.Finset.Basic


### PR DESCRIPTION
Adds [Erdős Problem 470](https://www.erdosproblems.com/470)

This PR also moves the definition of `primeGap` to its own separate file under `FormalConjectures/ForMathlib/NumberTheory/PrimeGap.lean` since this problem also uses the definition.