### PR TITLE
fix: missing quantification in `944.lean`

### DIFF
--- a/FormalConjectures/ErdosProblems/944.lean
+++ b/FormalConjectures/ErdosProblems/944.lean
@@ -30,7 +30,8 @@ namespace Erdos944
 open Erdos944
 
 /--
-The predicate that graph $G$ with chromatic number $k$ is such that every vertex is critical, yet every critical set of edges has size $>r$
+The predicate that graph $G$ with chromatic number $k$ is such that every vertex is critical, yet
+every critical set of edges has size $>r$
 -/
 def SimpleGraph.IsErdos944 (G : SimpleGraph V) (k r : ℕ) : Prop :=  G.IsCritical k ∧
     (∀ (edges : Set (Sym2 V)), G.IsCriticalEdges edges → r < edges.ncard)
@@ -41,7 +42,7 @@ Let $k \ge 4$ and $r\ge 1$. Must there exist a graph $G$ with chromatic number $
 -/
 @[category research open, AMS 11]
 theorem erdos_944 :
-    (∀ k ≥ 4, ∀ r ≥ 1, ∃ (G : SimpleGraph V), G.IsErdos944 k r) ↔ answer(sorry) := by
+    (∀ k ≥ 4, ∀ r ≥ 1, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k r) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -52,7 +53,7 @@ This was conjectured by Dirac in 1970.
 -/
 @[category research open, AMS 11]
 theorem erdos_944.variants.dirac_conjecture :
-    (∀ k ≥ 4, ∃ (G : SimpleGraph V), G.IsErdos944 k 1) ↔ answer(sorry) := by
+    (∀ k ≥ 4, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1) ↔ answer(sorry) := by
   sorry
 
 
@@ -64,7 +65,8 @@ has no critical edge.
 [Br92] Brown, Jason I., A vertex critical graph without critical edges. Discrete Math. (1992), 99--101
 -/
 @[category research solved, AMS 11]
-theorem erdos_944.variants.dirac_conjecture.k_eq_5 : ∃ G : SimpleGraph V, G.IsErdos944 5 1 := by
+theorem erdos_944.variants.dirac_conjecture.k_eq_5 :
+    ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 5 1 := by
   sorry
 
 /--
@@ -75,7 +77,7 @@ $k - 1$ is not prime.
 -/
 @[category research solved, AMS 11]
 theorem erdos_944.variants.dirac_conjecture.k_sub_one_not_prime (k : ℕ) (hk : 4 ≤ k)
-    (h : ¬ (k - 1).Prime) : ∃ (G : SimpleGraph V), G.IsErdos944 k 1 := by
+    (h : ¬ (k - 1).Prime) : ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1 := by
   sorry
 
 /--
@@ -84,8 +86,8 @@ Jensen [Je02] gave an construction for $k$-critical graphs without any critical 
 [Je02] Jensen, Tommy R., Dense critical and vertex-critical graphs. Discrete Math. (2002), 63--84.
 -/
 @[category research solved, AMS 11]
-theorem erdos_944.variants.dirac_conure.k_ge_five (k : ℕ) (hk : 5 ≤ k) :
-    ∃ (G : SimpleGraph V), G.IsErdos944 k 1 := by
+theorem erdos_944.variants.dirac_conjecture.k_ge_five (k : ℕ) (hk : 5 ≤ k) :
+    ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1 := by
   sorry
 
 /--
@@ -93,7 +95,7 @@ The case $k=4$ and $r=1$ remains open: Are there $4$-critical graphs without any
 -/
 @[category research open, AMS 11]
 theorem erdos_944.dirac_conjecture.k_eq_four :
-    (∃ (G : SimpleGraph V), G.IsErdos944 4 1) ↔ answer(sorry) := by
+    (∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 4 1) ↔ answer(sorry) := by
   sorry
 
 /--
@@ -105,7 +107,7 @@ yet every critical set of edges has size $>r$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_944.variants.large_k_for_any_r (r : ℕ) (hr : 1 ≤ r) : ∀ᶠ k in Filter.atTop,
-    ∃ (G : SimpleGraph V), G.IsErdos944 k r := by
+    ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k r := by
   sorry
 
   end Erdos944

--- a/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -56,6 +56,13 @@ and deleting any single vertex reduces the chromatic number.
 -/
 def IsCritical (k : ℕ) : Prop := G.chromaticNumber = k ∧ ∀ v, (⊤ : G.Subgraph).IsCritialVertex v
 
+theorem not_isCritical_of_fintype_lt [Fintype V] (k : ℕ) (hk : Fintype.card V < k) :
+   ¬G.IsCritical k := by
+  simp [IsCritical]
+  intro h
+  have := h ▸ SimpleGraph.chromaticNumber_le_iff_colorable.2 G.colorable_of_fintype
+  simp at this
+  grind
 
 open SimpleGraph
 


### PR DESCRIPTION
the existence claims for a simple graph in `erdos_944*` should also quantify over the vertex type, else these are disprovable by taking e.g., any `k` larger than the number of vertices, from which `G.chromaticNumber = k` gives a contradiction