### PR TITLE
fix: exclude `0` and `1` cases when using `Set.IsAPOfLengthFree.maxCard`

### DIFF
--- a/FormalConjectures/ErdosProblems/139.lean
+++ b/FormalConjectures/ErdosProblems/139.lean
@@ -35,7 +35,7 @@ Let $r_k(N)$ be the size of the largest subset of ${1,...,N}$ which does not con
 $k$-term arithmetic progression. Prove that $r_k(N) = o(N)$.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_139 (k : ℕ) (hk : 1 ≤ k) :
+theorem erdos_139 (k : ℕ) (hk : 1 < k) :
     Filter.Tendsto (fun N => (r k N / N : ℝ)) Filter.atTop (𝓝 0) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/142.lean
+++ b/FormalConjectures/ErdosProblems/142.lean
@@ -42,7 +42,7 @@ Show that $r_k(N)=o_k(N/\log N)$, where $r_k(N)$ the largest possible size of a 
 of $\{1, \dots, N\}$ that does not contain any non-trivial $k$-term arithmetic progression.
 -/
 @[category research open, AMS 11]
-theorem erdos_142.variants.lower (k : ℕ) :
+theorem erdos_142.variants.lower (k : ℕ) (hk : 1 < k) :
     (fun N => (r k N : ℝ)) =o[atTop] (fun N : ℕ => N / (N : ℝ).log) := by
   sorry
 

--- a/FormalConjectures/ForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjectures/ForMathlib/Combinatorics/AP/Basic.lean
@@ -157,6 +157,17 @@ any non-trivial $k$-term arithmetic progression.
 noncomputable def Set.IsAPOfLengthFree.maxCard (k : ℕ) (N : ℕ) : ℕ :=
   sSup {Finset.card S | (S) (_ : S ⊆ Finset.Icc 1 N) (_ : S.toSet.IsAPOfLengthFree k)}
 
+theorem Set.IsAPOfLengthFree.maxCard_zero (N : ℕ) : maxCard 0 N = N := by
+  simp only [maxCard, Nat.cast_zero, isAPOfLengthFree_zero, exists_const, exists_prop]
+  apply IsGreatest.csSup_eq
+  refine ⟨⟨Finset.Icc 1 N, Subset.rfl, Nat.card_Icc _ _⟩, ?_⟩
+  rintro n ⟨S, hS, rfl⟩
+  exact S.card_mono hS |>.trans_eq (Nat.card_Icc _ _)
+
+theorem Set.IsAPOfLengthFree.maxCard_one (N : ℕ) : maxCard 1 N = N := by
+  nth_rw 2 [← maxCard_zero N]
+  simp [maxCard, isAPOfLengthFree_one, isAPOfLengthFree_zero]
+
 def ContainsMonoAPofLength {κ : Type} [Finite κ] {M : Set α}
     (coloring : M → κ) (k : ℕ) : Prop :=
   ∃ c : κ, ∃ ap : Set M, ((·.1) '' ap).IsAPOfLength k ∧


### PR DESCRIPTION
When `k = 0` and `k = 1` we have `Set.IsAPOfLengthFree.maxCard k N = N`, so these cases should be excluded for asymptotic claims that assert an answer on the RHS. Those with `answer(sorry)`s can be left as is