### PR TITLE
feat: functions of elementary growth

### DIFF
--- a/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
@@ -18,7 +18,6 @@ import Mathlib.Analysis.Asymptotics.Defs
 import Mathlib.Order.Filter.AtTopBot.Defs
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
-open scoped Nat
 open Filter
 
 notation f " ≫ " g => Asymptotics.IsBigO Filter.atTop g f

--- a/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
@@ -17,9 +17,9 @@ limitations under the License.
 import Mathlib.Analysis.Asymptotics.Defs
 import Mathlib.Order.Filter.AtTopBot.Defs
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
 
 open scoped Nat
+open Filter
 
 notation f " ≫ " g => Asymptotics.IsBigO Filter.atTop g f
 notation g " ≪ " f => Asymptotics.IsBigO Filter.atTop g f
@@ -30,20 +30,33 @@ inductive ElementaryGrowth : Type
   | id    : ElementaryGrowth
   | log   : ElementaryGrowth
   | exp   : ElementaryGrowth
+  | atTop : (f : ℝ → ℝ) → (Tendsto f atTop atTop) → ElementaryGrowth
   | add   : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth
   | mul   : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth
   | comp  : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth
 
 namespace ElementaryGrowth
 
+def neg : ElementaryGrowth → ElementaryGrowth := fun f => mul (const (-1)) f
+
+def sub : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth := fun f g => add f (neg g)
+
+def pow : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth :=
+  fun f g => comp exp (mul g (comp log f))
+
+def inv : ElementaryGrowth → ElementaryGrowth := fun f => pow f (const (-1))
+
+def div : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth := fun f g => mul f (inv g)
+
 /-- The evaluation map of the type of common growth functions. -/
 noncomputable def Real.eval : ElementaryGrowth → ℝ → ℝ
-  | const c  => fun _ => c
-  | id       => fun x => x
-  | log      => fun x => x.log
-  | exp      => fun x => x.exp
-  | add f g  => fun x => eval f x + eval g x
-  | mul f g  => fun x => eval f x * eval g x
-  | comp f g => eval f ∘ eval g
+  | const c   => fun _ => c
+  | id        => fun x => x
+  | log       => fun x => x.log
+  | exp       => fun x => x.exp
+  | atTop f _ => f
+  | add f g   => fun x => eval f x + eval g x
+  | mul f g   => fun x => eval f x * eval g x
+  | comp f g  => eval f ∘ eval g
 
 end ElementaryGrowth

--- a/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
@@ -16,6 +16,47 @@ limitations under the License.
 
 import Mathlib.Analysis.Asymptotics.Defs
 import Mathlib.Order.Filter.AtTopBot.Defs
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
+
+open scoped Nat
 
 notation f " ≫ " g => Asymptotics.IsBigO Filter.atTop g f
 notation g " ≪ " f => Asymptotics.IsBigO Filter.atTop g f
+
+/-- The type of common functions used to estimate growth rate. -/
+inductive CommonFn : Type
+  | const : ℝ → CommonFn
+  | id    : CommonFn
+  | log   : CommonFn
+  | exp   : CommonFn
+  | Gamma : CommonFn
+  | add   : CommonFn → CommonFn → CommonFn
+  | mul   : CommonFn → CommonFn → CommonFn
+  | comp  : CommonFn → CommonFn → CommonFn
+
+namespace CommonFn
+
+/-- The evaluation map of the type of common growth functions. -/
+noncomputable def Real.eval : CommonFn → ℝ → ℝ
+  | const c  => fun _ => c
+  | id       => fun x => x
+  | log      => fun x => x.log
+  | exp      => fun x => x.exp
+  | Gamma    => fun x => x.Gamma
+  | add f g  => fun x => eval f x + eval g x
+  | mul f g  => fun x => eval f x * eval g x
+  | comp f g => eval f ∘ eval g
+
+/-- The evaluation map of the type of common growth functions. -/
+noncomputable def Nat.eval : CommonFn → ℕ → ℝ
+  | const c  => fun _ => c
+  | id       => fun x => x
+  | log      => fun x => (x : ℝ).log
+  | exp      => fun x => (x : ℝ).log
+  | Gamma    => fun x => x !
+  | add f g  => fun x => eval f x + eval g x
+  | mul f g  => fun x => eval f x * eval g x
+  | comp f g => Real.eval f ∘ eval g
+
+end CommonFn

