### PR TITLE
fix(ErdosProblems/128): correct inequality in assumption

### DIFF
--- a/FormalConjectures/ErdosProblems/128.lean
+++ b/FormalConjectures/ErdosProblems/128.lean
@@ -38,4 +38,4 @@ theorem erdos_128 :
     ↔ answer(sorry) := by
   sorry
 
-end Erdos128 m ≥ ⌊n/2⌋ ↔ 2 * m + 1 ≥ n
+end Erdos128


### PR DESCRIPTION
`m ≥ ⌊n/2⌋ ↔ 2 * m + 1 ≥ n`, not `2 * m ≥ n`