### PR TITLE
fix: non-empty condition in `union_closed.variants.cardinality_even_of_union_closed_tight`

### DIFF
--- a/FormalConjectures/Wikipedia/UnionClosed.lean
+++ b/FormalConjectures/Wikipedia/UnionClosed.lean
@@ -205,7 +205,7 @@ Reference: Conjecture 3 in https://www.nieuwarchief.nl/serie5/pdf/naw5-2023-24-4
 -/
 @[category research open, AMS 5]
 theorem union_closed.variants.cardinality_even_of_union_closed_tight
-    [Nonempty n] (hA : A ≠ {∅}) (hA : IsUnionClosed A)
+    [Nonempty n] (hA : A ≠ {∅} ∧ A ≠ ∅) (hA : IsUnionClosed A)
     (UCC_tight : ∀ i, #{x ∈ A | i ∈ x} = (1 / 2 : ℝ) * #A) :
     ∃ k, #A = 2 ^ k := by
   sorry


### PR DESCRIPTION
As well as `{{}}`, should also exclude `{}`