### PR TITLE
fix: typing and repetition in `erdos_354`

### DIFF
--- a/FormalConjectures/ErdosProblems/354.lean
+++ b/FormalConjectures/ErdosProblems/354.lean
@@ -23,15 +23,22 @@ import FormalConjectures.Util.ProblemImports
 -/
 namespace Erdos354
 
-/-- The set `{⌊a⌋, ⌊2 * a⌋, ⌊4 * a⌋, ...}`. -/
-def FloorMultiples (a γ : ℝ) : Set ℝ := Set.range (fun (n : ℕ) ↦ ⌊γ ^ n * a⌋)
+/-- The sequence `⌊a⌋, ⌊2 * a⌋, ⌊4 * a⌋, ..., ⌊2 ^ i * a⌋, ...`. -/
+noncomputable def FloorMultiples (a γ : ℝ) (n : ℕ) : ℤ := ⌊γ ^ n * a⌋
+
+/-- The sequence `⌊a⌋, ⌊b⌋, ⌊2 * a⌋, ⌊2 * a⌋, ... ⌊2 ^ i * a⌋, ⌊2 ^ i * b⌋, ...` -/
+noncomputable def FloorMultiples.interleave (a b γ : ℝ) (n : ℕ) : ℤ :=
+  if n % 2 = 0 then
+    FloorMultiples a γ n
+  else
+    FloorMultiples b γ n
 
 /-- Let $\alpha,\beta\in \mathbb{R}_{>0}$ such that $\alpha/\beta$ is irrational. Is
 \[\{ \lfloor \alpha\rfloor,\lfloor 2\alpha\rfloor,\lfloor 4\alpha\rfloor,\ldots\}\cup
 \{ \lfloor \beta\rfloor,\lfloor 2\beta\rfloor,\lfloor 4\beta\rfloor,\ldots\}\] complete?-/
 @[category research open, AMS 11]
 theorem erdos_354.parts.i : (∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
-    IsAddComplete (FloorMultiples α 2 ∪ FloorMultiples β 2)) ↔ answer(sorry) := by
+    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2)) ↔ answer(sorry) := by
   sorry
 
 /-- Let $\alpha,\beta\in \mathbb{R}_{>0}$ such that $\alpha/\beta$ is irrational. Is
@@ -39,7 +46,7 @@ theorem erdos_354.parts.i : (∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
 \{ \lfloor \beta\rfloor,\lfloor \gamma\beta\rfloor,\lfloor \gamma^2\beta\rfloor,\ldots\}\] complete? -/
 @[category research open, AMS 11]
 theorem erdos_354.parts.ii : (∃ γ ∈ Set.Ioo 1 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
-    IsAddComplete (FloorMultiples α γ ∪ FloorMultiples β γ)) ↔ answer(sorry) := by
+    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2)) ↔ answer(sorry) := by
   sorry
 
 end Erdos354

--- a/FormalConjectures/ForMathlib/NumberTheory/AdditivelyComplete.lean
+++ b/FormalConjectures/ForMathlib/NumberTheory/AdditivelyComplete.lean
@@ -19,13 +19,19 @@ import Mathlib.Order.Filter.AtTopBot.Defs
 
 variable {M : Type*} [AddCommMonoid M]
 
+open scoped List
+
 /-- The set of subset sums of a set `A ⊆ M`. -/
 def subsetSums (A : Set M) : Set M :=
   {n | ∃ B : Finset M, B.toSet ⊆ A ∧ n = ∑ i ∈ B, i}
 
-/-- The set of subset sums of a set `A ⊆ M`. -/
+/-- The set of subset sums of a sequence `ℕ → M`. -/
 def subseqSums (A : ℕ → M) : Set M :=
   {n | ∃ B : Finset ℕ, B.toSet.InjOn A ∧ n = ∑ i ∈ B, A i}
+
+/-- The set of subset sums of a sequence `ℕ → M`, where repetition is allowed. -/
+def subseqSums' (A : ℕ → M) : Set M :=
+  {n | ∃ B : Finset ℕ, n = ∑ i ∈ B, A i}
 
 /-- A set `A ⊆ M` is complete if every sufficiently large element of `M` is a subset sum of `A`. -/
 def IsAddComplete [Preorder M] (A : Set M) : Prop :=
@@ -35,3 +41,8 @@ def IsAddComplete [Preorder M] (A : Set M) : Prop :=
 distinct terms of `A`. -/
 def IsAddCompleteNatSeq [Preorder M] (A : ℕ → M) : Prop :=
   ∀ᶠ k in Filter.atTop, k ∈ subseqSums A
+
+/-- A sequence `A` is complete if every sufficiently large element of `M` is a sum of
+(not necessarily distinct) terms of `A`. -/
+def IsAddCompleteNatSeq' [Preorder M] (A : ℕ → M) : Prop :=
+  ∀ᶠ k in Filter.atTop, k ∈ subseqSums' A


### PR DESCRIPTION
- Typing of  `FloorMultiples` should be `ℤ` or `ℕ`, so that the correct typing is inferred in `IsAddCompleteNatSeq'`
- According to the comments, repetition should be allowed up to multiplicity, so that if some floors coincide the number can appear twice in the sums. So define a primes `IsAddCompleteNatSeq'` to allow repetition by removing the injectivity requirement.