### PR TITLE
fix: `erdos_128` should use induced subgraphs

### DIFF
--- a/FormalConjectures/ErdosProblems/128.lean
+++ b/FormalConjectures/ErdosProblems/128.lean
@@ -32,10 +32,9 @@ vertices has more than $n^2/50$ edges. Must G contain a triangle?
 -/
 @[category research open, AMS 5]
 theorem erdos_128 :
-    ((∀ (G' : G.Subgraph) [Fintype G'.verts] [Fintype G'.edgeSet],
-        letI n := Fintype.card V;
-        2 * G'.verts.toFinset.card ≥ n →
-        50 * G'.edgeSet.toFinset.card > n^2) → ¬ (G.CliqueFree 3))
+    ((∀ (V' : Set V),
+      2 * V'.ncard ≥ Fintype.card V →
+        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2) → ¬(G.CliqueFree 3))
     ↔ answer(sorry) := by
   sorry
 


### PR DESCRIPTION
Original statement ([source](https://www.tandfonline.com/doi/epdf/10.1080/16073606.1993.9631741?needAccess=true)) uses induced subgraphs rather than general subgraphs