### PR TITLE
feat: state results and conjectures on VCₘ dim of convex sets in ℝⁿ

### DIFF
--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -31,37 +31,38 @@ open scoped EuclideanGeometry Pointwise
 
 /-! ### What's known in the literature -/
 
-/-- Every convex set in ℝ² has VC dimension at most 3. -/
+/-- Every convex set in $\mathbb R^2$ has VC dimension at most 3. -/
 @[category research solved, AMS 5 52]
 lemma hasAddVCDimAtMost_three_of_convex_r2 {C : Set ℝ²} (hC : Convex ℝ C) : HasAddVCDimAtMost C 3 :=
   sorry
 
-/-- There exists a set in ℝ³ shattering an infinite set. -/
+/-- There exists a set in $\mathbb R^3$ shattering an infinite set. -/
 @[category research solved, AMS 5 52]
 lemma exists_infinite_convex_r3_shatters :
     ∃ A C : Set ℝ³, A.Infinite ∧ Convex ℝ C ∧ Shatters {t +ᵥ C | t : ℝ³} A := sorry
 
 /-! ### What's not in the literature -/
 
-/-- There exists a set of infinite VCₙ dimension in ℝⁿ⁺². -/
+/-- There exists a set of infinite $\mathrm{VC}_n$ dimension in $\mathbb R^{n + 2}$. -/
 @[category research solved, AMS 5 52]
 lemma exists_convex_rn_add_two_vc_n_forall_not_hasAddVCNDimAtMost (n : ℕ) :
     ∃ C : Set (Fin (n + 2) → ℝ), Convex ℝ C ∧ ∀ d, ¬ HasAddVCNDimAtMost C n d := sorry
 
 /-! ### Conjectures -/
 
-/-- Every convex set in ℝ³ has VC₂ dimension at most 1. -/
+/-- Every convex set in $\mathbb R^3$ has $\mathrm{VC}_2$ dimension at most 1. -/
 @[category research open, AMS 5 52]
 lemma hasAddVCNDimAtMost_two_one_of_convex_r3 {C : Set ℝ³} (hC : Convex ℝ C) :
     HasAddVCNDimAtMost C 2 1 := sorry
 
-/-- For every `n` there exists some `d` such that every convex set in ℝⁿ⁺¹ has VCₙ dimension at
-most `d`. -/
+/-- For every $n$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has
+$\mathrm{VC}_n$ dimension at most $d$. -/
 @[category research open, AMS 5 52]
 lemma exists_hasAddVCNDimAtMost_n_of_convex_rn_add_one (n : ℕ) :
     ∃ d : ℕ, ∀ C : Set (Fin (n + 1) → ℝ), Convex ℝ C → HasAddVCNDimAtMost C n d := sorry
 
-/-- If `n ≥ 2`, every convex set in ℝⁿ⁺¹ has VCₙ dimension at most 1. -/
+/-- If $n \ge 2$, every convex set in $\mathbb R^{n + 1}$ has $\mathrm{VC}_n$ dimension at most 1.
+-/
 @[category research open, AMS 5 52]
 lemma hasAddVCNDimAtMost_n_one_of_convex_rn_add_one {n : ℕ} (hn : 2 ≤ n) {C : Set (Fin (n + 1) → ℝ)}
     (hC : Convex ℝ C) : HasAddVCNDimAtMost C n 1 := sorry

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -33,6 +33,7 @@ import FormalConjecturesForMathlib.Combinatorics.Additive.Convolution
 import FormalConjecturesForMathlib.Combinatorics.Additive.VCDim
 import FormalConjecturesForMathlib.Combinatorics.Basic
 import FormalConjecturesForMathlib.Combinatorics.Ramsey
+import FormalConjecturesForMathlib.Combinatorics.SetFamily.VCDim
 import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Balanced
 import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Clique
 import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Coloring

