### PR TITLE
fix: remove `isTranscendenceBasis_ncard_eq_trdeg`

### DIFF
--- a/FormalConjectures/Wikipedia/Schanuel.lean
+++ b/FormalConjectures/Wikipedia/Schanuel.lean
@@ -28,16 +28,6 @@ open IntermediateField
 namespace Schanuel
 
 /--
-The transcendence degree is independent of the choice of a transcendence basis.
--/
-@[category graduate, AMS 12 13 14]
-theorem isTranscendenceBasis_ncard_eq_trdeg (R : Type*) {A ι : Type*}
-    [CommRing R] [CommRing A] [Algebra R A] (h : Function.Injective (algebraMap R A))
-    (𝒷 : ι → A) (hS : IsTranscendenceBasis R 𝒷) :
-    (Set.univ : Set ι).ncard = Algebra.trdeg R A := by
-  sorry
-
-/--
 The transcendence degree of $A$ adjoined $\{x_1, ..., x_n\}$ is $\leq n$.
 -/
 @[category graduate, AMS 12 13 14]


### PR DESCRIPTION
This was misformalised due to
- If the transcendence degree is infinite, the use of `Set.ncard` made LHS `0`, so should use `Cardinal.mk`
- If `R` is trivial then `IsTranscendenceBasis` does not guarantee injectivity of `b`, so should count either the image of `b` or assert non-triviality of `R`.

Removing because this is now in mathlib as [`IsTranscendenceBasis.cardinalMk_eq_trdeg`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.html#IsTranscendenceBasis.cardinalMk_eq_trdeg)