### PR TITLE
feat(ErdosProblems): 1080

### DIFF
--- a/FormalConjectures/ErdosProblems/1080.lean
+++ b/FormalConjectures/ErdosProblems/1080.lean
@@ -37,11 +37,9 @@ contain a $C_6$?
 -/
 @[category research open, AMS 5]
 theorem erdos_1080 :
-    (∃ c > (0 : ℝ), ∀ (V : Type) [Fintype V] [DecidableEq V] {Nonempty V]
-      (G : SimpleGraph V)
-        [DecidableRel G.Adj] (X Y : Set V)
-        IsBipartition G X Y ∧ X.ncard = ⌊(Fintype.card V : ℝ) ^ (2/3 : ℝ)⌋₊ ∧
-        Fintype.card G.edgeSet ≥ c * Fintype.card V ∧
+    (∃ c > (0 : ℝ), ∀ (V : Type) [Fintype V] [Nonempty V] (G : SimpleGraph V) (X Y : Set V),
+      IsBipartition G X Y → X.ncard = ⌊(Fintype.card V : ℝ) ^ (2/3 : ℝ)⌋₊ →
+      G.edgeSet.ncard ≥ c * Fintype.card V →
         ∃ (v : V) (walk : G.Walk v v), walk.IsCycle ∧ walk.length = 6) ↔ answer(sorry) := by
   sorry
 


### PR DESCRIPTION
This PR formalizes the statement for **Erdős Problem 1080**.

**Problem Statement:**
Let $G$ be a bipartite graph on $n$ vertices such that one part has $\lfloor n^{2/3} \rfloor$ vertices. Is there a constant $c > 0$ such that if $G$ has at least $cn$ edges, then $G$ must contain a $C_6$?

**Source:**
https://www.erdosproblems.com/1080

Closes #1119