### PR TITLE
feat(Arxiv): Independent Domination Conjecture

### DIFF
--- a/FormalConjectures/Arxiv/2107.00295/IndependentDomination.lean
+++ b/FormalConjectures/Arxiv/2107.00295/IndependentDomination.lean
@@ -30,12 +30,11 @@ variable {V : Type*} [Fintype V] [DecidableEq V] (G : SimpleGraph V) [DecidableR
 
 /--
 **Conjecture 1.6 (Even case).**
-For an isolate-free graph $G$ on $n$ vertices with maximum degree $D \geq 1$,
+For a nonempty isolate-free graph $G$ on $n$ vertices,
 if $D$ is even, then $(D + 2)^2 \cdot i(G) \leq (D^2 + 4) \cdot n$.
 -/
 @[category research open, AMS 5]
-theorem independentDominationEven (hIso : 0 < G.minDegree) (hMax : 1 ≤ G.maxDegree)
-    (hEven : Even G.maxDegree) :
+theorem independentDominationEven (hIso : 0 < G.minDegree) (hEven : Even G.maxDegree) :
     let D := G.maxDegree
     let i := G.indepDominationNumber
     let n := Fintype.card V
@@ -44,12 +43,11 @@ theorem independentDominationEven (hIso : 0 < G.minDegree) (hMax : 1 ≤ G.maxDe
 
 /--
 **Conjecture 1.6 (Odd case).**
-For an isolate-free graph $G$ on $n$ vertices with maximum degree $D \geq 1$,
+For a nonempty isolate-free graph $G$ on $n$ vertices,
 if $D$ is odd, then $(D + 1)(D + 3) \cdot i(G) \leq (D^2 + 3) \cdot n$.
 -/
 @[category research open, AMS 5]
-theorem independentDominationOdd (hIso : 0 < G.minDegree) (hMax : 1 ≤ G.maxDegree)
-    (hOdd : Odd G.maxDegree) :
+theorem independentDominationOdd (hIso : 0 < G.minDegree) (hOdd : Odd G.maxDegree) :
     let D := G.maxDegree
     let i := G.indepDominationNumber
     let n := Fintype.card V


### PR DESCRIPTION
fixes #227

Formalization of Conjecture 1.6 from "On independent domination of regular graphs" (arXiv:2107.00295) by Cho, Choi, and Park. This conjecture provides an upper bound on the independent domination number i(G) for isolate-free graphs with maximum degree D ≥ 1, with separate bounds for even and odd D. The file includes definitions for dominating sets and the independent domination number, building on Mathlib's existing `IsIndepSet`. 

This work was done as part of ItaLean 2025.