### PR TITLE
fix: finiteness and quantification fixes in `723.lean`

### DIFF
--- a/FormalConjectures/ErdosProblems/723.lean
+++ b/FormalConjectures/ErdosProblems/723.lean
@@ -42,7 +42,8 @@ These always exist if $n$ is a prime power.
 -/
 @[category research solved, AMS 5]
 theorem erdos_732.prime_pow_is_projplane_order :
-    ∀ n, IsPrimePow n → ∃ pp : ProjectivePlane P L, pp.order = n := by
+    ∀ n, IsPrimePow n → ∃ (P L : Type) (_ : Membership P L) (_ : Fintype P) (_ : Fintype L)
+      (pp : ProjectivePlane P L), pp.order = n := by
   sorry
 
 /--


### PR DESCRIPTION
- `P` and  `L` should be finite throughout 
- Quantification should go within parens in `.eq_12` because for small `P` and `L` no such plane is possible; similar fix for `.prime_pow_is_projplane_order`