### PR TITLE
fix: `erdos_108`

### DIFF
--- a/FormalConjectures/ErdosProblems/108.lean
+++ b/FormalConjectures/ErdosProblems/108.lean
@@ -23,7 +23,6 @@ import FormalConjectures.Util.ProblemImports
 -/
 
 universe u
-variable {V : Type u}
 
 namespace Erdos108
 
@@ -35,10 +34,12 @@ contains a subgraph of girth ≥ r and chromatic number ≥ k?
 -/
 @[category research open, AMS 5]
 theorem erdos_108 :
-    (∀ r ≥ 4, ∀ k ≥ 2, ∃ (f : ℕ),
-    ∀ (G : SimpleGraph V) (hchro : SimpleGraph.chromaticNumber G ≤ f),
+    (∀ r ≥ 4, ∀ k ≥ (2 : ℕ), ∃ (f : ℕ),
+    ∀ (V : Type u) (G : SimpleGraph V) (_ : Nonempty V)
+      (hchro : f ≤ SimpleGraph.chromaticNumber G),
     ∃ (H : G.Subgraph), (SimpleGraph.girth H.coe ≥ r) ∧
-    (SimpleGraph.chromaticNumber H.coe ≥ k)) ↔ answer(sorry) := by sorry
+    (SimpleGraph.chromaticNumber H.coe ≥ k)) ↔ answer(sorry) := by
+  sorry
 
 -- TODO: Proof for the case r=4 and statement for the infinite case
 


### PR DESCRIPTION
fixes #1345
- the vertex type should be quantified after `answer(sorry)`
- `V` needs to be non-empty
- fix direction of `≤` in `hchro`
- inferred typing of `k` is `ENat`, should be `Nat`