### PR TITLE
feat(ErdosProblems): 1102

### DIFF
--- a/FormalConjectures/ErdosProblems/1102.lean
+++ b/FormalConjectures/ErdosProblems/1102.lean
@@ -88,7 +88,7 @@ theorem erdos_1102.lower_density_Q_exists :
     ∃ A : ℕ → ℕ, StrictMono A ∧
     (∀ j, Squarefree (A j)) ∧
     HasPropertyQ (range A) ∧
-    Tendsto (fun j : ℕ  ↦ (j / A j : ℝ )) atTop (𝓝 (6 / Real.pi^2)) := by
+    Tendsto (fun j : ℕ  ↦ (j / A j : ℝ)) atTop (𝓝 (6 / Real.pi^2)) := by
   sorry
 
 end Erdos1102


### PR DESCRIPTION
This PR attempts to add Erdos Problem [1102](https://www.erdosproblems.com/1102). The problem seems to be solved as per a recent [article ](https://arxiv.org/pdf/2512.01087).

Problem statement 
We say that $A\subseteq N$ has property $P$ if, for all $n≥1$, there are only finitely many $a\in A$ such that $n+a$ is squarefree.

We say that $A$ has property $Q$ if there are infinitely many n such that $n+a$ is squarefree for all $a<n$.

How fast must sequences $$A = \set  {a_1 < a_2 \cdots }  $$ with properties $P$ or $Q$ increase? The task is to determine lower bounds for this monotonic sequence.

Closes #1299