### PR TITLE
fix : add nontriviality of vertex type in Written on the Wall II

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture1.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture1.lean
@@ -29,7 +29,7 @@ tree satisfies `Ls(G) ≥ n(G) + 1 - 2·m(G)` where `n(G)` counts vertices and
 -/
 
 @[category research solved, AMS 5]
-theorem conjecture1 {α : Type*} [Fintype α] [DecidableEq α]
+theorem conjecture1 {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
     (G : SimpleGraph α) [DecidableRel G.Adj] (h_conn : G.Connected) :
     n G + 1 - 2 * m G ≤ Ls G := by
   sorry

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
@@ -33,7 +33,7 @@ satisfies
 eccentricity and `l(G)` is the independence number of neighbourhoods.
 -/
 @[category research open, AMS 5]
-theorem conjecture19 (G : SimpleGraph α) [Nonempty α] (h_conn : G.Connected) :
+theorem conjecture19 (G : SimpleGraph α) [Nontrivial α] (h_conn : G.Connected) :
     FLOOR ((∑ v ∈ Finset.univ, ecc G v) / (Fintype.card α : ℝ) + sSup (Set.range (indepNeighbors G)))
       ≤ b G := by
   sorry

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
@@ -21,7 +21,7 @@ namespace WrittenOnTheWallII.GraphConjecture2
 
 open Classical SimpleGraph
 
-variable {α : Type*} [Fintype α] [DecidableEq α]
+variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
 /--
 WOWII [Conjecture 2](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture3.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture3.lean
@@ -32,7 +32,8 @@ tree satisfies `Ls(G) ≥ gi(G) * MaxTemp(G)`, where `gi(G)` is the independent
 domination number and `MaxTemp(G)` is `max_v deg(v)/(n(G) - deg(v))`.
 -/
 @[category research solved, AMS 5]
-theorem conjecture3 {G : SimpleGraph α} [DecidableEq α] [DecidableRel G.Adj] [Nonempty α] (h_conn : G.Connected) :
+theorem conjecture3 {G : SimpleGraph α} [DecidableEq α] [DecidableRel G.Adj] [Nontrivial α]
+    (h_conn : G.Connected) :
     gi G * MaxTemp G ≤ Ls G := by
   sorry
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -34,7 +34,7 @@ Then
 `path(G) ≥ ceil( distavg(G, center) + distavg(G, maxEccentricityVertices G) )`.
 -/
 @[category research open, AMS 5]
-theorem conjecture34 [Nonempty α] (G : SimpleGraph α) (h_conn : G.Connected) :
+theorem conjecture34 [Nontrivial α] (G : SimpleGraph α) (h_conn : G.Connected) :
     Int.ceil (distavg G (graphCenter G) + distavg G (maxEccentricityVertices G)) ≤ (path G : ℤ) := by
   sorry
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture4.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture4.lean
@@ -30,7 +30,7 @@ trees satisfies `Ls(G) ≥ NG(G) - 1` where `NG(G)` is the minimal neighbourhood
 size of a non-edge of `G`.
 -/
 @[category research solved, AMS 5]
-theorem conjecture4 (G : SimpleGraph α) [DecidableRel G.Adj] [Nonempty α] (h_conn : G.Connected) :
+theorem conjecture4 (G : SimpleGraph α) [DecidableRel G.Adj] [Nontrivial α] (h_conn : G.Connected) :
     NG G - 1 ≤ Ls G := by
   sorry
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture40.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture40.lean
@@ -20,7 +20,7 @@ namespace WrittenOnTheWallII.GraphConjecture40
 
 open SimpleGraph
 
-variable {α : Type*} [Fintype α] [DecidableEq α] (G : SimpleGraph α)
+variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α] (G : SimpleGraph α)
 
 /--
 WOWII [Conjecture 40](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
@@ -20,7 +20,7 @@ namespace WrittenOnTheWallII.GraphConjecture5
 
 open SimpleGraph
 
-variable {V : Type*} [Fintype V] [DecidableEq V]
+variable {V : Type*} [Fintype V] [DecidableEq V] [Nontrivial V]
 
 open Classical
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture58.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture58.lean
@@ -20,7 +20,7 @@ namespace WrittenOnTheWallII.GraphConjecture58
 
 open SimpleGraph
 
-variable {α : Type*} [Fintype α] [DecidableEq α] (G : SimpleGraph α)
+variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α] (G : SimpleGraph α)
 
 /--
 WOWII [Conjecture 58](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture6.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture6.lean
@@ -23,7 +23,7 @@ namespace WrittenOnTheWallII.GraphConjecture6
 
 open SimpleGraph
 
-variable {α : Type*} [Fintype α] [DecidableEq α]
+variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
 /--
 WOWII [Conjecture 6](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)


### PR DESCRIPTION
Certain conjectures, e.g. `conjecture1`, are false if `G` has a single node. Conservatively adding `Nontrivial` instances to all the conjectures in this directory, sometimes overwriting `Nonempty`.