### PR TITLE
chore: Add more namespaces

### DIFF
--- a/FormalConjectures/ForMathlib/Test/Computability/TuringMachine.lean
+++ b/FormalConjectures/ForMathlib/Test/Computability/TuringMachine.lean
@@ -20,6 +20,8 @@ import Mathlib.Tactic.DeriveFintype
 --sanity checks for the definition of halting added in `ForMathlib`.
 --These should be easy to prove
 
+namespace BusyBeasverTest
+
 open Turing BusyBeaver Machine
 
 inductive Γ where
@@ -57,3 +59,5 @@ theorem haltsAfterOne_haltingNumber : haltsAfterOne.haltingNumber = 1 := by
   · use { q := some Λ.T, tape := ⟨Γ.A, Quotient.mk'' [Γ.A], default⟩}
     rfl
   · rfl
+
+end BusyBeasverTest

--- a/FormalConjectures/Util/Answer.lean
+++ b/FormalConjectures/Util/Answer.lean
@@ -69,3 +69,5 @@ where go : _ → InfoTree → _
           return #[⟨ctx, t⟩]
     return (← cs.mapM (go <| i.updateContext? ctx)).toArray.flatten
   | _, _ => pure #[]
+
+end Google

--- a/FormalConjectures/Util/Linters/AMSLinter.lean
+++ b/FormalConjectures/Util/Linters/AMSLinter.lean
@@ -28,6 +28,8 @@ the appropriate subject tags.
 
 open Lean Elab Meta Linter Command Parser Term ProblemAttributes
 
+namespace AMSLinter
+
 /-- Checks if a command has the `AMS` attribute. -/
 def toAMS (stx : TSyntax ``Command.declModifiers) :
     CommandElabM (Array <| TSyntaxArray `num) := do
@@ -77,3 +79,6 @@ def AMSLinter : Linter where
 
 initialize do
   addLinter AMSLinter
+
+
+end AMSLinter

--- a/FormalConjectures/Util/Linters/AMSLinterTest.lean
+++ b/FormalConjectures/Util/Linters/AMSLinterTest.lean
@@ -16,6 +16,8 @@ limitations under the License.
 
 import FormalConjectures.Util.Linters.AMSLinter
 
+namespace AMSLinter
+
 --Definitions aren't required to have an AMS attribute
 #guard_msgs in
 def foo : Nat := 1
@@ -85,3 +87,5 @@ theorem test_out_of_order : 1 + 1 = 2 := by
 @[AMS 3 3]
 theorem test_dup : 1 + 1 = 2 := by
   rfl
+
+end AMSLinter

--- a/FormalConjectures/Util/Linters/CategoryLinter.lean
+++ b/FormalConjectures/Util/Linters/CategoryLinter.lean
@@ -18,15 +18,17 @@ import FormalConjectures.Util.Attributes
 import Mathlib.Tactic.Lemma
 
 
-/-! # The Problem Status Linter
+/-! # The Category Linter
 
-The `problemStatusLinter` is a linter to aid with formatting contributions to
+The `categoryLinter` is a linter to aid with formatting contributions to
 the Formal Conjectures repository by ensuring that results in a file have
 the appropriate tags in order to distinguish between open/already solved
 problems and background results/sanity checks.
 -/
 
 open Lean Elab Meta Linter Command Parser Term
+
+namespace CategoryLinter
 
 /-- Checks if a command has the `category` attribute. -/
 def toCategory
@@ -42,7 +44,7 @@ def toCategory
 
 /-- The problem category linter checks that every theorem/lemma/example
 has been given a problem category attribute. -/
-def problemStatusLinter : Linter where
+def categoryLinter : Linter where
   run := fun stx => do
     match stx with
       | `(command| $a:declModifiers theorem $_ $_:bracketedBinder* : $_ := $_)
@@ -57,4 +59,6 @@ def problemStatusLinter : Linter where
       | _ => return
 
 initialize do
-  addLinter problemStatusLinter
+  addLinter categoryLinter
+
+end CategoryLinter

--- a/FormalConjectures/Util/Linters/CategoryLinterTest.lean
+++ b/FormalConjectures/Util/Linters/CategoryLinterTest.lean
@@ -16,6 +16,8 @@ limitations under the License.
 
 import FormalConjectures.Util.Linters.CategoryLinter
 
+namespace CategoryLinter
+
 --Definitions aren't required to have a category attribute
 #guard_msgs in
 def foo : Nat := 1
@@ -71,3 +73,4 @@ theorem test_1 : 1 + 1 = 2 := by
 theorem test_3 : 1 + 1 = 2 := by
   rfl
 
+end CategoryLinter

--- a/FormalConjectures/Util/Linters/CopyrightLinter.lean
+++ b/FormalConjectures/Util/Linters/CopyrightLinter.lean
@@ -20,6 +20,8 @@ import Mathlib.Tactic.Linter.Header
 
 open Lean Elab Meta Command Syntax
 
+namespace CopyrightLinter
+
 def correctCopyrightHeader : String :=
 "/-
 Copyright 2025 The Formal Conjectures Authors.
@@ -55,3 +57,5 @@ def copyrightLinter : Linter where run := withSetOptionIn fun stx ↦ do
       ++ correctCopyrightHeader
 
 initialize addLinter copyrightLinter
+
+end CopyrightLinter


### PR DESCRIPTION
This is useful e.g. when importing all files in the Lean project (several test files seem to use `foo` as a declaration name!)