### PR TITLE
feat(ErdosProblems): 1060

### DIFF
--- a/FormalConjectures/ErdosProblems/1060.lean
+++ b/FormalConjectures/ErdosProblems/1060.lean
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
-
 import FormalConjectures.Util.ProblemImports
 
 /-!
@@ -22,7 +21,8 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/1060](https://www.erdosproblems.com/1060)
 -/
 
-open Asymptotics ArithmeticFunction Finset Filter Real
+open Asymptotics Finset Filter Real
+open scoped ArithmeticFunction
 
 namespace Erdos1060
 
@@ -34,13 +34,11 @@ $\log n$.
 
 @[category research open, AMS 11]
 theorem erdos_1060.bound_one (n : ℕ) :
-  ∃ h : ℕ → ℝ,
-    h =o[atTop](fun n => (1 / Real.log (Real.log n))) ∧
-      #{k  ≤ n | k * σ 1 k = n} ≤ (n:ℝ) ^ h n := by sorry
+    ∃ h : ℕ → ℝ,
+      h =o[atTop] (fun n ↦ 1 / log (log n)) ∧ #{k ≤ n | k * σ 1 k = n} ≤ (n : ℝ) ^ h n := by sorry
 
 @[category research open, AMS 11]
-theorem erdos_1060.bound_two (n : ℕ ) :
- ∃ (C : ℝ), (fun n =>
-  (#{k  ≤ n | k * σ 1 k = n} : ℝ )) =O[atTop] (fun n => log n ^ C) := by sorry
+theorem erdos_1060.bound_two (n : ℕ) :
+    ∃ (C : ℝ), (fun n ↦ (#{k ≤ n | k * σ 1 k = n} : ℝ)) =O[atTop] (fun n ↦ log n ^ C) := by sorry
 
 end Erdos1060


### PR DESCRIPTION
Reference: https://www.erdosproblems.com/1060

Problem statement
Let $f(n)$ count the number of solutions to $k\sigma(k)=n$, where $\sigma(k)$ is the sum of divisors of $k$. Is it true that $f(n)\leq n^{o(\frac{1}{\log\log n})}$? Perhaps even $\leq (\log n)^{O(1)}$?

Closes #1102