### PR TITLE
fix: quantification in `Erdos672With`

### DIFF
--- a/FormalConjectures/ErdosProblems/672.lean
+++ b/FormalConjectures/ErdosProblems/672.lean
@@ -26,7 +26,7 @@ namespace Erdos672
 
 /-- Erdős problem 672 conjectures that the below holds for any $k ≥ 4$ and $l > 1$. -/
 def Erdos672With (k l : ℕ) : Prop :=
-  ∀ (s : Finset ℕ), s.card = k → ∃ᵉ (n > 0) (d > 0), n.gcd d = 1 →
+  ∀ (s : Finset ℕ), s.card = k → ∀ᵉ (n > 0) (d > 0), n.gcd d = 1 →
     Set.IsAPOfLengthWith s k n d → ∀ q, ∏ i ∈ s, i ≠ q ^ l
 
 /--


### PR DESCRIPTION
the definition `Erdos672With` is the negation of the boxed question on the website, so the inner `∃` should be `∀`