### PR TITLE
feat(ErdosProblems): 881, minimal additive basis of order k

### DIFF
--- a/FormalConjectures/ErdosProblems/881.lean
+++ b/FormalConjectures/ErdosProblems/881.lean
@@ -35,7 +35,7 @@ open Set
 namespace Erdos881
 
 /--
-A*minimal* additive basis of order `k` is a set `A` such that
+A *minimal* additive basis of order `k` is a set `A` such that
 * `A` is an asymptotic additive basis of order `k`, and
 * for every infinite subset `B ⊆ A`, the complement `A \ B` is *not*
   an asymptotic additive basis of order `k`.


### PR DESCRIPTION
State **Erdős Problem 881**, which concerns minimal additive bases of order `k`.  

The question asks whether every *minimal* asymptotic additive basis of order `k` contains an infinite subset whose removal yields an asymptotic additive basis of order `k + 1`.

Since the problem is open, I’ve marked the Lean statement as `research open` and left the answer as `answer(sorry)`.

Closes #999