### PR TITLE
fix: `erdos_853`

### DIFF
--- a/FormalConjectures/ErdosProblems/853.lean
+++ b/FormalConjectures/ErdosProblems/853.lean
@@ -40,8 +40,7 @@ integer $t$ such that $d_n = t$ has no solutions for $n \le x$.
 Is it true that $r(x) \to \infty$?
 -/
 @[category research open, AMS 11]
-theorem erdos_853 :
-    atTop.Tendsto r atTop := by
+theorem erdos_853 : atTop.Tendsto r atTop := by
   sorry
 
 /--


### PR DESCRIPTION
- Need to exclude `t = 0` from `r`, otherwise `r n = 0` always.
- Compactify statements using `Filter.Tendsto`