### PR TITLE
fix: `OmegaPowerRamsey` should keep track of the order type

### DIFF
--- a/FormalConjectures/ErdosProblems/590.lean
+++ b/FormalConjectures/ErdosProblems/590.lean
@@ -37,7 +37,7 @@ Let $α$ be the infinite ordinal $\omega^{\omega}$. It was proved by Chang [Ch72
 colouring of the edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
 @[category research solved, AMS 3]
-theorem erdos_590 : OmegaPowerRamsey ω 3 := by
+theorem erdos_590 : OrdinalCardinalRamsey (ω ^ ω) (ω ^ ω) 3 := by
   sorry
 
 /--
@@ -45,7 +45,7 @@ Specker [Sp57] proved that when $α=ω^2$ any red/blue
 colouring of the edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
 @[category research solved, AMS 3]
-theorem erdos_590.variants.two : OmegaPowerRamsey 2 3 := by
+theorem erdos_590.variants.two : OrdinalCardinalRamsey (ω ^ 2) (ω ^ 2) 3 := by
   sorry
 
 /--
@@ -53,7 +53,8 @@ Specker [Sp57] proved that when $α=ω^n$ for $3≤ n < \omega$ then it is not t
 red/blue colouring of the edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
 @[category research solved, AMS 3]
-theorem erdos_590.variants.ge_three_false (n : ℕ) (h : 3 ≤ n) : ¬ OmegaPowerRamsey n 3 := by
+theorem erdos_590.variants.ge_three_false {n : ℕ} (h : 3 ≤ n) :
+    ¬ OrdinalCardinalRamsey (ω ^ n) (ω ^ n) 3 := by
   sorry
 
 /--
@@ -62,7 +63,7 @@ It was proved by Milnor that any red/blue colouring of the edges of $K_α$ there
 red $K_α$ or a blue $K_3$. A shorter proof was found by Larson [La73]
 -/
 @[category research solved, AMS 3]
-theorem erdos_590.variants.finite_cardinal (m : ℕ): OmegaPowerRamsey ω m := by
+theorem erdos_590.variants.finite_cardinal (m : ℕ) : OrdinalCardinalRamsey (ω ^ ω) (ω ^ ω) m := by
   sorry
 
 end Erdos590

--- a/FormalConjectures/ErdosProblems/591.lean
+++ b/FormalConjectures/ErdosProblems/591.lean
@@ -33,7 +33,7 @@ Let $α$ be the infinite ordinal $\omega^{\omega^2}$. Is it true that any red/bl
 edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
 @[category research open, AMS 3]
-theorem erdos_591 : OmegaPowerRamsey (ω ^ 2) 3 ↔ answer(sorry) := by
+theorem erdos_591 : OrdinalCardinalRamsey (ω ^ ω ^ 2) (ω ^ ω ^ 2) 3 ↔ answer(sorry) := by
   sorry
 
 end Erdos591

--- a/FormalConjectures/ErdosProblems/592.lean
+++ b/FormalConjectures/ErdosProblems/592.lean
@@ -33,8 +33,8 @@ Determine which countable ordinals $β$ have the property that, if $α = \omega^
 red/blue colouring of the edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
 @[category research open, AMS 3]
-theorem erdos_592 (β : Ordinal.{u}) : (β.card ≤ ℵ₀) →
-  OmegaPowerRamsey β 3 ↔ (answer(sorry) : Ordinal.{u} → Prop) β := by
+theorem erdos_592 (β : Ordinal.{u}) : β.card ≤ ℵ₀ →
+    OrdinalCardinalRamsey (ω ^ β) (ω ^ β) 3 ↔ (answer(sorry) : Ordinal.{u} → Prop) β := by
   sorry
 
 -- TODO(firsching): add condition by Galvin and Larson.

--- a/FormalConjectures/ForMathlib/SetTheory/Cardinal/SimpleGraph.lean
+++ b/FormalConjectures/ForMathlib/SetTheory/Cardinal/SimpleGraph.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import Mathlib.Combinatorics.SimpleGraph.Clique
-import Mathlib.Order.CompletePartialOrder
 import Mathlib.SetTheory.Ordinal.Exponential
 
 open Cardinal Ordinal
@@ -23,23 +22,17 @@ open Cardinal Ordinal
 universe u
 
 /--
-This proposition asserts the ordinal Ramsey property `ω^β → (ω^β, c)₂`.
+This proposition asserts the ordinal Ramsey property `α → (β, c)²`.
 
-It states that for any linearly ordered type `V` that is order-isomorphic to the ordinal `ω^β`,
-and for any 2-coloring of the edges of the complete graph on `V` (represented by
-complementary graphs `G_red` and `G_blue`), one of the following must hold:
-
-* There is a `G_red` clique which is order-isomorphic to `ω^β`.
-* There is a `G_blue` clique of cardinality `c`.
+It states that for any 2-coloring of the complete graph on the ordinal `α`,
+one of the following must hold:
+* There is a red clique which is order-isomorphic to `β`.
+* There is a blue clique of cardinality `c`.
 -/
-def OmegaPowerRamsey (β : Ordinal.{u}) (c : Cardinal.{u}) : Prop :=
-  let α_ord := ω ^ β
-  -- We require V to have an order (LinearOrder)
-  ∀ (V : Type u) [LinearOrder V] [LE (Quotient.out α_ord).α],
-  Nonempty (V ≃o α_ord.out.α) →
-  ∀ (G_red G_blue : SimpleGraph V), IsCompl G_red G_blue →
-    -- ...there is either a red K_α
-    (∃ (s : Set V), G_red.IsClique s ∧ Nonempty (s ≃o α_ord.out.α)) ∨
-   -- ...or there is a blue K_c.
-   -- For the blue clique, size 'c' is enough (if c is finite),
-    (∃ (s : Set V), G_blue.IsClique s ∧ #s = c)
+def OrdinalCardinalRamsey (α β : Ordinal.{u}) (c : Cardinal.{u}) : Prop :=
+  -- For any 2-coloring of `α`,
+  ∀ red blue : SimpleGraph α.toType, IsCompl red blue →
+    -- either there is a red `K_β`
+    (∃ s, red.IsClique s ∧ typeLT s = β) ∨
+   -- or there is a blue `K_c`.
+    ∃ s, blue.IsClique s ∧ #s = c


### PR DESCRIPTION
This is now not just checking the cardinality but the order type