--- a/FormalConjecturesForMathlib/Combinatorics/Additive/VCDim.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Additive/VCDim.lean
@@ -13,21 +13,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
-import FormalConjectures.ForMathlib.Combinatorics.SetFamily.VCDim
-import Mathlib
+import FormalConjecturesForMathlib.Combinatorics.SetFamily.VCDim
+import Mathlib.Algebra.Group.Action.Pointwise.Set.Basic
+
+/-!
+# VC dimension in a group
+
+This file defines the Vapnik–Chervonenkis (aka VC) dimension of a set in a group, defined as the
+VC dimension of its family of translates.
+
+It also defines the VCₙ dimension, which has no set family analogue.
+-/
 
 open scoped Pointwise
 
 variable {G : Type*} [CommGroup G] {A B : Set G} {n d d' : ℕ}
 
-variable (A d n) in
+variable (A d) in
 /-- A set `A` in an abelian group has VC dimension at most `d` iff one cannot find two sequences
-`x` and `y` of elements indexed by `[d + 1]` and `2 ^ [d + 1]ⁿ` respectively such that
-`y s * x i ∈ A ↔ i ∈ s` for all `i ∈ [d + 1]ⁿ`, `s ⊆ [d + 1]ⁿ`. -/
+`x` and `y` of elements indexed by `[d + 1]` and `2 ^ [d + 1]` respectively such that
+`y s * x i ∈ A ↔ i ∈ s` for all `i ∈ [d + 1]`, `s ⊆ [d + 1]`. -/
 @[to_additive
-/-- A set `A` in an abelian group has VCₙ dimension at most `d` iff one cannot find two sequences
-`x` and `y` of elements indexed by `[n] × [d + 1]` and `2 ^ [d + 1]ⁿ` respectively such that
-`y s + ∑ k, x (k, i k) ∈ A ↔ i ∈ s` for all `i ∈ [d + 1]ⁿ`, `s ⊆ [d + 1]ⁿ`. -/]
+/-- A set `A` in an abelian group has VC dimension at most `d` iff one cannot find two sequences
+`x` and `y` of elements indexed by `[d + 1]` and `2 ^ [d + 1]` respectively such that
+`y s + x i ∈ A ↔ i ∈ s` for all `i ∈ [d + 1]`, `s ⊆ [d + 1]`. -/]
 def HasMulVCDimAtMost : Prop :=
   ∀ (x : Fin (d + 1) → G) (y : Set (Fin (d + 1)) → G), ¬ ∀ i s, y s * x i ∈ A ↔ i ∈ s
 

--- a/FormalConjecturesForMathlib/Combinatorics/SetFamily/VCDim.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SetFamily/VCDim.lean
@@ -63,7 +63,7 @@ lemma univ_shatters : Shatters .univ A := .of_forall_subset <| by simp
 variable (𝒜 d) in
 /-- A set family `𝒜` has VC dimension at most `d` if there are no families `x` of elements indexed
 by `[d + 1]` and `A` of sets of `𝒜` indexed by `2^[d + 1]` such that `x i ∈ A s ↔ i ∈ s` for all
-`i ∈ [d], s ⊆ [d]`. -/
+`i ∈ [d + 1], s ⊆ [d + 1]`. -/
 def HasVCDimAtMost : Prop :=
   ∀ (x : Fin (d + 1) → α) (A : Set (Fin (d + 1)) → Set α),
     (∀ s, A s ∈ 𝒜) → ¬ ∀ i s, x i ∈ A s ↔ i ∈ s


### PR DESCRIPTION
VC dimension of a set family is an old notion in learning theory. VC dimension of a *set* in a group (defined as the VC dimension of its family of translates) is a more recent notion motivated by additive combinatorics. VCₙ dimension of a set family is a very recent notion that appeared in the context of model theorym to extend the VC dimension of a set of translates.

This PR offers some conjectures in this direction. The conjectures are all mine and do not appear in the literature. They are very easily stated due to the elementary nature of VCₙ dimension.