### PR TITLE
Correct Littlewood Conjecture category to 'open'

### DIFF
--- a/FormalConjectures/Wikipedia/LittlewoodConjecture.lean
+++ b/FormalConjectures/Wikipedia/LittlewoodConjecture.lean
@@ -42,7 +42,7 @@ $$
 where $\||nx\|| := \min(|x - \lfloor x \rfloor|, |x - \lceil x \rceil|)$ is the distance
 to the nearest integer.
 -/
-@[category research solved, AMS 11]
+@[category research open, AMS 11]
 theorem littlewood_conjecture (α β : ℝ) :
     atTop.liminf (fun (n : ℕ) ↦ n * distToNearestInt (n * α) * distToNearestInt (n * β)) = 0 := by
   sorry


### PR DESCRIPTION
Correcting the category of the Littlewood Conjecture to match source.