### PR TITLE
fix(ErdosProblems/1038): exclude constant polynomials

### DIFF
--- a/FormalConjectures/ErdosProblems/1038.lean
+++ b/FormalConjectures/ErdosProblems/1038.lean
@@ -31,8 +31,8 @@ open MeasureTheory
 
 namespace Erdos1038
 
-/-- What is the infimum of `|{x ∈ ℝ : |f x| < 1}|` over all monic polynomials `f` such that
-all of its roots are real and contained in `[-1,1]`? -/
+/-- What is the infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such
+that all of its roots are real and contained in `[-1,1]`? -/
 @[category research open, AMS 28]
 theorem erdos_1038.inf (n : ℕ) : answer(sorry) =
     ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
@@ -40,7 +40,7 @@ theorem erdos_1038.inf (n : ℕ) : answer(sorry) =
     volume {x | |f.1.eval x| < 1} := by
   sorry
 
-/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all monic polynomials `f` such that
+/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
 all of its roots are real and contained in `[-1,1]` is `< 1.835`. -/
 @[category research solved, AMS 28]
 theorem erdos_1038.inf_upperBound (n : ℕ) : ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
@@ -48,7 +48,7 @@ theorem erdos_1038.inf_upperBound (n : ℕ) : ⨅ f : {f : Polynomial ℝ // f.M
     volume {x | |f.1.eval x| < 1} < 1.835 := by
   sorry
 
-/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all monic polynomials `f` such that
+/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
 all of its roots are real and contained in `[-1,1]` is `≥ 2 ^ (4 / 3) - 1`. -/
 @[category research solved, AMS 28]
 theorem erdos_1038.inf_lowerBound (n : ℕ) : 2 ^ (4 / 3 : ℝ) - 1 ≤


### PR DESCRIPTION
The infimum should range over nonconstant monic polynomials. Otherwise the infimum will be trivially equal to zero.