### PR TITLE
fix: zero indexing in `erdos_695.variants.upperBound` 

### DIFF
--- a/FormalConjectures/ErdosProblems/695.lean
+++ b/FormalConjectures/ErdosProblems/695.lean
@@ -55,6 +55,7 @@ theorem erdos_695.variant.upperBound :
       (∀ i, q (i + 1) % q i = 1) ∧
       ∃ o : ℕ → ℝ,
         (o =o[atTop] (1 : ℕ → ℝ)) ∧
+        -- We use `(k + 1)` here as the informal statement is 1-indexed.
         ∀ k, q k ≤ exp ((k + 1) * (log (k + 1)) ^ (1 + o k))) ↔
     answer(sorry) := by
   sorry


### PR DESCRIPTION
Sequence is one-indexed on [the website](https://www.erdosproblems.com/forum/thread/695) while we zero-index here. While this has no impact on the main problem, `k = 0` leads to a counterexample in the upper bound variant.