### PR TITLE
feat: Add erdos 276

### DIFF
--- a/FormalConjectures/ErdosProblems/276.lean
+++ b/FormalConjectures/ErdosProblems/276.lean
@@ -32,6 +32,6 @@ term of the sequence?
 -/
 @[category research open, AMS 11]
 theorem erdos_274 : (∃ (a : ℕ → ℕ),
-    IsLucasSequence a ∧ (∀ k, (a k).Composite) ∧ (∀ n > 1, ∃ k, ¬ n ∣ (a k))) ↔
+    IsLucasSequence a ∧ (∀ k, (a k).Composite) ∧ (∀ n > 1, ∃ k, Nat.gcd n (a k) = 1)) ↔
     answer(sorry) := by
   sorry

--- a/FormalConjectures/ErdosProblems/276.lean
+++ b/FormalConjectures/ErdosProblems/276.lean
@@ -23,7 +23,17 @@ import FormalConjectures.Util.ProblemImports
 [erdosproblems.com/276](https://www.erdosproblems.com/276)
 -/
 
-def IsLucasSequence (a : ℕ → ℕ) : Prop := ∀ n, a (n + 2) = a (n + 1) + a n
+/--
+We define a Lucas sequence to be a Fibonacci sequence with arbitrary starting points
+`L 0` and `L 1`.
+
+TODO: There seems to be multiple definitions in the literature, some of which also
+allow coefficients in the reccurence relation. For now this simple definition has been
+chosen as it agrees best with the Erdős problem in this same file.
+However before moving this into `ForMathlib` one should make a concious decision about
+which definition to choose.
+-/
+def IsLucasSequence (L : ℕ → ℕ) : Prop := ∀ n, L (n + 2) = L (n + 1) + L n
 
 namespace Erdos276
 

--- a/FormalConjectures/ErdosProblems/276.lean
+++ b/FormalConjectures/ErdosProblems/276.lean
@@ -25,13 +25,17 @@ import FormalConjectures.Util.ProblemImports
 
 def IsLucasSequence (a : ℕ → ℕ) : Prop := ∀ n, a (n + 2) = a (n + 1) + a n
 
+namespace Erdos276
+
 /--
 Is there an infinite Lucas sequence $a_0, a_1, \ldots$ where $a_{n+2} = a_{n+1} + a_n$ for
 $n \ge 0$ such that all $a_k$ are composite, and yet no integer has a common factor with every
 term of the sequence?
 -/
 @[category research open, AMS 11]
-theorem erdos_274 : (∃ (a : ℕ → ℕ),
+theorem erdos_276 : (∃ (a : ℕ → ℕ),
     IsLucasSequence a ∧ (∀ k, (a k).Composite) ∧ (∀ n > 1, ∃ k, Nat.gcd n (a k) = 1)) ↔
     answer(sorry) := by
   sorry
+
+end Erdos276

--- a/FormalConjectures/ErdosProblems/276.lean
+++ b/FormalConjectures/ErdosProblems/276.lean
@@ -17,28 +17,21 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Erdős Problem 463
+# Erdős Problem 276
 
-*Reference:* [erdosproblems.com/463](https://www.erdosproblems.com/463)
+*References:*
+[erdosproblems.com/276](https://www.erdosproblems.com/276)
 -/
 
-open Filter
-
-namespace Erdos463
+def IsLucasSequence (a : ℕ → ℕ) : Prop := ∀ n, a (n + 2) = a (n + 1) + a n
 
 /--
-Is there a function $f$ with $f(n)\to\infty$ as $n\to\infty$ such that,
-for all large $n$, there is a composite number $m$ such that
-$$
-n + f(n) < m < n + p(m)
-$$
-Here $p(m)$ is the least prime factor of $m$.
+Is there an infinite Lucas sequence $a_0, a_1, \ldots$ where $a_{n+2} = a_{n+1} + a_n$ for
+$n \ge 0$ such that all $a_k$ are composite, and yet no integer has a common factor with every
+term of the sequence?
 -/
 @[category research open, AMS 11]
-theorem erdos_463 : (∃ (f : ℕ → ℕ) (_ : Tendsto f atTop atTop),
-    ∀ᶠ n in atTop,
-      ∃ m, m.Composite ∧
-        n + f n < m ∧ m < n + m.minFac) ↔ answer(sorry) := by
+theorem erdos_274 : (∃ (a : ℕ → ℕ),
+    IsLucasSequence a ∧ (∀ k, (a k).Composite) ∧ (∀ n > 1, ∃ k, ¬ n ∣ (a k))) ↔
+    answer(sorry) := by
   sorry
-
-end Erdos463

--- a/FormalConjectures/ErdosProblems/541.lean
+++ b/FormalConjectures/ErdosProblems/541.lean
@@ -1,12 +1,9 @@
 /-
 Copyright 2025 The Formal Conjectures Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     https://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,50 +14,48 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Erdős Problem 541
-
-*Reference:* [erdosproblems.com/541](https://www.erdosproblems.com/541)
+# Erdős Problem 1077
+*Reference:* [erdosproblems.com/1077](https://www.erdosproblems.com/1077)
 -/
 
-open Filter
+namespace Erdos1077
 
-namespace Erdos541
+open Classical
+open Finset
+
+
+open Fintype
+
+namespace SimpleGraph
+
+variable {V : Type*} [Fintype V]
+/--
+We call a graph $D$-balanced (or $D$-almost-regular) if the maximum degree is at most $D$ times the
+minimum degree.
+-/
+def IsBalanced (G : SimpleGraph V) (D : ℝ) [DecidableRel G.Adj] : Prop :=
+    G.maxDegree <= D * G.minDegree
+
+end SimpleGraph
+
+
+open SimpleGraph
 
 /--
-Let $a_1, \dots, a_p$ be (not necessarily distinct) residues modulo a prime $p$, such that there
-exists some $r$ so that if $S \subseteq [p]$ is non-empty and
-$$\sum_{i \in S} a_i \equiv 0 \pmod{p}$$
-then $|S| = r$.
-
-Must there be at most two distinct residues amongst the $a_i$?
+We call a graph $D$-balanced (or $D$-almost-regular) if the maximum degree is at most $D$ times the
+minimum degree.
+Let $ϵ,α>0$ and $D$ and $n$ be sufficiently large. If $G$ is a graph on $n$ vertices with at least
+$n^{1+α}$ edges, then must $G$ contain a $D$-balanced subgraph on $m>n^{1−α}$ vertices with at least
+$ϵm^{1+α}$ edges?
 -/
-@[category research solved, AMS 11]
-theorem erdos_541 : (∀ p, Fact p.Prime → ∀ (a : Fin p → ZMod p),
-    (∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) →
-      (Set.range a).ncard ≤ 2) ↔ answer(True) := by
+@[category research open, AMS 11]
+theorem erdos_1077 : (∀ (ε α : ℝ) (h1 : (ε : ℝ) > 0) (h2 : α > 0),
+    ∃ (D0 n0 : ℕ), ∀ D > D0, ∀ n > n0, ∀ (G : SimpleGraph (Fin n)),
+    #G.edgeFinset > ((n : ℝ)^ (1 + α)) → ∃ (H : G.Subgraph),
+    IsBalanced H.coe D ∧
+    letI m := #H.verts.toFinset
+    m > (n : ℝ) ^ (1 - α) ∧ #H.edgeSet.toFinset > ε * (m ^ (1 + α)))
+    ↔ answer(sorry) := by
   sorry
 
-/-- Gao, Hamidoune, and Wang [GHW10] solved this for all moduli `p` (not necessarily prime).
-
-[GHW10] Gao, Weidong and Hamidoune, Yahya Ould and Wang, Guoqing,
-Distinct length modular zero-sum subsequences: a proof of Graham's conjecture.
-J. Number Theory (2010), 1425--1431.
--/
-@[category research solved, AMS 11]
-theorem erdos_541.variants.general_moduli (p : ℕ) (a : Fin p → ZMod p)
-    (ha₀ : ∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) :
-      (Set.range a).ncard ≤ 2 := by
-  sorry
-
-/-- This was proved by Erdős and Szemerédi [ErSz76] for p sufficiently large.
-
-[ErSz76] Erd\H os, E. and Szemerédi, E., On a problem of Graham.
-Publ. Math. Debrecen (1976), 123--127.
--/
-@[category research solved, AMS 11]
-theorem erdos_541.variants.large_primes : ∀ᶠ p in atTop, p.Prime → ∀ a : Fin p → ZMod p,
-    (∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) →
-      (Set.range a).ncard ≤ 2 := by
-  sorry
-
-end Erdos541
+end Erdos1077

--- a/FormalConjectures/ErdosProblems/541.lean
+++ b/FormalConjectures/ErdosProblems/541.lean
@@ -1,9 +1,12 @@
 /-
 Copyright 2025 The Formal Conjectures Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     https://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,48 +17,50 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Erdős Problem 1077
-*Reference:* [erdosproblems.com/1077](https://www.erdosproblems.com/1077)
+# Erdős Problem 541
+
+*Reference:* [erdosproblems.com/541](https://www.erdosproblems.com/541)
 -/
 
-namespace Erdos1077
+open Filter
 
-open Classical
-open Finset
-
-
-open Fintype
-
-namespace SimpleGraph
-
-variable {V : Type*} [Fintype V]
-/--
-We call a graph $D$-balanced (or $D$-almost-regular) if the maximum degree is at most $D$ times the
-minimum degree.
--/
-def IsBalanced (G : SimpleGraph V) (D : ℝ) [DecidableRel G.Adj] : Prop :=
-    G.maxDegree <= D * G.minDegree
-
-end SimpleGraph
-
-
-open SimpleGraph
+namespace Erdos541
 
 /--
-We call a graph $D$-balanced (or $D$-almost-regular) if the maximum degree is at most $D$ times the
-minimum degree.
-Let $ϵ,α>0$ and $D$ and $n$ be sufficiently large. If $G$ is a graph on $n$ vertices with at least
-$n^{1+α}$ edges, then must $G$ contain a $D$-balanced subgraph on $m>n^{1−α}$ vertices with at least
-$ϵm^{1+α}$ edges?
+Let $a_1, \dots, a_p$ be (not necessarily distinct) residues modulo a prime $p$, such that there
+exists some $r$ so that if $S \subseteq [p]$ is non-empty and
+$$\sum_{i \in S} a_i \equiv 0 \pmod{p}$$
+then $|S| = r$.
+
+Must there be at most two distinct residues amongst the $a_i$?
 -/
-@[category research open, AMS 11]
-theorem erdos_1077 : (∀ (ε α : ℝ) (h1 : (ε : ℝ) > 0) (h2 : α > 0),
-    ∃ (D0 n0 : ℕ), ∀ D > D0, ∀ n > n0, ∀ (G : SimpleGraph (Fin n)),
-    #G.edgeFinset > ((n : ℝ)^ (1 + α)) → ∃ (H : G.Subgraph),
-    IsBalanced H.coe D ∧
-    letI m := #H.verts.toFinset
-    m > (n : ℝ) ^ (1 - α) ∧ #H.edgeSet.toFinset > ε * (m ^ (1 + α)))
-    ↔ answer(sorry) := by
+@[category research solved, AMS 11]
+theorem erdos_541 : (∀ p, Fact p.Prime → ∀ (a : Fin p → ZMod p),
+    (∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) →
+      (Set.range a).ncard ≤ 2) ↔ answer(True) := by
   sorry
 
-end Erdos1077
+/-- Gao, Hamidoune, and Wang [GHW10] solved this for all moduli `p` (not necessarily prime).
+
+[GHW10] Gao, Weidong and Hamidoune, Yahya Ould and Wang, Guoqing,
+Distinct length modular zero-sum subsequences: a proof of Graham's conjecture.
+J. Number Theory (2010), 1425--1431.
+-/
+@[category research solved, AMS 11]
+theorem erdos_541.variants.general_moduli (p : ℕ) (a : Fin p → ZMod p)
+    (ha₀ : ∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) :
+      (Set.range a).ncard ≤ 2 := by
+  sorry
+
+/-- This was proved by Erdős and Szemerédi [ErSz76] for p sufficiently large.
+
+[ErSz76] Erd\H os, E. and Szemerédi, E., On a problem of Graham.
+Publ. Math. Debrecen (1976), 123--127.
+-/
+@[category research solved, AMS 11]
+theorem erdos_541.variants.large_primes : ∀ᶠ p in atTop, p.Prime → ∀ a : Fin p → ZMod p,
+    (∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) →
+      (Set.range a).ncard ≤ 2 := by
+  sorry
+
+end Erdos541

--- a/FormalConjectures/ForMathlib/Data/Nat/Prime/Composite.lean
+++ b/FormalConjectures/ForMathlib/Data/Nat/Prime/Composite.lean
@@ -1,0 +1,18 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import Mathlib.Data.Nat.Prime.Defs
+
+abbrev Nat.Composite (n : ℕ) : Prop := 1 < n ∧ ¬n.Prime

--- a/FormalConjectures/Util/ForMathlib.lean
+++ b/FormalConjectures/Util/ForMathlib.lean
@@ -39,6 +39,7 @@ import FormalConjectures.ForMathlib.Data.Nat.Factorization.Basic
 import FormalConjectures.ForMathlib.Data.Nat.Full
 import FormalConjectures.ForMathlib.Data.Nat.MaxPrimeFac
 import FormalConjectures.ForMathlib.Data.Nat.Prime.Defs
+import FormalConjectures.ForMathlib.Data.Nat.Prime.Composite
 import FormalConjectures.ForMathlib.Data.Nat.Prime.Finset
 import FormalConjectures.ForMathlib.Data.Nat.Squarefree
 import FormalConjectures.ForMathlib.Data.Real.Constants

--- a/FormalConjectures/Wikipedia/Grimm.lean
+++ b/FormalConjectures/Wikipedia/Grimm.lean
@@ -33,7 +33,7 @@ such that $p_i$ divides $n + i$ for all $0 \le i \le k-1$.
 -/
 @[category research open, AMS 11]
 theorem grimm_conjecture (n k : ℕ) (hn : 1 ≤ n) (hk : 1 ≤ k)
-    (h : ∀ i : Fin k, 1 < n + i ∧ ¬ (n + i).Prime) :
+    (h : ∀ i : Fin k, (n + i).Composite) :
     ∃ ps : Fin k ↪ ℕ,  ∀ i : Fin k, (ps i).Prime ∧ ps i ∣ (n + i) := by
   sorry
 
@@ -44,7 +44,7 @@ has at least $k$ distinct prime divisors.
 -/
 @[category research open, AMS 11]
 theorem grimm_conjecture_weak (n k : ℕ) (hn : 1 ≤ n) (hk : 1 ≤ k)
-    (h : ∀ i : Fin k, 1 < n + i ∧ ¬ (n + i).Prime) :
+    (h : ∀ i : Fin k, (n + i).Composite) :
     ∃ ps : Fin k ↪ ℕ,  ∀ i : Fin k, (ps i).Prime ∧ ∃ j : Fin k, ps i ∣ (n + j) := by
   sorry
 


### PR DESCRIPTION
Adds Erdos 276 as well as `Nat.Composite` to ForMathlib. Fixes #466.