### PR TITLE
fix overwrite_index: importModules changes

### DIFF
--- a/docbuild/scripts/overwrite_index.lean
+++ b/docbuild/scripts/overwrite_index.lean
@@ -96,13 +96,17 @@ unsafe def runWithImports {α : Type} (actionToRun : CoreM α) : IO α := do
   -- which we probably don't want to count here.
   let moduleImportNames := #[`FormalConjectures.All]
   initSearchPath (← findSysroot)
-  let modulesToImport : Array Import := moduleImportNames.map ({ module := · })
+
+  let imports : Array Import := moduleImportNames.map ({ module := · })
   let currentCtx := { fileName := "", fileMap := default }
   Lean.enableInitializersExecution
 
-  Lean.withImportModules modulesToImport {} fun env => do
-    let (result, _newState) ← Core.CoreM.toIO actionToRun currentCtx { env := env }
-    return result
+  let env ← withImporting do
+    let (_, s) ← importModulesCore imports |>.run
+    finalizeImport s imports {} (trustLevel := 1024) (leakEnv := false) (loadExts := true)
+
+  let (result, _newState) ← Core.CoreM.toIO actionToRun currentCtx { env := env }
+  return result
 
 unsafe def main (args : List String) : IO Unit := do
   let .some (file : String) := args[0]?

--- a/docbuild/scripts/overwrite_index.lean
+++ b/docbuild/scripts/overwrite_index.lean
@@ -96,14 +96,11 @@ unsafe def runWithImports {α : Type} (actionToRun : CoreM α) : IO α := do
   -- which we probably don't want to count here.
   let moduleImportNames := #[`FormalConjectures.All]
   initSearchPath (← findSysroot)
-
   let imports : Array Import := moduleImportNames.map ({ module := · })
   let currentCtx := { fileName := "", fileMap := default }
   Lean.enableInitializersExecution
 
-  let env ← withImporting do
-    let (_, s) ← importModulesCore imports |>.run
-    finalizeImport s imports {} (trustLevel := 1024) (leakEnv := false) (loadExts := true)
+  let env ← Lean.importModules imports {} (trustLevel := 1024) (loadExts := true)
 
   let (result, _newState) ← Core.CoreM.toIO actionToRun currentCtx { env := env }
   return result


### PR DESCRIPTION
The `overwrite_index.lean` script failed to count attributes after a Lean version bump. This was due to changes in how module imports handle environment extensions, as introduced in
https://github.com/leanprover/lean4/pull/6325 .

`Lean.withImportModules` no longer loads environment extensions. This commit refactors the `runWithImports` function to use the lower-level `importModulesCore` and `finalizeImport` functions, explicitly setting `loadExts := true` to ensure attributes are loaded and counted correctly.