### PR TITLE
feat(ErdosProblems): 1095

### DIFF
--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -24,43 +24,51 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Erdos1095
 
-open Nat
+open Real Nat Filter Asymptotics
 
-/-
+/--
 Let $g(k)>k+1$ be maximal such that
 if $n\leq g(k)$ then $\binom{n}{k}$ is divisible by a prime $\leq k$.
 Estimate $g(k)$.
 -/
+noncomputable def g (k : ℕ) : ℕ :=
+  sSup {m | ∀ n : ℕ, (k < n ∧ n ≤ m) → (∃ p, p.Prime ∧ p ≤ k ∧ (p ∣ choose n k))}
 
-noncomputable def erdos_1095.g (k : ℕ) : ℕ :=
-  sSup {m | ∀ n : ℕ, k < n ∧ n ≤ m → (∃ p, p.Prime ∧ p ≤ k ∧ p | choose n k)}
 
-
-/-
+/--
 The current record is\[g(k) \gg \exp(c(\log k)^2)\]for some $c>0$,
 due to Konyagin [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/S0025579300007555).
 -/
-@[category research solved, AMS]
-theorem erdos_1095.lower_solved :
-    ∃ c > 0, ∀ (k : Nat) erdos_1095.g k ≥ exp (c * (log k)^2) := by
+@[category research solved, AMS 05 11]
+theorem erdos_1095_lower_solved :
+    ∃ c > 0, (fun k : ℕ => exp (c * (log k : ℝ)^2)) =O[atTop] fun k => (g k: ℝ) := by
   sorry
 
