### PR TITLE
fix(LehmerMahlerMeasureProblem): `Polynomial.HasOddCoeffs` 

### DIFF
--- a/FormalConjectures/Wikipedia/LehmerMahlerMeasureProblem.lean
+++ b/FormalConjectures/Wikipedia/LehmerMahlerMeasureProblem.lean
@@ -67,7 +67,7 @@ theorem lehmer_mahler_measure_problem.variants.not_reciprocal (f : ℤ[X])
 
 /-- `Polynomial.HasOddCoeffs f` means that all coefficients of `f : Polynomial ℤ` are odd. -/
 def Polynomial.HasOddCoeffs (f : Polynomial ℤ) : Prop :=
-  ∀ i ∈ f.support, Odd (f.coeff i)
+  ∀ i ≤ f.natDegree, Odd (f.coeff i)
 
 /--
 If all the coefficients of `f` are odd and `M(f)>1`, `M(f) ≥ M(X^2 - X - 1)`.


### PR DESCRIPTION
The odd-coeff version of the problem should exclude, e.g., `x^3 - x - 1` where the `0` coefficient for `x^2` is even. By quantifying only over the support of a polynomial, we do not check the oddness of such coefficients. 