### PR TITLE
fix: exclude zero values in `erdos_288`

### DIFF
--- a/FormalConjectures/ErdosProblems/288.lean
+++ b/FormalConjectures/ErdosProblems/288.lean
@@ -31,8 +31,8 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_288 : Set.Finite { I : Fin 2 → ℕ × ℕ |
-      ∃ n : ℕ, (∑ j : Fin 2, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
+theorem erdos_288 : Set.Finite { I : Fin 2 → ℕ+ × ℕ+ |
+      ∃ n : ℕ+, (∑ j : Fin 2, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
     answer(sorry) := by
   sorry
 
@@ -40,8 +40,8 @@ theorem erdos_288 : Set.Finite { I : Fin 2 → ℕ × ℕ |
 This is still open even if $|I_2| = 1$.
 -/
 @[category research open, AMS 11]
-theorem erdos_288.variants.i2_card_eq_1 : Set.Finite { (I, n₂) : (ℕ × ℕ) × ℕ |
-      ∃ n : ℕ, ∑ n₁ ∈ Set.Icc I.1 I.2, (n₁⁻¹ : ℚ) + (n₂⁻¹ : ℚ) = n } ↔
+theorem erdos_288.variants.i2_card_eq_1 : Set.Finite { (I, n₂) : (ℕ+ × ℕ+) × ℕ+ |
+      ∃ n : ℕ+, ∑ n₁ ∈ Set.Icc I.1 I.2, (n₁⁻¹ : ℚ) + (n₂⁻¹ : ℚ) = n } ↔
     answer(sorry) := by
   sorry
 
@@ -49,8 +49,8 @@ theorem erdos_288.variants.i2_card_eq_1 : Set.Finite { (I, n₂) : (ℕ × ℕ) 
 It is perhaps true with two intervals replaced by any $k$ intervals.
 -/
 @[category research open, AMS 11]
-theorem erdos_288.variants.k_intervals : ∀ k, Set.Finite { I : Fin k → ℕ × ℕ |
-      ∃ n : ℕ, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
+theorem erdos_288.variants.k_intervals : ∀ k, Set.Finite { I : Fin k → ℕ+ × ℕ+ |
+      ∃ n : ℕ+, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
     answer(sorry) := by
   sorry
 
@@ -58,8 +58,8 @@ theorem erdos_288.variants.k_intervals : ∀ k, Set.Finite { I : Fin k → ℕ �
 Is it true for any $k > 2$ that only finitely many $k$ intervals satisfy this condition?
 -/
 @[category research open, AMS 11]
-theorem erdos_288.variants.exists_k_gt_2 : ∃ k > 2, Set.Finite { I : Fin k → ℕ × ℕ |
-      ∃ n : ℕ, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
+theorem erdos_288.variants.exists_k_gt_2 : ∃ k > 2, Set.Finite { I : Fin k → ℕ+ × ℕ+ |
+      ∃ n : ℕ+, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
     answer(sorry) := by
   sorry
 


### PR DESCRIPTION
Zero values need to be excluded to avoid junk division; otherwise the pair of intervals `[0, n], [0, n]` satisfy the condition in the set for any `n`.