### PR TITLE
fix(Wikipedia/WallSunSun): correct definition of Lucas-Wieferich primes

### DIFF
--- a/FormalConjectures/ForMathlib/Data/Nat/Init.lean
+++ b/FormalConjectures/ForMathlib/Data/Nat/Init.lean
@@ -1,0 +1,55 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import Mathlib.Data.Nat.Init
+
+namespace Nat
+variable {a b c : ℕ}
+
+@[simp] protected lemma dvd_add_mul_self : a ∣ b + c * a ↔ a ∣ b := by
+  rw [Nat.dvd_add_left (Nat.dvd_mul_left _ _)]
+
+@[simp] protected lemma dvd_add_self_mul : a ∣ b + a * c ↔ a ∣ b := by
+  rw [Nat.mul_comm, Nat.dvd_add_mul_self]
+
+@[simp] protected lemma dvd_mul_self_add : a ∣ b * a + c ↔ a ∣ c := by
+  rw [Nat.add_comm, Nat.dvd_add_mul_self]
+
+@[simp] protected lemma dvd_self_mul_add : a ∣ a * b + c ↔ a ∣ c := by
+  rw [Nat.mul_comm, Nat.dvd_mul_self_add]
+
+@[simp] lemma dvd_sub_iff_right' (hab : a ∣ b) : a ∣ b - c ↔ a ∣ c ∨ b ≤ c := by
+  obtain hbc | hcb := b.le_total c
+  · simp [*]
+  · simp +contextual [Nat.dvd_sub_iff_right, Nat.le_antisymm hcb, *]
+
+@[simp] lemma dvd_sub_iff_left' (hac : a ∣ c) : a ∣ b - c ↔ a ∣ b ∨ b ≤ c := by
+  obtain hbc | hcb := b.le_total c
+  · simp [*]
+  · simp +contextual [Nat.dvd_sub_iff_left, ← Nat.le_antisymm hcb, *]
+
+@[simp] protected lemma dvd_sub_mul_self : a ∣ b - c * a ↔ a ∣ b ∨ b ≤ c * a := by
+  rw [Nat.dvd_sub_iff_left' (Nat.dvd_mul_left _ _)]
+
+@[simp] protected lemma dvd_sub_self_mul : a ∣ b - a * c ↔ a ∣ b ∨ b ≤ c * a := by
+  rw [Nat.mul_comm, Nat.dvd_sub_mul_self]
+
+@[simp] protected lemma dvd_mul_self_sub : a ∣ b * a - c ↔ a ∣ c ∨ b * a ≤ c := by
+  rw [Nat.dvd_sub_iff_right' (Nat.dvd_mul_left _ _)]
+
+@[simp] protected lemma dvd_self_mul_sub : a ∣ a * b - c ↔ a ∣ c ∨ b * a ≤ c := by
+  rw [Nat.mul_comm, Nat.dvd_mul_self_sub]
+
+end Nat

--- a/FormalConjectures/ForMathlib/NumberTheory/LegendreSymbol/Basic.lean
+++ b/FormalConjectures/ForMathlib/NumberTheory/LegendreSymbol/Basic.lean
@@ -1,0 +1,19 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import Mathlib.NumberTheory.LegendreSymbol.Basic
+
+@[inherit_doc]
+scoped[NumberTheorySymbols] notation "L(" a " | " p ")" => legendreSym p a

--- a/FormalConjectures/ForMathlib/NumberTheory/WallSunSunPrimes.lean
+++ b/FormalConjectures/ForMathlib/NumberTheory/WallSunSunPrimes.lean
@@ -13,16 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
-
 import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
 
-/-! #
+
+/-!
+# Wall-Sun-Sun primes
 
 *References:*
 - [Wikipedia, Lucas_sequence](https://en.wikipedia.org/wiki/Lucas_sequence)
 - [Wikipedia, Wall–Sun–Sun prime](https://en.wikipedia.org/wiki/Wall%E2%80%93Sun%E2%80%93Sun_prime)
 - [Wikipedia, Wieferich prime](https://en.wikipedia.org/wiki/Lucas%E2%80%93Wieferich_prime)
 -/
+
+open scoped NumberTheorySymbols
 
 /--
 **The Lucas sequence of the first kind**
@@ -59,7 +62,7 @@ structure IsWallSunSunPrime (p : ℕ) : Prop where
 
 /--
 **Lucas–Wieferich prime**
-A Lucas–Wieferich prime associated with $(a,b)$ is an odd prime $p$, not dividing $a^2 - b$, such
+A Lucas–Wieferich prime associated with $(a,b)$ is an odd prime $p$, not dividing $a^2 - 4b$, such
 that $U_{p-\varepsilon}(a,b) \equiv 0 \pmod{p^2}$ where $U(a,b)$ is the Lucas sequence of the first
 kind and $\varepsilon$ is the Legendre symbol $\left({\tfrac {a^{2}-4b}{p}}\right)$.
 
@@ -70,7 +73,5 @@ for the condition that $p$ is odd and coprime to the discriminant
 structure IsLucasWieferichPrime (a b p : ℕ) : Prop where
   prime : p.Prime
   odd : Odd p
-  not_dvd : ¬p ∣ a ^ 2 - b
-  modeq :
-    letI index := p - jacobiSym p (a^2 - 4*b)
-    LucasSequence.U a b index.toNat ≡ 0 [ZMOD (p^2)]
+  not_dvd : ¬(p : ℤ) ∣ a ^ 2 - 4 * b
+  modeq : LucasSequence.U a b (p - J(a^2 - 4*b | p)).toNat ≡ 0 [ZMOD (p^2)]

--- a/FormalConjectures/Util/ForMathlib.lean
+++ b/FormalConjectures/Util/ForMathlib.lean
@@ -44,6 +44,7 @@ import FormalConjectures.ForMathlib.Data.Finset.Empty
 import FormalConjectures.ForMathlib.Data.Finset.OrdConnected
 import FormalConjectures.ForMathlib.Data.Nat.Factorization.Basic
 import FormalConjectures.ForMathlib.Data.Nat.Full
+import FormalConjectures.ForMathlib.Data.Nat.Init
 import FormalConjectures.ForMathlib.Data.Nat.MaxPrimeFac
 import FormalConjectures.ForMathlib.Data.Nat.Prime.Composite
 import FormalConjectures.ForMathlib.Data.Nat.Prime.Defs
@@ -64,6 +65,7 @@ import FormalConjectures.ForMathlib.NumberTheory.AdditivelyComplete
 import FormalConjectures.ForMathlib.NumberTheory.CoveringSystem
 import FormalConjectures.ForMathlib.NumberTheory.DirichletCharacter.Basic
 import FormalConjectures.ForMathlib.NumberTheory.Lacunary
+import FormalConjectures.ForMathlib.NumberTheory.LegendreSymbol.Basic
 import FormalConjectures.ForMathlib.NumberTheory.PrimeGap
 import FormalConjectures.ForMathlib.NumberTheory.WallSunSunPrimes
 import FormalConjectures.ForMathlib.Order.Filter.Cofinite


### PR DESCRIPTION
The inputs to `jacobiSym` were inverted, and `p | a ^ 2 - b` should have been `(p : Int) | a ^ 2 - 4b`. Also add some API that would have been useful to AP when generating its proof. I could PR it directly to mathlib if you prefer.