### PR TITLE
feat(OEIS/A303656): sum of two squares, a power of 3, and a power of 5

### DIFF
--- a/FormalConjectures/OEIS/303656.lean
+++ b/FormalConjectures/OEIS/303656.lean
@@ -24,7 +24,16 @@ nonnegative integers.
 
 Zhi-Wei Sun has offered a $3,500 prize for the first proof.
 
-*Reference:* [A303656](https://oeis.org/A303656)
+*References:*
+- [OEIS A303656](https://oeis.org/A303656)
+- Z.-W. Sun, "Restricted sums of four squares," arXiv preprint:
+  https://arxiv.org/abs/1701.05868v10
+- Z.-W. Sun, "Refining Lagrange's four-square theorem," Journal of Number Theory:
+  http://maths.nju.edu.cn/~zwsun/RefineFourSquareTh.pdf
+- Z.-W. Sun, "Restricted sums of three or four squares":
+  http://maths.nju.edu.cn/~zwsun/Square-sum.pdf
+- Zhi-Wei Sun's 1-3-5 conjecture and variations:
+  https://www.aimspress.com/aimspress-data/era/2020/2/PDF/1935-9179_2020_2_589.pdf
 -/
 
 namespace OeisA303656


### PR DESCRIPTION
Closes #1477

Adds formalization of Zhi-Wei Sun's conjecture from OEIS A303656: any integer n > 1 can be written as a² + b² + 3^c + 5^d where a, b, c, d are nonnegative integers.

### Changes
- Created `FormalConjectures/OEIS/303656.lean` with:
  - Predicate `IsSumOfTwoSquaresAndPowersOf3And5` defining the representation
  - Three test cases (n = 2, 5, 25) from OEIS examples
  - Main conjecture statement with appropriate attributes
 - Test cases verified: 2 = 0² + 0² + 3⁰ + 5⁰, 5 = 0² + 1² + 3¹ + 5⁰, 25 = 1² + 4² + 3¹ + 5¹

### Reference
- [OEIS A303656](https://oeis.org/A303656)
- Z.-W. Sun, “Restricted sums of four squares,” arXiv preprint:
https://arxiv.org/abs/1701.05868v10
- Z.-W. Sun, “Refining Lagrange’s four-square theorem,” Journal of Number Theory:
http://maths.nju.edu.cn/~zwsun/RefineFourSquareTh.pdf
- Z.-W. Sun, “Restricted sums of three or four squares”:
http://maths.nju.edu.cn/~zwsun/Square-sum.pdf
- Zhi-Wei Sun’s 1-3-5 conjecture and variations:
https://www.aimspress.com/aimspress-data/era/2020/2/PDF/1935-9179_2020_2_589.pdf

 Please let me know if any changes are needed or if I've missed anything.