### PR TITLE
feat: add Erdős Problem 680

### DIFF
--- a/FormalConjectures/ErdosProblems/680.lean
+++ b/FormalConjectures/ErdosProblems/680.lean
@@ -36,7 +36,7 @@ where $p(m)$ denotes the least prime factor of $m$?
 -/
 @[category research open, AMS 11]
 theorem erdos_680 :
-  (∀ᶠ (n : ℕ) in Filter.atTop, ∃ k, Nat.minFac (n + k) > k^2 + 1)
+  (∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0, Nat.minFac (n + k) > k^2 + 1)
   ↔ answer(sorry) := sorry
 
 /--
@@ -45,7 +45,7 @@ $\epsilon>0$, where $C_\epsilon>0$ is some constant?
 -/
 @[category research open, AMS 11]
 theorem erdos_680.variant : (∀ ε > 0, ∃ C > 0,
-  ¬ ∀ᶠ (n : ℕ) in Filter.atTop, ∃ k,
+  ¬ ∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0,
   Nat.minFac (n + k) > exp ((1 + ε) * √k) + C)
   ↔ answer(sorry) := sorry
 


### PR DESCRIPTION
Adds formalization of Erdős Problem 680

Erdős Problem 680: 
 Is it true that, for all sufficiently large $n$, there exists some $k$ such that
$$p(n+k)>k^2+1,$$
where $p(m)$ denotes the least prime factor of $m$?
Can one prove this is false if we replace $k^2+1$ by $e^{(1+\epsilon)\sqrt{k}}+C_\epsilon$, for all $\epsilon>0$, where $C_\epsilon>0$ is some constant?
see [https://www.erdosproblems.com/680](https://www.erdosproblems.com/680)

Closes https://github.com/google-deepmind/formal-conjectures/issues/874