--- a/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
@@ -30,7 +30,6 @@ inductive CommonFn : Type
   | id    : CommonFn
   | log   : CommonFn
   | exp   : CommonFn
-  | Gamma : CommonFn
   | add   : CommonFn → CommonFn → CommonFn
   | mul   : CommonFn → CommonFn → CommonFn
   | comp  : CommonFn → CommonFn → CommonFn
@@ -43,20 +42,8 @@ noncomputable def Real.eval : CommonFn → ℝ → ℝ
   | id       => fun x => x
   | log      => fun x => x.log
   | exp      => fun x => x.exp
-  | Gamma    => fun x => x.Gamma
   | add f g  => fun x => eval f x + eval g x
   | mul f g  => fun x => eval f x * eval g x
   | comp f g => eval f ∘ eval g
-
-/-- The evaluation map of the type of common growth functions. -/
-noncomputable def Nat.eval : CommonFn → ℕ → ℝ
-  | const c  => fun _ => c
-  | id       => fun x => x
-  | log      => fun x => (x : ℝ).log
-  | exp      => fun x => (x : ℝ).log
-  | Gamma    => fun x => x !
-  | add f g  => fun x => eval f x + eval g x
-  | mul f g  => fun x => eval f x * eval g x
-  | comp f g => Real.eval f ∘ eval g
 
 end CommonFn

--- a/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
@@ -26,18 +26,18 @@ notation g " ≪ " f => Asymptotics.IsBigO Filter.atTop g f
 
 /-- The type of common functions used to estimate growth rate. -/
 inductive ElementaryGrowth : Type
-  | const : ℝ → CommonFn
-  | id    : CommonFn
-  | log   : CommonFn
-  | exp   : CommonFn
-  | add   : CommonFn → CommonFn → CommonFn
-  | mul   : CommonFn → CommonFn → CommonFn
-  | comp  : CommonFn → CommonFn → CommonFn
+  | const : ℝ → ElementaryGrowth
+  | id    : ElementaryGrowth
+  | log   : ElementaryGrowth
+  | exp   : ElementaryGrowth
+  | add   : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth
+  | mul   : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth
+  | comp  : ElementaryGrowth → ElementaryGrowth → ElementaryGrowth
 
-namespace CommonFn
+namespace ElementaryGrowth
 
 /-- The evaluation map of the type of common growth functions. -/
-noncomputable def Real.eval : CommonFn → ℝ → ℝ
+noncomputable def Real.eval : ElementaryGrowth → ℝ → ℝ
   | const c  => fun _ => c
   | id       => fun x => x
   | log      => fun x => x.log
@@ -46,4 +46,4 @@ noncomputable def Real.eval : CommonFn → ℝ → ℝ
   | mul f g  => fun x => eval f x * eval g x
   | comp f g => eval f ∘ eval g
 
-end CommonFn
+end ElementaryGrowth

--- a/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
+++ b/FormalConjectures/ForMathlib/Analysis/Asymptotics/Basic.lean
@@ -25,7 +25,7 @@ notation f " ≫ " g => Asymptotics.IsBigO Filter.atTop g f
 notation g " ≪ " f => Asymptotics.IsBigO Filter.atTop g f
 
 /-- The type of common functions used to estimate growth rate. -/
-inductive CommonFn : Type
+inductive ElementaryGrowth : Type
   | const : ℝ → CommonFn
   | id    : CommonFn
   | log   : CommonFn


### PR DESCRIPTION
This PR intends to define the type of common functions used to estimate growth rate so that for example we can formalize a better statement in #1476 and potentially other Erdos problems.
I only include constants, identity function, log, exp, gamma (factorial), addition, multiplication, and composition because

1. `a^x = exp x * (log a)`
2. `x^a = exp a * (log x)`
3. `x^x = exp x * (log x)`
4. We certainly don't want other kinds of elementary functions (e.g. trigonometric functions) because they oscillate.
5. Subtraction is multiplying by -1.
6. `f/g = exp (log f - log g)`

This should include most of functions we are interested in.

I also only defined evaluation map for `ℝ → ℝ` and `ℕ → ℝ` instead of functions with more general domain/codomain because I think these are enough for Erdos problems.