### PR TITLE
Erdos 137: flipped quantifiers fix

### DIFF
--- a/FormalConjectures/ErdosProblems/137.lean
+++ b/FormalConjectures/ErdosProblems/137.lean
@@ -47,14 +47,14 @@ theorem erdos_137.variants.perfect_power (k : ℕ) (hk : k ≥ 2) (n : ℕ) (x l
   sorry
 
 /--
-Erdős [Er82c] conjectures that, if $k$ is fixed, then for all $n$ sufficiently large and
-all positive integers $m$, then there must be at least $k$ distict primes $p$ such that
+Erdős [Er82c] conjectures that, if $k$ is fixed, then for all $n$ sufficiently large and all
+positive integers $m$, there must be at least $k$ distinct primes $p$ such that
 $p\mid m(m+1)\cdots (m+n)$ and yet $p^2$ does not divide the right hand side.
 
 [Er82c] Erdős, Paul, "Miscellaneous problems in number theory". Congr. Numer. (1982), 25-45.,
 -/
 @[category research open, AMS 11]
-theorem erdos_137.multiple_powerful_factors (k : ℕ) : ∃ (n₀ : ℕ), ∀ n > n₀,
+theorem erdos_137.multiple_powerful_factors (k : ℕ) : ∀ᶠ n in Filter.atTop,
     ∀ (m : ℕ) (hm : 0 < m),
     letI N := ∏ x ∈ Finset.Ioc m (m + n), x
     ∃ P : Finset ℕ, P.card = k ∧ ∀ p ∈ P, p.Prime ∧


### PR DESCRIPTION
This is the fix for the issue https://github.com/google-deepmind/formal-conjectures/issues/1350. 
Changed the order of quantifiers from "∀ m k, ∃ n₀, ∀ n" to "∀ k, ∃ n₀, ∀ n m" as per the original [source](https://renyi.hu/~p_erdos/1982-08.pdf) in page 27. 

It's stated clearly that 
"... In fact I would conjecture that for every $k$ there is an $n_0$ so that for $n_0 > n$ at least $k$ of the them have exponents must be $1$...."