-/-
+/--
 Ecklund, Erdős, and Selfridge conjectured $g(k)\leq \exp(k^{1+o(1)})$
 [EES74](https://mathscinet.ams.org/mathscinet/relay-station?mr=1199990)
 -/
-@[category research open, AMS]
-theorem erdos_1095.upper_conjecture :
-    ∃ c ≥ 1, ∀ (k : Nat) erdos_1095.g k ≤ exp (k ^ c) := by
+@[category research open, AMS 05 11]
+theorem erdos_1095_upper_conjecture :
+    ∃ c ≥ 1, ∀ k : Nat, g k ≤ exp ((k : ℝ) ^ c) := by
   sorry
 
-/-
+/--
 Erdős, Lacampagne, and Selfridge [ELS93](https://www.ams.org/journals/mcom/1993-61-203/S0025-5718-1993-1199990-6/S0025-5718-1993-1199990-6.pdf)
 write 'it is clear to every right-thinking person' that
 $g(k)\geq\exp(c\frac{k}{\log k})$ for some constant $c>0$.
 -/
-@[category research open, AMS]
-theorem erdos_1095.lower_conjecture :
-    ∃ c > 0, ∀ (k : Nat) erdos_1095.g k ≥ exp (c * (k / log k)) := by
+@[category research open, AMS 05 11]
+theorem erdos_1095_lower_conjecture :
+    ∃ c > 0, ∀ k : Nat, g k ≥ exp (c * (k : ℝ) / log (k : ℝ)) := by
   sorry
+
+/--
+[Sorenson, Sorenson, and Webster](https://mathscinet.ams.org/mathscinet/relay-station?mr=4235124) give heuristic evidence that
+\[\log g(k) \asymp \frac{k}{\log k}.\]
+-/
+@[category research open, AMS 05 11]
+theorem erdos_1095_theta :
+    (fun k => log (g k : ℝ)) =Θ[atTop] (fun k => (k : ℝ) / log (k : ℝ)) :=
+sorry
 end Erdos1095

--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -1,0 +1,66 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 1095
+
+*Reference:* [erdosproblems.com/1095](https://www.erdosproblems.com/1095)
+-/
+
+namespace Erdos1095
+
+open Nat
+
+/-
+Let $g(k)>k+1$ be maximal such that
+if $n\leq g(k)$ then $\binom{n}{k}$ is divisible by a prime $\leq k$.
+Estimate $g(k)$.
+-/
+
+noncomputable def erdos_1095.g (k : ℕ) : ℕ :=
+  sSup {m | ∀ n : ℕ, k < n ∧ n ≤ m → (∃ p, p.Prime ∧ p ≤ k ∧ p | choose n k)}
+
+
+/-
+The current record is\[g(k) \gg \exp(c(\log k)^2)\]for some $c>0$,
+due to Konyagin [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/S0025579300007555).
+-/
+@[category research solved, AMS]
+theorem erdos_1095.lower_solved :
+    ∃ c > 0, ∀ (k : Nat) erdos_1095.g k ≥ exp (c * (log k)^2) := by
+  sorry
+
+/-
+Ecklund, Erdős, and Selfridge conjectured $g(k)\leq \exp(k^{1+o(1)})$
+[EES74](https://mathscinet.ams.org/mathscinet/relay-station?mr=1199990)
+-/
+@[category research open, AMS]
+theorem erdos_1095.upper_conjecture :
+    ∃ c ≥ 1, ∀ (k : Nat) erdos_1095.g k ≤ exp (k ^ c) := by
+  sorry
+
+/-
+Erdős, Lacampagne, and Selfridge [ELS93](https://www.ams.org/journals/mcom/1993-61-203/S0025-5718-1993-1199990-6/S0025-5718-1993-1199990-6.pdf)
+write 'it is clear to every right-thinking person' that
+$g(k)\geq\exp(c\frac{k}{\log k})$ for some constant $c>0$.
+-/
+@[category research open, AMS]
+theorem erdos_1095.lower_conjecture :
+    ∃ c > 0, ∀ (k : Nat) erdos_1095.g k ≥ exp (c * (k / log k)) := by
+  sorry
+end Erdos1095

--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos1095
 
 open Real Filter Asymptotics
-open Nat hiding log
+open _root_.Nat hiding log
 
 /--
 Let $g(k)>k+1$ be maximal such that
@@ -33,7 +33,7 @@ if $n\leq g(k)$ then $\binom{n}{k}$ is divisible by a prime $\leq k$.
 Estimate $g(k)$.
 -/
 noncomputable def g (k : ℕ) : ℕ :=
-  sSup {m | ∀ n ≤ m, ∃ p ≤ k, p.Prime ∧ p ∣ choose n k}
+  sSup {m | ∀ n ∈ Set.Ioc k m, ∃ p ≤ k, p.Prime ∧ p ∣ choose n k}
 
 
 /--
@@ -42,7 +42,7 @@ due to Konyagin [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1
 -/
 @[category research solved, AMS 05 11]
 theorem erdos_1095_lower_solved :
-    ∃ c > 0, (fun k : ℕ => exp (c * log k ^ 2)) =O[atTop] fun k => g k := by
+    ∃ c > 0, (fun k : ℕ => exp (c * (log k) ^ 2)) =O[atTop] fun k => (g k: ℝ) := by
   sorry
 
 /--
@@ -51,7 +51,7 @@ Ecklund, Erdős, and Selfridge conjectured $g(k)\leq \exp(k^{1+o(1)})$
 -/
 @[category research open, AMS 05 11]
 theorem erdos_1095_upper_conjecture :
-    ∃ c ≥ 1, ∀ k : Nat, g k ≤ exp ((k : ℝ) ^ c) := by
+    ∀ c ≥ 1, ∀ᶠ k in atTop, g k ≤ exp ((k : ℝ) ^ c) := by
   sorry
 
 /--
@@ -65,12 +65,12 @@ theorem erdos_1095_lower_conjecture :
   sorry
 
 /--
-[Sorenson, Sorenson, and Webster](https://mathscinet.ams.org/mathscinet/relay-station?mr=4235124) give heuristic evidence that
-\[\log g(k) \asymp \frac{k}{\log k}.\]
+[Sorenson, Sorenson, and Webster](https://mathscinet.ams.org/mathscinet/relay-station?mr=4235124)
+give heuristic evidence that \[\log g(k) \asymp \frac{k}{\log k}.\]
 -/
 @[category research open, AMS 05 11]
 theorem erdos_1095_theta :
-    (fun k => log (g k)) =Θ[atTop] (fun k => k / log k) :=
+    (fun k => log (g k)) ~[atTop] (fun k => k / log k) :=
   sorry
 
 end Erdos1095

--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -22,10 +22,11 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/1095](https://www.erdosproblems.com/1095)
 -/
 
-namespace Erdos1095
+open Nat hiding log
+open Real Filter
+open scoped Asymptotics Topology
 
-open Real Filter Asymptotics
-open _root_.Nat hiding log
+namespace Erdos1095
 
 /--
 Let $g(k)>k+1$ be maximal such that
@@ -35,14 +36,13 @@ Estimate $g(k)$.
 noncomputable def g (k : ℕ) : ℕ :=
   sSup {m | ∀ n ∈ Set.Ioc k m, ∃ p ≤ k, p.Prime ∧ p ∣ choose n k}
 
-
 /--
-The current record is\[g(k) \gg \exp(c(\log k)^2)\]for some $c>0$,
-due to Konyagin [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/S0025579300007555).
+The current record is\[g(k) \gg \exp(c(\log k)^2)\]for some $c>0$, due to Konyagin
+[Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/S0025579300007555).
 -/
 @[category research solved, AMS 05 11]
 theorem erdos_1095_lower_solved :
-    ∃ c > 0, (fun k : ℕ => exp (c * (log k) ^ 2)) =O[atTop] fun k => (g k: ℝ) := by
+    ∃ c > 0, (fun k : ℕ ↦ exp (c * log k ^ 2)) =O[atTop] fun k ↦ (g k : ℝ) := by
   sorry
 
 /--
@@ -51,7 +51,7 @@ Ecklund, Erdős, and Selfridge conjectured $g(k)\leq \exp(k^{1+o(1)})$
 -/
 @[category research open, AMS 05 11]
 theorem erdos_1095_upper_conjecture :
-    ∀ c ≥ 1, ∀ᶠ k in atTop, g k ≤ exp ((k : ℝ) ^ c) := by
+    ∃ f : ℕ → ℝ, Tendsto f atTop (𝓝 0) ∧ ∀ k, g k ≤ exp (k ^ (1 + f k)) := by
   sorry
 
 /--
@@ -60,8 +60,7 @@ write 'it is clear to every right-thinking person' that
 $g(k)\geq\exp(c\frac{k}{\log k})$ for some constant $c>0$.
 -/
 @[category research open, AMS 05 11]
-theorem erdos_1095_lower_conjecture :
-    ∃ c > 0, ∀ k, g k ≥ exp (c * k / log k) := by
+theorem erdos_1095_lower_conjecture : ∃ c > 0, ∀ k, g k ≥ exp (c * k / log k) :=
   sorry
 
 /--
@@ -69,8 +68,7 @@ theorem erdos_1095_lower_conjecture :
 give heuristic evidence that \[\log g(k) \asymp \frac{k}{\log k}.\]
 -/
 @[category research open, AMS 05 11]
-theorem erdos_1095_theta :
-    (fun k => log (g k)) ~[atTop] (fun k => k / log k) :=
+theorem erdos_1095_log_equivalent : (fun k ↦ log (g k)) ~[atTop] (fun k ↦ k / log k) :=
   sorry
 
 end Erdos1095

--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -24,7 +24,8 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Erdos1095
 
-open Real Nat Filter Asymptotics
+open Real Filter Asymptotics
+open Nat hiding log
 
 /--
 Let $g(k)>k+1$ be maximal such that
@@ -32,7 +33,7 @@ if $n\leq g(k)$ then $\binom{n}{k}$ is divisible by a prime $\leq k$.
 Estimate $g(k)$.
 -/
 noncomputable def g (k : ℕ) : ℕ :=
-  sSup {m | ∀ n : ℕ, (k < n ∧ n ≤ m) → (∃ p, p.Prime ∧ p ≤ k ∧ (p ∣ choose n k))}
+  sSup {m | ∀ n ≤ m, ∃ p ≤ k, p.Prime ∧ p ∣ choose n k}
 
 
 /--
@@ -41,7 +42,7 @@ due to Konyagin [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1
 -/
 @[category research solved, AMS 05 11]
 theorem erdos_1095_lower_solved :
-    ∃ c > 0, (fun k : ℕ => exp (c * (log k : ℝ)^2)) =O[atTop] fun k => (g k: ℝ) := by
+    ∃ c > 0, (fun k : ℕ => exp (c * log k ^ 2)) =O[atTop] fun k => g k := by
   sorry
 
 /--
@@ -60,7 +61,7 @@ $g(k)\geq\exp(c\frac{k}{\log k})$ for some constant $c>0$.
 -/
 @[category research open, AMS 05 11]
 theorem erdos_1095_lower_conjecture :
-    ∃ c > 0, ∀ k : Nat, g k ≥ exp (c * (k : ℝ) / log (k : ℝ)) := by
+    ∃ c > 0, ∀ k, g k ≥ exp (c * k / log k) := by
   sorry
 
 /--
@@ -69,6 +70,7 @@ theorem erdos_1095_lower_conjecture :
 -/
 @[category research open, AMS 05 11]
 theorem erdos_1095_theta :
-    (fun k => log (g k : ℝ)) =Θ[atTop] (fun k => (k : ℝ) / log (k : ℝ)) :=
-sorry
+    (fun k => log (g k)) =Θ[atTop] (fun k => k / log k) :=
+  sorry
+
 end Erdos1095

--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -40,7 +40,7 @@ noncomputable def g (k : ℕ) : ℕ :=
 The current record is\[g(k) \gg \exp(c(\log k)^2)\]for some $c>0$, due to Konyagin
 [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/S0025579300007555).
 -/
-@[category research solved, AMS 05 11]
+@[category research solved, AMS 11]
 theorem erdos_1095_lower_solved :
     ∃ c > 0, (fun k : ℕ ↦ exp (c * log k ^ 2)) =O[atTop] fun k ↦ (g k : ℝ) := by
   sorry
@@ -49,7 +49,7 @@ theorem erdos_1095_lower_solved :
 Ecklund, Erdős, and Selfridge conjectured $g(k)\leq \exp(k^{1+o(1)})$
 [EES74](https://mathscinet.ams.org/mathscinet/relay-station?mr=1199990)
 -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 11]
 theorem erdos_1095_upper_conjecture :
     ∃ f : ℕ → ℝ, Tendsto f atTop (𝓝 0) ∧ ∀ k, g k ≤ exp (k ^ (1 + f k)) := by
   sorry
@@ -59,7 +59,7 @@ Erdős, Lacampagne, and Selfridge [ELS93](https://www.ams.org/journals/mcom/1993
 write 'it is clear to every right-thinking person' that
 $g(k)\geq\exp(c\frac{k}{\log k})$ for some constant $c>0$.
 -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 11]
 theorem erdos_1095_lower_conjecture : ∃ c > 0, ∀ k, g k ≥ exp (c * k / log k) :=
   sorry
 
@@ -67,7 +67,7 @@ theorem erdos_1095_lower_conjecture : ∃ c > 0, ∀ k, g k ≥ exp (c * k / log
 [Sorenson, Sorenson, and Webster](https://mathscinet.ams.org/mathscinet/relay-station?mr=4235124)
 give heuristic evidence that \[\log g(k) \asymp \frac{k}{\log k}.\]
 -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 11]
 theorem erdos_1095_log_equivalent : (fun k ↦ log (g k)) ~[atTop] (fun k ↦ k / log k) :=
   sorry
 


### PR DESCRIPTION
This PR adds the formalization of [Erdős Problems 1095](https://www.erdosproblems.com/1095).

### Problem Statement
Let $g(k)>k+1$ be maximal such that if $n\leq g(k)$ then $\binom{n}{k}$ is divisible by a prime $\leq k$. Estimate $g(k)$.

### Summary
- Defined `g(k)` with the condition `k < n` to handle the edge case where `choose n k = 1` when `n = k`.
- Added the known lower bound from [Ko99b](https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/S0025579300007555).
- Added the conjectures from [EES74](https://mathscinet.ams.org/mathscinet/relay-station?mr=1199990) and [ELS93](https://www.ams.org/journals/mcom/1993-61-203/S0025-5718-1993-1199990-6/S0025-5718-1993-1199990-6.pdf).
- Added the heuristic conjecture from [SSW20](https://mathscinet.ams.org/mathscinet/relay-station?mr=4235124).

---
**Note to reviewers**
I'm new to the library, so please let me know if there are any misformalization or formatting issues. I would greatly appreciate any feedback.

Closes #1294 