### PR TITLE
fix: `exists_semiring_unique_left_right_maximal_ne`

### DIFF
--- a/FormalConjectures/Mathoverflow/486451.lean
+++ b/FormalConjectures/Mathoverflow/486451.lean
@@ -35,9 +35,9 @@ theorem exists_semiring_unique_left_maximal_not_unique_right_maximal :
 which are not the same as sets. -/
 @[category research open, AMS 16]
 theorem exists_semiring_unique_left_right_maximal_ne :
-    (∃ (R : Type) (_ : Semiring R),
-      (∃! I : Ideal R, I.IsMaximal) ∧ (∃! J : Ideal Rᵐᵒᵖ, J.IsMaximal) ∧
-      ∃ (I : Ideal R) (J : Ideal Rᵐᵒᵖ), (I : Set R) ≠ MulOpposite.op ⁻¹' J) ↔ answer(sorry) := by
+    (∃ (R : Type) (_ : Semiring R) (hI : ∃! I : Ideal R, I.IsMaximal)
+      (hJ : ∃! J : Ideal Rᵐᵒᵖ, J.IsMaximal),
+        (hI.choose : Set R) ≠ MulOpposite.op ⁻¹' hJ.choose) ↔ answer(sorry) := by
   sorry
 
 end Mathoverflow486451


### PR DESCRIPTION
Previously there was a choice of any `I` and `J` in the statements conclusion, these should be the unique left/right maximal ideals resp.