### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
           lake update formal_conjectures
 
       - name: Cache documentation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: docbuild/.lake/build/doc
           key: MathlibDoc-${{ hashFiles('docbuild/lake-manifest.json') }}-${{ hashFiles('**/*.lean') }}
@@ -113,7 +113,7 @@ jobs:
           rsync -a --files-from=out-files.txt --relative .lake/build/doc ./out
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12.9'
 

--- a/.github/workflows/check_copyright_header.yml
+++ b/.github/workflows/check_copyright_header.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run copyright check script
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const script = require('./scripts/check_copyright_header.js')


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [``](https://github.com/actions/cache/releases/tag/) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) |  |
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/github-script` | [``](https://github.com/actions/github-script/releases/tag/) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) |  |
| `actions/setup-python` | [``](https://github.com/actions/setup-python/releases/tag/) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
