### PR TITLE
fix: add cardinality condition to `erdos_274` 

### DIFF
--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -35,9 +35,8 @@ If `G` is a group then can there exist an exact covering of `G` by more than one
 different sizes? (i.e. each element is contained in exactly one of the cosets.)
 -/
 @[category research open, AMS 20]
-theorem erdos_274 :
-    (∀ (G : Type*), [Group G] → 1 < ENat.card G →
-    ∃ (P : Partition (⊤ : Subgroup G)),
+theorem erdos_274 (G : Type*) [Group G] (hG : 1 < ENat.card G) :
+    (∃ (P : Partition (⊤ : Subgroup G)),
       1 < P.parts.ncard ∧
       (∀ A ∈ P.parts, ∃ᵉ (s : G) (H : Subgroup G), s • (H : Set G) = A) ∧
       P.parts.Pairwise fun A B ↦ #A ≠ #B) ↔ answer(sorry) := by


### PR DESCRIPTION
1. All claims are false if `ENat.card G ≤ 1` because no partition of `G` of size `> 1` can exist.
2. The website has since been updated to remove the condition that `G` is abelian since that case was solved.