### PR TITLE
Add Brocard’s (Ramanujan’s) conjecture on factorials and squares

### DIFF
--- a/FormalConjectures/Other/Brocard.lean
+++ b/FormalConjectures/Other/Brocard.lean
@@ -1,0 +1,12 @@
+import Mathlib
+
+/--
+Brocard’s (Ramanujan’s) conjecture.
+
+The only natural numbers `n` such that `n! + 1` is a perfect square
+are `n = 4`, `n = 5`, and `n = 7`.
+-/
+axiom brocard_conjecture :
+  ∀ n m : ℕ,
+    n.factorial + 1 = m^2 →
+    n = 4 ∨ n = 5 ∨ n = 7


### PR DESCRIPTION
This PR adds Brocard’s (Ramanujan’s) conjecture, stating that the only
natural numbers `n` such that `n! + 1` is a perfect square are
`n = 4`, `n = 5`, and `n = 7`.

The conjecture is added as an `axiom`, following repository conventions
for formal conjectures.

Related issue: #1417 