### PR TITLE
add `erdos_26`

### DIFF
--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -89,7 +89,7 @@ for some $a\in A$?
 -/
 @[category research open, AMS 11]
 theorem erdos_26 (A : ℕ → ℕ) (hA : StrictMono A) (h : IsThick A) :
-    (∃ k, IsBehrend (A · + k)) ↔ answer(True) := by
+    (∃ k, IsBehrend (A · + k)) ↔ answer(sorry) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -101,7 +101,7 @@ theorem erdos_26.variants.rusza : ∃ A : ℕ → ℕ,
   sorry
 
 /--
-Tenenbaum asked the weaker variant (still open) where for every $\epsilon>0$ there is
+Tenenbaum asked the weaker variant where for every $\epsilon>0$ there is
 some $k=k(\epsilon)$ such that at least $1-\epsilon$ density of all integers have a
 divisor of the form $a+k$ for some $a\in A$.
 -/

--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -1,0 +1,103 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 26
+
+*References:*
+- [erdosproblems.com/26](https://www.erdosproblems.com/26)
+- [Te19](https://arxiv.org/pdf/1908.00488) G. Tenenbaum,
+  _Some of Erdős' unconventional problems in number theory, thirty-four years later_,
+  arXiv:1908.00488 [math.NT] (2019)
+-/
+
+namespace Erdos26
+
+/-- A sequence of naturals $(a_i)$ is _thick_ if their sum of reciprocals diverges:
+$$
+  \sum_i \frac{1}{a_i} = \infty
+$$-/
+def IsThick {ι : Type*} (A : ι → ℕ) : Prop := ¬Summable (fun i ↦ (1 : ℝ) / A i)
+
+@[category test, AMS 11]
+theorem not_isThick_of_finite {ι : Type*} [Finite ι] (A : ι → ℕ) : ¬IsThick A := by
+  simpa [IsThick] using .of_finite
+
+/-- The set of multiples of a sequence $(a_i)$ is $\{ na_i | n \in \mathbb{N}, i\}$. -/
+def MultiplesOf {ι : Type*} (A : ι → ℕ) : Set ℕ := Set.range fun (n, i) ↦ n * A i
+
+@[category test, AMS 11]
+theorem multiplesOf_eq_univ {ι : Type*} (A : ι → ℕ) (h : 1 ∈ Set.range A) :
+    MultiplesOf A = Set.univ := by
+  obtain ⟨i, hi⟩ := h
+  exact top_unique fun n hn ↦ ⟨(n, i), by simp [hi]⟩
+
+/-- A sequence of naturals $(a_i)$ is _Behrend_ if almost all integers are a multiple of
+some $a_i$. In other words, if the set of multples has natural density $1$. -/
+def IsBehrend {ι : Type*} (A : ι → ℕ) : Prop := (MultiplesOf A).HasDensity 1
+
+/-- A sequence of naturals $(a_i)$ is _weakly Behrend_ with respect to $\varepsilon \in \mathbb{R}$
+if at least $1 - \varepsilon$ density of all numbers are a multiple of $A$. -/
+def IsWeaklyBehrend {ι : Type*} (A : ι → ℕ) (ε : ℝ) : Prop :=
+  ∀ d > (0 : ℝ), (MultiplesOf A).HasDensity d → 1 - ε ≤ d
+
+@[category test, AMS 11]
+theorem isBehrend_of_contains_one {ι : Type*} (A : ι → ℕ) (h : 1 ∈ Set.range A) :
+    IsBehrend A := by
+  rw [IsBehrend, Set.HasDensity]
+  exact tendsto_atTop_of_eventually_const (i₀ := 1) fun n hn ↦ by
+    field_simp [multiplesOf_eq_univ A h, Set.partialDensity]
+
+@[category test, AMS 11]
+theorem not_isBehrend_finite {ι : Type*} [Finite ι] [Preorder ι] (A : ι → ℕ) (h : StrictMono A)
+    (h : 1 ∉ Set.range A) : ¬IsBehrend A := by
+  sorry
+
+@[category test, AMS 11]
+theorem isWeaklyBehrend_of_ge_one {ι : Type*} (A : ι → ℕ) {ε : ℝ} (hε : 1 ≤ ε) :
+    IsWeaklyBehrend A ε := fun _ h _ => (sub_nonpos.2 hε).trans h.le
+
+/--
+Let $A\subset\mathbb{N}$ be infinite such that $\sum_{a \in A} \frac{1}{a} = \infty$. Must
+there exist some $k\geq 1$ such that almost all integers have a divisor of the form $a+k$
+for some $a\in A$?
+-/
+@[category research open, AMS 11]
+theorem erdos_26 (A : ℕ → ℕ) (hA : StrictMono A) (h : IsThick A) :
+    (∃ k, IsBehrend (A · + k)) ↔ answer(True) := by
+  sorry
+
+/--
+If we allow for $\sum_{a\in A} \frac{1}{a} < \infty$ then Rusza has found a counter-example.
+-/
+@[category research solved, AMS 11]
+theorem erdos_26.variants.rusza : ∃ A : ℕ → ℕ,
+    StrictMono A ∧ ¬IsThick A ∧ ∀ k, ¬IsBehrend (A · + k) := by
+  sorry
+
+/--
+Tenenbaum asked the weaker variant (still open) where for every $\epsilon>0$ there is
+some $k=k(\epsilon)$ such that at least $1-\epsilon$ density of all integers have a
+divisor of the form $a+k$ for some $a\in A$.
+-/
+@[category research open, AMS 11]
+theorem erdos_26.variants.tenenbaum (A : ℕ → ℕ) (hA : StrictMono A) (h : IsThick A) :
+    (∀ ε > (0 : ℝ), ∃ k, IsWeaklyBehrend (A · + k) ε) ↔ answer(sorry) := by
+  sorry
+
+end Erdos26

--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -53,8 +53,7 @@ def IsBehrend {ι : Type*} (A : ι → ℕ) : Prop := (MultiplesOf A).HasDensity
 
 /-- A sequence of naturals $(a_i)$ is _weakly Behrend_ with respect to $\varepsilon \in \mathbb{R}$
 if at least $1 - \varepsilon$ density of all numbers are a multiple of $A$. -/
-def IsWeaklyBehrend {ι : Type*} (A : ι → ℕ) (ε : ℝ) : Prop :=
-  ∀ d > (0 : ℝ), (MultiplesOf A).HasDensity d → 1 - ε ≤ d
+def IsWeaklyBehrend {ι : Type*} (A : ι → ℕ) (ε : ℝ) : Prop := 1 - ε ≤ (MultiplesOf A).lowerDensity
 
 @[category test, AMS 11]
 theorem isBehrend_of_contains_one {ι : Type*} (A : ι → ℕ) (h : 1 ∈ Set.range A) :
@@ -64,13 +63,15 @@ theorem isBehrend_of_contains_one {ι : Type*} (A : ι → ℕ) (h : 1 ∈ Set.r
     field_simp [multiplesOf_eq_univ A h, Set.partialDensity]
 
 @[category test, AMS 11]
-theorem not_isBehrend_finite {ι : Type*} [Finite ι] [Preorder ι] (A : ι → ℕ) (h : StrictMono A)
-    (h : 1 ∉ Set.range A) : ¬IsBehrend A := by
-  sorry
+theorem isWeaklyBehrend_of_ge_one {ι : Type*} (A : ι → ℕ) {ε : ℝ} (hε : 1 ≤ ε) :
+    IsWeaklyBehrend A ε := by
+  exact (sub_nonpos.2 hε).trans (Set.lowerDensity_nonneg _)
 
 @[category test, AMS 11]
-theorem isWeaklyBehrend_of_ge_one {ι : Type*} (A : ι → ℕ) {ε : ℝ} (hε : 1 ≤ ε) :
-    IsWeaklyBehrend A ε := fun _ h _ => (sub_nonpos.2 hε).trans h.le
+theorem not_isWeaklyBehrend_of_neg {ι : Type*} (A : ι → ℕ) {ε : ℝ} (hε : ε < 0) :
+    ¬IsWeaklyBehrend A ε := by
+  norm_num [IsWeaklyBehrend]
+  exact (add_lt_of_neg_right _ hε).trans_le (Set.lowerDensity_le_one _)
 
 /--
 Let $A\subset\mathbb{N}$ be infinite such that $\sum_{a \in A} \frac{1}{a} = \infty$. Must

--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -38,6 +38,15 @@ def IsThick {ι : Type*} (A : ι → ℕ) : Prop := ¬Summable (fun i ↦ (1 : �
 theorem not_isThick_of_finite {ι : Type*} [Finite ι] (A : ι → ℕ) : ¬IsThick A := by
   simpa [IsThick] using .of_finite
 
+@[category test, AMS 11]
+theorem not_isThick_of_geom_one_lt (r : ℕ) (hr : r > 1) : ¬IsThick fun n : ℕ ↦ r ^ n := by
+  simpa [IsThick] using summable_geometric_of_lt_one (r := 1 / r) (by aesop)
+    (div_lt_self zero_lt_one (mod_cast hr))
+
+@[category test, AMS 11]
+theorem isThick_const {ι : Type*} [Infinite ι] (r : ℕ) (h : r > 0) : IsThick fun _ : ι ↦ r := by
+  field_simp [IsThick, h, summable_const_iff]
+
 /-- The set of multiples of a sequence $(a_i)$ is $\{ na_i | n \in \mathbb{N}, i\}$. -/
 def MultiplesOf {ι : Type*} (A : ι → ℕ) : Set ℕ := Set.range fun (n, i) ↦ n * A i
 

--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -47,7 +47,7 @@ theorem not_isThick_of_geom_one_lt (r : ℕ) (hr : r > 1) : ¬IsThick fun n : �
 theorem isThick_const {ι : Type*} [Infinite ι] (r : ℕ) (h : r > 0) : IsThick fun _ : ι ↦ r := by
   field_simp [IsThick, h, summable_const_iff]
 
-/-- The set of multiples of a sequence $(a_i)$ is $\{ na_i | n \in \mathbb{N}, i\}$. -/
+/-- The set of multiples of a sequence $(a_i)$ is $\{na_i | n \in \mathbb{N}, i\}$. -/
 def MultiplesOf {ι : Type*} (A : ι → ℕ) : Set ℕ := Set.range fun (n, i) ↦ n * A i
 
 @[category test, AMS 11]
@@ -57,7 +57,7 @@ theorem multiplesOf_eq_univ {ι : Type*} (A : ι → ℕ) (h : 1 ∈ Set.range A
   exact top_unique fun n hn ↦ ⟨(n, i), by simp [hi]⟩
 
 /-- A sequence of naturals $(a_i)$ is _Behrend_ if almost all integers are a multiple of
-some $a_i$. In other words, if the set of multples has natural density $1$. -/
+some $a_i$. In other words, if the set of multiples has natural density $1$. -/
 def IsBehrend {ι : Type*} (A : ι → ℕ) : Prop := (MultiplesOf A).HasDensity 1
 
 /-- A sequence of naturals $(a_i)$ is _weakly Behrend_ with respect to $\varepsilon \in \mathbb{R}$

--- a/FormalConjectures/ForMathlib/Data/Set/Density.lean
+++ b/FormalConjectures/ForMathlib/Data/Set/Density.lean
@@ -37,6 +37,11 @@ noncomputable abbrev partialDensity {β : Type*} [Preorder β] [LocallyFiniteOrd
     (S : Set β) (A : Set β := Set.univ) (b : β) : ℝ :=
   (Set.interIio (S ∩ A) b).ncard / (Set.interIio A b).ncard
 
+theorem partialDensity_le_one {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) (b : β) : S.partialDensity A b ≤ 1 := by
+  apply div_le_one_of_le₀ _ (Nat.cast_nonneg _)
+  exact mod_cast Set.ncard_le_ncard <| Set.inter_subset_inter_left _ inter_subset_right
+
 /--
 Given a set `S` in an order `β`, where all intervals bounded above are finite, we define the upper
 density of `S` (relative to a set `A`) to be the limsup of the partial densities of `S`
@@ -44,7 +49,7 @@ density of `S` (relative to a set `A`) to be the limsup of the partial densities
 -/
 noncomputable def upperDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) : ℝ :=
-  atTop.limsup (fun (b : β) ↦ S.partialDensity A b)
+  atTop.limsup fun (b : β) ↦ S.partialDensity A b
 
 /--
 Given a set `S` in an order `β`, where all intervals bounded above are finite, we define the lower
@@ -53,7 +58,22 @@ density of `S` (relative to a set `A`) to be the liminf of the partial densities
 -/
 noncomputable def lowerDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) : ℝ :=
-  atTop.liminf (fun (b : β) ↦ S.partialDensity A b)
+  atTop.liminf fun (b : β) ↦ S.partialDensity A b
+
+theorem lowerDensity_le_one {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) : S.lowerDensity A ≤ 1 := by
+  by_cases h : atTop (α := β) = ⊥
+  · simp_all[Set.partialDensity,Set.lowerDensity]
+    norm_num[Filter.liminf_eq]at*
+  · have : (atTop (α := β)).NeBot := ⟨h⟩
+    apply Real.sSup_le (fun x hx ↦ ?_) one_pos.le
+    simpa using hx.mono fun y hy ↦ hy.trans (Set.partialDensity_le_one _ _ y)
+
+theorem lowerDensity_nonneg {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) : 0 ≤ S.lowerDensity A := by
+  rw [Set.lowerDensity, Filter.liminf_eq]
+  exact (em _).elim (le_csSup · <| .of_forall fun _ ↦ by positivity)
+    (Real.sSup_of_not_bddAbove · |>.ge)
 
 /--
 A set `S` in an order `β` where all intervals bounded above are finite is said to have
@@ -80,17 +100,17 @@ namespace HasDensity
 
 -- TODO(mercuris): generalise these to non-univ `A`
 
-/-- In a directed non-trivial partial order with a least element, the set of all
+/-- In a non-trivial partial order with a least element, the set of all
 elements has density one. -/
 @[simp]
-theorem univ {β : Type*} [PartialOrder β] [LocallyFiniteOrder β]
-    [OrderBot β] [Nontrivial β] [IsDirected β fun x1 x2 ↦ x1 ≤ x2] :
+theorem univ {β : Type*} [PartialOrder β] [LocallyFiniteOrder β] [OrderBot β] [Nontrivial β] :
     (@Set.univ β).HasDensity 1 := by
-  simp [HasDensity, partialDensity]
-  let ⟨b, hb⟩ := Set.Iio_eventually_ncard_ne_zero β
-  exact Tendsto.congr'
-    (eventually_atTop.2 ⟨b, fun n hn => (div_self <| Nat.cast_ne_zero.2 (hb n hn)).symm⟩)
-      tendsto_const_nhds
+  by_cases h : atTop (α := β) = ⊥
+  · field_simp [h, HasDensity]
+  · simp [HasDensity, partialDensity]
+    let ⟨b, hb⟩ := Set.Iio_eventually_ncard_ne_zero β
+    refine tendsto_const_nhds.congr' ?_
+    exact (eventually_ge_atTop b).mono fun n hn ↦ (div_self <| mod_cast hb n hn).symm
 
 theorem univ_nat_hasDensity_one : (@Set.univ ℕ).HasDensity 1 := univ
 
@@ -100,19 +120,17 @@ theorem empty {β : Type*} [Preorder β] [LocallyFiniteOrderBot β] (A : Set β 
   simpa [HasDensity, partialDensity] using tendsto_const_nhds
 
 theorem mono {β : Type*} [PartialOrder β] [LocallyFiniteOrder β] [OrderBot β]
-    {S T : Set β} {αS αT : ℝ} [(atTop : Filter β).NeBot] [IsDirected β fun x1 x2 ↦ x1 ≤ x2]
-    [Nontrivial β] (h : S ⊆ T) (hS : S.HasDensity αS) (hT : T.HasDensity αT) : αS ≤ αT := by
+    {S T : Set β} {αS αT : ℝ} [(atTop (α := β)).NeBot] (h : S ⊆ T) (hS : S.HasDensity αS)
+    (hT : T.HasDensity αT) : αS ≤ αT := by
   simp_all [HasDensity]
   apply le_of_tendsto_of_tendsto hS hT
-  rw [EventuallyLE, eventually_atTop]
-  let ⟨b, hb⟩ := Set.Iio_eventually_ncard_ne_zero β
-  refine ⟨b, fun c hc => ?_⟩
-  rw [div_le_div_iff_of_pos_right (by simpa using Nat.pos_of_ne_zero (hb c hc))]
-  simpa using Set.ncard_le_ncard (Set.interIio_mono h c)
+  filter_upwards [eventually_ge_atTop ⊥] with b hb
+  apply div_le_div_of_nonneg_right
+  grw [Set.ncard_le_ncard (inter_subset_inter_left _ (inter_subset_inter_left _ h))]
+  exact Nat.cast_nonneg _
 
 theorem nonneg {β : Type*} [Preorder β] [LocallyFiniteOrderBot β] [(atTop : Filter β).NeBot]
-    {S : Set β} {α : ℝ}  (h : S.HasDensity α) :
-    0 ≤ α :=
+    {S : Set β} {α : ℝ} (h : S.HasDensity α) : 0 ≤ α :=
   le_of_tendsto_of_tendsto' empty h fun b => by simp [div_nonneg, partialDensity]
 
 end Set.HasDensity

--- a/FormalConjectures/ForMathlib/Data/Set/Density.lean
+++ b/FormalConjectures/ForMathlib/Data/Set/Density.lean
@@ -63,8 +63,7 @@ noncomputable def lowerDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot
 theorem lowerDensity_le_one {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) : S.lowerDensity A ≤ 1 := by
   by_cases h : atTop (α := β) = ⊥
-  · simp_all[Set.partialDensity,Set.lowerDensity]
-    norm_num[Filter.liminf_eq]at*
+  · field_simp [h, Set.lowerDensity, Filter.liminf_eq]
   · have : (atTop (α := β)).NeBot := ⟨h⟩
     apply Real.sSup_le (fun x hx ↦ ?_) one_pos.le
     simpa using hx.mono fun y hy ↦ hy.trans (Set.partialDensity_le_one _ _ y)
@@ -122,7 +121,7 @@ theorem empty {β : Type*} [Preorder β] [LocallyFiniteOrderBot β] (A : Set β 
 theorem mono {β : Type*} [PartialOrder β] [LocallyFiniteOrder β] [OrderBot β]
     {S T : Set β} {αS αT : ℝ} [(atTop (α := β)).NeBot] (h : S ⊆ T) (hS : S.HasDensity αS)
     (hT : T.HasDensity αT) : αS ≤ αT := by
-  simp_all [HasDensity]
+  rw [HasDensity] at hS hT
   apply le_of_tendsto_of_tendsto hS hT
   filter_upwards [eventually_ge_atTop ⊥] with b hb
   apply div_le_div_of_nonneg_right


### PR DESCRIPTION
- `erdos_26` plus variants. While this has status disproved on the website, it appears to still be open if restricting to thick sets
- add to `Set.HasDensity` API and remove some unnecessary hypotheses there