### PR TITLE
feat: add Erdős Problem 888

### DIFF
--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -51,5 +51,5 @@ theorem erdos_888_Sárközy : (fun n ↦ (Nat.findGreatest (p n) n : ℝ)) =o[at
 
 /-- The primes show that `|A| ≫ n/log n` is possible. -/
 @[category research solved, AMS 11]
-theorem erdos_888_primes : (fun n : ℕ  ↦ (Nat.findGreatest (p n) n : ℝ )) ≫ (fun n : ℕ  ↦ n / (n : ℝ).log)  := by
+theorem erdos_888_primes : (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ )) ≫ (fun n : ℕ ↦ n / (n : ℝ).log)  := by
   sorry


### PR DESCRIPTION
Adds formalization of Erdős Problem 888

Erdős Problem 888: What is the size of the largest $A\subseteq \{1,\ldots,n\}$ such that if $a\leq b\leq c\leq d\in A$ are such that $abcd$ is a square then $ad=bc$?
see [https://www.erdosproblems.com/888](https://www.erdosproblems.com/888)
I wasn't quite sure if the bottom two theorems should be classified as solved or open.

Closes https://github.com/google-deepmind/formal-conjectures/issues/1005