### PR TITLE
chore: prefer `answer(sorry) ↔ ...`

### DIFF
--- a/FormalConjectures/ErdosProblems/10.lean
+++ b/FormalConjectures/ErdosProblems/10.lean
@@ -37,7 +37,7 @@ Is there some $k$ such that every integer is the sum of a prime and at most $k$
 powers of $2$?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_10 : (∃ k, sumPrimeAndTwoPows k = Set.univ \ {0, 1}) ↔ answer(sorry) := by
+theorem erdos_10 : answer(sorry) ↔ ∃ k, sumPrimeAndTwoPows k = Set.univ \ {0, 1} := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1003.lean
+++ b/FormalConjectures/ErdosProblems/1003.lean
@@ -32,7 +32,7 @@ Are there infinitely many solutions to $\phi(n) = \phi(n+1)$, where $\phi$ is th
 function?
 -/
 @[category research open, AMS 11]
-theorem erdos_1003 : Set.Infinite {n | φ n = φ (n + 1)} ↔ answer(sorry) := by
+theorem erdos_1003 : answer(sorry) ↔ Set.Infinite {n | φ n = φ (n + 1)} := by
   sorry
 
 /--
@@ -43,7 +43,7 @@ $$\phi(n) = \phi(n+1) = \cdots = \phi (n+k)$$ has infinitely many solutions.
 -/
 @[category research open, AMS 11]
 theorem erdos_1003.variants.Icc :
-    (∀ k ≥ 1, Set.Infinite {n | ∀ i ∈ Set.Icc 1 k, φ n = φ (n + i)}) ↔ answer(sorry) := by
+    answer(sorry) ↔ (∀ k ≥ 1, Set.Infinite {n | ∀ i ∈ Set.Icc 1 k, φ n = φ (n + i)}) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1003.lean
+++ b/FormalConjectures/ErdosProblems/1003.lean
@@ -43,7 +43,7 @@ $$\phi(n) = \phi(n+1) = \cdots = \phi (n+k)$$ has infinitely many solutions.
 -/
 @[category research open, AMS 11]
 theorem erdos_1003.variants.Icc :
-    answer(sorry) ↔ (∀ k ≥ 1, Set.Infinite {n | ∀ i ∈ Set.Icc 1 k, φ n = φ (n + i)}) := by
+    answer(sorry) ↔ ∀ k ≥ 1, {n | ∀ i ∈ Set.Icc 1 k, φ n = φ (n + i)}.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1004.lean
+++ b/FormalConjectures/ErdosProblems/1004.lean
@@ -32,8 +32,8 @@ This is an open problem.
 -/
 @[category research open, AMS 11]
 theorem erdos_1004 :
-    (∀ c > (0 : ℝ), ∀ᶠ x in atTop, ∃ n ≤ x,
-      IsDistinctTotientRun n ⌊(Real.log (x : ℝ)) ^ c⌋₊) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ c > (0 : ℝ), ∀ᶠ x in atTop, ∃ n ≤ x,
+      IsDistinctTotientRun n ⌊(Real.log (x : ℝ)) ^ c⌋₊ := by
   sorry
 
 /--
@@ -43,10 +43,9 @@ Here we state the existence of such a constant c.
 -/
 @[category research solved, AMS 11]
 theorem erdos_1004.EPS87_theorem :
-    (∃ (c : ℝ) (hc : c > 0),
+    answer(True) ↔ ∃ (c : ℝ) (hc : c > 0),
       ∀ (n K : ℕ), n > 0 → IsDistinctTotientRun n K →
-        (K : ℝ) ≤ (n : ℝ) / Real.exp (c * (Real.log n) ^ (1/3 : ℝ))) ↔
-      answer(True) := by
+        (K : ℝ) ≤ (n : ℝ) / Real.exp (c * (Real.log n) ^ (1/3 : ℝ)) := by
   sorry
 
 end Erdos1004

--- a/FormalConjectures/ErdosProblems/1043.lean
+++ b/FormalConjectures/ErdosProblems/1043.lean
@@ -43,9 +43,9 @@ Pommerenke [Po61] proved that the answer is no.
 -/
 @[category research solved, AMS 28 30]
 theorem erdos_1043 :
-    (∀ (f : ℂ[X]), f.Monic → f.degree ≥ 1 →
+    answer(sorry) ↔ ∀ (f : ℂ[X]), f.Monic → f.degree ≥ 1 →
       ∃ (u : ℂ), ‖u‖ = 1 ∧
-      volume ((ℝ ∙ u).orthogonalProjection '' levelSet f) ≤ 2) ↔ answer(False) := by
+      volume ((ℝ ∙ u).orthogonalProjection '' levelSet f) ≤ 2 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1043.lean
+++ b/FormalConjectures/ErdosProblems/1043.lean
@@ -43,7 +43,7 @@ Pommerenke [Po61] proved that the answer is no.
 -/
 @[category research solved, AMS 28 30]
 theorem erdos_1043 :
-    answer(sorry) ↔ ∀ (f : ℂ[X]), f.Monic → f.degree ≥ 1 →
+    answer(False) ↔ ∀ (f : ℂ[X]), f.Monic → f.degree ≥ 1 →
       ∃ (u : ℂ), ‖u‖ = 1 ∧
       volume ((ℝ ∙ u).orthogonalProjection '' levelSet f) ≤ 2 := by
   sorry

--- a/FormalConjectures/ErdosProblems/1051.lean
+++ b/FormalConjectures/ErdosProblems/1051.lean
@@ -44,8 +44,8 @@ $\sum_{n=0}^\infty \frac{1}{a_n \cdot a_{n+1}}$ is irrational?
 -/
 @[category research open, AMS 11]
 theorem erdos_1051 :
-    (∀ (a : ℕ → ℤ), StrictMono a → GrowthCondition a →
-      Irrational (ErdosSeries a)) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ (a : ℕ → ℤ), StrictMono a → GrowthCondition a →
+      Irrational (ErdosSeries a) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1052.lean
+++ b/FormalConjectures/ErdosProblems/1052.lean
@@ -37,7 +37,7 @@ def IsUnitaryPerfect (n : ℕ) : Prop :=
 Are there only finitely many unitary perfect numbers? -/
 @[category research open, AMS 11]
 theorem erdos_1052 :
-    Set.Finite IsUnitaryPerfect ↔ answer(sorry) := by
+    answer(sorry) ↔ Set.Finite IsUnitaryPerfect := by
   sorry
 
 /-- All unitary perfect numbers are even. -/

--- a/FormalConjectures/ErdosProblems/1052.lean
+++ b/FormalConjectures/ErdosProblems/1052.lean
@@ -37,7 +37,7 @@ def IsUnitaryPerfect (n : ℕ) : Prop :=
 Are there only finitely many unitary perfect numbers? -/
 @[category research open, AMS 11]
 theorem erdos_1052 :
-    answer(sorry) ↔ Set.Finite IsUnitaryPerfect := by
+    answer(sorry) ↔ {n | IsUnitaryPerfect n}.Finite := by
   sorry
 
 /-- All unitary perfect numbers are even. -/

--- a/FormalConjectures/ErdosProblems/1054.lean
+++ b/FormalConjectures/ErdosProblems/1054.lean
@@ -36,21 +36,21 @@ noncomputable def f (n : ℕ) : ℕ :=
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors
 of $m$ for some $k\geq 1$. Is it true that $f(n)=o(n)$?-/
 @[category research open, AMS 11]
-theorem erdos_1054.parts.i : (fun n ↦ (f n : ℝ)) =o[atTop] (fun n ↦ (n : ℝ)) ↔ answer(sorry) := by
+theorem erdos_1054.parts.i : answer(sorry) ↔ (fun n ↦ (f n : ℝ)) =o[atTop] (fun n ↦ (n : ℝ)) := by
   sorry
 
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors
 of $m$ for some $k\geq 1$. Is it true that $f(n)=o(n)$ for almost all $n$? -/
 @[category research open, AMS 11]
-theorem erdos_1054.parts.ii : (∃ (A : Set ℕ), A.HasDensity 1 ∧
-    (fun (n : A) ↦ (f ↑n : ℝ)) =o[atTop] (fun n ↦ (n : ℝ))) ↔ answer(sorry) := by
+theorem erdos_1054.parts.ii : answer(sorry) ↔ ∃ (A : Set ℕ), A.HasDensity 1 ∧
+    (fun (n : A) ↦ (f ↑n : ℝ)) =o[atTop] (fun n ↦ (n : ℝ)) := by
   sorry
 
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors
 of $m$ for some $k\geq 1$. Is it true that $\limsup f(n)/n=\infty$? -/
 @[category research open, AMS 11]
-theorem erdos_1054.parts.iii : (∃ (A : Set ℕ), A.HasDensity 1 ∧
-    atTop.limsup (fun n ↦ (f n : EReal) / n) = ⊤) ↔ answer(sorry) := by
+theorem erdos_1054.parts.iii : answer(sorry) ↔ ∃ (A : Set ℕ), A.HasDensity 1 ∧
+    atTop.limsup (fun n ↦ (f n : EReal) / n) = ⊤ := by
   sorry
 
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors

--- a/FormalConjectures/ErdosProblems/1056.lean
+++ b/FormalConjectures/ErdosProblems/1056.lean
@@ -39,10 +39,9 @@ Let $k ≥ 2$. Does there exist a prime $p$ and consecutive intervals $I_0,\dots
 such that $\prod\limits_{n{\in}I_i}n \equiv 1 \mod n$ for all $1 \le i \le k$?
 -/
 @[category research open, AMS 11]
-theorem erdos_1056 :
-    (∀ k ≥ 2, ∃ (p : ℕ) (_ : p.Prime) (boundaries : Fin (k + 1) → ℕ) (_ : StrictMono boundaries),
-    AllModProdEqualsOne p boundaries)
-  ↔ answer(sorry) := by
+theorem erdos_1056 : answer(sorry) ↔
+    ∀ k ≥ 2, ∃ (p : ℕ) (_ : p.Prime) (boundaries : Fin (k + 1) → ℕ) (_ : StrictMono boundaries),
+    AllModProdEqualsOne p boundaries := by
   sorry
 
 /--
@@ -71,9 +70,9 @@ $q_1! \equiv \dots \equiv q_k! \mod p$ for arbitrarily large $k$ (with $q_1 < \d
 -/
 @[category research open, AMS 11]
 theorem noll_simmons :
-    (∀ᶠ k in Filter.atTop,
+    answer(sorry) ↔ ∀ᶠ k in Filter.atTop,
     ∃ (p : ℕ) (_ : p.Prime) (Q : Fin k → ℕ) (_ : StrictMono Q) (_ : ∀ i, Q i < p),
-    ∀ i j : Fin k, (Q i)! ≡ (Q j)! [MOD p]) ↔ answer(sorry) := by
+    ∀ i j : Fin k, (Q i)! ≡ (Q j)! [MOD p] := by
   sorry
 
 end Erdos1056

--- a/FormalConjectures/ErdosProblems/1059.lean
+++ b/FormalConjectures/ErdosProblems/1059.lean
@@ -36,7 +36,7 @@ def AllFactorialSubtractionsComposite (n : ℕ) : Prop :=
 /-- Are there infinitely many primes $p$ such that $p - k!$ is composite for each $k$ such that $1 ≤ k! < p$? -/
 @[category research open, AMS 11]
 theorem erdos_1059 :
-    Set.Infinite {p | p.Prime ∧ AllFactorialSubtractionsComposite p} ↔ answer(sorry) := by
+    answer(sorry) ↔ Set.Infinite {p | p.Prime ∧ AllFactorialSubtractionsComposite p} := by
   sorry
 
 abbrev DecidableIsFactorial (d : ℕ) : Prop :=

--- a/FormalConjectures/ErdosProblems/1065.lean
+++ b/FormalConjectures/ErdosProblems/1065.lean
@@ -28,14 +28,13 @@ namespace Erdos1065
 Are there infinitely many primes $p$ such that $p = 2^k * q + 1$
 for some prime $q$ and $k ≥ 0$?
 
-This is mentioned as B46 
+This is mentioned as B46
 in [Unsolved Problems in Number Theory](https://doi.org/10.1007/978-0-387-26677-0)
 by *Richard K. Guy*
  -/
 @[category research open, AMS 11]
 theorem erdos_1065a :
-    Set.Infinite {p | ∃ q k, p.Prime ∧ q.Prime ∧ p = 2^k * q + 1}
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ Set.Infinite {p | ∃ q k, p.Prime ∧ q.Prime ∧ p = 2^k * q + 1} := by
   sorry
 
 /--
@@ -43,8 +42,8 @@ Are there infinitely many primes $p$ such that $p = 2^k 3^l q + 1$
 for some prime $q$ and $k ≥ 0$, $l ≥ 0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_1065b : Set.Infinite {p | ∃ q k l, p.Prime ∧ q.Prime ∧ p = 2^k * 3^l * q + 1}
-    ↔ answer(sorry) := by
+theorem erdos_1065b : answer(sorry) ↔
+    Set.Infinite {p | ∃ q k l, p.Prime ∧ q.Prime ∧ p = 2^k * 3^l * q + 1} := by
   sorry
 
 end Erdos1065

--- a/FormalConjectures/ErdosProblems/107.lean
+++ b/FormalConjectures/ErdosProblems/107.lean
@@ -44,7 +44,7 @@ contain $n$ points which form the vertices of a convex $n$-gon.
 Prove that $f(n) = 2^{n-2} + 1$.
 -/
 @[category research open, AMS 52]
-theorem erdos_107 : (∀ n ≥ 3, f n = 2^(n - 2) + 1) ↔ answer(sorry) := by
+theorem erdos_107 : answer(sorry) ↔ ∀ n ≥ 3, f n = 2^(n - 2) + 1 := by
   sorry
 
 /-- For every $n ≥ 3$, there exists $N$ such that any $N$ points, no three on a line,

--- a/FormalConjectures/ErdosProblems/1072.lean
+++ b/FormalConjectures/ErdosProblems/1072.lean
@@ -32,15 +32,14 @@ noncomputable def f (p : ℕ) : ℕ := sInf {n | (n)! + 1 ≡ 0 [MOD p]}
 
 /-- Is it true that there are infinitely many $p$ for which $f(p) = p − 1$? -/
 @[category research open, AMS 11]
-theorem erdos_1072a : Set.Infinite {p | p.Prime ∧ f p = p - 1} ↔ answer(sorry) := by
+theorem erdos_1072a : answer(sorry) ↔ Set.Infinite {p | p.Prime ∧ f p = p - 1} := by
   sorry
 
 /-- Is it true that $f(p)/p \to 0$ for $p \to \infty$ in a density 1 subset of the primes? -/
 @[category research open, AMS 11]
 theorem erdos_1072b :
-    (∃ (P : Set ℕ), P ⊆ {p | p.Prime} ∧ P.HasDensity 1 {p | p.Prime} ∧
-      Tendsto (fun p => (f p / p : ℝ)) (atTop ⊓ principal P) (𝓝 0))
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (P : Set ℕ), P ⊆ {p | p.Prime} ∧ P.HasDensity 1 {p | p.Prime} ∧
+      Tendsto (fun p => (f p / p : ℝ)) (atTop ⊓ principal P) (𝓝 0) := by
   sorry
 /--
 Erdős, Hardy, and Subbarao [HaSu02], believed that the number of $p \le x$ for which $f(p)=p−1$

--- a/FormalConjectures/ErdosProblems/1073.lean
+++ b/FormalConjectures/ErdosProblems/1073.lean
@@ -34,7 +34,7 @@ noncomputable def A (x : ℕ) : ℝ := {u | u.Composite ∧ ∃ n, n ! + 1 ≡ 0
 /-- Is it true that $A(x) \le x^{o(1)}$? -/
 @[category research open, AMS 11]
 theorem erdos_1073 :
-    (∃ (o : ℕ → ℝ), o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ x, A x ≤ x ^ (o x)) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (o : ℕ → ℝ), o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ x, A x ≤ x ^ (o x) := by
   sorry
 
 end Erdos1073

--- a/FormalConjectures/ErdosProblems/1074.lean
+++ b/FormalConjectures/ErdosProblems/1074.lean
@@ -43,7 +43,7 @@ $$
 $$
 exist? -/
 @[category research open, AMS 11]
-theorem erdos_1074.part8_i_i : (∃ c, EHSNumbers.HasDensity c) ↔ answer(sorry) := by
+theorem erdos_1074.part8_i_i : answer(sorry) ↔ ∃ c, EHSNumbers.HasDensity c := by
   sorry
 
 /-- Let $S$ be the set of all $m\geq 1$ such that there exists a prime $p\not\equiv 1\pmod{m}$ such
@@ -62,7 +62,7 @@ $$
 $$
 exist? -/
 @[category research open, AMS 11]
-theorem erdos_1074.part_ii_i : (∃ c, PillaiPrimes.HasDensity c {p | p.Prime}) ↔ answer(sorry) := by
+theorem erdos_1074.part_ii_i : answer(sorry) ↔ ∃ c, PillaiPrimes.HasDensity c {p | p.Prime} := by
   sorry
 
 /-- Similarly, if $P$ is the set of all primes $p$ such that there exists an $m$ with

--- a/FormalConjectures/ErdosProblems/1077.lean
+++ b/FormalConjectures/ErdosProblems/1077.lean
@@ -36,7 +36,7 @@ at least $εm^{1+α}$ edges?
 -/
 @[category research solved, AMS 5]
 theorem erdos_1077 :
-    answer(sorry) ↔ ∀ ε > (0 : ℝ), ε < 1 → ∀ α > (0 : ℝ), α < 1 → ∀ᶠ D in atTop, ∀ᶠ n in atTop,
+    answer(False) ↔ ∀ ε > (0 : ℝ), ε < 1 → ∀ α > (0 : ℝ), α < 1 → ∀ᶠ D in atTop, ∀ᶠ n in atTop,
       ∀ G : SimpleGraph (Fin n), G.edgeSet.ncard > (n : ℝ) ^ (1 + α) →
         ∃ (H : Subgraph G),
           letI m := H.verts.ncard

--- a/FormalConjectures/ErdosProblems/1077.lean
+++ b/FormalConjectures/ErdosProblems/1077.lean
@@ -36,14 +36,13 @@ at least $εm^{1+α}$ edges?
 -/
 @[category research solved, AMS 5]
 theorem erdos_1077 :
-    (∀ ε > (0 : ℝ), ε < 1 → ∀ α > (0 : ℝ), α < 1 → ∀ᶠ D in atTop, ∀ᶠ n in atTop,
+    answer(sorry) ↔ ∀ ε > (0 : ℝ), ε < 1 → ∀ α > (0 : ℝ), α < 1 → ∀ᶠ D in atTop, ∀ᶠ n in atTop,
       ∀ G : SimpleGraph (Fin n), G.edgeSet.ncard > (n : ℝ) ^ (1 + α) →
         ∃ (H : Subgraph G),
           letI m := H.verts.ncard
           IsBalanced H.coe D ∧
           m > (n : ℝ) ^ (1 - α) ∧
-          H.edgeSet.ncard > ε * m ^ (1 + α))
-      ↔ answer(False) := by
+          H.edgeSet.ncard > ε * m ^ (1 + α) := by
   sorry
 
 end Erdos1077

--- a/FormalConjectures/ErdosProblems/108.lean
+++ b/FormalConjectures/ErdosProblems/108.lean
@@ -34,11 +34,11 @@ contains a subgraph of girth ≥ r and chromatic number ≥ k?
 -/
 @[category research open, AMS 5]
 theorem erdos_108 :
-    (∀ r ≥ 4, ∀ k ≥ (2 : ℕ), ∃ (f : ℕ),
+    answer(sorry) ↔ ∀ r ≥ 4, ∀ k ≥ (2 : ℕ), ∃ (f : ℕ),
     ∀ (V : Type u) (G : SimpleGraph V) (_ : Nonempty V)
       (hchro : f ≤ SimpleGraph.chromaticNumber G),
     ∃ (H : G.Subgraph), (SimpleGraph.girth H.coe ≥ r) ∧
-    (SimpleGraph.chromaticNumber H.coe ≥ k)) ↔ answer(sorry) := by
+    (SimpleGraph.chromaticNumber H.coe ≥ k) := by
   sorry
 
 -- TODO: Proof for the case r=4 and statement for the infinite case

--- a/FormalConjectures/ErdosProblems/1080.lean
+++ b/FormalConjectures/ErdosProblems/1080.lean
@@ -37,10 +37,11 @@ contain a $C_6$?
 -/
 @[category research open, AMS 5]
 theorem erdos_1080 :
-    (∃ c > (0 : ℝ), ∀ (V : Type) [Fintype V] [Nonempty V] (G : SimpleGraph V) (X Y : Set V),
+    answer(sorry) ↔
+    ∃ c > (0 : ℝ), ∀ (V : Type) [Fintype V] [Nonempty V] (G : SimpleGraph V) (X Y : Set V),
       IsBipartition G X Y → X.ncard = ⌊(Fintype.card V : ℝ) ^ (2/3 : ℝ)⌋₊ →
       G.edgeSet.ncard ≥ c * Fintype.card V →
-        ∃ (v : V) (walk : G.Walk v v), walk.IsCycle ∧ walk.length = 6) ↔ answer(sorry) := by
+        ∃ (v : V) (walk : G.Walk v v), walk.IsCycle ∧ walk.length = 6 := by
   sorry
 
 end Erdos1080

--- a/FormalConjectures/ErdosProblems/1093.lean
+++ b/FormalConjectures/ErdosProblems/1093.lean
@@ -37,8 +37,8 @@ Are there infinitely many binomial coefficients with deficiency 1?
 -/
 @[category research open, AMS 5]
 theorem erdos_1093.parts.i :
-    {x : ℕ × ℕ | let k := x.1; let n := x.2; k < n ∧ deficiency n k = 1 ∧
-      ∀ p, p.Prime → (p ∣ choose n k) → k < p}.Infinite ↔ answer(sorry) := by
+    answer(sorry) ↔ {x : ℕ × ℕ | let k := x.1; let n := x.2; k < n ∧ deficiency n k = 1 ∧
+      ∀ p, p.Prime → (p ∣ choose n k) → k < p}.Infinite := by
   sorry
 
 /--
@@ -47,7 +47,7 @@ Are there only finitely many binomial coefficients with deficiency > 1?
 @[category research open, AMS 5]
 theorem erdos_1093.parts.ii :
     {x : ℕ × ℕ | let k := x.1; let n := x.2; k < n ∧ deficiency n k > 1 ∧
-      ∀ p, p.Prime → (p ∣ choose n k) → k < p}.Finite ↔ answer(sorry) := by
+      ∀ p, p.Prime → (p ∣ choose n k) → k < p}.Finite := by
   sorry
 
 end Erdos1093

--- a/FormalConjectures/ErdosProblems/1097.lean
+++ b/FormalConjectures/ErdosProblems/1097.lean
@@ -37,8 +37,8 @@ The main conjecture: for any finite set of integers $A$ with $|A| = n$, the numb
 common differences in three-term arithmetic progressions is $O(n^{3/2})$.
 -/
 @[category research open, AMS 11]
-theorem erdos_1097 : (∃ C > (0 : ℝ), ∀ (A : Finset ℤ),
-    (CommonDifferencesThreeTermAP A).ncard ≤ C * (A.card : ℝ) ^ (3 / 2 : ℝ)) ↔ answer(sorry) := by
+theorem erdos_1097 : answer(sorry) ↔ ∃ C > (0 : ℝ), ∀ (A : Finset ℤ),
+    (CommonDifferencesThreeTermAP A).ncard ≤ C * (A.card : ℝ) ^ (3 / 2 : ℝ) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1108.lean
+++ b/FormalConjectures/ErdosProblems/1108.lean
@@ -42,8 +42,8 @@ def IsPowerful (n : ℕ) : Prop :=
 For each $k \geq 2$, does the set $A = \left\{ \sum_{n\in S}n! : S\subset \mathbb{N}\text{ finite}\right\}$ of all finite sums of distinct factorials contain only finitely many $k$-th powers?
 -/
 @[category research open, AMS 11]
-theorem erdos_1108.k_th_powers : (∀ k ≥ 2,
-    Set.Finite { a | a ∈ FactorialSums ∧ ∃ m : ℕ, m ^ k = a }) ↔ answer(sorry) := by
+theorem erdos_1108.k_th_powers : answer(sorry) ↔ ∀ k ≥ 2,
+    Set.Finite { a | a ∈ FactorialSums ∧ ∃ m : ℕ, m ^ k = a } := by
   sorry
 
 /--
@@ -51,7 +51,7 @@ Does the set $A = \left\{ \sum_{n\in S}n! : S\subset \mathbb{N}\text{ finite}\ri
 -/
 @[category research open, AMS 11]
 theorem erdos_1108.powerful_numbers :
-     {a ∈ FactorialSums | IsPowerful a}.Finite ↔ answer(sorry) := by
+     answer(sorry) ↔ {a ∈ FactorialSums | IsPowerful a}.Finite := by
   sorry
 
 end Erdos1108

--- a/FormalConjectures/ErdosProblems/119.lean
+++ b/FormalConjectures/ErdosProblems/119.lean
@@ -51,8 +51,8 @@ Wagner [Wa80] proved that there is some $c > 0$ with $M_n > (\log n)^c$ infintel
 -/
 @[category research solved, AMS 30]
 theorem erdos_119_1 :
-    (∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
-      atTop.limsup (fun n => (M z n : EReal)) = ⊤) ↔ answer(True) := by
+    answer(True) ↔ ∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
+      atTop.limsup (fun n => (M z n : EReal)) = ⊤ := by
   sorry
 
 /-- Question 2:
@@ -65,8 +65,8 @@ Beck [Be91] proved that there exists some $c > 0$ such that $\max_{n \leq N} M_n
 -/
 @[category research solved, AMS 30]
 theorem erdos_119_2 :
-    (∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
-      ∃ (c : ℝ) (hc : c > 0), Infinite {n : ℕ | M z n > n ^ c}) ↔ answer(True) := by
+    answer(True) ↔ ∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
+      ∃ (c : ℝ) (hc : c > 0), Infinite {n : ℕ | M z n > n ^ c} := by
   sorry
 
 /-- Question 3:
@@ -75,9 +75,9 @@ Is it true that there exists $c > 0$ such that, for all large $n$, $\sum_{k \leq
 -/
 @[category research open, AMS 30]
 theorem erdos_119_3 :
-    (∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
+    answer(sorry) ↔ ∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
       ∃ (c : ℝ) (hc : c > 0), ∀ᶠ n in atTop,
-        ∑ k ∈ range n, M z k > n ^ (1 + c)) ↔ answer(sorry) := by
+        ∑ k ∈ range n, M z k > n ^ (1 + c) := by
   sorry
 
 end Erdos119

--- a/FormalConjectures/ErdosProblems/12.lean
+++ b/FormalConjectures/ErdosProblems/12.lean
@@ -48,9 +48,9 @@ such that $a \mid (b+c)$ and $b,c > a$. Is there such an $A$ with
 $\liminf \frac{|A \cap \{1, \dotsc, N\}|}{N^{1/2}} > 0$ ?
 -/
 @[category research open, AMS 11]
-theorem erdos_12.parts.i : (∃ (A : Set ℕ), IsGood A ∧
+theorem erdos_12.parts.i : answer(sorry) ↔ ∃ (A : Set ℕ), IsGood A ∧
     (0 : ℝ) < Filter.atTop.liminf
-      (fun N => (A.interIcc 1 N).ncard / (N : ℝ).sqrt)) ↔ answer(sorry) := by
+      (fun N => (A.interIcc 1 N).ncard / (N : ℝ).sqrt) := by
   sorry
 
 /--
@@ -60,8 +60,8 @@ such that there are always infinitely many $N$
 with $|A \cap \{1, \dotsc, N\}| < N^{1−c}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_12.parts.ii : (∃ c > (0 : ℝ), ∀ (A : Set ℕ), IsGood A →
-  {N : ℕ| (A.interIcc 1 N).ncard < (N : ℝ) ^ (1 - c)}.Infinite) ↔ answer(sorry) := by
+theorem erdos_12.parts.ii : answer(sorry) ↔ ∃ c > (0 : ℝ), ∀ (A : Set ℕ), IsGood A →
+  {N : ℕ| (A.interIcc 1 N).ncard < (N : ℝ) ^ (1 - c)}.Infinite := by
   sorry
 
 /--
@@ -70,7 +70,7 @@ such that $a \mid (b+c)$ and $b,c > a$. Is it true that $∑_{n \in A} \frac{1}{
 -/
 @[category research open, AMS 11]
 theorem erdos_12.parts.iii :
-    (∀ (A : Set ℕ), IsGood A → Summable (fun (n : A) ↦ (1 / n : ℝ))) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ (A : Set ℕ), IsGood A → Summable (fun (n : A) ↦ (1 / n : ℝ)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/123.lean
+++ b/FormalConjectures/ErdosProblems/123.lean
@@ -69,8 +69,8 @@ Note: For this not to reduce to the two-integer case, we need the integers
 to be greater than one and distinct.
 -/
 @[category research open, AMS 11]
-theorem erdos_123 : (∀ a > 1, ∀ b > 1, ∀ c > 1, PairwiseCoprime a b c →
-    IsDComplete (↑(powers a) * ↑(powers b) * ↑(powers c))) ↔ answer(sorry) := by sorry
+theorem erdos_123 : answer(sorry) ↔ ∀ a > 1, ∀ b > 1, ∀ c > 1, PairwiseCoprime a b c →
+    IsDComplete (↑(powers a) * ↑(powers b) * ↑(powers c)) := by sorry
 
 /--
 Erdős and Lewin proved this conjecture when $a = 3$, $b = 5$, and $c = 7$.
@@ -105,8 +105,8 @@ $b_1 < ... < b_t$ of the form $2^k 3^l 5^j$ where $b_t < (1 + ϵ) b_1$.
 -/
 @[category research open, AMS 11]
 theorem erdos_123.variants.powers_2_3_5_snug :
-    (∀ ε > 0, ∀ᶠ n in atTop,
+    answer(sorry) ↔ ∀ ε > 0, ∀ᶠ n in atTop,
       ∃ A : Finset ℕ, (A : Set ℕ) ⊆ ↑(powers 2) * ↑(powers 3) * ↑(powers 5) ∧ IsSnug ε A ∧
-        ∑ x ∈ A, x = n) ↔ answer(sorry) := by sorry
+        ∑ x ∈ A, x = n := by sorry
 
 end Erdos123

--- a/FormalConjectures/ErdosProblems/124.lean
+++ b/FormalConjectures/ErdosProblems/124.lean
@@ -37,12 +37,12 @@ where $c_i\in \{0, 1\}$ and $a_i$ has only the digits $0, 1$ when written in bas
 Conjectured by Burr, Erdős, Graham, and Li [BEGL96]
 -/
 @[category research open, AMS 11]
-theorem erdos_124 : (∀ k, ∀ d : Fin k → ℕ,
+theorem erdos_124 : answer(sorry) ↔ ∀ k, ∀ d : Fin k → ℕ,
     (∀ i, 3 ≤ d i) →  StrictMono d → 1 ≤ ∑ i : Fin k, (1 : ℚ) / (d i - 1) →
     ∀ᶠ n in atTop, ∃ c : Fin k → ℕ, ∃ a : Fin k → ℕ,
     ∀ i, c i ∈ ({0, 1} : Finset ℕ) ∧
     ∀ i, ((d i).digits (a i)).toFinset ⊆ {0, 1} ∧
-    n = ∑ i, c i * a i) ↔ answer(sorry) := by
+    n = ∑ i, c i * a i := by
   sorry
 
 -- TODO(firsching): formalize the other two claims from the additional material

--- a/FormalConjectures/ErdosProblems/125.lean
+++ b/FormalConjectures/ErdosProblems/125.lean
@@ -35,8 +35,8 @@ Does $A + B$ have positive density?
 
 @[category research open, AMS 11]
 theorem erdos_125 :
-    ({ x : ℕ | (digits 3 x).toFinset ⊆ {0, 1} } +
-      { x : ℕ | (digits 4 x).toFinset ⊆ {0, 1} }).HasPosDensity ↔ answer(sorry) := by
+    answer(sorry) ↔ ({ x : ℕ | (digits 3 x).toFinset ⊆ {0, 1} } +
+      { x : ℕ | (digits 4 x).toFinset ⊆ {0, 1} }).HasPosDensity := by
   sorry
 
 end Erdos125

--- a/FormalConjectures/ErdosProblems/126.lean
+++ b/FormalConjectures/ErdosProblems/126.lean
@@ -38,8 +38,8 @@ $\prod_{a\neq b\in A}(a + b)$ has at least $f(n)$ distinct prime factors.
 Is it true that $\frac{f(n)}{\log n} \to\infty$?
 -/
 @[category research open, AMS 11]
-theorem erdos_126 : (∀ (f : ℕ → ℕ), IsMaximalAddFactorsCard f →
-    Tendsto (fun n => f n / Real.log n) atTop atTop) ↔ answer(sorry) := by
+theorem erdos_126 : answer(sorry) ↔ ∀ (f : ℕ → ℕ), IsMaximalAddFactorsCard f →
+    Tendsto (fun n => f n / Real.log n) atTop atTop := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/128.lean
+++ b/FormalConjectures/ErdosProblems/128.lean
@@ -32,10 +32,9 @@ vertices has more than $n^2/50$ edges. Must G contain a triangle?
 -/
 @[category research open, AMS 5]
 theorem erdos_128 :
-    ((∀ V' : Set V,
+    answer(sorry) ↔ (∀ V' : Set V,
       2 * V'.ncard + 1 ≥ Fintype.card V →
-        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2) → ¬ G.CliqueFree 3)
-    ↔ answer(sorry) := by
+        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2) → ¬ G.CliqueFree 3 := by
   sorry
 
 end Erdos128

--- a/FormalConjectures/ErdosProblems/137.lean
+++ b/FormalConjectures/ErdosProblems/137.lean
@@ -30,8 +30,7 @@ Let $k\geq 3$. Can the product of any $k$ consecutive integers $N$ ever be power
 must there always exist a prime $p\mid N$ such that $p^2\nmid N$?
 -/
 @[category research open, AMS 11]
-theorem erdos_137 :
-    (∀ k ≥ 3, ∀ n, ¬ (∏ x ∈ Finset.Ioc n (n + k), x).Powerful) ↔ answer(sorry) := by
+theorem erdos_137 : answer(sorry) ↔ ∀ k ≥ 3, ∀ n, ¬ (∏ x ∈ Finset.Ioc n (n + k), x).Powerful := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/138.lean
+++ b/FormalConjectures/ErdosProblems/138.lean
@@ -79,7 +79,7 @@ In [Er80] Erdős asks whether
 $$ \lim_{k \to \infty} (W(k))^{1/k} = \infty $$
 -/
 @[category research open, AMS 11]
-theorem erdos_138 : atTop.Tendsto (fun k => (W k : ℝ)^(1/(k : ℝ))) atTop ↔ answer(sorry) := by
+theorem erdos_138 : answer(sorry) ↔ atTop.Tendsto (fun k => (W k : ℝ)^(1/(k : ℝ))) atTop := by
   sorry
 
 
@@ -102,7 +102,7 @@ In [Er81] Erdős asks whether $\frac{W(k+1)}{W(k)} \to \infty$.
 -/
 @[category research open, AMS 11]
 theorem erdos_138.variants.quotient :
-    atTop.Tendsto (fun k => ((W (k + 1) : ℚ)/(W k))) atTop ↔ answer(sorry) := by
+    answer(sorry) ↔ atTop.Tendsto (fun k => ((W (k + 1) : ℚ)/(W k))) atTop := by
   sorry
 
 /--
@@ -110,7 +110,7 @@ In [Er81] Erdős asks whether $W(k+1) - W(k) \to \infty$.
 -/
 @[category research open, AMS 11]
 theorem erdos_138.variants.difference :
-    atTop.Tendsto (fun k => (W (k + 1) - W k)) atTop ↔ answer(sorry) := by
+    answer(sorry) ↔ atTop.Tendsto (fun k => (W (k + 1) - W k)) atTop := by
   sorry
 
 /--
@@ -118,5 +118,5 @@ In [Er80] Erdős asks whether $W(k)/2^k\to \infty$.
 -/
 @[category research open, AMS 11]
 theorem erdos_138.variants.dvd_two_pow :
-    atTop.Tendsto (fun k => ((W k : ℚ)/ (2 ^ k))) atTop ↔ answer(sorry) := by
+    answer(sorry) ↔ atTop.Tendsto (fun k => ((W k : ℚ)/ (2 ^ k))) atTop := by
   sorry

--- a/FormalConjectures/ErdosProblems/14.lean
+++ b/FormalConjectures/ErdosProblems/14.lean
@@ -50,14 +50,14 @@ $\epsilon > 0$ and large $N$, $|\{1,\ldots,N\} \setminus B| \gg_\epsilon N^{1/2 
 -/
 @[category research open, AMS 11]
 theorem erdos_14a :
-    (∀ A, ∀ ε > 0, nonUniqueSumCount A ≫ almostSquareRoot ε) ↔ answer(sorry) := by sorry
+    answer(sorry) ↔ ∀ A, ∀ ε > 0, nonUniqueSumCount A ≫ almostSquareRoot ε := by sorry
 
 /--
 Is it possible that $|\{1,\ldots,N\} \setminus B| = o(N^\frac{1}{2})$?
 -/
 @[category research open, AMS 11]
 theorem erdos_14b :
-    (∃ (A : Set ℕ), IsLittleO atTop (nonUniqueSumCount A) squareRoot) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (A : Set ℕ), IsLittleO atTop (nonUniqueSumCount A) squareRoot := by
   sorry
 
 end Erdos14

--- a/FormalConjectures/ErdosProblems/141.lean
+++ b/FormalConjectures/ErdosProblems/141.lean
@@ -72,8 +72,8 @@ theorem exists_three_consecutive_primes_in_ap : ∃ (s : Set ℕ), s.IsAPAndPrim
 Let $k≥3$. Are there $k$ consecutive primes in arithmetic progression?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_141 : (∀ k ≥ 3, ∃ (s : Set ℕ), s.IsAPAndPrimeProgressionOfLength k)
-    ↔ answer(sorry) := by
+theorem erdos_141 : answer(sorry) ↔
+    ∀ k ≥ 3, ∃ (s : Set ℕ), s.IsAPAndPrimeProgressionOfLength k := by
   sorry
 
 /--
@@ -88,8 +88,8 @@ theorem erdos_141.variant.first_cases :
 Are there $11$ consecutive primes in arithmetic progression?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_141.variant.eleven : (∃ (s : Set ℕ), s.IsAPAndPrimeProgressionOfLength 11)
-    ↔ answer(sorry) := by
+theorem erdos_141.variant.eleven : answer(sorry) ↔
+    ∃ (s : Set ℕ), s.IsAPAndPrimeProgressionOfLength 11 := by
   sorry
 
 /--
@@ -102,16 +102,16 @@ def consecutivePrimeArithmeticProgressions (k : ℕ) : Set (Set ℕ) :=
 It is open, even for $k=3$, whether there are infinitely many such progressions.
 -/
 @[category research open, AMS 5 11]
-theorem erdos_141.variant.infinite_three :
-    (consecutivePrimeArithmeticProgressions 3).Infinite ↔ answer(sorry) :=
+theorem erdos_141.variant.infinite_three : answer(sorry) ↔
+    (consecutivePrimeArithmeticProgressions 3).Infinite :=
   sorry
 
 /--
 Fix a $k \geq 3$. Is it true that there are infinitely many arithmetic prime progressions of length $k$?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_141.variant.infinite_general_case  (k : ℕ) (hk : k ≥ 3) :
-    (consecutivePrimeArithmeticProgressions k).Infinite ↔ answer(sorry) :=
+theorem erdos_141.variant.infinite_general_case : answer(sorry) ↔
+    ∀ᵉ (k ≥ 3), (consecutivePrimeArithmeticProgressions k).Infinite :=
   sorry
 
 end Erdos141

--- a/FormalConjectures/ErdosProblems/141.lean
+++ b/FormalConjectures/ErdosProblems/141.lean
@@ -111,7 +111,7 @@ Fix a $k \geq 3$. Is it true that there are infinitely many arithmetic prime pro
 -/
 @[category research open, AMS 5 11]
 theorem erdos_141.variant.infinite_general_case : answer(sorry) ↔
-    ∀ᵉ (k ≥ 3), (consecutivePrimeArithmeticProgressions k).Infinite :=
+    ∀ k ≥ 3, (consecutivePrimeArithmeticProgressions k).Infinite :=
   sorry
 
 end Erdos141

--- a/FormalConjectures/ErdosProblems/143.lean
+++ b/FormalConjectures/ErdosProblems/143.lean
@@ -42,8 +42,8 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_143.parts.i : (∀ (A : Set ℝ), WellSeparatedSet A →
-    liminf (fun x => (A ∩ (Set.Icc 1 x)).ncard / x) atTop = 0) ↔ answer(sorry) := by
+theorem erdos_143.parts.i : answer(sorry) ↔ ∀ (A : Set ℝ), WellSeparatedSet A →
+    liminf (fun x => (A ∩ (Set.Icc 1 x)).ncard / x) atTop = 0 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/145.lean
+++ b/FormalConjectures/ErdosProblems/145.lean
@@ -44,9 +44,8 @@ exists?
 -/
 @[category research open, AMS 11]
 theorem erdos_145 :
-    (∀ α ≥ (0 : ℝ), ∃ β : ℝ,
-      atTop.Tendsto (fun x : ℝ ↦ 1 / x * ∑ n ∈ A x, (s (n + 1) - s n : ℝ) ^ α) (𝓝 β)) ↔
-    answer(sorry) := by
+    answer(sorry) ↔ ∀ α ≥ (0 : ℝ), ∃ β : ℝ,
+      atTop.Tendsto (fun x : ℝ ↦ 1 / x * ∑ n ∈ A x, (s (n + 1) - s n : ℝ) ^ α) (𝓝 β) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/155.lean
+++ b/FormalConjectures/ErdosProblems/155.lean
@@ -39,8 +39,7 @@ $$
 for all sufficiently large $N$?
 -/
 @[category research open, AMS 5]
-theorem erdos_155 :
-    (∀ k ≥ 1, ∀ᶠ N in atTop, F (N + k) ≤ F N + 1) ↔ answer(sorry) := by
+theorem erdos_155 : answer(sorry) ↔ ∀ k ≥ 1, ∀ᶠ N in atTop, F (N + k) ≤ F N + 1 := by
   sorry
 
 -- TODO: This may even hold with $k \approx ε * N ^ (1 / 2)$.

--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -81,8 +81,8 @@ theorem erdos_168.parts.i :
 
 /-- Is the limit $F(N)/N$ as $N \to \infty$ irrational? -/
 @[category research open, AMS 5 11]
-theorem erdos_168.parts.ii :
-    Irrational (Filter.atTop.limsup (fun N => (F N / N : ℝ))) ↔ answer(sorry):= by
+theorem erdos_168.parts.ii : answer(sorry) ↔
+    Irrational (Filter.atTop.limsup (fun N => (F N / N : ℝ))) := by
   sorry
 
 /-- The limit $F(N)/N$ as $N \to \infty$ exists. (proved by Graham, Spencer, and Witsenhausen) -/

--- a/FormalConjectures/ErdosProblems/17.lean
+++ b/FormalConjectures/ErdosProblems/17.lean
@@ -36,8 +36,7 @@ def IsClusterPrime (p : ℕ) : Prop :=
 
 /-- **Erdős Problem 17.** Are there infinitely many cluster primes? -/
 @[category research open, AMS 11]
-theorem erdos_17 :
-    {p : ℕ | IsClusterPrime p}.Infinite ↔ answer(sorry) := by
+theorem erdos_17 : answer(sorry) ↔ {p : ℕ | IsClusterPrime p}.Infinite := by
   sorry
 
 /-- The counting function of cluster primes $\le n$. -/

--- a/FormalConjectures/ErdosProblems/172.lean
+++ b/FormalConjectures/ErdosProblems/172.lean
@@ -29,9 +29,9 @@ Is it true that in any finite colouring of $\mathbb{N}$ there exist arbitrarily 
 and products of distinct elements in $A$ are the same colour?
 -/
 @[category research open, AMS 5]
-theorem erdos_172 :
-    (∀ (n : ℕ) (color : ℕ → Fin n) (m), ∃ (A : Finset ℕ), A.card ≥ m ∧ ∃ c, ∀ (S : Finset A),
-    S.Nonempty → color (∑ x ∈ S, x) = c ∧ color (∏ x ∈ S, x) = c) ↔ answer(sorry) := by
+theorem erdos_172 : answer(sorry) ↔
+    ∀ (n : ℕ) (color : ℕ → Fin n) (m), ∃ (A : Finset ℕ), A.card ≥ m ∧ ∃ c, ∀ (S : Finset A),
+    S.Nonempty → color (∑ x ∈ S, x) = c ∧ color (∏ x ∈ S, x) = c := by
   sorry
 
 -- TODO: add the statements from the additional material

--- a/FormalConjectures/ErdosProblems/189.lean
+++ b/FormalConjectures/ErdosProblems/189.lean
@@ -48,11 +48,11 @@ In fact, Kovač's colouring is even Jordan measurable (the topological boundary 
 monochromatic region is Lebesgue measurable and has measure zero). -/
 @[category research solved, AMS 5 51]
 theorem erdos_189 :
-    Erdos189For
+    answer(False) ↔ Erdos189For
       (fun a b c d ↦
         line[ℝ, a, b].direction ⟂ line[ℝ, b, c].direction ∧
         line[ℝ, b, c].direction ⟂ line[ℝ, c, d].direction)
-      (fun a b c d ↦ dist a b * dist b c) ↔ answer(False) := by
+      (fun a b c d ↦ dist a b * dist b c) := by
   sorry
 
 /-- Graham claims this is "easy to see". -/

--- a/FormalConjectures/ErdosProblems/196.lean
+++ b/FormalConjectures/ErdosProblems/196.lean
@@ -25,9 +25,8 @@ namespace Erdos196
 
 /-- Must every permutation of $\mathbb{N}$, contain a monotone 4-term arithmetic progression?-/
 @[category research open, AMS 5 11]
-theorem erdos_196 : (∀ (f : ℕ ≃ ℕ), ∃ (a : List ℕ),
-    ((a.Sorted (· < · )) ∨ (a.Sorted (· > · ))) ∧ (a.map f).IsAPOfLength 4)
-    ↔ answer(sorry) := by
+theorem erdos_196 : answer(sorry) ↔ ∀ (f : ℕ ≃ ℕ), ∃ (a : List ℕ),
+    ((a.Sorted (· < · )) ∨ (a.Sorted (· > · ))) ∧ (a.map f).IsAPOfLength 4 := by
   sorry
 
 end Erdos196

--- a/FormalConjectures/ErdosProblems/20.lean
+++ b/FormalConjectures/ErdosProblems/20.lean
@@ -74,8 +74,7 @@ theorem f_0_1 : f 0 1 = 1 := by
 Is it true that $f(n,k) < c_k^n$ for some constant $c_k>0$ and for all $n > 0$?
 -/
 @[category research open, AMS 5]
-theorem erdos_20 :
-    (∃ (c : ℕ → ℕ), ∀ n k, n > 0 → f n k < (c k) ^ n ↔ answer(sorry)) := by
+theorem erdos_20 : answer(sorry) ↔ ∃ (c : ℕ → ℕ), ∀ n k, n > 0 → f n k < (c k) ^ n := by
   sorry
 
 -- TODO(firsching): add the various known bounds as variants.

--- a/FormalConjectures/ErdosProblems/200.lean
+++ b/FormalConjectures/ErdosProblems/200.lean
@@ -36,8 +36,8 @@ noncomputable def longestPrimeArithmeticProgressions (n : ℕ) : ℕ :=
 Does the longest arithmetic progression of primes in $\{1,\ldots,N\}$ have length $o(\log N)$?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_200 : (fun n => (longestPrimeArithmeticProgressions n : ℝ))
-    =o[atTop] (fun n => log n) ↔ answer(sorry) := by
+theorem erdos_200 : answer(sorry) ↔
+    (fun n => (longestPrimeArithmeticProgressions n : ℝ)) =o[atTop] (fun n => log n) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/203.lean
+++ b/FormalConjectures/ErdosProblems/203.lean
@@ -29,7 +29,7 @@ Is there an integer $m$ with $(m, 6) = 1$ such that none of $2^k \cdot 3^\ell \c
 for any $k, \ell \ge 0$?
 -/
 @[category research open, AMS 5]
-theorem erdos_203 : (∃ m, m.Coprime 6 ∧ ∀ k l, ¬ (2^k * 3^l * m + 1).Prime) ↔ answer(sorry) := by
+theorem erdos_203 : answer(sorry) ↔ ∃ m, m.Coprime 6 ∧ ∀ k l, ¬ (2^k * 3^l * m + 1).Prime := by
   sorry
 
 --TODO(rdivyanshu): add statements about covering system and odd integers `m` such that none of 2^k*m + 1 is prime

--- a/FormalConjectures/ErdosProblems/208.lean
+++ b/FormalConjectures/ErdosProblems/208.lean
@@ -35,18 +35,16 @@ Let $s_1 < s_2 < \dots$ be the sequence of squarefree numbers. Is it true that
 for any $\epsilon > 0$ and large $n$, $s_{n+1} - s_n \ll_\epsilon s_n^\epsilon$?
 -/
 @[category research open, AMS 11]
-theorem erdos_208.i :
-    (∀ ε > (0 : ℝ), (fun n => (s (n + 1) - s n : ℝ)) =O[atTop] (fun n => (s n : ℝ)^ε)) ↔
-    answer(sorry) := by sorry
+theorem erdos_208.i : answer(sorry) ↔
+    ∀ ε > (0 : ℝ), (fun n => (s (n + 1) - s n : ℝ)) =O[atTop] (fun n => (s n : ℝ)^ε) := by sorry
 
 /--
 Let $s_1 < s_2 < \dots$ be the sequence of squarefree numbers. Is it true that
 $s_{n + 1} - s_n \le (1 + o(1)) \cdot (\pi^2 / 6) \cdot \log (s_n) / \log (\log (s_n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_208.ii :
-    (∃ (c : ℕ → ℝ), (c =o[atTop] (1 : ℕ → ℝ)) ∧ ∀ᶠ n in atTop,
-      s (n + 1) - s n ≤ (1 + (c n)) * (π^2 / 6) * log (s n) / log (log (s n))) ↔ answer(sorry) := by
+theorem erdos_208.ii : answer(sorry) ↔ ∃ (c : ℕ → ℝ), (c =o[atTop] (1 : ℕ → ℝ)) ∧ ∀ᶠ n in atTop,
+      s (n + 1) - s n ≤ (1 + (c n)) * (π^2 / 6) * log (s n) / log (log (s n)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/212.lean
+++ b/FormalConjectures/ErdosProblems/212.lean
@@ -29,7 +29,7 @@ Is there a dense subset of ℝ^2 such that all pairwise distances
 are rational?
 -/
 @[category research open, AMS 52]
-theorem erdos_212 : (∃ u : Set ℂ,
-  Dense u ∧ u.Pairwise fun c₁ c₂ => dist c₁ c₂ ∈ Set.range Rat.cast) ↔ answer(sorry) := by sorry
+theorem erdos_212 : answer(sorry) ↔
+    ∃ u : Set ℂ, Dense u ∧ u.Pairwise fun c₁ c₂ => dist c₁ c₂ ∈ Set.range Rat.cast := by sorry
 
 end Erdos212

--- a/FormalConjectures/ErdosProblems/213.lean
+++ b/FormalConjectures/ErdosProblems/213.lean
@@ -41,7 +41,7 @@ Let $n \geq 4$. Are there $n$ points in $\mathbb{R}^2$, no three on a line and n
 such that all pairwise distances are integers?
 -/
 @[category research open, AMS 52]
-theorem erdos_213 : (∀ n : ℕ, n ≥ 4 → Erdos213For n) ↔ answer(sorry) := by sorry
+theorem erdos_213 : answer(sorry) ↔ ∀ n : ℕ, n ≥ 4 → Erdos213For n := by sorry
 
 /--
 The best construction to date, due to Kreisel and Kurz, has $n = 7$.

--- a/FormalConjectures/ErdosProblems/219.lean
+++ b/FormalConjectures/ErdosProblems/219.lean
@@ -69,7 +69,7 @@ Ref: Green, Ben and Tao, Terence, _The primes contain arbitrarily long arithmeti
 -/
 
 @[category research solved, AMS 5 11]
-theorem erdos_219 : (∀ N : ℕ, ∃ l ∈ primeArithmeticProgressions, N ≤ ENat.card l) ↔ answer(True) := by
+theorem erdos_219 : answer(True) ↔ ∀ N : ℕ, ∃ l ∈ primeArithmeticProgressions, N ≤ ENat.card l := by
   sorry
 
 end Erdos219

--- a/FormalConjectures/ErdosProblems/228.lean
+++ b/FormalConjectures/ErdosProblems/228.lean
@@ -35,11 +35,11 @@ The answer is yes, proved by Balister, Bollobás, Morris, Sahasrabudhe, and Tiba
 -/
 @[category research solved, AMS 5 12 41] --TODO(lezeau): I'm a little unhappy with the `41` tag
 theorem erdos_228 :
-    (∃ (c₁ : ℝ) (c₂ : ℝ), ∀ᶠ n : ℕ in Filter.atTop,
+    answer(True) ↔ ∃ (c₁ : ℝ) (c₂ : ℝ), ∀ᶠ n : ℕ in Filter.atTop,
     ∃ p : Polynomial ℂ, p.degree = n ∧
     (∀ i ≤ n, p.coeff i = 1 ∨ p.coeff i = -1) ∧
     ∀ z : ℂ, ‖z‖ = 1 →
-    ( √n < c₁ * ‖p.eval z‖ ∧ ‖p.eval z‖ < c₂ * √n )) ↔ answer(True) := by
+    ( √n < c₁ * ‖p.eval z‖ ∧ ‖p.eval z‖ < c₂ * √n ) := by
   sorry
 
 end Erdos228

--- a/FormalConjectures/ErdosProblems/229.lean
+++ b/FormalConjectures/ErdosProblems/229.lean
@@ -39,9 +39,9 @@ _the derivatives of an entire function_. Proc. Amer. Math. Soc. (1972), 229--232
 @[category research solved, AMS 30]
 theorem erdos_229 :
     letI := Polynomial.algebraPi ℂ ℂ ℂ
-    (∀ (S : ℕ → Set ℂ), (∀ n, derivedSet (S n) = ∅) →
+    answer(True) ↔ ∀ (S : ℕ → Set ℂ), (∀ n, derivedSet (S n) = ∅) →
     ∃ (f : ℂ → ℂ), Transcendental (Polynomial ℂ) f ∧ Differentiable ℂ f ∧ ∀ n ≥ 1,
-      ∃ k, ∀ z ∈ S n, iteratedDeriv k f z = 0) ↔ answer(True) := by
+      ∃ k, ∀ z ∈ S n, iteratedDeriv k f z = 0 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/244.lean
+++ b/FormalConjectures/ErdosProblems/244.lean
@@ -27,8 +27,8 @@ namespace Erdos244
 /-- Let $C > 1$. Does the set of integers of the form $p + \lfloor C^k \rfloor$,
 for some prime $p$ and $k\geq 0$, have density $>0$? -/
 @[category research open, AMS 11]
-theorem erdos_244 : (∀ C > (1 : ℝ), 0 < { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.lowerDensity) ↔
-    answer(sorry) := by
+theorem erdos_244 : answer(sorry) ↔
+    ∀ C > (1 : ℝ), 0 < { p + ⌊C ^ k⌋₊ | (p) (k) (_ : p.Prime) }.lowerDensity := by
   sorry
 
 /-- Romanoff [Ro34] proved that the answer is yes if $C$ is an integer.

--- a/FormalConjectures/ErdosProblems/245.lean
+++ b/FormalConjectures/ErdosProblems/245.lean
@@ -41,11 +41,10 @@ The answer is yes, proved by Freiman [Fr73].
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_245 :
-    (∀ (A : Set ℕ), A.Infinite →
+    answer(True) ↔ ∀ (A : Set ℕ), A.Infinite →
       atTop.Tendsto (fun N ↦ (A.interIcc 1 ⌊N⌋₊ |>.ncard : ℝ) / N) (𝓝 0) →
       3 ≤ atTop.limsup
-        fun N : ℝ ↦ ((A + A).interIcc 1 ⌊N⌋₊ |>.ncard : EReal) / (A.interIcc 1 ⌊N⌋₊).ncard) ↔
-    answer(True) := by
+        fun N : ℝ ↦ ((A + A).interIcc 1 ⌊N⌋₊ |>.ncard : EReal) / (A.interIcc 1 ⌊N⌋₊).ncard := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/247.lean
+++ b/FormalConjectures/ErdosProblems/247.lean
@@ -38,9 +38,9 @@ $$
 transcendental?
 -/
 @[category research open, AMS 11]
-theorem erdos_247 : (∀ (n : ℕ → ℕ), (StrictMono n) →
+theorem erdos_247 : answer(sorry) ↔ ∀ (n : ℕ → ℕ), (StrictMono n) →
     atTop.limsup (fun k => (n k / k.succ : EReal)) = ⊤ →
-    Transcendental ℚ (∑' k, (1 : ℝ) / 2 ^ n k)) ↔ answer(sorry) := by
+    Transcendental ℚ (∑' k, (1 : ℝ) / 2 ^ n k) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/249.lean
+++ b/FormalConjectures/ErdosProblems/249.lean
@@ -32,7 +32,7 @@ $$\sum_{n} \frac{\phi(n)}{2^n}$$
 irrational? Here $\phi$ is the Euler totient function.
 -/
 @[category research open, AMS 11]
-theorem erdos_249 : Irrational (∑' n : ℕ, (φ n) / (2 ^ n)) ↔ answer(sorry) := by
+theorem erdos_249 : answer(sorry) ↔ Irrational (∑' n : ℕ, (φ n) / (2 ^ n)) := by
   sorry
 
 end Erdos249

--- a/FormalConjectures/ErdosProblems/25.lean
+++ b/FormalConjectures/ErdosProblems/25.lean
@@ -39,11 +39,10 @@ $a_i \pmod{n_i}$. Let $A$ be the set of integers $n$ such that for every $i$ eit
 $n \not\equiv a_i \pmod{n_i}$. Must the logarithmic density of $A$ exist?
 -/
 @[category research open, AMS 11]
-theorem erdos_25 :
-    (∀ (seq_n : ℕ → ℕ) (seq_a : ℕ → ℤ), (∀ i, 0 < seq_n i) → StrictMono seq_n →
+theorem erdos_25 : answer(sorry) ↔
+    ∀ (seq_n : ℕ → ℕ) (seq_a : ℕ → ℤ), (∀ i, 0 < seq_n i) → StrictMono seq_n →
       ∃ d, Set.HasLogDensity
-        { x : ℕ | ∀ i, (x : ℤ) < seq_n i ∨ ¬((x : ℤ) ≡ seq_a i [ZMOD seq_n i]) } d)
-    ↔ answer(sorry) := by
+        { x : ℕ | ∀ i, (x : ℤ) < seq_n i ∨ ¬((x : ℤ) ≡ seq_a i [ZMOD seq_n i]) } d := by
   sorry
 
 end Erdos25

--- a/FormalConjectures/ErdosProblems/251.lean
+++ b/FormalConjectures/ErdosProblems/251.lean
@@ -28,7 +28,7 @@ namespace Erdos251
 Is $\sum_{n=1}^\infty \frac{p_n}{2^n}$ irrational? Here $p_n$ is the $n$-th prime ($p_1=2, p_2=3, \dots$).
 -/
 @[category research open, AMS 11]
-theorem erdos_251 : Irrational (∑' n : ℕ, (Nat.nth Nat.Prime n) / (2 ^ n)) ↔ answer(sorry) := by
+theorem erdos_251 : answer(sorry) ↔ Irrational (∑' n : ℕ, (Nat.nth Nat.Prime n) / (2 ^ n)) := by
   sorry
 
 end Erdos251

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -32,8 +32,8 @@ $$
 irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_257 : (∀ (A : Set ℕ), A.Infinite →
-    Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1))) ↔ answer(sorry) := by
+theorem erdos_257 : answer(sorry) ↔ ∀ (A : Set ℕ), A.Infinite →
+    Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -29,10 +29,9 @@ Let $a_n \to \infty$ be a sequence of non-zero natural numbers. Is
 $\sum_n \frac{d(n)}{(a_1 ... a_n)}$ irrational, where $d(n)$ is the number of divisors of $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_258 : (∀ (a : ℕ → ℕ), (∀ n, a n ≠ 0) →
+theorem erdos_258 : answer(sorry) ↔ ∀ (a : ℕ → ℕ), (∀ n, a n ≠ 0) →
     Filter.Tendsto a Filter.atTop Filter.atTop →
-    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i))) ↔
-    answer(sorry) := by
+    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) := by
   sorry
 
 
@@ -43,9 +42,10 @@ Is $\sum_n \frac{d(n)}{(a_1 ... a_n)}$ irrational, where $d(n)$ is the number of
 Solution: True (proved by Erdős and Straus, see Erdős Problems website).
 -/
 @[category research solved, AMS 11]
-theorem erdos_258.variants.Monotone : (∀ (a : ℕ → ℤ), (∀ n, a n ≠ 0) → Monotone a →
+theorem erdos_258.variants.Monotone : answer(True) ↔
+    ∀ (a : ℕ → ℤ), (∀ n, a n ≠ 0) → Monotone a →
     Filter.Tendsto a Filter.atTop Filter.atTop →
-    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i))) ↔ answer(True) := by
+    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / ∏ i ∈ Finset.Icc 1 n, a i)) := by
   sorry
 
 
@@ -55,8 +55,8 @@ Is $\sum_n \frac{d(n)}{t^n}$ irrational, where $t ≥ 2$ is an integer.
 Solution: True (proved by Erdős, see Erdős Problems website)
 -/
 @[category research solved, AMS 11]
-theorem erdos_258.variants.Constant : (∀ t ≥ (2 : ℕ),
-    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / t^n))) ↔ answer(True) := by
+theorem erdos_258.variants.Constant : answer(True) ↔ ∀ t ≥ (2 : ℕ),
+    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / t^n)) := by
   sorry
 
 end Erdos258

--- a/FormalConjectures/ErdosProblems/26.lean
+++ b/FormalConjectures/ErdosProblems/26.lean
@@ -88,8 +88,8 @@ there exist some $k\geq 1$ such that almost all integers have a divisor of the f
 for some $a\in A$?
 -/
 @[category research open, AMS 11]
-theorem erdos_26 : (∀ A : ℕ → ℕ, StrictMono A → IsThick A →
-    ∃ k, IsBehrend (A · + k)) ↔ answer(sorry) := by
+theorem erdos_26 : answer(sorry) ↔ ∀ A : ℕ → ℕ, StrictMono A → IsThick A →
+    ∃ k, IsBehrend (A · + k) := by
   sorry
 
 /--
@@ -106,8 +106,8 @@ some $k=k(\epsilon)$ such that at least $1-\epsilon$ density of all integers hav
 divisor of the form $a+k$ for some $a\in A$.
 -/
 @[category research open, AMS 11]
-theorem erdos_26.variants.tenenbaum : (∀ᵉ (A : ℕ → ℕ), StrictMono A → IsThick A → 
-    (∀ ε > (0 : ℝ), ∃ k, IsWeaklyBehrend (A · + k) ε)) ↔ answer(sorry) := by
+theorem erdos_26.variants.tenenbaum : answer(sorry) ↔ ∀ᵉ (A : ℕ → ℕ), StrictMono A → IsThick A →
+    (∀ ε > (0 : ℝ), ∃ k, IsWeaklyBehrend (A · + k) ε) := by
   sorry
 
 end Erdos26

--- a/FormalConjectures/ErdosProblems/264.lean
+++ b/FormalConjectures/ErdosProblems/264.lean
@@ -52,7 +52,7 @@ theorem erdos_264.parts.i : ¬IsIrrationalitySequence (2 ^ ·) := by sorry
 Is $n!$ an example of an irrationality sequence?
 -/
 @[category research open, AMS 11]
-theorem erdos_264.parts.ii : IsIrrationalitySequence Nat.factorial ↔ answer(sorry) := by sorry
+theorem erdos_264.parts.ii : answer(sorry) ↔ IsIrrationalitySequence Nat.factorial := by sorry
 
 /--
 One example is $2^{2^n}$.

--- a/FormalConjectures/ErdosProblems/267.lean
+++ b/FormalConjectures/ErdosProblems/267.lean
@@ -30,8 +30,8 @@ Let $n_1 < n_2 < \dots$ be an infinite sequence with $\frac{n_{k+1}}{n_k} \ge c 
 $\sum_k \frac 1 {F_{n_k}}$ be irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_267 : (∀ᵉ (n : ℕ → ℕ) (c > (1 : ℚ)), StrictMono n → (∀ k, c ≤ n (k+1) / n k) →
-    Irrational (∑' k, 1 / (Nat.fib <| n k))) ↔ answer(sorry) := by
+theorem erdos_267 : answer(sorry) ↔ ∀ᵉ (n : ℕ → ℕ) (c > (1 : ℚ)), StrictMono n → (∀ k, c ≤ n (k+1) / n k) →
+    Irrational (∑' k, 1 / (Nat.fib <| n k)) := by
   sorry
 
 /--
@@ -40,9 +40,9 @@ Let $n_1 < n_2 < \dots$ be an infinite sequence with $\frac {n_k}{k} \to \infty$
 $\sum_k \frac 1 {F_{n_k}}$ be irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_267.variants.generalisation_ratio_limit_to_infinity : (∀ (n : ℕ → ℕ),
+theorem erdos_267.variants.generalisation_ratio_limit_to_infinity : answer(sorry) ↔ ∀ (n : ℕ → ℕ),
     StrictMono n → Filter.Tendsto (fun k => (n (k+1) / k.succ : ℝ)) Filter.atTop Filter.atTop →
-    Irrational (∑' k, 1 / (Nat.fib <| n k))) ↔ answer(sorry) := by
+    Irrational (∑' k, 1 / (Nat.fib <| n k)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/269.lean
+++ b/FormalConjectures/ErdosProblems/269.lean
@@ -57,8 +57,9 @@ $$ \sum_{n=1}^\infty \frac{1}{[a_1,\ldots,a_n]} $$
 rational?
 -/
 @[category research open, AMS 11]
-theorem erdos_269.variants.rational : (∀ᵉ (P : Finset ℕ) (h : ∀ p ∈ P, p.Prime) (h_card : P.card ≥ 2),
-    ∃ (q : ℚ), q = (series (P : Set ℕ))) ↔ answer(sorry) := by
+theorem erdos_269.variants.rational : answer(sorry) ↔
+    ∀ᵉ (P : Finset ℕ) (h : ∀ p ∈ P, p.Prime) (h_card : P.card ≥ 2),
+    ∃ (q : ℚ), q = (series (P : Set ℕ)) := by
   sorry
 
 /--
@@ -69,8 +70,9 @@ $$ \sum_{n=1}^\infty \frac{1}{[a_1,\ldots,a_n]} $$
 irrational?
 -/
 @[category research open, AMS 11]
-theorem erdos_269.variants.irrational : (∀ᵉ (P : Finset ℕ) (h : ∀ p ∈ P, p.Prime) (h_card : P.card ≥ 2),
-    Irrational (series (P : Set ℕ))) ↔ answer(sorry) := by
+theorem erdos_269.variants.irrational : answer(sorry) ↔
+    ∀ᵉ (P : Finset ℕ) (h : ∀ p ∈ P, p.Prime) (h_card : P.card ≥ 2),
+    Irrational (series (P : Set ℕ)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/273.lean
+++ b/FormalConjectures/ErdosProblems/273.lean
@@ -27,16 +27,16 @@ namespace Erdos273
 Is there a covering system all of whose moduli are of the form $p-1$ for some primes $p \geq 5$?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_273 : (∃ c : StrictCoveringSystem ℤ, ∀ i, ∃ (p : ℕ), p.Prime ∧ 5 ≤ p ∧
-    c.moduli i = Ideal.span {↑(p - 1)}) ↔ answer(sorry) := by
+theorem erdos_273 : answer(sorry) ↔ ∃ c : StrictCoveringSystem ℤ, ∀ i, ∃ (p : ℕ), p.Prime ∧ 5 ≤ p ∧
+    c.moduli i = Ideal.span {↑(p - 1)} := by
   sorry
 
 /--
 Is there a covering system all of whose moduli are of the form $p-1$ for some primes $p \geq 3$?
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_273.variants.three : (∃ c : StrictCoveringSystem ℕ, ∀ i, ∃ p, p.Prime ∧ 3 ≤ p ∧
-    c.moduli i = Ideal.span {↑(p - 1)}) ↔ answer(True) := by
+theorem erdos_273.variants.three : answer(True) ↔ ∃ c : StrictCoveringSystem ℕ, ∀ i, ∃ p, p.Prime ∧ 3 ≤ p ∧
+    c.moduli i = Ideal.span {↑(p - 1)} := by
   -- TODO(Paul-Lez): find reference for this and perhaps formalize the proof?
   sorry
 

--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -50,7 +50,7 @@ If `G` is a group then can there exist an exact covering of `G` by more than one
 different sizes? (i.e. each element is contained in exactly one of the cosets.)
 -/
 @[category research open, AMS 20]
-theorem erdos_274 : answer(True) ↔ ∀ᵉ (G : Type*) (h : Group G) (hG : 1 < ENat.card G),
+theorem erdos_274 : answer(sorry) ↔ ∀ᵉ (G : Type*) (h : Group G) (hG : 1 < ENat.card G),
     (∃ (ι : Type*) (_ : Fintype ι) (P : Group.ExactCovering G ι),
       1 < Fintype.card ι ∧ (Set.range P.parts).Pairwise fun A B ↦ #A ≠ #B) := by
   sorry

--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -50,9 +50,9 @@ If `G` is a group then can there exist an exact covering of `G` by more than one
 different sizes? (i.e. each element is contained in exactly one of the cosets.)
 -/
 @[category research open, AMS 20]
-theorem erdos_274 : (∀ᵉ (G : Type*) (h : Group G) (hG : 1 < ENat.card G),
+theorem erdos_274 : answer(True) ↔ ∀ᵉ (G : Type*) (h : Group G) (hG : 1 < ENat.card G),
     (∃ (ι : Type*) (_ : Fintype ι) (P : Group.ExactCovering G ι),
-      1 < Fintype.card ι ∧ (Set.range P.parts).Pairwise fun A B ↦ #A ≠ #B)) ↔ answer(sorry) := by
+      1 < Fintype.card ι ∧ (Set.range P.parts).Pairwise fun A B ↦ #A ≠ #B) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/276.lean
+++ b/FormalConjectures/ErdosProblems/276.lean
@@ -43,9 +43,9 @@ $n \ge 0$ such that all $a_k$ are composite, and yet no integer has a common fac
 term of the sequence?
 -/
 @[category research open, AMS 11]
-theorem erdos_276 : (∃ (a : ℕ → ℕ),
-    IsLucasSequence a ∧ (∀ k, (a k).Composite) ∧ (∀ n > 1, ∃ k, Nat.gcd n (a k) = 1)) ↔
-    answer(sorry) := by
+theorem erdos_276 : answer(sorry) ↔
+    ∃ (a : ℕ → ℕ),
+    IsLucasSequence a ∧ (∀ k, (a k).Composite) ∧ (∀ n > 1, ∃ k, Nat.gcd n (a k) = 1) := by
   sorry
 
 end Erdos276

--- a/FormalConjectures/ErdosProblems/283.lean
+++ b/FormalConjectures/ErdosProblems/283.lean
@@ -49,7 +49,7 @@ and
 $$m=p(n_1)+\cdots+p(n_k)$$?
 -/
 @[category research open, AMS 11]
-theorem erdos_283 : (∀ p : ℤ[X], Condition p) ↔ answer(sorry) := by
+theorem erdos_283 : answer(sorry) ↔ ∀ p : ℤ[X], Condition p := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/285.lean
+++ b/FormalConjectures/ErdosProblems/285.lean
@@ -43,8 +43,8 @@ Proved by Martin [Ma00].
 [Ma00] Martin, Greg, _Denser Egyptian fractions_. Acta Arith. (2000), 231-260.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_285
-    (f : ℕ → ℕ)
+theorem erdos_285 :
+    answer(True) ↔ ∀ᵉ (f : ℕ → ℕ)
     (S : Set ℕ)
     (hS : S = {k | ∃ (n : Fin k.succ → ℕ), StrictMono n ∧ 0 ∉ Set.range n ∧
       1 = ∑ i, (1 : ℝ) / n i })
@@ -52,9 +52,9 @@ theorem erdos_285
       IsLeast
         { n (Fin.last k) | (n : Fin k.succ → ℕ) (_ : StrictMono n) (_ : 0 ∉ Set.range n)
           (_ : 1 = ∑ i, (1 : ℝ) / n i) }
-        (f k)) :
-    (∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
-      ∀ k ∈ S, f k = (1 + o k) * rexp 1 / (rexp 1 - 1) * (k + 1)) ↔ answer(True) := by
+        (f k)),
+    ∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
+      ∀ k ∈ S, f k = (1 + o k) * rexp 1 / (rexp 1 - 1) * (k + 1) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/288.lean
+++ b/FormalConjectures/ErdosProblems/288.lean
@@ -31,36 +31,33 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_288 : Set.Finite { I : Fin 2 → ℕ+ × ℕ+ |
-      ∃ n : ℕ+, (∑ j : Fin 2, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
-    answer(sorry) := by
+theorem erdos_288 : answer(sorry) ↔ Set.Finite { I : Fin 2 → ℕ+ × ℕ+ |
+    ∃ n : ℕ+, (∑ j : Fin 2, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } := by
   sorry
 
 /--
 This is still open even if $|I_2| = 1$.
 -/
 @[category research open, AMS 11]
-theorem erdos_288.variants.i2_card_eq_1 : Set.Finite { (I, n₂) : (ℕ+ × ℕ+) × ℕ+ |
-      ∃ n : ℕ+, ∑ n₁ ∈ Set.Icc I.1 I.2, (n₁⁻¹ : ℚ) + (n₂⁻¹ : ℚ) = n } ↔
-    answer(sorry) := by
+theorem erdos_288.variants.i2_card_eq_1 : answer(sorry) ↔ Set.Finite { (I, n₂) : (ℕ+ × ℕ+) × ℕ+ |
+    ∃ n : ℕ+, ∑ n₁ ∈ Set.Icc I.1 I.2, (n₁⁻¹ : ℚ) + (n₂⁻¹ : ℚ) = n } := by
   sorry
 
 /--
 It is perhaps true with two intervals replaced by any $k$ intervals.
 -/
 @[category research open, AMS 11]
-theorem erdos_288.variants.k_intervals : ∀ k, Set.Finite { I : Fin k → ℕ+ × ℕ+ |
-      ∃ n : ℕ+, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
-    answer(sorry) := by
+theorem erdos_288.variants.k_intervals : answer(sorry) ↔ ∀ k, Set.Finite { I : Fin k → ℕ+ × ℕ+ |
+    ∃ n : ℕ+, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } := by
   sorry
 
 /--
 Is it true for any $k > 2$ that only finitely many $k$ intervals satisfy this condition?
 -/
 @[category research open, AMS 11]
-theorem erdos_288.variants.exists_k_gt_2 : ∃ k > 2, Set.Finite { I : Fin k → ℕ+ × ℕ+ |
-      ∃ n : ℕ+, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } ↔
-    answer(sorry) := by
+theorem erdos_288.variants.exists_k_gt_2 : answer(sorry) ↔
+    ∃ k > 2, Set.Finite { I : Fin k → ℕ+ × ℕ+ |
+    ∃ n : ℕ+, (∑ j : Fin k, ∑ nⱼ ∈ Set.Icc (I j).1 (I j).2, (nⱼ⁻¹ : ℚ)) = n } := by
   sorry
 
 end Erdos288

--- a/FormalConjectures/ErdosProblems/289.lean
+++ b/FormalConjectures/ErdosProblems/289.lean
@@ -32,10 +32,10 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_289 :
+theorem erdos_289 : answer(sorry) ↔
     (∀ᶠ k : ℕ in atTop, ∃ I : Fin k → Finset ℕ,
       (∀ i, 2 ≤ #(I i) ∧ ∃ a b, 0 < a ∧ I i = Finset.Icc a b) ∧
-      ∑ i, ∑ n ∈ I i, (n⁻¹ : ℚ) = 1) ↔ answer(sorry) := by
+      ∑ i, ∑ n ∈ I i, (n⁻¹ : ℚ) = 1) := by
   sorry
 
 end Erdos289

--- a/FormalConjectures/ErdosProblems/295.lean
+++ b/FormalConjectures/ErdosProblems/295.lean
@@ -51,7 +51,7 @@ Is it true that $\lim_{N \to \infty} k(N) - (e - 1)N = \infty$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_295 :
-    Filter.atTop.Tendsto (fun N => k N - (rexp 1 - 1)*N) Filter.atTop ↔ answer(sorry) := by
+    answer(sorry) ↔ Filter.atTop.Tendsto (fun N => k N - (rexp 1 - 1)*N) Filter.atTop := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/298.lean
+++ b/FormalConjectures/ErdosProblems/298.lean
@@ -34,16 +34,16 @@ The answer is yes, proved by Bloom [Bl21].
 Note: The solution to this problem has been formalized in Lean 3 by T. Bloom and B. Mehta, see
 https://github.com/b-mehta/unit-fractions -/
 @[category research solved, AMS 11]
-theorem erdos_298 : (∀ (A : Set ℕ), 0 ∉ A → A.HasPosDensity →
-    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) ↔ answer(True) := by
+theorem erdos_298 : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → A.HasPosDensity →
+    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) := by
   sorry
 
 /--
 In [Bl21] it is proved under the weaker assumption that `A` only has positive upper density.
 -/
 @[category research solved, AMS 11]
-theorem erdos_298.variants.upper_density : (∀ (A : Set ℕ), 0 ∉ A → 0 < A.upperDensity →
-    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) ↔ answer(True) := by
+theorem erdos_298.variants.upper_density : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → 0 < A.upperDensity →
+    ∃ (S : Finset ℕ), S.toSet ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) := by
   sorry
 
 end Erdos298

--- a/FormalConjectures/ErdosProblems/299.lean
+++ b/FormalConjectures/ErdosProblems/299.lean
@@ -31,10 +31,10 @@ Is there an infinite sequence $a_1 < a_2 < \dots$ such that $a_{i+1} - a_i = O(1
 sum of $\frac{1}{a_i}$ is equal to 1?
 -/
 @[category research solved, AMS 11 40]
-theorem erdos_299 : (∃ (a : ℕ → ℕ),
+theorem erdos_299 : answer(False) ↔ (∃ (a : ℕ → ℕ),
     StrictMono a ∧ (∀ n, 0 < a n) ∧
     (fun n ↦ (a (n + 1) : ℝ) - a n) =O[atTop] (1 : ℕ → ℝ) ∧
-    ∀ S : Finset ℕ, ∑ i ∈ S, (1 : ℝ) / a i ≠ 1) ↔ answer(False) := by
+    ∀ S : Finset ℕ, ∑ i ∈ S, (1 : ℝ) / a i ≠ 1) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/3.lean
+++ b/FormalConjectures/ErdosProblems/3.lean
@@ -29,9 +29,9 @@ If $A \subset \mathbb{N} has $\sum_{n \in A}\frac 1 n = \infty$, then must $A$ c
 long arithmetic progressions?
 -/
 @[category research open, AMS 11]
-theorem erdos_3 : (∀ A : Set ℕ,
+theorem erdos_3 : answer(sorry) ↔ ∀ A : Set ℕ,
     (¬ Summable fun a : A ↦ 1 / (a : ℝ)) →
-    ∃ᶠ (k : ℕ) in Filter.atTop, ∃ S ⊆ A, S.IsAPOfLength k) ↔ answer(sorry) := by
+    ∃ᶠ (k : ℕ) in Filter.atTop, ∃ S ⊆ A, S.IsAPOfLength k := by
   sorry
 
 --TODO(firsching): add the various known bounds as variants.

--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -34,9 +34,8 @@ open Filter
 Is it true that, for every $\varepsilon > 0$, $h(N) = \sqrt N + O_{\varespilon}(N^\varespilon)
 -/
 @[category research open, AMS 11]
-theorem erdos_30 :
-    (∀ᵉ (ε > 0), (fun N => h N - (N : Real).sqrt) =O[atTop] fun N => (N : ℝ)^(ε : ℝ))
-    ↔ answer(sorry) := by
+theorem erdos_30 : answer(sorry) ↔
+    ∀ᵉ (ε > 0), (fun N => h N - (N : Real).sqrt) =O[atTop] fun N => (N : ℝ)^(ε : ℝ) := by
   sorry
 
 -- TODO(firsching): add the various known bounds as variants.

--- a/FormalConjectures/ErdosProblems/303.lean
+++ b/FormalConjectures/ErdosProblems/303.lean
@@ -35,8 +35,9 @@ Bull. Austral. Math. Soc. (1991), 387-392.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_303 :
+    answer(True) ↔
     --For any finite colouring of the integers
-    (∀ (𝓒 : ℤ → ℤ), (Set.range 𝓒).Finite →
+    ∀ (𝓒 : ℤ → ℤ), (Set.range 𝓒).Finite →
       --There exists integers `a, b, c`
       ∃ (a b c : ℤ),
       --that are non-zero and distinct.
@@ -44,7 +45,7 @@ theorem erdos_303 :
       --`a, b, c` satisfy the equation
       (1/a : ℝ) = 1/b + 1/c ∧
       --`a, b, c` have the same color
-      (𝓒 '' {a, b, c}).Subsingleton) ↔ answer(True) := by
+      (𝓒 '' {a, b, c}).Subsingleton := by
   sorry
 
 end Erdos303

--- a/FormalConjectures/ErdosProblems/304.lean
+++ b/FormalConjectures/ErdosProblems/304.lean
@@ -170,9 +170,8 @@ theorem erdos_304.variants.upper_1985 :
 Is it true that $$N(b) \ll \log \log b$$?
 -/
 @[category research open, AMS 11]
-theorem upper_bound :
-    (fun b : ℕ => (smallestCollectionTo b : ℝ)) =O[atTop]
-      (fun b : ℕ => Real.log (Real.log b)) ↔ answer(sorry) := by
+theorem upper_bound : answer(sorry) ↔
+    (fun b : ℕ => (smallestCollectionTo b : ℝ)) =O[atTop] (fun b : ℕ => Real.log (Real.log b)) := by
   sorry
 
 end Erdos304

--- a/FormalConjectures/ErdosProblems/306.lean
+++ b/FormalConjectures/ErdosProblems/306.lean
@@ -32,10 +32,10 @@ Let $\frac a b\in \mathbb{Q}_{>0}$ with $b$ squarefree. Are there integers $1 < 
 each the product of two distinct primes, such that $\frac{a}{b}=\frac{1}{n_1}+\cdots+\frac{1}{n_k}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_306 : (∀ (q : ℚ), 0 < q → Squarefree q.den →
+theorem erdos_306 : answer(sorry) ↔ ∀ (q : ℚ), 0 < q → Squarefree q.den →
     ∃ k : ℕ, ∃ (n : Fin (k + 1) → ℕ), n 0 = 1 ∧ StrictMono n ∧
     (∀ i ∈ Finset.Icc 1 (Fin.last k), ω (n i) = 2 ∧ Ω (n i) = 2) ∧
-    q = ∑ i ∈ Finset.Icc 1 (Fin.last k), (1 : ℚ) / (n i)) ↔ answer(sorry) := by
+    q = ∑ i ∈ Finset.Icc 1 (Fin.last k), (1 : ℚ) / (n i) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/307.lean
+++ b/FormalConjectures/ErdosProblems/307.lean
@@ -39,17 +39,17 @@ Asked by Barbeau [Ba76].
 [Ba76] Barbeau, E. J., _Computer challenge corner: Problem 477: A brute force program._
 -/
 @[category research open, AMS 11]
-theorem erdos_307 : (∃ P Q : Finset ℕ, (∀ p ∈ P, p.Prime) ∧ (∀ q ∈ Q, q.Prime) ∧
-    (1 = (∑ p ∈ P, (p : ℚ)⁻¹) * (∑ q ∈ Q, (q : ℚ)⁻¹))) ↔ answer(sorry) := by
+theorem erdos_307 : answer(sorry) ↔ ∃ P Q : Finset ℕ, (∀ p ∈ P, p.Prime) ∧ (∀ q ∈ Q, q.Prime) ∧
+    (1 = (∑ p ∈ P, (p : ℚ)⁻¹) * (∑ q ∈ Q, (q : ℚ)⁻¹)) := by
   sorry
 
 /--
 Instead of asking for sets of primes, ask only that all primes in the sets be relatively coprime.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_307_coprime : (∃ P Q : Finset ℕ, 1 < #P ∧ 1 < #Q ∧ Set.Pairwise P Nat.Coprime ∧
+theorem erdos_307_coprime : answer(sorry) ↔ ∃ P Q : Finset ℕ, 1 < #P ∧ 1 < #Q ∧ Set.Pairwise P Nat.Coprime ∧
     Set.Pairwise Q Nat.Coprime ∧
-    (1 = (∑ p ∈ P, (p : ℚ)⁻¹) * (∑ q ∈ Q, (q : ℚ)⁻¹))) ↔ answer(sorry) := by
+    (1 = (∑ p ∈ P, (p : ℚ)⁻¹) * (∑ q ∈ Q, (q : ℚ)⁻¹)) := by
   sorry
 
 end Erdos307

--- a/FormalConjectures/ErdosProblems/312.lean
+++ b/FormalConjectures/ErdosProblems/312.lean
@@ -39,7 +39,7 @@ theorem erdos_312 :
             (n ≥ N₀ ∧ (∑ i : Fin n, (a i : ℝ)⁻¹) > K) →
               ∃ (S : Finset (Fin n)),
                 1 - Real.exp (-(c * K)) < (∑ i ∈ S, (a i : ℝ)⁻¹) ∧
-                (∑ i ∈ S, (a i : ℝ)⁻¹) ≤ 1 := by
+                ∑ i ∈ S, (a i : ℝ)⁻¹ ≤ 1 := by
   sorry
 
 end Erdos312

--- a/FormalConjectures/ErdosProblems/312.lean
+++ b/FormalConjectures/ErdosProblems/312.lean
@@ -31,15 +31,15 @@ $1 - \exp(-(c*K)) < \sum_{n \in S} 1/n \le 1$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_312 :
-    (∃ (c : ℝ), 0 < c ∧
+    answer(sorry) ↔
+    ∃ (c : ℝ), 0 < c ∧
       ∀ (K : ℝ), 1 < K →
         ∃ (N₀ : ℕ),
           ∀ (n : ℕ) (a : Fin n → ℕ),
             (n ≥ N₀ ∧ (∑ i : Fin n, (a i : ℝ)⁻¹) > K) →
               ∃ (S : Finset (Fin n)),
                 1 - Real.exp (-(c * K)) < (∑ i ∈ S, (a i : ℝ)⁻¹) ∧
-                (∑ i ∈ S, (a i : ℝ)⁻¹) ≤ 1)
-    ↔ answer(sorry) := by
+                (∑ i ∈ S, (a i : ℝ)⁻¹) ≤ 1 := by
   sorry
 
 end Erdos312

--- a/FormalConjectures/ErdosProblems/313.lean
+++ b/FormalConjectures/ErdosProblems/313.lean
@@ -40,7 +40,7 @@ and `P` is a set of distinct primes such that the following equation holds:
 $\sum_{p \in P} \frac{1}{p} = 1 - \frac{1}{m}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_313_conjecture : erdos_313_solutions.Infinite ↔ answer(sorry) := by
+theorem erdos_313_conjecture : answer(sorry) ↔ erdos_313_solutions.Infinite := by
   sorry
 
 @[category test, AMS 11]

--- a/FormalConjectures/ErdosProblems/316.lean
+++ b/FormalConjectures/ErdosProblems/316.lean
@@ -37,8 +37,7 @@ theorem erdos_316 : answer(False) ↔ ∀ A : Finset ℕ, 0 ∉ A → 1 ∉ A �
     ∑ n ∈ A, (1 / n : ℚ) < 2 → ∃ (A₁ A₂ : Finset ℕ),
       Disjoint A₁ A₂ ∧ A = A₁ ∪ A₂ ∧
       ∑ n ∈ A₁, (1 / n : ℚ) < 1 ∧ ∑ n ∈ A₂, (1 / n : ℚ) <  1 := by
-  symm
-  simp only [one_div, iff_false, not_forall, not_exists, not_and, not_lt]
+  simp only [one_div, false_iff, not_forall, not_exists, not_and, not_lt]
   let A : Finset ℕ := {2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15}
   refine ⟨A, by decide, by decide, by decide +kernel, ?_⟩
   suffices h : ∀ B ⊆ A, ∑ n ∈ B, (n : ℚ)⁻¹ < 1 → 1 ≤ ∑ n ∈ A \ B, (n : ℚ)⁻¹ by

--- a/FormalConjectures/ErdosProblems/316.lean
+++ b/FormalConjectures/ErdosProblems/316.lean
@@ -36,7 +36,7 @@ This is not true in general, as shown by Sándor [Sa97].
 theorem erdos_316 : answer(False) ↔ ∀ A : Finset ℕ, 0 ∉ A → 1 ∉ A →
     ∑ n ∈ A, (1 / n : ℚ) < 2 → ∃ (A₁ A₂ : Finset ℕ),
       Disjoint A₁ A₂ ∧ A = A₁ ∪ A₂ ∧
-      (∑ n ∈ A₁, (1 / n : ℚ) < 1 ∧ ∑ n ∈ A₂, (1 / n : ℚ) < 1) := by
+      ∑ n ∈ A₁, (1 / n : ℚ) < 1 ∧ ∑ n ∈ A₂, (1 / n : ℚ) <  1 := by
   symm
   simp only [one_div, iff_false, not_forall, not_exists, not_and, not_lt]
   let A : Finset ℕ := {2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15}

--- a/FormalConjectures/ErdosProblems/316.lean
+++ b/FormalConjectures/ErdosProblems/316.lean
@@ -33,10 +33,11 @@ This is not true in general, as shown by Sándor [Sa97].
 [Sa97] S\'{A}ndor, Csaba, _On a problem of Erdős_. J. Number Theory (1997), 203-210.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_316 : (∀ A : Finset ℕ, 0 ∉ A → 1 ∉ A →
+theorem erdos_316 : answer(False) ↔ ∀ A : Finset ℕ, 0 ∉ A → 1 ∉ A →
     ∑ n ∈ A, (1 / n : ℚ) < 2 → ∃ (A₁ A₂ : Finset ℕ),
       Disjoint A₁ A₂ ∧ A = A₁ ∪ A₂ ∧
-      (∑ n ∈ A₁, (1 / n : ℚ) < 1 ∧ ∑ n ∈ A₂, (1 / n : ℚ) < 1)) ↔ answer(False) := by
+      (∑ n ∈ A₁, (1 / n : ℚ) < 1 ∧ ∑ n ∈ A₂, (1 / n : ℚ) < 1) := by
+  symm
   simp only [one_div, iff_false, not_forall, not_exists, not_and, not_lt]
   let A : Finset ℕ := {2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15}
   refine ⟨A, by decide, by decide, by decide +kernel, ?_⟩

--- a/FormalConjectures/ErdosProblems/317.lean
+++ b/FormalConjectures/ErdosProblems/317.lean
@@ -31,11 +31,11 @@ Is there some constant $c>0$ such that for every $n\geq 1$ there exists some $\d
 \[0< \left\lvert \sum_{1\leq k\leq n}\frac{\delta_k}{k}\right\rvert < \frac{c}{2^n}?\]
 -/
 @[category research open, AMS 11]
-theorem erdos_317 :
-    (∃ c > 0, ∀ n ≥ 1, ∃ δ : Fin n → ℚ,
+theorem erdos_317 : answer(sorry) ↔
+    ∃ c > 0, ∀ n ≥ 1, ∃ δ : Fin n → ℚ,
       Set.range δ ⊆ {-1, 0, 1} ∧
       letI lhs : ℝ := |∑ k, (δ k) / (k + 1)|
-      0 < lhs ∧ lhs < c / 2^n) ↔ answer(sorry) := by
+      0 < lhs ∧ lhs < c / 2^n := by
   sorry
 
 /--
@@ -44,10 +44,10 @@ Is it true that for sufficiently large $n$, for any $\delta_k\in \{-1,0,1\}$,
 whenever the left-hand side is not zero?
 -/
 @[category research open, AMS 11]
-theorem erdos_317.variants.claim2 : (∀ᶠ n in atTop,
-    ∀ δ : (Fin n) → ℚ, δ '' Set.univ ⊆ {-1,0,1} →
+theorem erdos_317.variants.claim2 : answer(sorry) ↔
+    ∀ᶠ n in atTop, ∀ δ : (Fin n) → ℚ, δ '' Set.univ ⊆ {-1,0,1} →
     letI lhs := |∑ k, ((δ k : ℚ) / (k + 1))|
-    lhs ≠ 0 → lhs > 1 / (Icc 1 n).lcm id) ↔ answer(sorry) := by
+    lhs ≠ 0 → lhs > 1 / (Icc 1 n).lcm id := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/324.lean
+++ b/FormalConjectures/ErdosProblems/324.lean
@@ -31,9 +31,8 @@ Does there exist a polynomial $f(x)\in\mathbb{Z}[x]$ such that all the sums $f(a
 $a < b$ nonnegative integers are distinct?
 -/
 @[category research open, AMS 11]
-theorem erdos_324 : (∃ f : ℤ[X],
-    {(a, b) : ℕ × ℕ | a < b}.InjOn fun (a, b) => f.eval (a : ℤ) + f.eval (b : ℤ))
-    ↔ answer(sorry) := by
+theorem erdos_324 : answer(sorry) ↔
+    ∃ f : ℤ[X], {(a, b) : ℕ × ℕ | a < b}.InjOn fun (a, b) => f.eval (a : ℤ) + f.eval (b : ℤ) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/325.lean
+++ b/FormalConjectures/ErdosProblems/325.lean
@@ -38,8 +38,8 @@ is it true that $f_{k, 3}(x) \gg x ^ (3 / k)$?
 -/
 @[category research open, AMS 11]
 theorem erdos_325 :
-    (∀ k : ℕ, 3 ≤ k → (fun x : ℕ => (x : ℝ) ^ (3 / k : ℝ)) =O[atTop]
-      (fun x : ℕ => (cardIsSumThreePowerBelow k x : ℝ))) ↔ answer(sorry) := by
+     answer(sorry) ↔ ∀ k : ℕ, 3 ≤ k → (fun x : ℕ => (x : ℝ) ^ (3 / k : ℝ)) =O[atTop]
+      (fun x : ℕ => (cardIsSumThreePowerBelow k x : ℝ)) := by
   sorry
 
 /--
@@ -48,8 +48,8 @@ is it even true that $f_{k, 3}(x) \gg_{\epsilon} x ^ (3 / k - \epsilon)$?
 -/
 @[category research open, AMS 11]
 theorem erdos_325.variants.weaker :
-    (∀ ε > 0, ∀ k : ℕ, 3 ≤ k → (fun x : ℕ => (x : ℝ) ^ ((3 / k : ℝ) - ε)) =O[atTop]
-      (fun x => (cardIsSumThreePowerBelow k x : ℝ))) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ ε > 0, ∀ k : ℕ, 3 ≤ k → (fun x : ℕ => (x : ℝ) ^ ((3 / k : ℝ) - ε)) =O[atTop]
+      (fun x => (cardIsSumThreePowerBelow k x : ℝ)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -35,9 +35,9 @@ Must there exist $B = \{b_1 < b_2 < \dots\} \subseteq A$ which is also a basis s
 $\lim_{k\to\infty} \frac{b_k}{k^2}$ does not exist?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_326 : (∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
+theorem erdos_326 : answer(sorry) ↔ ∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
     ∃ (b : ℕ → ℕ), StrictMono b ∧ ∀ n, b n ∈ A ∧ (Set.range b).IsAddBasis ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x)) ↔ answer(sorry) := by
+      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/330.lean
+++ b/FormalConjectures/ErdosProblems/330.lean
@@ -43,13 +43,13 @@ def MinAsymptoticAddBasis (A : Set ℕ) : Prop :=
 
 /--
 Does there exist a minimal basis $A \subset \mathbb{N}$ with positive density
-such that, for any $n \in A$, the (upper) density of integers which 
+such that, for any $n \in A$, the (upper) density of integers which
 cannot be represented without using $n$ is positive?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_330_statement :
-    (∃ (A : Set ℕ),  MinAsymptoticAddBasis A ∧ A.HasPosDensity ∧
-    ∀ n ∈ A, Set.HasPosDensity (UnrepWithout A n)) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (A : Set ℕ),  MinAsymptoticAddBasis A ∧ A.HasPosDensity ∧
+    ∀ n ∈ A, Set.HasPosDensity (UnrepWithout A n) := by
   sorry
 
 end Erdos330

--- a/FormalConjectures/ErdosProblems/340.lean
+++ b/FormalConjectures/ErdosProblems/340.lean
@@ -152,8 +152,8 @@ theorem erdos_340.variants._22_mem_sub :
 The smallest integer which is unknown to be in $A - A$ is $33$.
  -/
 @[category research open, AMS 5]
-theorem erdos_340.variants._33_mem_sub :
-    33 ∈ Set.range greedySidon - Set.range greedySidon ↔ answer(sorry) :=
+theorem erdos_340.variants._33_mem_sub : answer(sorry) ↔
+    33 ∈ Set.range greedySidon - Set.range greedySidon :=
   sorry
 
 -- Formalisation note: there is some slight ambiguity in the meaning of
@@ -164,17 +164,16 @@ theorem erdos_340.variants._33_mem_sub :
 It may be true that all or almost all integers are in $A - A$.
 -/
 @[category research open, AMS 5]
-theorem erdos_340.variants.cofinite_sub :
-    (∀ᶠ n in cofinite, n ∈ Set.range greedySidon - Set.range greedySidon) ↔ answer(sorry) :=
+theorem erdos_340.variants.cofinite_sub : answer(sorry) ↔
+    ∀ᶠ n in cofinite, n ∈ Set.range greedySidon - Set.range greedySidon :=
   sorry
 
 /--
 It may be true that all or almost all integers are in $A - A$.
 -/
 @[category research open, AMS 5]
-theorem erdos_340.variants.co_density_zero_sub :
-    (∃ S : Set ℕ, S.HasDensity 0 ∧ ∀ n ∈ Sᶜ, n ∈ Set.range greedySidon - Set.range greedySidon)
-      ↔ answer(sorry) :=
+theorem erdos_340.variants.co_density_zero_sub : answer(sorry) ↔
+    ∃ S : Set ℕ, S.HasDensity 0 ∧ ∀ n ∈ Sᶜ, n ∈ Set.range greedySidon - Set.range greedySidon :=
   sorry
 
 end Erdos340

--- a/FormalConjectures/ErdosProblems/347.lean
+++ b/FormalConjectures/ErdosProblems/347.lean
@@ -40,10 +40,9 @@ has density $1$ for every cofinite subsequence $A'$ of $A$?
 -/
 @[category research open, AMS 11]
 theorem erdos_347 :
-    (∃ a : ℕ → ℕ, (Monotone a) ∧
+    answer(sorry) ↔ ∃ a : ℕ → ℕ, (Monotone a) ∧
       (Tendsto (fun n ↦ (a (n + 1) : ℝ) / (a n : ℝ)) atTop (𝓝 2)) ∧
-      (∀ ι : ℕ → ℕ, (range ι)ᶜ.Finite → HasDensity (𝓟 (range (a ∘ ι))) 1))
-    ↔ answer(sorry) := by
+      (∀ ι : ℕ → ℕ, (range ι)ᶜ.Finite → HasDensity (𝓟 (range (a ∘ ι))) 1) := by
   sorry
 
 end Erdos347

--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -69,7 +69,7 @@ often and even infinitely often?
 -/
 @[category research open, AMS 11]
 theorem erdos_349.variants.floor_3_halves_odd :
-    {n | Odd ⌊(3/2 : ℝ) ^ n⌋}.Infinite ↔ answer(sorry) := by
+    answer(sorry) ↔ {n | Odd ⌊(3/2 : ℝ) ^ n⌋}.Infinite := by
   sorry
 
 /--
@@ -77,7 +77,7 @@ Is it true that the terms of the sequence $\lfloor (3/2)^n\rfloor$ are even infi
 -/
 @[category research open, AMS 11]
 theorem erdos_349.variants.floor_3_halves_even :
-    {n | Even ⌊(3/2 : ℝ) ^ n⌋}.Infinite ↔ answer(sorry) := by
+    answer(sorry) ↔ {n | Even ⌊(3/2 : ℝ) ^ n⌋}.Infinite := by
   sorry
 
 end Erdos349

--- a/FormalConjectures/ErdosProblems/351.lean
+++ b/FormalConjectures/ErdosProblems/351.lean
@@ -52,7 +52,7 @@ in the sense that, for any finite set $B$,
 contains all sufficiently large integers? -/
 @[category research open, AMS 11]
 theorem erdos_351 :
-    (∀ P : ℚ[X], 0 < P.natDegree → 0 < P.leadingCoeff → HasCompleteImage P) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ P : ℚ[X], 0 < P.natDegree → 0 < P.leadingCoeff → HasCompleteImage P := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/352.lean
+++ b/FormalConjectures/ErdosProblems/352.lean
@@ -33,11 +33,10 @@ Is there some $c > 0$ such that every measurable $A \subseteq \mathbb{R}^2$ of m
 -/
 @[category research open, AMS 51]
 theorem erdos_352 :
-    (∃ c > (0: ℝ), ∀ A : Set ℝ², MeasurableSet A → ℙ A ≥ c.toEReal
+    answer(sorry) ↔ ∃ c > (0: ℝ), ∀ A : Set ℝ², MeasurableSet A → ℙ A ≥ c.toEReal
        → (∃ t : Affine.Triangle ℝ ℝ²,
            (∀ p : Fin 3, t.points p ∈ A) ∧
-           EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) = 1))
-    ↔ answer(sorry) := by
+           EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) = 1) := by
   sorry
 
 end Erdos352

--- a/FormalConjectures/ErdosProblems/354.lean
+++ b/FormalConjectures/ErdosProblems/354.lean
@@ -37,16 +37,16 @@ noncomputable def FloorMultiples.interleave (a b γ : ℝ) (n : ℕ) : ℤ :=
 \[\{ \lfloor \alpha\rfloor,\lfloor \gamma\alpha\rfloor,\lfloor \gamma^2\alpha\rfloor,\ldots\}\cup
 \{ \lfloor \beta\rfloor,\lfloor \gamma\beta\rfloor,\lfloor \gamma^2\beta\rfloor,\ldots\}\] complete?-/
 @[category research open, AMS 11]
-theorem erdos_354.parts.i : (∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
-    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2)) ↔ answer(sorry) := by
+theorem erdos_354.parts.i : answer(sorry) ↔ ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
+    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2) := by
   sorry
 
 /-- Let $\alpha,\beta\in \mathbb{R}_{>0}$ such that $\alpha/\beta$ is irrational. Is
 \[\{ \lfloor \alpha\rfloor,\lfloor \gamma\alpha\rfloor,\lfloor \gamma^2\alpha\rfloor,\ldots\}\cup
 \{ \lfloor \beta\rfloor,\lfloor \gamma\beta\rfloor,\lfloor \gamma^2\beta\rfloor,\ldots\}\] complete? -/
 @[category research open, AMS 11]
-theorem erdos_354.parts.ii : (∃ γ ∈ Set.Ioo 1 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
-    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2)) ↔ answer(sorry) := by
+theorem erdos_354.parts.ii : answer(sorry) ↔ ∃ γ ∈ Set.Ioo 1 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
+    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2) := by
   sorry
 
 end Erdos354

--- a/FormalConjectures/ErdosProblems/355.lean
+++ b/FormalConjectures/ErdosProblems/355.lean
@@ -34,7 +34,7 @@ contain all rationals in some open interval?
 @[category research open, AMS 11]
 theorem erdos_355 :
     answer(sorry) ↔ ∃ A : ℕ → ℕ, IsLacunary A ∧ ∃ u v : ℝ, u < v ∧ ∀ q : ℚ, ↑q ∈ Set.Ioo u v →
-      q ∈  {(∑ a ∈ A', (1 / a : ℚ)) | (A' : Finset ℕ) (_ : A'.toSet ⊆ Set.range A)} := by
+      q ∈ {∑ a ∈ A', (1 / a : ℚ) | (A' : Finset ℕ) (_ : A'.toSet ⊆ Set.range A)} := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/355.lean
+++ b/FormalConjectures/ErdosProblems/355.lean
@@ -33,9 +33,8 @@ contain all rationals in some open interval?
 -/
 @[category research open, AMS 11]
 theorem erdos_355 :
-    (∃ A : ℕ → ℕ, IsLacunary A ∧ ∃ u v : ℝ, u < v ∧ ∀ q : ℚ, ↑q ∈ Set.Ioo u v →
-      q ∈  {(∑ a ∈ A', (1 / a : ℚ)) | (A' : Finset ℕ) (_ : A'.toSet ⊆ Set.range A)})
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ A : ℕ → ℕ, IsLacunary A ∧ ∃ u v : ℝ, u < v ∧ ∀ q : ℚ, ↑q ∈ Set.Ioo u v →
+      q ∈  {(∑ a ∈ A', (1 / a : ℚ)) | (A' : Finset ℕ) (_ : A'.toSet ⊆ Set.range A)} := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/358.lean
+++ b/FormalConjectures/ErdosProblems/358.lean
@@ -68,7 +68,7 @@ Is there such an $A$ for which $f(n)\to \infty$ as $n\to \infty$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_358.parts.i :
-    (∃ A, StrictMono A ∧ atTop.Tendsto (f A) atTop) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ A, StrictMono A ∧ atTop.Tendsto (f A) atTop := by
   sorry
 
 /--
@@ -78,7 +78,7 @@ Is there an $A$ such that $f(n)\geq 2$ for all large $n$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_358.parts.ii :
-    (∃ A, StrictMono A ∧ ∀ᶠ n in atTop, 2 ≤ f A n) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ A, StrictMono A ∧ ∀ᶠ n in atTop, 2 ≤ f A n := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/366.lean
+++ b/FormalConjectures/ErdosProblems/366.lean
@@ -28,7 +28,7 @@ namespace Erdos366
 Are there any $2$-full $n$ such that $n+1$ is $3$-full?
 -/
 @[category research open, AMS 11]
-theorem erdos_366 : (∃ n > 0, (2).Full n ∧ (3).Full (n + 1)) ↔ answer(sorry) := by
+theorem erdos_366 : answer(sorry) ↔ ∃ n > 0, (2).Full n ∧ (3).Full (n + 1) := by
   sorry
 
 /--
@@ -44,14 +44,14 @@ Are there infinitely many 3-full $n$ such that $n+1$ is 2-full?
 -/
 @[category research open, AMS 11]
 theorem erdos_366.variant.three_two :
-    {n | (3).Full n ∧ (2).Full (n + 1)}.Infinite  ↔ answer(sorry) := by
+    answer(sorry) ↔ {n | (3).Full n ∧ (2).Full (n + 1)}.Infinite := by
   sorry
 
 /--
 Are there any consecutive pairs of $3$-full integers?
 -/
 @[category undergraduate, AMS 11]
-theorem erdos_366.variant.weaker : (∃ n > 0, (3).Full n ∧ (3).Full (n + 1))  ↔ answer(sorry) := by
+theorem erdos_366.variant.weaker : answer(sorry) ↔ ∃ n > 0, (3).Full n ∧ (3).Full (n + 1) := by
   sorry
 
 end Erdos366

--- a/FormalConjectures/ErdosProblems/370.lean
+++ b/FormalConjectures/ErdosProblems/370.lean
@@ -31,8 +31,8 @@ the largest prime factor of $n + 1$ is $< (n + 1)^{\frac{1}{2}}$.
 Steinerberger has pointed out this problem has a trivial solution.
 -/
 @[category research solved, AMS 11]
-theorem erdos_370 :
-    { n | Nat.maxPrimeFac n < √n ∧ Nat.maxPrimeFac (n + 1) < √(n + 1) }.Infinite ↔ answer(True) := by
+theorem erdos_370 : answer(True) ↔
+    { n | Nat.maxPrimeFac n < √n ∧ Nat.maxPrimeFac (n + 1) < √(n + 1) }.Infinite := by
   sorry
 
 end Erdos370

--- a/FormalConjectures/ErdosProblems/376.lean
+++ b/FormalConjectures/ErdosProblems/376.lean
@@ -28,7 +28,7 @@ namespace Erdos376
 Are there infinitely many $n$ such that ${2n\choose n}$ is coprime to $105$?
 -/
 @[category research open, AMS 11]
-theorem erdos_376 : { (n : ℕ) | n.centralBinom.Coprime 105 }.Infinite ↔ answer(sorry) := by
+theorem erdos_376 : answer(sorry) ↔ { (n : ℕ) | n.centralBinom.Coprime 105 }.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/377.lean
+++ b/FormalConjectures/ErdosProblems/377.lean
@@ -43,8 +43,8 @@ $$
 for all $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_377 : (∃ C > (0 : ℝ), ∀ (n : ℕ), sumInvPrimesNotDvdCentralBinom n ≤ C) ↔
-    answer(sorry) := by
+theorem erdos_377 : answer(sorry) ↔
+    ∃ C > (0 : ℝ), ∀ (n : ℕ), sumInvPrimesNotDvdCentralBinom n ≤ C := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/383.lean
+++ b/FormalConjectures/ErdosProblems/383.lean
@@ -33,9 +33,8 @@ $$
 is $p$?
 -/
 @[category research open, AMS 11]
-theorem erdos_383 :
-    (∀ k, {p : ℕ | p.Prime ∧ Nat.maxPrimeFac (∏ i ∈ Finset.Icc 0 k, (p ^ 2 + i)) = p}.Infinite) ↔
-    answer(sorry) := by
+theorem erdos_383 : answer(sorry) ↔
+    ∀ k, {p : ℕ | p.Prime ∧ Nat.maxPrimeFac (∏ i ∈ Finset.Icc 0 k, (p ^ 2 + i)) = p}.Infinite := by
   sorry
 
 end Erdos383

--- a/FormalConjectures/ErdosProblems/389.lean
+++ b/FormalConjectures/ErdosProblems/389.lean
@@ -31,9 +31,8 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_389 :
-    (∀ n ≥ 1, ∃ k ≥ 1, ∏ i ∈ Finset.range k, (n + i) ∣ ∏ i ∈ Finset.range k, (n + k + i)) ↔
-    answer(sorry) := by
+theorem erdos_389 : answer(sorry) ↔
+    ∀ n ≥ 1, ∃ k ≥ 1, ∏ i ∈ Finset.range k, (n + i) ∣ ∏ i ∈ Finset.range k, (n + k + i) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/39.lean
+++ b/FormalConjectures/ErdosProblems/39.lean
@@ -32,10 +32,9 @@ $\lvert A\cap \{1\ldots,N\}\rvert \gg_\epsilon N^{1/2-\epsilon}$
 for all $\varepsilon > 0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_39 : (∃ (A : Set ℕ), A.Infinite ∧ IsSidon A ∧
+theorem erdos_39 : answer(sorry) ↔ ∃ (A : Set ℕ), A.Infinite ∧ IsSidon A ∧
     ∀ᵉ  (ε  > (0 : ℝ)),
-    (· ^ (1 / 2 - ε) : ℕ → ℝ) =O[atTop] fun N => (((Set.Icc 1 N) ∩ A).ncard : ℝ))
-    ↔ answer(sorry) := by
+    (· ^ (1 / 2 - ε) : ℕ → ℝ) =O[atTop] fun N => (((Set.Icc 1 N) ∩ A).ncard : ℝ) := by
   sorry
 
 --TODO(firsching): add the various known bounds as variants.

--- a/FormalConjectures/ErdosProblems/396.lean
+++ b/FormalConjectures/ErdosProblems/396.lean
@@ -30,7 +30,7 @@ Is it true that for every $k$ there exists $n$ such that
 $$\prod_{0\leq i\leq k}(n-i) \mid \binom{2n}{n}?$$
 -/
 @[category research open, AMS 11]
-theorem erdos_396 : (∀ k : ℕ, ∃ n : ℕ, descFactorial n (k + 1) ∣ centralBinom n) ↔ answer(sorry) := by
+theorem erdos_396 : answer(sorry) ↔ ∀ k : ℕ, ∃ n : ℕ, descFactorial n (k + 1) ∣ centralBinom n := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/397.lean
+++ b/FormalConjectures/ErdosProblems/397.lean
@@ -35,9 +35,9 @@ $$
 with the $m_i,n_j$ distinct?
 -/
 @[category research open, AMS 11]
-theorem erdos_397 :
-  {(M, N) : Finset ℕ × Finset ℕ | Disjoint M N ∧
-    ∏ i ∈ M, centralBinom i = ∏ j ∈ N, centralBinom j}.Finite ↔ answer(sorry) := by
+theorem erdos_397 : answer(sorry) ↔
+    {(M, N) : Finset ℕ × Finset ℕ | Disjoint M N ∧
+    ∏ i ∈ M, centralBinom i = ∏ j ∈ N, centralBinom j}.Finite := by
   sorry
 
 end Erdos397

--- a/FormalConjectures/ErdosProblems/398.lean
+++ b/FormalConjectures/ErdosProblems/398.lean
@@ -33,7 +33,7 @@ namespace Erdos398
 Does $n! + 1 = m^2$ have integer solutions other than $n = 4, 5, 7$?
 -/
 @[category research open, AMS 11]
-theorem erdos_398 : {n | ∃ m, n ! + 1 = m ^ 2} = {4, 5, 7} ↔ answer(sorry) := by
+theorem erdos_398 : answer(sorry) ↔ {n | ∃ m, n ! + 1 = m ^ 2} = {4, 5, 7} := by
   sorry
 
 end Erdos398

--- a/FormalConjectures/ErdosProblems/4.lean
+++ b/FormalConjectures/ErdosProblems/4.lean
@@ -37,7 +37,7 @@ $$
 $$
 -/
 @[category research solved, AMS 11]
-theorem erdos_4 : (∀ C > 0, Erdos4For C) ↔ answer(True) := by
+theorem erdos_4 : answer(True) ↔ (∀ C > 0, Erdos4For C) := by
   sorry
 
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/406.lean
+++ b/FormalConjectures/ErdosProblems/406.lean
@@ -29,7 +29,7 @@ Is it true that there are only finitely many powers of $2$ which have only the d
 and $1$ when written in base $3$?
 -/
 @[category research open, AMS 11]
-theorem erdos_406 : { n | n.isPowerOfTwo ∧ Nat.digits 3 n ⊆ [0, 1] }.Finite ↔ answer(sorry) := by
+theorem erdos_406 : answer(sorry) ↔ { n | n.isPowerOfTwo ∧ Nat.digits 3 n ⊆ [0, 1] }.Finite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -86,7 +86,7 @@ Can infinitely many $n$ reach the same prime under the iteration $n\mapsto\phi(n
 -/
 @[category research open, AMS 11]
 theorem erdos_409.parts.ii :
-    (∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (φ · + 1)^[i] n = p }.Infinite) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (φ · + 1)^[i] n = p }.Infinite := by
   sorry
 
 /--
@@ -151,7 +151,7 @@ Can infinitely many $n$ reach the same prime under the iteration $n\mapsto\sigma
 -/
 @[category research open, AMS 11]
 theorem erdos_409.variants.sigma.parts.ii :
-    (∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (σ 1 · - 1)^[i] n = p }.Infinite) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (p : ℕ) (hp : p.Prime), { n | ∃ i, (σ 1 · - 1)^[i] n = p }.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/410.lean
+++ b/FormalConjectures/ErdosProblems/410.lean
@@ -37,7 +37,7 @@ Erdos, Granville, Pomerance, Spiro
 (page 169 of the book "Analytic Number Theory", 1990).
 -/
 @[category research open, AMS 11]
-theorem erdos_410 : answer(sorry) ↔ ∀ᵉ (n > 1),
+theorem erdos_410 : answer(sorry) ↔ ∀ n > 1,
     Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/410.lean
+++ b/FormalConjectures/ErdosProblems/410.lean
@@ -37,8 +37,8 @@ Erdos, Granville, Pomerance, Spiro
 (page 169 of the book "Analytic Number Theory", 1990).
 -/
 @[category research open, AMS 11]
-theorem erdos_410 : (∀ᵉ (n > 1),
-    Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop) ↔ answer(sorry) := by
+theorem erdos_410 : answer(sorry) ↔ ∀ᵉ (n > 1),
+    Tendsto (fun k : ℕ ↦ ((sigma 1)^[k] n : ℝ) ^ (1 / (k : ℝ))) atTop atTop := by
   sorry
 
 end Erdos410

--- a/FormalConjectures/ErdosProblems/412.lean
+++ b/FormalConjectures/ErdosProblems/412.lean
@@ -33,7 +33,7 @@ Let $σ_1(n)=σ(n)$, the sum of divisors function, and $σ_k(n) = σ(σ_{k-1}(n)
 Is it true that, for every $m, n ≥ 2$, there exist some $i, j$ such that $σ_i(m) = σ_j(n)$?
 -/
 @[category research open, AMS 11]
-theorem erdos_412 : (∀ᵉ (m ≥ 2) (n ≥ 2), ∃ i j, (σ 1)^[i] m = (σ 1)^[j] n) ↔ answer(sorry) := by
+theorem erdos_412 : answer(sorry) ↔ ∀ᵉ (m ≥ 2) (n ≥ 2), ∃ i j, (σ 1)^[i] m = (σ 1)^[j] n := by
   sorry
 
 end Erdos412

--- a/FormalConjectures/ErdosProblems/414.lean
+++ b/FormalConjectures/ErdosProblems/414.lean
@@ -33,7 +33,7 @@ Let $h_1(n) = h(n)$ and $h_k(n) = h(h_{k-1}(n))$. Is it true, for any $m,n$, the
 $i$ and $j$ such that $h_i(m) = h_j(n)$?
 -/
 @[category research open, AMS 11]
-theorem erdos_414 : (∀ᵉ  (m > 0) (n > 0), ∃ i j, h^[i] m = h^[j] n) ↔ answer(sorry) := by
+theorem erdos_414 : answer(sorry) ↔ ∀ᵉ  (m > 0) (n > 0), ∃ i j, h^[i] m = h^[j] n := by
   sorry
 
 end Erdos414

--- a/FormalConjectures/ErdosProblems/418.lean
+++ b/FormalConjectures/ErdosProblems/418.lean
@@ -37,7 +37,7 @@ This is true, as shown by Browkin and Schinzel [BrSc95].
 Colloq. Math. (1995), 55-58.
 -/
 @[category research solved, AMS 11]
-theorem erdos_418 : { (n - n.totient : ℕ) | n }ᶜ.Infinite ↔ answer(True) := by
+theorem erdos_418 : answer(True) ↔ { (n - n.totient : ℕ) | n }ᶜ.Infinite := by
   sorry
 
 /--
@@ -99,7 +99,7 @@ not of the form $n - \phi(n)$.
 -/
 @[category research open, AMS 11]
 theorem erdos_418.variants.density :
-    (∃ (S : Set ℕ) (hS : S.HasPosDensity), S ⊆ { (n - n.totient : ℕ) | n }ᶜ) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (S : Set ℕ) (hS : S.HasPosDensity), S ⊆ { (n - n.totient : ℕ) | n }ᶜ := by
   sorry
 
 end Erdos418

--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -36,9 +36,10 @@ maximal Sidon set `A ⊆ {1,…,N}` there is another Sidon set `B ⊆ {1,…,N}`
 `(A - A) ∩ (B - B) = {0}`?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_42 : (∀ M ≥ 1, ∀ᶠ N in atTop, ∀ (A : Set ℕ) (_ : IsMaximalSidonSetIn A N),
+theorem erdos_42 : answer(sorry) ↔
+    ∀ M ≥ 1, ∀ᶠ N in atTop, ∀ (A : Set ℕ) (_ : IsMaximalSidonSetIn A N),
     ∃ᵉ (B : Set ℕ), B ⊆ Set.Icc 1 N ∧ IsSidon B ∧ B.ncard = M ∧
-    ((A - A) ∩ (B - B)) = {0}) ↔ answer(sorry) := by
+    ((A - A) ∩ (B - B)) = {0} := by
   sorry
 
 /--
@@ -49,10 +50,11 @@ every maximal Sidon set A ⊆ {1,…,N} has another Sidon set B ⊆ {1,…,N} of
 disjoint difference sets (apart from 0).
 -/
 @[category research open, AMS 5 11]
-theorem erdos_42.constructive : (∃ (f : ℕ → ℕ), ∀ (M N : ℕ) (_ : 1 ≤ M) (_ : f M ≤ N),
+theorem erdos_42.constructive : answer(sorry) ↔
+    ∃ (f : ℕ → ℕ), ∀ (M N : ℕ) (_ : 1 ≤ M) (_ : f M ≤ N),
     ∀ (A : Set ℕ) (_ : IsMaximalSidonSetIn A N), ∃ᵉ (B : Set ℕ),
       B ⊆ Set.Icc 1 N ∧ IsSidon B ∧ B.ncard = M ∧
-      ((A - A) ∩ (B - B)) = {0}) ↔ answer(sorry) := by
+      ((A - A) ∩ (B - B)) = {0} := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/421.lean
+++ b/FormalConjectures/ErdosProblems/421.lean
@@ -30,8 +30,9 @@ namespace Erdos421
 Is there a sequence $1 \le d_1 < d_2 < \dots$ with density 1 such that all products
 $\prod_{u \le i \le v} d_i$ are distinct? -/
 @[category research open, AMS 11]
-theorem erdos_421 : (∃ (d : ℕ → ℕ), StrictMono d ∧ 1 ≤ d 0 ∧ HasDensity (Set.range d) 1 ∧
-    {(u, v) : ℕ × ℕ | u ≤ v}.InjOn fun (u, v) => ∏ i ∈ Finset.Icc u v, d i) ↔ answer(sorry) := by
+theorem erdos_421 : answer(sorry) ↔
+    ∃ (d : ℕ → ℕ), StrictMono d ∧ 1 ≤ d 0 ∧ HasDensity (Set.range d) 1 ∧
+    {(u, v) : ℕ × ℕ | u ≤ v}.InjOn fun (u, v) => ∏ i ∈ Finset.Icc u v, d i := by
   sorry
 
 end Erdos421

--- a/FormalConjectures/ErdosProblems/422.lean
+++ b/FormalConjectures/ErdosProblems/422.lean
@@ -44,14 +44,14 @@ partial def f : ℕ+ → ℕ+
 Does $f(n)$ miss infinitely many integers?
 -/
 @[category research open, AMS 11]
-theorem erdos_422 : Set.Infinite {n | ∀ x, f x ≠ n} ↔ answer(sorry) := by
+theorem erdos_422 : answer(sorry) ↔ Set.Infinite {n | ∀ x, f x ≠ n} := by
   sorry
 
 /--
 Is $f$ surjective?
 -/
 @[category research open, AMS 11]
-theorem erdos_422.variants.surjective : f.Surjective ↔ answer(sorry) := by
+theorem erdos_422.variants.surjective : answer(sorry) ↔ f.Surjective := by
   sorry
 
 /--
@@ -66,7 +66,7 @@ theorem erdos_422.variants.growth_rate :
 Does $f$ become stationary at some point?
 -/
 @[category research open, AMS 11]
-theorem erdos_422.variants.eventually_const : EventuallyConst f atTop ↔ answer(sorry) := by
+theorem erdos_422.variants.eventually_const : answer(sorry) ↔ EventuallyConst f atTop := by
   sorry
 
 end Erdos422

--- a/FormalConjectures/ErdosProblems/424.lean
+++ b/FormalConjectures/ErdosProblems/424.lean
@@ -52,7 +52,7 @@ values of $a_i a_j - 1$ with $i \neq j$.
 Is it true that the set of integers which eventually appear has positive density?
 -/
 @[category research open, AMS 11]
-theorem erdos_424 : generatedSet.HasPosDensity ↔ answer(sorry) := by
+theorem erdos_424 : answer(sorry) ↔ generatedSet.HasPosDensity := by
   sorry
 
 -- TODO(firsching): formalize the statements from the additional material

--- a/FormalConjectures/ErdosProblems/427.lean
+++ b/FormalConjectures/ErdosProblems/427.lean
@@ -45,7 +45,7 @@ $$
 where $p_r$ denotes the $r$th prime?
 -/
 @[category research solved, AMS 11]
-theorem erdos_427 : erdos427 ↔ answer(True) := by
+theorem erdos_427 : answer(sorry) ↔ erdos427 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/427.lean
+++ b/FormalConjectures/ErdosProblems/427.lean
@@ -45,7 +45,7 @@ $$
 where $p_r$ denotes the $r$th prime?
 -/
 @[category research solved, AMS 11]
-theorem erdos_427 : answer(sorry) ↔ erdos427 := by
+theorem erdos_427 : answer(True) ↔ erdos427 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/434.lean
+++ b/FormalConjectures/ErdosProblems/434.lean
@@ -60,10 +60,10 @@ does $A = \{n, n - 1, \dots, n - k + 1\}$ maximise the number of integers
 not representable as the sum of finitely many elements from $A$ (with repetitions allowed)?
 -/
 @[category research open, AMS 11]
-theorem erdos_434.parts.ii : (∀ᵉ (n ≥ 1) (k ≥ 1), k ≤ n →
+theorem erdos_434.parts.ii : answer(sorry) ↔ ∀ᵉ (n ≥ 1) (k ≥ 1), k ≤ n →
     IsGreatest
       { Nat.NcardUnrepresentable S | (S : Set ℕ) (_ : S ⊆ Set.Icc 1 n) (_ : S.ncard = k) }
-      (Nat.NcardUnrepresentable <| Set.Icc (n - k + 1 : ℕ) n)) ↔ answer(sorry) := by
+      (Nat.NcardUnrepresentable <| Set.Icc (n - k + 1 : ℕ) n) := by
   sorry
 
 end Erdos434

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -42,17 +42,17 @@ This problem asks whether any Sidon set can be extended to achieve a density
 arbitrarily close to the optimal density for Sidon sets.
 -/
 @[category research open, AMS 5 11]
-theorem erdos_44 : (∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N), IsSidon A →
+theorem erdos_44 : answer(sorry) ↔ ∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N), IsSidon A →
     ∀ᵉ (ε > (0 : ℝ)), ∃ᵉ (M > N) (B ⊆ Finset.Icc (N + 1) M),
-      IsSidon (A ∪ B) ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card) ↔ answer(sorry) := by
+      IsSidon (A ∪ B) ∧ (1 - ε) * Real.sqrt M ≤ (A ∪ B).card := by
   sorry
 
 /--
 The case where we start with an empty set (constructing large Sidon sets).
 -/
 @[category research open, AMS 5 11]
-theorem erdos_44.empty_start : (∀ᵉ (ε > (0 : ℝ)), ∀ᶠ (M : ℕ) in Filter.atTop,
-    ∃ᵉ (A ⊆ Finset.Icc 1 M), IsSidon A ∧ (1 - ε) * Real.sqrt M ≤ A.card) ↔ answer(sorry) := by
+theorem erdos_44.empty_start : answer(sorry) ↔ ∀ᵉ (ε > (0 : ℝ)), ∀ᶠ (M : ℕ) in Filter.atTop,
+    ∃ᵉ (A ⊆ Finset.Icc 1 M), IsSidon A ∧ (1 - ε) * Real.sqrt M ≤ A.card := by
   sorry
 
 /-! ## Related results and examples -/

--- a/FormalConjectures/ErdosProblems/442.lean
+++ b/FormalConjectures/ErdosProblems/442.lean
@@ -77,11 +77,11 @@ arXiv:2407.04226 (2024).
 Note: the informal and formal statements follow the solution paper https://arxiv.org/pdf/2407.04226
 -/
 @[category research solved, AMS 11]
-theorem erdos_442 : (∀ (A : Set ℕ),
+theorem erdos_442 : answer(False) ↔ ∀ (A : Set ℕ),
     Tendsto (fun (x : ℝ) =>
       1 / x.maxLogOne.maxLogOne * ∑ n ∈ A.interIcc 1 ⌊x⌋₊, (1 : ℝ) / n) atTop atTop →
     Tendsto (fun (x : ℝ) => 1 / (∑ n ∈ A.interIcc 1 ⌊x⌋₊, (1 : ℝ) / n) ^ 2 *
-      ∑ nm ∈ A.bddProdUpper x, (1 : ℝ) / nm.1.lcm nm.2) atTop atTop) ↔ answer(False) := by
+      ∑ nm ∈ A.bddProdUpper x, (1 : ℝ) / nm.1.lcm nm.2) atTop atTop := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/457.lean
+++ b/FormalConjectures/ErdosProblems/457.lean
@@ -32,9 +32,9 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_457 : (∃ ε > (0 : ℝ),
+theorem erdos_457 : answer(sorry) ↔ ∃ ε > (0 : ℝ),
     { (n : ℕ) | ∀ (p : ℕ), p ≤ (2 + ε) * Real.log n → p.Prime →
-      p ∣ ∏ i ∈ Finset.Icc 1 ⌊Real.log n⌋₊, (n + i) }.Infinite) ↔ answer(sorry) := by
+      p ∣ ∏ i ∈ Finset.Icc 1 ⌊Real.log n⌋₊, (n + i) }.Infinite := by
   sorry
 
 /-- Let $q(n, k)$ denote the least prime which does not divide
@@ -50,8 +50,8 @@ problem asks whether $q(n, \log n) \ge (2 + \epsilon) \log n$
 infinitely often.
 -/
 @[category research open, AMS 11]
-theorem erdos_457.variants.qnk : (∃ ε > (0 : ℝ),
-    { (n : ℕ) | (2 + ε) * Real.log n ≤ q n (Real.log n) }.Infinite) ↔ answer(sorry) := by
+theorem erdos_457.variants.qnk : answer(sorry) ↔ ∃ ε > (0 : ℝ),
+    { (n : ℕ) | (2 + ε) * Real.log n ≤ q n (Real.log n) }.Infinite := by
   sorry
 
 /--
@@ -64,8 +64,8 @@ Can one prove that $q(n, \log n) < (1 - \epsilon) (\log n)^2$
 for all large $n$ and some $\epsilon > 0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_457.variants.one_sub : (∃ ε > (0 : ℝ),
-    ∀ᶠ n in Filter.atTop, q n (Real.log n) < (1 - ε) * Real.log n ^ 2) ↔ answer(sorry) := by
+theorem erdos_457.variants.one_sub : answer(sorry) ↔ ∃ ε > (0 : ℝ),
+    ∀ᶠ n in Filter.atTop, q n (Real.log n) < (1 - ε) * Real.log n ^ 2 := by
   sorry
 
 end Erdos457

--- a/FormalConjectures/ErdosProblems/458.lean
+++ b/FormalConjectures/ErdosProblems/458.lean
@@ -36,8 +36,8 @@ Is it true that for all $k \geq 1$, $\operatorname{lcm}(1, \dots, p_{k+1}-1) < p
 -/
 @[category research open, AMS 11]
 theorem erdos_458 :
-    (∀ k : ℕ, lcm_upto ((k + 1).nth Prime - 1)
-     < k.nth Prime * lcm_upto (k.nth Prime)) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ k : ℕ, lcm_upto ((k + 1).nth Prime - 1)
+     < k.nth Prime * lcm_upto (k.nth Prime) := by
     sorry
 
 end Erdos458

--- a/FormalConjectures/ErdosProblems/463.lean
+++ b/FormalConjectures/ErdosProblems/463.lean
@@ -35,10 +35,10 @@ $$
 Here $p(m)$ is the least prime factor of $m$.
 -/
 @[category research open, AMS 11]
-theorem erdos_463 : (∃ (f : ℕ → ℕ) (_ : Tendsto f atTop atTop),
+theorem erdos_463 : answer(sorry) ↔ ∃ (f : ℕ → ℕ) (_ : Tendsto f atTop atTop),
     ∀ᶠ n in atTop,
       ∃ m, m.Composite ∧
-        n + f n < m ∧ m < n + m.minFac) ↔ answer(sorry) := by
+        n + f n < m ∧ m < n + m.minFac := by
   sorry
 
 end Erdos463

--- a/FormalConjectures/ErdosProblems/469.lean
+++ b/FormalConjectures/ErdosProblems/469.lean
@@ -41,7 +41,7 @@ converge?
 @[category research open, AMS 11]
 theorem erdos_469 :
     letI A := {n : ℕ | 0 < n ∧ n.IsSumDivisors ∧ ∀ m < n, m ∣ n → ¬ m.IsSumDivisors}
-    (Summable fun n : A ↦ 1 / (n : ℝ)) ↔ answer(sorry) := by
+    answer(sorry) ↔ Summable fun n : A ↦ 1 / (n : ℝ) := by
   sorry
 
 end Erdos469

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -38,14 +38,14 @@ def AbundancyIndex (n : ℕ) : ℚ := (∑ d ∈ n.divisors, d) / n
 Are there any odd weird numbers?
 -/
 @[category research open, AMS 11]
-theorem erdos_470.part1 : (∃ n : ℕ, n.Weird ∧ Odd n) ↔ answer(sorry) := by
+theorem erdos_470.part1 : answer(sorry) ↔ ∃ n : ℕ, n.Weird ∧ Odd n := by
   sorry
 
 /--
 Are there infinitely many primitive weird numbers?
 -/
 @[category research open, AMS 11]
-theorem erdos_470.part2 : (Set.Infinite PrimitiveWeird) ↔ answer(sorry) := by
+theorem erdos_470.part2 : answer(sorry) ↔ Set.Infinite PrimitiveWeird := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -30,8 +30,8 @@ that every $z\in \mathbb{Z}$ has exactly one representation as $z=a+f(n)$ for so
 $n > 0$?
 -/
 @[category research open, AMS 12]
-theorem erdos_477 : (∀ (f : Polynomial ℤ), 2 ≤ f.degree →
-    (∃ (A : Set ℤ), ∀ z, ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2)) ↔ answer(sorry) := by
+theorem erdos_477 : answer(sorry) ↔ ∀ (f : Polynomial ℤ), 2 ≤ f.degree →
+    (∃ (A : Set ℤ), ∀ z, ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/479.lean
+++ b/FormalConjectures/ErdosProblems/479.lean
@@ -29,7 +29,7 @@ Is it true that, for all $k\neq 1$, there are infinitely many $n$ such that
 $2^n\equiv k\pmod{n}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_479 : (∀ᵉ (k > 1), { n | 2 ^ n ≡ k [MOD n]}.Infinite) ↔ answer(sorry) := by
+theorem erdos_479 : answer(sorry) ↔ ∀ᵉ (k > 1), { n | 2 ^ n ≡ k [MOD n]}.Infinite := by
   sorry
 
 end Erdos479

--- a/FormalConjectures/ErdosProblems/48.lean
+++ b/FormalConjectures/ErdosProblems/48.lean
@@ -31,7 +31,7 @@ Are there infinitely many integers $n, m$ such that $ϕ(n) = σ(m)$?
 -/
 @[category research solved, AMS 11]
 theorem erdos_48 :
-    {(n, m) : ℕ × ℕ | n.totient = σ 1 m}.Infinite ↔ answer(True) := by
+    answer(True) ↔ {(n, m) : ℕ × ℕ | n.totient = σ 1 m}.Infinite := by
   sorry
 
 end Erdos48

--- a/FormalConjectures/ErdosProblems/480.lean
+++ b/FormalConjectures/ErdosProblems/480.lean
@@ -31,9 +31,8 @@ such that $|x_{m+n} - x_m| \le \frac 1 {\sqrt 5 n}$?
 This was proved Chung and Graham.
 -/
 @[category research solved, AMS 11]
-theorem erdos_480 : (∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
-    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x m| ≤ 1 / (√5 * n))}.Infinite) ↔
-    answer(True) := by
+theorem erdos_480 : answer(True) ↔ ∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
+    {(m, n) | (m) (n) (_ : m ≠ 0) (_ : |x (m + n) - x m| ≤ 1 / (√5 * n))}.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/486.lean
+++ b/FormalConjectures/ErdosProblems/486.lean
@@ -36,9 +36,8 @@ Let $B = \{m \in \mathbb{N} : \forall n, m \not\equiv x \pmod{n} \text{ for all 
 Must $B$ have a logarithmic density?
 -/
 @[category research open, AMS 11]
-theorem erdos_486 :
-    (∀ X : (n : ℕ) → Set (ZMod n), ∃ d, {m : ℕ | ∀ n, (m : ZMod n) ∉ X n}.HasLogDensity d)
-    ↔ answer(sorry) := by
+theorem erdos_486 : answer(sorry) ↔
+    ∀ X : (n : ℕ) → Set (ZMod n), ∃ d, {m : ℕ | ∀ n, (m : ZMod n) ∉ X n}.HasLogDensity d := by
   sorry
 
 end Erdos486

--- a/FormalConjectures/ErdosProblems/488.lean
+++ b/FormalConjectures/ErdosProblems/488.lean
@@ -33,11 +33,11 @@ Is it true that, for every $m > n \ge \max(A)$,
 $$\frac{|B \cap [1, m]|}{m} < 2 \frac{|B \cap [1, n]|}{n}?$$
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_488 : (∀ (A : Finset ℕ), A.Nonempty → 0 ∉ A → 1 ∉ A →
+theorem erdos_488 : answer(sorry) ↔ ∀ (A : Finset ℕ), A.Nonempty → 0 ∉ A → 1 ∉ A →
     letI B := {n ≥ 1 | ∀ a ∈ A, ¬ a ∣ n}
     ∀ᵉ (n : ℕ) (m > n), A.max ≤ n →
       ((Finset.Icc 1 m).filter (· ∈ B)).card / (m : ℚ) <
-        2 * ((Finset.Icc 1 n).filter (· ∈ B)).card / n) ↔ answer(False):= by
+        2 * ((Finset.Icc 1 n).filter (· ∈ B)).card / n := by
   sorry
 
 end Erdos488

--- a/FormalConjectures/ErdosProblems/488.lean
+++ b/FormalConjectures/ErdosProblems/488.lean
@@ -33,7 +33,7 @@ Is it true that, for every $m > n \ge \max(A)$,
 $$\frac{|B \cap [1, m]|}{m} < 2 \frac{|B \cap [1, n]|}{n}?$$
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_488 : answer(sorry) ↔ ∀ (A : Finset ℕ), A.Nonempty → 0 ∉ A → 1 ∉ A →
+theorem erdos_488 : answer(False) ↔ ∀ (A : Finset ℕ), A.Nonempty → 0 ∉ A → 1 ∉ A →
     letI B := {n ≥ 1 | ∀ a ∈ A, ¬ a ∣ n}
     ∀ᵉ (n : ℕ) (m > n), A.max ≤ n →
       ((Finset.Icc 1 m).filter (· ∈ B)).card / (m : ℚ) <

--- a/FormalConjectures/ErdosProblems/499.lean
+++ b/FormalConjectures/ErdosProblems/499.lean
@@ -36,9 +36,8 @@ This is true, and was proved by Marcus and Minc [MaMi62]
 -/
 @[category research solved, AMS 15]
 lemma erdos_499 :
-    (∀ n, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ : Equiv.Perm (Fin n),
-      n ^ (- n : ℤ) ≤ ∏ i, M i (σ i)) ↔
-    answer(True) := by
+    answer(True) ↔ (∀ n, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ : Equiv.Perm (Fin n),
+      n ^ (- n : ℤ) ≤ ∏ i, M i (σ i)) := by
   sorry
 
 /--
@@ -68,9 +67,8 @@ Proved by Marcus and Ree [MaRe59].
 -/
 @[category research solved, AMS 15]
 lemma erdos_499.variants.one_le :
-    (∀ n > 0, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ : Equiv.Perm (Fin n),
-      (∀ i, M i (σ i) ≠ 0) ∧ 1 ≤ ∑ i, M i (σ i)) ↔
-    answer(True) := by
+    answer(True) ↔ ∀ n > 0, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ : Equiv.Perm (Fin n),
+      (∀ i, M i (σ i) ≠ 0) ∧ 1 ≤ ∑ i, M i (σ i) := by
   sorry
 
 end Erdos499

--- a/FormalConjectures/ErdosProblems/509.lean
+++ b/FormalConjectures/ErdosProblems/509.lean
@@ -79,8 +79,8 @@ $\{z ∈ ℂ : |f(z)| ≤ 1\}$
 be covered by a set of closed discs the sum of whose radii is $≤ 2$?
 -/
 @[category research open, AMS 30]
-theorem erdos_509 : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
-    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι)) ↔ answer(sorry) := by
+theorem erdos_509 : answer(sorry) ↔ ∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι) := by
   sorry
 
 /--
@@ -93,18 +93,18 @@ lacunaires et leurs applications*, Henri Cartan,
 http://www.numdam.org/article/ASENS_1928_3_45__255_0.pdf
 -/
 @[category research solved, AMS 30]
-theorem erdos_509.variants.Cartan_bound : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
-    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} (2*rexp 1) ι)) ↔ answer(True) := by
+theorem erdos_509.variants.Cartan_bound : answer(True) ↔ ∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} (2*rexp 1) ι) := by
   sorry
 
 /--
 Let $f(z) ∈ $ℂ[z]$ be a monic non-constant polynomial. Can the set
 $\{z ∈ ℂ : |f(z)| ≤ 1\}$
-be covered by a set of closed discs the sum of whose radii is $≤ 2.59$? 
+be covered by a set of closed discs the sum of whose radii is $≤ 2.59$?
 Solution: True. This is due to Pommerenke.
 -/@[category research solved, AMS 30]
-theorem erdos_509.variants.Pommerenke_bound : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
-    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2.59 ι)) ↔ answer(True) := by
+theorem erdos_509.variants.Pommerenke_bound : answer(True) ↔ ∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2.59 ι) := by
   sorry
 
 /--
@@ -114,9 +114,9 @@ be covered by a set of circles the sum of whose radii is $≤ 2$?
 Solution: True. This is due to Pommerenke.
 -/
 @[category research solved, AMS 30]
-theorem erdos_509.variants.Pommerenke_connected : (∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
+theorem erdos_509.variants.Pommerenke_connected : answer(True) ↔ ∀ (f : ℂ[X]), f.Monic → f.natDegree ≠ 0 →
     IsConnected {z | ‖f.eval z‖ ≤ 1} →
-    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι)) ↔ answer(True) := by
+    ∃ (ι : Type), Nonempty (BoundedDiscCover {z | ‖f.eval z‖ ≤ 1} 2 ι) := by
   sorry
 
 end Erdos509

--- a/FormalConjectures/ErdosProblems/51.lean
+++ b/FormalConjectures/ErdosProblems/51.lean
@@ -33,12 +33,10 @@ there is an integer n such that $\phi(n)=a$, and
 yet if $n_a$ is the smallest such integer, then $\frac{n_a}{a} → \infty$ as $a → ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_51 :
-    (∃ A : Set ℕ, ∃ n : A → ℕ,
+theorem erdos_51 : answer(sorry) ↔ ∃ A : Set ℕ, ∃ n : A → ℕ,
       A.Infinite ∧
       (∀ a : A, IsLeast (φ ⁻¹' {(a : ℕ)}) (n a)) ∧
-      Tendsto (fun a : A => (n a : ℝ) / (a : ℝ)) atTop atTop)
-    ↔ answer(sorry) := by
+      Tendsto (fun a : A => (n a : ℝ) / (a : ℝ)) atTop atTop := by
   sorry
 
 /-

--- a/FormalConjectures/ErdosProblems/510.lean
+++ b/FormalConjectures/ErdosProblems/510.lean
@@ -34,9 +34,9 @@ $$\sum_{n\in A}\cos(n\theta) < -cN^{1/2}?$$
 -/
 @[category research open, AMS 11]
 theorem erdos_510 :
-    (∃ (c : ℝ) (hc : 0 < c),
+    answer(sorry) ↔ ∃ (c : ℝ) (hc : 0 < c),
       ∀ N > 0, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
-      (∃ (θ : ℝ), (∑ n ∈ A, (n * θ).cos) < -c * (N : ℝ).sqrt)) ↔ answer(sorry) := by
+      (∃ (θ : ℝ), (∑ n ∈ A, (n * θ).cos) < -c * (N : ℝ).sqrt) := by
   sorry
 
 -- TODO(firsching): add the additional material

--- a/FormalConjectures/ErdosProblems/520.lean
+++ b/FormalConjectures/ErdosProblems/520.lean
@@ -52,9 +52,8 @@ Does there exist some constant $c > 0$ such that, almost surely,
 -/
 @[category research open, AMS 11 60]
 theorem erdos_520 :
-    (∃ c > 0, ∀ (f : ℕ → Ω → ℝ), IsRademacherMultiplicative f →
-      ∀ᵐ ω, limsup (fun N ↦ ∑ m ≤ N, f m ω / sqrt (N * log (log N))) atTop = c)
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ c > 0, ∀ (f : ℕ → Ω → ℝ), IsRademacherMultiplicative f →
+      ∀ᵐ ω, limsup (fun N ↦ ∑ m ≤ N, f m ω / sqrt (N * log (log N))) atTop = c := by
   sorry
 
 end Erdos520

--- a/FormalConjectures/ErdosProblems/536.lean
+++ b/FormalConjectures/ErdosProblems/536.lean
@@ -33,11 +33,10 @@ where $[\cdot, \cdot]$ denotes the least common multiple?
 -/
 @[category research open, AMS 11]
 theorem erdos_536 :
-    (∀ᵉ (ε > (0: ℝ)), ∀ᶠ N in atTop,
+    answer(sorry) ↔ ∀ᵉ (ε > (0: ℝ)), ∀ᶠ N in atTop,
     ∀ (A : Finset ℕ), A ⊆ Icc 1 N → (ε * (N : ℝ)) ≤ (A.card : ℝ) →
     ∃ᵉ  (a ∈ A) (b ∈ A) (c ∈ A),
-    # {a, b, c} = 3 ∧ a.lcm b = b.lcm c ∧ b.lcm c = a.lcm c)
-    ↔ answer(sorry) := by
+    # {a, b, c} = 3 ∧ a.lcm b = b.lcm c ∧ b.lcm c = a.lcm c := by
   sorry
 
 -- TODO(firsching): add the statements from the additional material

--- a/FormalConjectures/ErdosProblems/541.lean
+++ b/FormalConjectures/ErdosProblems/541.lean
@@ -35,9 +35,9 @@ then $|S| = r$.
 Must there be at most two distinct residues amongst the $a_i$?
 -/
 @[category research solved, AMS 11]
-theorem erdos_541 : (∀ p, Fact p.Prime → ∀ (a : Fin p → ZMod p),
+theorem erdos_541 : answer(True) ↔ (∀ p, Fact p.Prime → ∀ (a : Fin p → ZMod p),
     (∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) →
-      (Set.range a).ncard ≤ 2) ↔ answer(True) := by
+      (Set.range a).ncard ≤ 2) := by
   sorry
 
 /-- Gao, Hamidoune, and Wang [GHW10] solved this for all moduli `p` (not necessarily prime).

--- a/FormalConjectures/ErdosProblems/591.lean
+++ b/FormalConjectures/ErdosProblems/591.lean
@@ -33,7 +33,7 @@ Let $α$ be the infinite ordinal $\omega^{\omega^2}$. Is it true that any red/bl
 edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
 @[category research open, AMS 3]
-theorem erdos_591 : OrdinalCardinalRamsey (ω ^ ω ^ 2) (ω ^ ω ^ 2) 3 ↔ answer(sorry) := by
+theorem erdos_591 : answer(sorry) ↔ OrdinalCardinalRamsey (ω ^ ω ^ 2) (ω ^ ω ^ 2) 3 := by
   sorry
 
 end Erdos591

--- a/FormalConjectures/ErdosProblems/598.lean
+++ b/FormalConjectures/ErdosProblems/598.lean
@@ -40,10 +40,10 @@ Can one colour the countable subsets of $m$ using $\kappa$ many colours so that 
 $X \subseteq m$ with $|X| = \kappa$ contains subsets of all possible colours?
 -/
 @[category research open, AMS 03 05]
-theorem erdos_598 :
-    (∃ c : { s : Set m // s.Countable } → κ.out,
+theorem erdos_598 : answer(sorry) ↔
+    ∃ c : { s : Set m // s.Countable } → κ.out,
     ∀ X : Set m, #X = κ →
-    c '' { s : { sub : Set m // sub.Countable } | s.1 ⊆ X } = Set.univ) ↔ answer(sorry) := by
+    c '' { s : { sub : Set m // sub.Countable } | s.1 ⊆ X } = Set.univ := by
   sorry
 
 end Erdos598

--- a/FormalConjectures/ErdosProblems/61.lean
+++ b/FormalConjectures/ErdosProblems/61.lean
@@ -44,8 +44,8 @@ $H$ such that we can take $f(n) = n^{c(H)}$ in the above formulation.
 -/
 @[category research open, AMS 05]
 theorem erdos_61 :
-    (∀ {α : Type*} [Fintype α] [DecidableEq α] (H : SimpleGraph α),
-      ∃ c > (0 : ℝ), IsErdosHajnalLowerBound H (fun n : ℕ => (n : ℝ) ^ c)) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ {α : Type*} [Fintype α] [DecidableEq α] (H : SimpleGraph α),
+      ∃ c > (0 : ℝ), IsErdosHajnalLowerBound H (fun n : ℕ => (n : ℝ) ^ c) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/623.lean
+++ b/FormalConjectures/ErdosProblems/623.lean
@@ -33,9 +33,9 @@ $X$ to $X$ such that $f(A)\not\in A$ for all $A$. Must there exist an infinite $
 that is independent - that is, for all finite $B\subset Y$ we have $f(B)\not\in Y$?
 -/
 @[category research open, AMS 3]
-theorem erdos_623 : (∀ (X : Type u) (hX : #X = ℵ_ ω)
+theorem erdos_623 : answer(sorry) ↔ ∀ (X : Type u) (hX : #X = ℵ_ ω)
     (f : Finset X → X), (∀ A : Finset X, f A ∉ A) →
-    (∃ Y : Set X, Set.Infinite Y ∧ (∀ (B : Finset X), ↑B ⊆ Y → f B ∉ Y))) ↔ answer(sorry) := by
+    (∃ Y : Set X, Set.Infinite Y ∧ (∀ (B : Finset X), ↑B ⊆ Y → f B ∉ Y)) := by
   sorry
 
 -- TODO(firsching): formalize the statement about X < ℵ_ω

--- a/FormalConjectures/ErdosProblems/64.lean
+++ b/FormalConjectures/ErdosProblems/64.lean
@@ -30,9 +30,9 @@ contain a cycle of length $2^k$ for some $k \geq 2$?
 -/
 @[category research open, AMS 5]
 theorem erdos_64 :
-    (∀ (V : Type*) (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj],
+    answer(sorry) ↔ ∀ (V : Type*) (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj],
         G.minDegree ≥ 3 → ∃ (k : ℕ) (v : V) (c : G.Walk v v),
-            k ≥ 2 ∧ c.IsCycle ∧ c.length = 2^k) ↔ answer(sorry) := by
+            k ≥ 2 ∧ c.IsCycle ∧ c.length = 2^k := by
   sorry
 
 -- TODO(firsching): add more context

--- a/FormalConjectures/ErdosProblems/647.lean
+++ b/FormalConjectures/ErdosProblems/647.lean
@@ -31,7 +31,7 @@ $$
   \max_{m < n}(m + \tau(m)) \leq n + 2?
 $$ -/
 @[category research open, AMS 11]
-theorem erdos_647 : (∃ n > 24, ⨆ m : Fin n, m + σ 0 m ≤ n + 2) ↔ answer(sorry) := by
+theorem erdos_647 : answer(sorry) ↔ ∃ n > 24, ⨆ m : Fin n, m + σ 0 m ≤ n + 2 := by
   sorry
 
 /-- This is true for $n = 24$. -/
@@ -46,7 +46,7 @@ $$
 $$ -/
 @[category research open, AMS 11]
 theorem erdos_647.variants.lim :
-    atTop.Tendsto (fun n ↦ ⨆ m : Fin n, σ 0 m + m - n) atTop ↔ answer(sorry) := by
+    answer(sorry) ↔ atTop.Tendsto (fun n ↦ ⨆ m : Fin n, σ 0 m + m - n) atTop := by
   sorry
 
 /-- Erdős says it 'seems certain' that for every $k$ there are infinitely many $n$
@@ -56,8 +56,7 @@ $$
 $$ -/
 @[category research open, AMS 11]
 theorem erdos_647.variants.infinite :
-    (∀ k, { n | ⨆ m : Set.Ioo (n - k) n, ↑m + σ 0 m ≤ n + 2 }.Infinite) ↔
-      answer(sorry) := by
+    answer(sorry) ↔ ∀ k, { n | ⨆ m : Set.Ioo (n - k) n, ↑m + σ 0 m ≤ n + 2 }.Infinite := by
   sorry
 
 end Erdos647

--- a/FormalConjectures/ErdosProblems/659.lean
+++ b/FormalConjectures/ErdosProblems/659.lean
@@ -36,10 +36,9 @@ Is there a set of $n$ points in $\mathbb{R}^2$ such that every subset of $4$ poi
 least $3$ distances, yet the total number of distinct distances is $\ll \frac{n}{\sqrt{\log n}}$?
 -/
 @[category research open, AMS 52]
-theorem erdos_659 : (∃ (a : ℕ → Finset ℝ²), ∀ n, #(a n) = n ∧
+theorem erdos_659 : answer(sorry) ↔ ∃ (a : ℕ → Finset ℝ²), ∀ n, #(a n) = n ∧
     3 ≤ minimalDistinctDistancesSubsetOfSize (a n) 4 ∧
-    (fun n => (distinctDistances (a n) : ℝ)) ≪ fun (n : ℕ) => n / (n : ℝ).log.sqrt)
-    ↔ answer(sorry) := by
+    (fun n => (distinctDistances (a n) : ℝ)) ≪ fun (n : ℕ) => n / (n : ℝ).log.sqrt := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/66.lean
+++ b/FormalConjectures/ErdosProblems/66.lean
@@ -34,8 +34,8 @@ $$\lim_{n\to \infty}\frac{1_A\ast 1_A(n)}{\log n}$$
 exists and is $\ne 0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_66 : (∃ (A : Set ℕ) (c : ℝ), c ≠ 0 ∧
-    Tendsto (fun n ↦ (sumRep A n : ℝ) / Real.log n) atTop (𝓝 c)) ↔ answer(sorry) := by
+theorem erdos_66 : answer(sorry) ↔ ∃ (A : Set ℕ) (c : ℝ), c ≠ 0 ∧
+    Tendsto (fun n ↦ (sumRep A n : ℝ) / Real.log n) atTop (𝓝 c) := by
   sorry
 
 -- TODO(firsching): add the theorems/conjectures for the comments on the page

--- a/FormalConjectures/ErdosProblems/672.lean
+++ b/FormalConjectures/ErdosProblems/672.lean
@@ -35,7 +35,7 @@ of length ≥ 4, with $(n, d) = 1$, be a perfect power?
 -/
 @[category research open, AMS 11]
 theorem erdos_672 :
-    (∀ᵉ (k) (l > 1), k ≥ 4 → Erdos672With k l) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ᵉ (k) (l > 1), k ≥ 4 → Erdos672With k l := by
   sorry
 
 /-- According to https://www.erdosproblems.com/672, Euler proved this. -/

--- a/FormalConjectures/ErdosProblems/678.lean
+++ b/FormalConjectures/ErdosProblems/678.lean
@@ -65,9 +65,8 @@ The answer is yes, as proved in a strong form by Cambie [Ca24].
 [Ca24] S. Cambie, Resolution of an Erdős' problem on least common multiples. arXiv:2410.09138 (2024).
 -/
 @[category research solved, AMS 11]
-theorem erdos_678 :
-    (∀ᶠ k in atTop, {(m, n) | n + k ≤ m ∧ lcmInterval m (k + 1) < lcmInterval n k}.Infinite) ↔
-      answer(True) := by
+theorem erdos_678 : answer(True) ↔
+    ∀ᶠ k in atTop, {(m, n) | n + k ≤ m ∧ lcmInterval m (k + 1) < lcmInterval n k}.Infinite := by
   sorry
 
 end Erdos678

--- a/FormalConjectures/ErdosProblems/68.lean
+++ b/FormalConjectures/ErdosProblems/68.lean
@@ -31,7 +31,7 @@ irrational?
 -/
 @[category research open, AMS 11]
 theorem erdos_68 :
-    Irrational (∑' n : ℕ, 1 / ((n + 2).factorial - 1 : ℝ)) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (∑' n : ℕ, 1 / ((n + 2).factorial - 1 : ℝ)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/680.lean
+++ b/FormalConjectures/ErdosProblems/680.lean
@@ -36,17 +36,15 @@ where $p(m)$ denotes the least prime factor of $m$?
 -/
 @[category research open, AMS 11]
 theorem erdos_680 :
-  (∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0, Nat.minFac (n + k) > k^2 + 1)
-  ↔ answer(sorry) := sorry
+  answer(sorry) ↔ ∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0, Nat.minFac (n + k) > k^2 + 1 := sorry
 
 /--
 Can one prove this is false if we replace $k^2+1$ by $e^{(1+\epsilon)\sqrt{k}}+C_\epsilon$, for all
 $\epsilon>0$, where $C_\epsilon>0$ is some constant?
 -/
 @[category research open, AMS 11]
-theorem erdos_680.variant : (∀ ε > 0, ∃ C > 0,
+theorem erdos_680.variant : answer(sorry) ↔ ∀ ε > 0, ∃ C > 0,
   ¬ ∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0,
-  Nat.minFac (n + k) > exp ((1 + ε) * √k) + C)
-  ↔ answer(sorry) := sorry
+  Nat.minFac (n + k) > exp ((1 + ε) * √k) + C := sorry
 
 end Erdos680

--- a/FormalConjectures/ErdosProblems/680.lean
+++ b/FormalConjectures/ErdosProblems/680.lean
@@ -36,7 +36,7 @@ where $p(m)$ denotes the least prime factor of $m$?
 -/
 @[category research open, AMS 11]
 theorem erdos_680 :
-  answer(sorry) ↔ ∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0, Nat.minFac (n + k) > k^2 + 1 := sorry
+    answer(sorry) ↔ ∀ᶠ (n : ℕ) in .atTop, ∃ k ≠ 0, (n + k).minFac > k^2 + 1 := sorry
 
 /--
 Can one prove this is false if we replace $k^2+1$ by $e^{(1+\epsilon)\sqrt{k}}+C_\epsilon$, for all

--- a/FormalConjectures/ErdosProblems/681.lean
+++ b/FormalConjectures/ErdosProblems/681.lean
@@ -35,7 +35,7 @@ where $p(m)$ is the least prime factor of $m$ ?
 -/
 @[category research open, AMS 11]
 theorem erdos_681 : answer(sorry) ↔
-    ∃ N, ∀ n > N, ∃ k > 0, (n + k).Composite ∧ ∀ p, IsLPF p (n + k) → p > k ^ 2 := by
+    ∀ᶠ n in .atTop, ∃ k > 0, (n + k).Composite ∧ ∀ p, IsLPF p (n + k) → p > k ^ 2 := by
   sorry
 
 end Erdos681

--- a/FormalConjectures/ErdosProblems/681.lean
+++ b/FormalConjectures/ErdosProblems/681.lean
@@ -34,9 +34,8 @@ such that $n + k$ is composite and $p(n+k) > k^2$,
 where $p(m)$ is the least prime factor of $m$ ?
 -/
 @[category research open, AMS 11]
-theorem erdos_681 :
-    (∃ N, ∀ n > N, ∃ k > 0, (n + k).Composite ∧ ∀ p, IsLPF p (n + k) → p > k ^ 2) ↔
-    answer(sorry) := by
+theorem erdos_681 : answer(sorry) ↔
+    ∃ N, ∀ n > N, ∃ k > 0, (n + k).Composite ∧ ∀ p, IsLPF p (n + k) → p > k ^ 2 := by
   sorry
 
 end Erdos681

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -30,9 +30,8 @@ for some $k≥2$ and $m≥n+k$?
 -/
 @[category research open, AMS 11]
 theorem erdos_686 :
-    (∀ (N : ℕ), N ≥ 2 → ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
-      (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)))
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ (N : ℕ), N ≥ 2 → ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+      (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
   sorry
 
 -- TODO: also formalize the follow-up question:

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -30,7 +30,7 @@ for some $k≥2$ and $m≥n+k$?
 -/
 @[category research open, AMS 11]
 theorem erdos_686 :
-    answer(sorry) ↔ ∀ (N : ℕ), N ≥ 2 → ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+    answer(sorry) ↔ ∀ N ≥ 2, ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
       (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/689.lean
+++ b/FormalConjectures/ErdosProblems/689.lean
@@ -30,7 +30,7 @@ Let `n` be sufficiently large. Is there some choice of congruence class `a_p` fo
 -/
 @[category research open, AMS 11]
 theorem erdos_689 :
-    answer(sorry) ↔ ∀ᶠ n in Filter.atTop, ∃ a : ℕ → ℕ, ∀ m ∈ Finset.Icc 1 n,
+    answer(sorry) ↔ ∀ᶠ n in .atTop, ∃ a : ℕ → ℕ, ∀ m ∈ Finset.Icc 1 n,
       2 ≤ (Finset.Icc 1 n |>.filter fun p => p.Prime ∧ a p ≡ m [MOD p]).card := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/689.lean
+++ b/FormalConjectures/ErdosProblems/689.lean
@@ -30,9 +30,8 @@ Let `n` be sufficiently large. Is there some choice of congruence class `a_p` fo
 -/
 @[category research open, AMS 11]
 theorem erdos_689 :
-    (∀ᶠ n in Filter.atTop, ∃ a : ℕ → ℕ, ∀ m ∈ Finset.Icc 1 n,
-      2 ≤ (Finset.Icc 1 n |>.filter fun p => p.Prime ∧ a p ≡ m [MOD p]).card)
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ᶠ n in Filter.atTop, ∃ a : ℕ → ℕ, ∀ m ∈ Finset.Icc 1 n,
+      2 ≤ (Finset.Icc 1 n |>.filter fun p => p.Prime ∧ a p ≡ m [MOD p]).card := by
   sorry
 
 end Erdos689

--- a/FormalConjectures/ErdosProblems/694.lean
+++ b/FormalConjectures/ErdosProblems/694.lean
@@ -48,7 +48,7 @@ exactly one solution, that is $\frac{f_\max(n)}{f_\min(n)} = 1$.
 -/
 @[category research open, AMS 11]
 theorem erdos_694.variants.carmichael :
-    (∃ n > 0, ∃! m, Nat.totient m = n) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ n > 0, ∃! m, Nat.totient m = n := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/695.lean
+++ b/FormalConjectures/ErdosProblems/695.lean
@@ -33,12 +33,12 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_695 :
-    (∀ {q : ℕ → ℕ},
+theorem erdos_695 : answer(sorry) ↔
+    ∀ {q : ℕ → ℕ},
       StrictMono q →
       (∀ i, (q i).Prime) →
       (∀ i, q (i + 1) % q i = 1) →
-      Tendsto (fun k => (q k : ℝ) ^ (1 / k : ℝ)) atTop atTop) ↔ answer(sorry) := by
+      Tendsto (fun k => (q k : ℝ) ^ (1 / k : ℝ)) atTop atTop := by
   sorry
 
 /--
@@ -48,16 +48,15 @@ q(k) \leq \exp(k (\log k)^{1 + o(1)})?
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_695.variant.upperBound :
-    (∃ q : ℕ → ℕ,
+theorem erdos_695.variant.upperBound : answer(sorry) ↔
+    ∃ q : ℕ → ℕ,
       StrictMono q ∧
       (∀ i, (q i).Prime) ∧
       (∀ i, q (i + 1) % q i = 1) ∧
       ∃ o : ℕ → ℝ,
         (o =o[atTop] (1 : ℕ → ℝ)) ∧
         -- We use `(k + 1)` here as the informal statement is 1-indexed.
-        ∀ k, q k ≤ exp ((k + 1) * (log (k + 1)) ^ (1 + o k))) ↔
-    answer(sorry) := by
+        ∀ k, q k ≤ exp ((k + 1) * (log (k + 1)) ^ (1 + o k)) := by
   sorry
 
 end Erdos695

--- a/FormalConjectures/ErdosProblems/695.lean
+++ b/FormalConjectures/ErdosProblems/695.lean
@@ -56,7 +56,7 @@ theorem erdos_695.variant.upperBound : answer(sorry) ↔
       ∃ o : ℕ → ℝ,
         (o =o[atTop] (1 : ℕ → ℝ)) ∧
         -- We use `(k + 1)` here as the informal statement is 1-indexed.
-        ∀ k, q k ≤ exp ((k + 1) * (log (k + 1)) ^ (1 + o k)) := by
+        ∀ k, q k ≤ exp ((k + 1) * log (k + 1) ^ (1 + o k)) := by
   sorry
 
 end Erdos695

--- a/FormalConjectures/ErdosProblems/699.lean
+++ b/FormalConjectures/ErdosProblems/699.lean
@@ -35,26 +35,24 @@ theorem sylvester_schur (n i : ℕ) (hi : 1 ≤ i) (hi_half : i ≤ n / 2) :
 $p \ge i$ with $p \mid \gcd\big(\binom{n}{i}, \binom{n}{j}\big)$?
 -/
 @[category research open, AMS 11]
-theorem erdos_699 :
-    (∀ n i j : ℕ,
+theorem erdos_699 : answer(sorry) ↔
+    ∀ n i j : ℕ,
       1 ≤ i →
       i < j →
       j ≤ n / 2 →
-      ∃ p : ℕ, p.Prime ∧ i ≤ p ∧ p ∣ Nat.gcd (Nat.choose n i) (Nat.choose n j)) ↔
-    answer(sorry) := by
+      ∃ p : ℕ, p.Prime ∧ i ≤ p ∧ p ∣ Nat.gcd (Nat.choose n i) (Nat.choose n j) := by
   sorry
 
 /-- Erdős and Szekeres conjectured that, apart from a finite exceptional set of triples `(n, i, j)`,
 one can always take `p > i` in the prime divisor statement. -/
 @[category research open, AMS 11]
-theorem erdos_szekeres_strengthening :
-    (∃ E : Finset (ℕ × ℕ × ℕ), ∀ n i j : ℕ,
+theorem erdos_szekeres_strengthening : answer(sorry) ↔
+    ∃ E : Finset (ℕ × ℕ × ℕ), ∀ n i j : ℕ,
       1 ≤ i →
       i < j →
       j ≤ n / 2 →
       (n, i, j) ∉ E →
-      ∃ p : ℕ, p.Prime ∧ i < p ∧ p ∣ Nat.gcd (Nat.choose n i) (Nat.choose n j)) ↔
-    answer(sorry) := by
+      ∃ p : ℕ, p.Prime ∧ i < p ∧ p ∣ Nat.gcd (Nat.choose n i) (Nat.choose n j) := by
   sorry
 
 end Erdos699

--- a/FormalConjectures/ErdosProblems/705.lean
+++ b/FormalConjectures/ErdosProblems/705.lean
@@ -33,9 +33,9 @@ Is there some k such that if G has girth ≥ k, then χ(G) ≤ 3?
 -/
 @[category research open, AMS 5]
 theorem erdos_705:
-  (∀ (V : Set ℝ²) (hf: V.Finite),
-    ∃ k, (UnitDistancePlaneGraph V).girth ≥ k ∧ (UnitDistancePlaneGraph V).chromaticNumber ≤ 3) ↔
-    answer(sorry) := by sorry
+  answer(sorry) ↔ ∀ (V : Set ℝ²) (hf: V.Finite),
+    ∃ k, (UnitDistancePlaneGraph V).girth ≥ k ∧ (UnitDistancePlaneGraph V).chromaticNumber ≤ 3 := by
+  sorry
 
 
 -- TODO: add statements for the concrete constructions in the additional material

--- a/FormalConjectures/ErdosProblems/723.lean
+++ b/FormalConjectures/ErdosProblems/723.lean
@@ -33,8 +33,8 @@ If there is a finite projective plane of order $n$ then must $n$ be a prime powe
 -/
 @[category research open, AMS 5]
 theorem erdos_723 :
-    (∀ {P L : Type} (_: Membership P L) (_ : Fintype P) (_ : Fintype L),
-      ∀ pp : ProjectivePlane P L, IsPrimePow pp.order) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ {P L : Type} (_: Membership P L) (_ : Fintype P) (_ : Fintype L),
+      ∀ pp : ProjectivePlane P L, IsPrimePow pp.order := by
   sorry
 
 /--
@@ -58,9 +58,9 @@ theorem erdos_723.leq_11 {P L : Type} [Membership P L] [Fintype P] [Fintype L] :
 It is open whether there exists a projective plane of order 12.
 -/
 @[category research open, AMS 5]
-theorem erdos_723.eq_12 :
-    (∃ (P L : Type) (_ : Membership P L) (_ : Fintype P) (_ : Fintype L) (pp : ProjectivePlane P L),
-      pp.order = 12) ↔ answer(sorry) := by
+theorem erdos_723.eq_12 : answer(sorry) ↔
+    ∃ (P L : Type) (_ : Membership P L) (_ : Fintype P) (_ : Fintype L) (pp : ProjectivePlane P L),
+      pp.order = 12 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -30,8 +30,8 @@ namespace Erdos727
 Let $k ≥ 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_727 : (∀ k ≥ 2,
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)}) ↔ answer(sorry) := by
+theorem erdos_727 : answer(sorry) ↔ ∀ k ≥ 2,
+    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} := by
   sorry
 
 /--
@@ -41,7 +41,7 @@ Let $k = 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many n?
 @[category research open, AMS 11]
 theorem erdos_727_variants.k_2 :
     letI k := 2
-    Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} ↔ answer(sorry) := by
+    answer(sorry) ↔ Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} := by
   sorry
 
 /--
@@ -52,7 +52,7 @@ Let $k = 1$. Does $((n+k)!)^2∣(2n)!$ for infinitely many $n$?
 @[category research solved, AMS 11]
 theorem erdos_727_variants.k_1 :
     letI k := 1
-    Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} ↔ answer(True) := by
+    answer(True) ↔ Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -34,7 +34,7 @@ Are there infinitely many pairs of integers $n < m$ such that $\binom{2n}{n}$
 and $\binom{2m}{m}$ have the same set of prime divisors?
 -/
 @[category research open, AMS 11]
-theorem erdos_730 : S.Infinite ↔ answer(sorry) := by
+theorem erdos_730 : answer(sorry) ↔ S.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/74.lean
+++ b/FormalConjectures/ErdosProblems/74.lean
@@ -121,9 +121,9 @@ Is there a graph of infinite chromatic number such that every finite subgraph on
 vertices can be made bipartite by deleting at most $f(n)$ edges?
 -/
 @[category research open, AMS 5]
-theorem erdos_74 : (∀ f : ℕ → ℕ, Tendsto f atTop atTop →
+theorem erdos_74 : answer(sorry) ↔ ∀ f : ℕ → ℕ, Tendsto f atTop atTop →
     (∃ (V : Type u) (G : SimpleGraph V), G.chromaticNumber = ⊤ ∧
-    ∀ n, G.maxSubgraphEdgeDistToBipartite n ≤ f n)) ↔ answer(sorry):= by
+    ∀ n, G.maxSubgraphEdgeDistToBipartite n ≤ f n) := by
   sorry
 
 /--
@@ -131,8 +131,9 @@ Is there a graph of infinite chromatic number such that every finite subgraph on
 vertices can be made bipartite by deleting at most $\sqrt{n}$ edges?
 -/
 @[category research open, AMS 5]
-theorem erdos_74.variants.sqrt : (∃ (V : Type u) (G : SimpleGraph V), G.chromaticNumber = ⊤ ∧
-    ∀ n, G.maxSubgraphEdgeDistToBipartite n ≤ (n : ℝ).sqrt) ↔ answer(sorry):= by
+theorem erdos_74.variants.sqrt : answer(sorry) ↔
+    ∃ (V : Type u) (G : SimpleGraph V), G.chromaticNumber = ⊤ ∧
+    ∀ n, G.maxSubgraphEdgeDistToBipartite n ≤ (n : ℝ).sqrt := by
   sorry
 
 -- TODO(firsching): add the remaining statements/comments

--- a/FormalConjectures/ErdosProblems/749.lean
+++ b/FormalConjectures/ErdosProblems/749.lean
@@ -31,7 +31,7 @@ such that the lower density of $A+A$ is at least $1-\epsilon$
 and yet $1_A\ast 1_A(n) \ll_\epsilon 1$ for all $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_749 : answer(sorry) ↔ ∀ᵉ (ε > (0 : ℝ)),
+theorem erdos_749 : answer(sorry) ↔ ∀ ε > (0 : ℝ),
     ∃ A : Set ℕ, 1 - ε ≤ lowerDensity (A + A) ∧
     ((Nat.cast (R := ℝ) ∘ sumRep A) ≪ (fun n => (1: ℝ))) := by
   sorry

--- a/FormalConjectures/ErdosProblems/749.lean
+++ b/FormalConjectures/ErdosProblems/749.lean
@@ -31,9 +31,9 @@ such that the lower density of $A+A$ is at least $1-\epsilon$
 and yet $1_A\ast 1_A(n) \ll_\epsilon 1$ for all $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_749 : (∀ᵉ (ε > (0 : ℝ)),
+theorem erdos_749 : answer(sorry) ↔ ∀ᵉ (ε > (0 : ℝ)),
     ∃ A : Set ℕ, 1 - ε ≤ lowerDensity (A + A) ∧
-    ((Nat.cast (R := ℝ) ∘ sumRep A) ≪ (fun n => (1: ℝ)))) ↔ answer(sorry) := by
+    ((Nat.cast (R := ℝ) ∘ sumRep A) ≪ (fun n => (1: ℝ))) := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -45,8 +45,8 @@ such that $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold whe
 $r = s$?
 -/
 @[category research open, AMS 11]
-theorem erdos_786.parts.i : (∀ ε > 0, ε ≤ 1 →
-    ∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet) ↔ answer(sorry) := by
+theorem erdos_786.parts.i : answer(sorry) ↔ ∀ ε > 0, ε ≤ 1 →
+    ∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet := by
   sorry
 
 /--
@@ -55,9 +55,9 @@ $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold when
 $r = s$?
 -/
 @[category research open, AMS 11]
-theorem erdos_786.parts.ii : (∃ (A : ℕ → Set ℕ) (f : ℕ → ℝ) (_ : f =o[atTop] (1 : ℕ → ℝ)),
-    ∀ N, A N ⊆ Set.Icc 1 (N + 1) ∧ (1 - f N) * N ≤ (A N).ncard ∧ (A N).IsMulCardSet) ↔
-    answer(sorry) := by
+theorem erdos_786.parts.ii : answer(sorry) ↔
+    ∃ (A : ℕ → Set ℕ) (f : ℕ → ℝ) (_ : f =o[atTop] (1 : ℕ → ℝ)),
+    ∀ N, A N ⊆ Set.Icc 1 (N + 1) ∧ (1 - f N) * N ≤ (A N).ncard ∧ (A N).IsMulCardSet := by
   sorry
 
 /--
@@ -89,9 +89,11 @@ with $a_i, b_j\in A$ can only hold when $r = s$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_786.parts.i.selfridge (ε : ℝ) (hε : 0 < ε ∧ ε ≤ 1) :
-    -- TODO(mercuris) : I think we want `k` to be allowed to vary somehow as well, but maybe the exists is sufficient
+    -- TODO(mercuris) : I think we want `k` to be allowed to vary somehow as well, but maybe the
+    -- exists is sufficient
     ∃ (k : ℕ),
-      -- Sufficient to take L^∞ norm to guarantee all primes are large, due to the consecutivePrimes assertion
+      -- Sufficient to take L^∞ norm to guarantee all primes are large, due to the consecutivePrimes
+      -- assertion
       ∀ᶠ (p : Fin (k + 2) → ℕ) in atTop, consecutivePrimes p ∧
         ∑ i ∈ Finset.univ.filter (· < Fin.last _), (1 : ℝ) / p i < 1 ∧
           1 < ∑ i, (1 : ℝ) / p i →

--- a/FormalConjectures/ErdosProblems/817.lean
+++ b/FormalConjectures/ErdosProblems/817.lean
@@ -49,7 +49,7 @@ $$ -/
 -- Formalisation note : only formalising the "In particular" part
 @[category research open, AMS 5 11]
 theorem erdos_817 :
-    ((fun n => (3 ^ n : ℝ)) =O[atTop] fun n => (g 3 n : ℝ)) ↔ answer(sorry) := by
+    answer(sorry) ↔ (fun n => (3 ^ n : ℝ)) =O[atTop] fun n => (g 3 n : ℝ) := by
   sorry
 
 /-- A problem of Erdős and Sárközy who proved

--- a/FormalConjectures/ErdosProblems/822.lean
+++ b/FormalConjectures/ErdosProblems/822.lean
@@ -35,10 +35,9 @@ The problem is known to have an affirmative answer.
 -/
 @[category research solved, AMS 11]
 theorem erdos_822 :
-    (Set.range fun n => n + Nat.totient n).HasPosDensity ↔ answer(True) := by
+    answer(True) ↔ (Set.range fun n => n + Nat.totient n).HasPosDensity := by
   -- TODO: Replace `sorry` with a formal proof using the results of
   -- Gabdullin–Iudelevich–Luca once an appropriate library interface is available.
   sorry
 
 end Erdos822
-

--- a/FormalConjectures/ErdosProblems/825.lean
+++ b/FormalConjectures/ErdosProblems/825.lean
@@ -32,9 +32,9 @@ $\sigma(n) > Cn$ is the distinct sum of proper divisors of $n$?
 -/
 @[category research open, AMS 11]
 theorem erdos_825 :
-    (∃ (C : ℝ) (_ : C > 0),
+    answer(sorry) ↔ ∃ (C : ℝ) (_ : C > 0),
       ∀ (n) (_ : σ 1 n > C * n),
-        ∃ s ⊆ n.properDivisors, n = s.sum id) ↔ answer(sorry) := by
+        ∃ s ⊆ n.properDivisors, n = s.sum id := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/826.lean
+++ b/FormalConjectures/ErdosProblems/826.lean
@@ -33,8 +33,8 @@ $$
 $$
 -/
 @[category research open, AMS 11]
-theorem erdos_826 : (∃ C > (0 : ℝ), { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite) ↔
-    answer(sorry) := by
+theorem erdos_826 : answer(sorry) ↔
+    ∃ C > (0 : ℝ), { n | ∀ k ≥ 1, σ 0 (n + k) ≤ C * k }.Infinite := by
   sorry
 
 end Erdos826

--- a/FormalConjectures/ErdosProblems/828.lean
+++ b/FormalConjectures/ErdosProblems/828.lean
@@ -31,14 +31,14 @@ Is it true that, for any $a \in \mathbb{Z}$, there are infinitely many $n$ such 
 $$\phi(n) | n + a$$?
 -/
 @[category research open, AMS 11]
-theorem erdos_828 : (∀ a : ℤ, Set.Infinite {n : ℕ | ↑(φ n) ∣ n + a}) ↔ answer(sorry) := by
+theorem erdos_828 : answer(sorry) ↔ ∀ a : ℤ, Set.Infinite {n : ℕ | ↑(φ n) ∣ n + a} := by
   sorry
 
 /--
 When $n > 1$, Lehmer conjectured that $\phi(n) | n - 1$ if and only if $n$ is prime.
 -/
 @[category research open, AMS 11]
-theorem erdos_828.variants.lehmer_conjecture : (∀ n > 1, φ n ∣ n - 1 ↔ Prime n) ↔ answer(sorry) := by
+theorem erdos_828.variants.lehmer_conjecture : answer(sorry) ↔ ∀ n > 1, φ n ∣ n - 1 ↔ Prime n := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -47,7 +47,7 @@ We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b
 infinitely many amicable pairs?
 -/
 @[category research open, AMS 11]
-theorem erdos_830.parts.i : {(a, b) | IsAmicable a b}.Infinite ↔ answer(sorry) := by
+theorem erdos_830.parts.i : answer(sorry) ↔ {(a, b) | IsAmicable a b}.Infinite := by
   sorry
 
 /-- **Erdos Problem 830, Part 2**
@@ -56,8 +56,8 @@ If $A(x)$ counts the number of amicable $1\leq a\leq b\leq x$ then is it true th
 \[A(x) > x^{1-o(1)}?\]
 -/
 @[category research open, AMS 11]
-theorem erdos_830.parts.ii : (∃ o : ℝ → ℝ, o =o[atTop] (1 : ℝ → ℝ) ∧ ∀ᶠ x in atTop,
-    x ^ (1 - o x) < A x) ↔ answer(sorry) := by
+theorem erdos_830.parts.ii : answer(sorry) ↔ ∃ o : ℝ → ℝ, o =o[atTop] (1 : ℝ → ℝ) ∧ ∀ᶠ x in atTop,
+    x ^ (1 - o x) < A x := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/845.lean
+++ b/FormalConjectures/ErdosProblems/845.lean
@@ -30,10 +30,10 @@ with $b_1 < \cdots < b_t$, where $b_i = 2^{k_i}3^{l_i}$ for $1 \leq i\leq t$ and
 $b_t \leq Cb_1$ has density $0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_845 : (∀ᵉ (C : ℝ) (hC : 0 < C),
+theorem erdos_845 : answer(sorry) ↔ ∀ᵉ (C : ℝ) (hC : 0 < C),
     let f : ℕ × ℕ → ℕ := fun (k, l) ↦ 2 ^ k * 3 ^ l
     { ∑ x ∈ B, f x | (B : Finset (ℕ × ℕ)) (h : B.Nonempty)
-      (hB : B.sup f ≤ C * B.inf' h f) }.HasDensity 0) ↔ answer(sorry) := by
+      (hB : B.sup f ≤ C * B.inf' h f) }.HasDensity 0 := by
   sorry
 
 end Erdos845

--- a/FormalConjectures/ErdosProblems/846.lean
+++ b/FormalConjectures/ErdosProblems/846.lean
@@ -51,8 +51,8 @@ In other words, prove or disprove the following statement: every infinite `ε`-n
 plane is weakly non-trilinar.
 -/
 @[category research open, AMS 11]
-theorem erdos_846 : (∀ᵉ (A : Set ℝ²) (ε > 0), A.Infinite → NonTrilinearFor A ε →
-    WeaklyNonTrilinear A) ↔ answer(sorry) := by
+theorem erdos_846 : answer(sorry) ↔ ∀ᵉ (A : Set ℝ²) (ε > 0), A.Infinite → NonTrilinearFor A ε →
+    WeaklyNonTrilinear A := by
   sorry
 
 end Erdos846

--- a/FormalConjectures/ErdosProblems/85.lean
+++ b/FormalConjectures/ErdosProblems/85.lean
@@ -37,7 +37,7 @@ noncomputable def f (n : ℕ) : ℕ :=
 Is it true that, for all large $n$, $f(n + 1) \ge f(n)$?
 -/
 @[category research open, AMS 5]
-theorem erdos_85 : (∀ᶠ n in atTop, f n ≤ f (n + 1)) ↔ answer(sorry) := by
+theorem erdos_85 : answer(sorry) ↔ ∀ᶠ n in atTop, f n ≤ f (n + 1) := by
   sorry
 
 -- TODO: add connection to Ramsey number, weaker version and implied bounds from additional material.

--- a/FormalConjectures/ErdosProblems/850.lean
+++ b/FormalConjectures/ErdosProblems/850.lean
@@ -29,9 +29,9 @@ $x+1,y+1$ have the same prime factors, and $x+2,y+2$ also have the same prime fa
 -/
 @[category research open, AMS 11]
 theorem erdos_850 :
-    (∃ x y : ℕ, x ≠ y ∧ x.primeFactors = y.primeFactors
+    answer(sorry) ↔ ∃ x y : ℕ, x ≠ y ∧ x.primeFactors = y.primeFactors
       ∧ (x + 1).primeFactors = (y + 1).primeFactors
-      ∧ (x + 2).primeFactors = (y + 2).primeFactors) ↔ answer(sorry) := by
+      ∧ (x + 2).primeFactors = (y + 2).primeFactors := by
     sorry
 
 -- TODO(Paul-Lez): formalise remaining problems

--- a/FormalConjectures/ErdosProblems/868.lean
+++ b/FormalConjectures/ErdosProblems/868.lean
@@ -39,10 +39,9 @@ $n$ can be written as the sum of two elements from $A$. If $f(n) \to \infty$ as 
 must $A$ contain a minimal additive basis of order $2$? -/
 @[category research open, AMS 5 11]
 theorem erdos_868.parts.i :
-    (∀ (A : Set ℕ), A.IsAsymptoticAddBasisOfOrder 2 →
+    answer(sorry) ↔ ∀ (A : Set ℕ), A.IsAsymptoticAddBasisOfOrder 2 →
       atTop.Tendsto (fun n => ncard_add_repr A 2 n) atTop → ∃ B ⊆ A,
-      B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B, ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2) ↔
-    answer(sorry) := by
+      B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B, ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := by
   sorry
 
 /-- Let $A$ be an additive basis of order $2$, let $f(n)$ denote the number of ways in which
@@ -51,20 +50,18 @@ and an arbitrary fixed $\epsilon > 0$, then must $A$ contain a minimal additive
 basis of order $2$? -/
 @[category research open, AMS 5 11]
 theorem erdos_868.parts.ii :
-    (∀ᵉ (A : Set ℕ) (ε > 0), A.IsAsymptoticAddBasisOfOrder 2 →
+    answer(sorry) ↔ ∀ᵉ (A : Set ℕ) (ε > 0), A.IsAsymptoticAddBasisOfOrder 2 →
       (∀ᶠ (n : ℕ) in atTop, ε * Real.log n < ncard_add_repr A 2 n) → ∃ B ⊆ A,
-      B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B, ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2) ↔
-    answer(sorry) := by
+      B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B, ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := by
   sorry
 
 /-- Erdős and Nathanson proved that this is true if $f(n) > (\log \frac{4}{3})^{-1} \log n$ for
 all large $n$. -/
 @[category research solved, AMS 5 11]
 theorem erdos_868.variants.fixed_ε :
-    (∀ (A : Set ℕ), A.IsAsymptoticAddBasisOfOrder 2 →
+    answer(True) ↔ ∀ (A : Set ℕ), A.IsAsymptoticAddBasisOfOrder 2 →
       (∀ᶠ (n : ℕ) in atTop, (Real.log (4 / 3))⁻¹ * Real.log n < ncard_add_repr A 2 n) → ∃ B ⊆ A,
-      B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B, ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2) ↔
-    answer(True) := by
+      B.IsAsymptoticAddBasisOfOrder 2 ∧ ∀ b ∈ B, ¬(B \ {b}).IsAsymptoticAddBasisOfOrder 2 := by
   sorry
 
 /-- Härtter and Nathanson proved that there exist additive bases which do not contain

--- a/FormalConjectures/ErdosProblems/873.lean
+++ b/FormalConjectures/ErdosProblems/873.lean
@@ -35,8 +35,8 @@ such that $[a_i,a_{i+1}, \dots ,a_{i+k−1}] < X$, where the left-hand side is t
 multiple. Is it true that, for every $\epsilon > 0$, there exists some $k$ such that
 $F(A,X,k) < X^\epsilon$?-/
 @[category research open, AMS 11]
-theorem erdos_873 : (∀ᵉ (a : ℕ → ℕ) (ε > (0 : ℝ)), 0 < a 0 → StrictMono a →
-    ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal) ↔ answer(sorry) := by
+theorem erdos_873 : answer(sorry) ↔ ∀ᵉ (a : ℕ → ℕ) (ε > (0 : ℝ)), 0 < a 0 → StrictMono a →
+    ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal := by
   sorry
 
 end Erdos873

--- a/FormalConjectures/ErdosProblems/881.lean
+++ b/FormalConjectures/ErdosProblems/881.lean
@@ -55,12 +55,10 @@ is an additive basis of order `k + 1`?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_881 :
-    (∀ (k : ℕ) (A : Set ℕ),
+    answer(sorry) ↔ ∀ (k : ℕ) (A : Set ℕ),
       IsMinimalAsymptoticAddBasisOfOrder k A →
         ∃ (B : Set ℕ), B ⊆ A ∧ B.Infinite ∧
-          (A \ B).IsAsymptoticAddBasisOfOrder (k + 1)) ↔
-      answer(sorry) := by
+          (A \ B).IsAsymptoticAddBasisOfOrder (k + 1) := by
   sorry
 
 end Erdos881
-

--- a/FormalConjectures/ErdosProblems/889.lean
+++ b/FormalConjectures/ErdosProblems/889.lean
@@ -83,7 +83,7 @@ Does $v_1(n) = 1$ have finite solutions?
 -/
 @[category research open, AMS 11]
 theorem erdos_889.variants.v1_eq_1_finite :
-    {n | v_l 1 n = 1}.Finite ↔ answer(sorry) := by
+    answer(sorry) ↔ {n | v_l 1 n = 1}.Finite := by
   sorry
 
 /--
@@ -112,7 +112,7 @@ which might make it more amenable to attack according to [ErSe67].
 -/
 @[category research open, AMS 11]
 theorem erdos_889.variants.V1_eq_1_finite :
-    {n | V_l 1 n = 1}.Finite ↔ answer(sorry) := by
+    answer(sorry) ↔ {n | V_l 1 n = 1}.Finite := by
   sorry
 
 end Erdos889

--- a/FormalConjectures/ErdosProblems/893.lean
+++ b/FormalConjectures/ErdosProblems/893.lean
@@ -42,7 +42,7 @@ Does the limit $\lim_{n\to\infty} \frac{f(2n)}{f(n)}$ tend to infinity?
 -/
 @[category research open, AMS 5]
 theorem erdos_893 :
-    Tendsto (fun n : ℕ => (f (2 * n) : ℝ) / (f n : ℝ)) atTop atTop ↔ answer(sorry) := by
+    answer(sorry) ↔ Tendsto (fun n : ℕ => (f (2 * n) : ℝ) / (f n : ℝ)) atTop atTop := by
   sorry
 
 

--- a/FormalConjectures/ErdosProblems/897.lean
+++ b/FormalConjectures/ErdosProblems/897.lean
@@ -31,12 +31,11 @@ if $(a,b)=1$ such that $\limsup_{p,k} f(p^k) \log(p^k) = ∞$.
 Is it true that $\limsup_n (f(n+1)−f(n))/ \log n = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.parts.i : (∀ (f : ℕ → ℝ),
+theorem erdos_897.parts.i : answer(sorry) ↔ ∀ (f : ℕ → ℝ),
     (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
     ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
       (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤) ↔
-    answer(sorry) := by
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
   sorry
 
 /--
@@ -45,11 +44,11 @@ if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) \log(p^k) = ∞$.
 Is it true that $\limsup_n f(n+1)/ f(n) = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.parts.ii : (∀ (f : ℕ → ℝ),
+theorem erdos_897.parts.ii : answer(sorry) ↔ ∀ (f : ℕ → ℝ),
     (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
     ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
       (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤) ↔ answer(sorry) := by
+    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
   sorry
 
 /--
@@ -76,13 +75,12 @@ or $f(p^k) = kf(p)$.
 Is it true that $\limsup_n (f(n+1)−f(n))/ \log n = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.variants.parts.i : (∀ (f : ℕ → ℝ),
+theorem erdos_897.variants.parts.i : answer(sorry) ↔ ∀ (f : ℕ → ℝ),
     (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
     ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
       (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
     (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤) ↔
-      answer(sorry) := by
+    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
   sorry
 
 /--
@@ -92,12 +90,12 @@ or $f(p^k) = kf(p)$.
 Is it true that $\limsup_n f(n+1)/f(n) = ∞$?
 -/
 @[category research open, AMS 11]
-theorem erdos_897.variants.parts.ii : (∀ (f : ℕ → ℝ),
+theorem erdos_897.variants.parts.ii : answer(sorry) ↔ ∀ (f : ℕ → ℝ),
     (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
     ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
       (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
     (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤) ↔ answer(sorry) := by
+    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
   sorry
 
 end Erdos897

--- a/FormalConjectures/ErdosProblems/899.lean
+++ b/FormalConjectures/ErdosProblems/899.lean
@@ -42,10 +42,10 @@ The answer is yes, proved by Ruzsa [Ru78].
 [Ru78] Ruzsa, I. Z., _On the cardinality of {$A+A$}\ and {$A-A$}_. (1978), 933--938.
 -/
 @[category research solved, AMS 5]
-theorem erdos_899 : (∀ (A : Set ℕ), A.Infinite →
+theorem erdos_899 : answer(True) ↔ ∀ (A : Set ℕ), A.Infinite →
     Tendsto (fun N => (A.interIcc 1 N |>.ncard : ℝ) / N) atTop (𝓝 0) →
-    Tendsto (fun N => ((A - A : Set ℕ).interIcc 1 N |>.ncard : ℝ) / (A.interIcc 1 N).ncard) atTop atTop) ↔
-    answer(True) := by
+    Tendsto (fun N => ((A - A : Set ℕ).interIcc 1 N |>.ncard : ℝ) /
+      (A.interIcc 1 N).ncard) atTop atTop := by
   sorry
 
 end Erdos899

--- a/FormalConjectures/ErdosProblems/9.lean
+++ b/FormalConjectures/ErdosProblems/9.lean
@@ -70,7 +70,7 @@ Is the upper density of the set of odd numbers that cannot be expressed as a pri
 two powers of 2 positive?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_9 : 0 < Erdos9A.upperDensity ↔ answer(sorry) := by
+theorem erdos_9 : answer(sorry) ↔ 0 < Erdos9A.upperDensity := by
   sorry
 
 end Erdos9

--- a/FormalConjectures/ErdosProblems/90.lean
+++ b/FormalConjectures/ErdosProblems/90.lean
@@ -72,9 +72,8 @@ Does every set of $n$ distinct points in $\mathbb{R}^2$ contain at most
 $n^{1+O(\frac{1}{\log\log n})}$ many pairs which are distance $1$ apart?
 -/
 @[category research open, AMS 52]
-theorem erdos_90 : (∃ (O : ℕ → ℝ) (hO : O =O[atTop] (fun n => 1 / (n : ℝ).log.log)),
-    (fun n => (maxUnitDistances n : ℝ)) =ᶠ[atTop] fun (n : ℕ) => (n : ℝ) ^ (1 + O n)) ↔
-      answer(sorry) := by
+theorem erdos_90 : answer(sorry) ↔ ∃ (O : ℕ → ℝ) (hO : O =O[atTop] (fun n => 1 / (n : ℝ).log.log)),
+    (fun n => (maxUnitDistances n : ℝ)) =ᶠ[atTop] fun (n : ℕ) => (n : ℝ) ^ (1 + O n) := by
   sorry
 
 -- TODO(firsching): add the statements from the rest of the page.

--- a/FormalConjectures/ErdosProblems/913.lean
+++ b/FormalConjectures/ErdosProblems/913.lean
@@ -34,9 +34,8 @@ $$
 is the factorisation into distinct primes then all exponents $k_i$ are distinct?
 -/
 @[category research open, AMS 11]
-theorem erdos_913 :
-    { n | Set.InjOn (n * (n + 1)).factorization (n * (n + 1)).primeFactors }.Infinite ↔
-    answer(sorry) := by
+theorem erdos_913 : answer(sorry) ↔
+    { n | Set.InjOn (n * (n + 1)).factorization (n * (n + 1)).primeFactors }.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/918.lean
+++ b/FormalConjectures/ErdosProblems/918.lean
@@ -36,18 +36,16 @@ subgraph on $\aleph_1$ vertices has chromatic number $\leq\aleph_0$? -/
 -- Formalisation note: source material [ErHa68b] uses only induced subgraphs
 @[category research open, AMS 5]
 theorem erdos_918.parts.i :
-    (∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ 2 ∧ G.chromaticCardinal = ℵ_ 2 ∧
-      ∀ (W : Set V) (_ : #W = ℵ₁), (G.induce W).chromaticCardinal ≤ ℵ₀) ↔
-    answer(sorry) := by
+    answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ 2 ∧ G.chromaticCardinal = ℵ_ 2 ∧
+      ∀ (W : Set V) (_ : #W = ℵ₁), (G.induce W).chromaticCardinal ≤ ℵ₀ := by
   sorry
 
 /-- Is there a graph with $\aleph_{\omega+1}$ vertices and chromatic number $\aleph_1$ such that
 every subgraph on $\aleph_\omega$ vertices has chromatic number $\leq\aleph_0$? -/
 @[category research open, AMS 5]
 theorem erdos_918.parts.ii (ω : Ordinal) :
-    (∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
-      ∀ (W : Set V) (_ : #W = ℵ_ ω), (G.induce W).chromaticCardinal ≤ ℵ₀) ↔
-    answer(sorry) := by
+    answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
+      ∀ (W : Set V) (_ : #W = ℵ_ ω), (G.induce W).chromaticCardinal ≤ ℵ₀ := by
   sorry
 
 /-- Is there a graph with $\aleph_2$ vertices and chromatic number $\aleph_2$ such that every
@@ -55,18 +53,16 @@ subgraph on $\aleph_1$ vertices has chromatic number $\leq\aleph_0$? -/
 -- Formalisation note: It is not clear whether this question for general subgraphs is open or not
 @[category research open, AMS 5]
 theorem erdos_918.variants.all_subgraphs.parts.i :
-    (∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ 2 ∧ G.chromaticCardinal = ℵ_ 2 ∧
-      ∀ (H : G.Subgraph) (_ : #H.verts = ℵ₁), H.coe.chromaticCardinal ≤ ℵ₀) ↔
-    answer(sorry) := by
+    answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ 2 ∧ G.chromaticCardinal = ℵ_ 2 ∧
+      ∀ (H : G.Subgraph) (_ : #H.verts = ℵ₁), H.coe.chromaticCardinal ≤ ℵ₀ := by
   sorry
 
 /-- Is there a graph with $\aleph_{\omega+1}$ vertices and chromatic number $\aleph_1$ such that
 every subgraph on $\aleph_\omega$ vertices has chromatic number $\leq\aleph_0$? -/
 @[category research open, AMS 5]
 theorem erdos_918.variants.all_subgraphs.parts.ii (ω : Ordinal) :
-    (∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
-      ∀ (H : G.Subgraph) (_ : #H.verts = ℵ_ ω), H.coe.chromaticCardinal ≤ ℵ₀) ↔
-    answer(sorry) := by
+    answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
+      ∀ (H : G.Subgraph) (_ : #H.verts = ℵ_ ω), H.coe.chromaticCardinal ≤ ℵ₀ := by
   sorry
 
 /-- A question of Erd\H{o}s and Hajnal [ErHa68b], who proved that for every finite $k$

--- a/FormalConjectures/ErdosProblems/92.lean
+++ b/FormalConjectures/ErdosProblems/92.lean
@@ -74,16 +74,16 @@ noncomputable def f (n : ℕ) : ℕ := sSup <| possible_f_values n
 Is it true that $f(n)\leq n^{o(1)}$?
 -/
 @[category research open, AMS 52]
-theorem erdos_92.variants.weak : (∃ o : ℕ → ℝ,
-  o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ n, (f n : ℝ) ≤ n^(o n)) ↔ answer(sorry) := by
+theorem erdos_92.variants.weak : answer(sorry) ↔ ∃ o : ℕ → ℝ,
+  o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ n, (f n : ℝ) ≤ n^(o n) := by
 sorry
 
 /--
 Or even $f(n) < n^{c/\log\log n}$ for some constant $c > 0$?
 -/
 @[category research open, AMS 52]
-theorem erdos_92.variants.strong :
-  (∃ c > 0, ∀ n, (f n : ℝ) ≤ n^(c / (n : ℝ).log.log)) ↔ answer(sorry) := by
+theorem erdos_92.variants.strong : answer(sorry) ↔
+    ∃ c > 0, ∀ n, (f n : ℝ) ≤ n^(c / (n : ℝ).log.log) := by
 sorry
 
 -- TODO(firsching): formalize the rest of the remarks

--- a/FormalConjectures/ErdosProblems/930.lean
+++ b/FormalConjectures/ErdosProblems/930.lean
@@ -44,10 +44,10 @@ is not a perfect power?
 -/
 @[category research open, AMS 11]
 theorem erdos_930 :
-    (∀ r > 0, ∃ k, ∀ I₁ I₂ : Fin r → ℕ,
+    answer(sorry) ↔ ∀ r > 0, ∃ k, ∀ I₁ I₂ : Fin r → ℕ,
       (∀ i : Fin r, 0 < I₁ i ∧ I₁ i + k ≤ I₂ i + 1) →
         (∀ i j : Fin r, i < j → I₂ i < I₁ j) →
-          ¬ IsPower (∏ i : Fin r, ∏ m ∈ Icc (I₁ i) (I₂ i), m)) ↔ answer(sorry) := by
+          ¬ IsPower (∏ i : Fin r, ∏ m ∈ Icc (I₁ i) (I₂ i), m) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/931.lean
+++ b/FormalConjectures/ErdosProblems/931.lean
@@ -33,10 +33,10 @@ $$
 have the same prime factors?
 -/
 @[category research open, AMS 11]
-theorem erdos_931 : (∀ᵉ (k₁ : ℕ) (k₂ ≥ 3), k₂ ≤ k₁ →
+theorem erdos_931 : answer(sorry) ↔ ∀ᵉ (k₁ : ℕ) (k₂ ≥ 3), k₂ ≤ k₁ →
     { (n₁, n₂) | n₁ + k₁ ≤ n₂ ∧
       (∏ i ∈ Finset.Icc 1 k₁, (n₁ + i)).primeFactors =
-      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors }.Finite) ↔ answer(sorry) := by
+      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors }.Finite := by
   sorry
 
 /--
@@ -45,10 +45,10 @@ $n_2 > 2(n_1 + k_1)$.
 It is an open question whether this is true when allowing a finite number of counterexamples.
 -/
 @[category research open, AMS 11]
-theorem erdos_931.variants.additional_condition : (∀ᵉ (k₁ : ℕ) (k₂ ≥ 3), k₂ ≤ k₁ →
+theorem erdos_931.variants.additional_condition : answer(sorry) ↔ ∀ᵉ (k₁ : ℕ) (k₂ ≥ 3), k₂ ≤ k₁ →
     {(n₁, n₂) | n₁ + k₁ ≤ n₂ ∧ n₂ ≤ 2 * (n₁ + k₁) ∧
       (∏ i ∈ Finset.Icc 1 k₁, (n₁ + i)).primeFactors =
-      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors}.Finite) ↔ answer(sorry) := by
+      (∏ j ∈ Finset.Icc 1 k₂, (n₂ + j)).primeFactors}.Finite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/936.lean
+++ b/FormalConjectures/ErdosProblems/936.lean
@@ -33,25 +33,25 @@ def EventuallyNotPowerful (a : ℕ → ℕ) : Prop := atTop.Eventually (fun n =>
 /-- Is $2^n + 1$ powerful for finitely many $n$? -/
 @[category research open, AMS 11]
 theorem erdos_936.variants.two_pow_add_one :
-   EventuallyNotPowerful (2 ^ · + 1) ↔ answer(sorry) := by
+   answer(sorry) ↔ EventuallyNotPowerful (2 ^ · + 1) := by
   sorry
 
 /-- Is $2^n - 1$ powerful for finitely many $n$? -/
 @[category research open, AMS 11]
 theorem erdos_936.variants.two_pow_sub_one :
-   EventuallyNotPowerful (2 ^ · - 1) ↔ answer(sorry) := by
+   answer(sorry) ↔ EventuallyNotPowerful (2 ^ · - 1) := by
   sorry
 
 /-- Is $n! + 1$ powerful for finitely many $n$? -/
 @[category research open, AMS 11]
 theorem erdos_936.variants.factorial_add_one :
-   EventuallyNotPowerful (·! + 1) ↔ answer(sorry) := by
+   answer(sorry) ↔ EventuallyNotPowerful (·! + 1) := by
   sorry
 
 /-- Is $n! - 1$ powerful for finitely many $n$? -/
 @[category research open, AMS 11]
 theorem erdos_936.variants.factorial_sub_one :
-   EventuallyNotPowerful (·! - 1) ↔ answer(sorry) := by
+   answer(sorry) ↔ EventuallyNotPowerful (·! - 1) := by
   sorry
 
 end Erdos936

--- a/FormalConjectures/ErdosProblems/938.lean
+++ b/FormalConjectures/ErdosProblems/938.lean
@@ -30,8 +30,8 @@ Let $A=\{n_1 < n_2 < \cdots\}$ be the sequence of powerful numbers (if $p\mid n$
 Are there only finitely many three-term progressions of consecutive terms $n_k,n_{k+1},n_{k+2}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_938 : {P : Finset ℕ | Set.IsAPOfLength P.toSet 3 ∧ ∃ k,
-    P = {nth Powerful k, nth Powerful (k + 1), nth Powerful (k + 2)}}.Finite ↔ answer(sorry) := by
+theorem erdos_938 : answer(sorry) ↔ {P : Finset ℕ | Set.IsAPOfLength P.toSet 3 ∧ ∃ k,
+    P = {nth Powerful k, nth Powerful (k + 1), nth Powerful (k + 2)}}.Finite := by
   sorry
 
 end Erdos938

--- a/FormalConjectures/ErdosProblems/939.lean
+++ b/FormalConjectures/ErdosProblems/939.lean
@@ -39,7 +39,7 @@ def Erdos939Sums (r : ℕ) :=
 If $r≥4$ then can the sum of $r-2$ coprime $r$-powerful numbers ever be itself $r$-powerful?
 -/
 @[category research open, AMS 11]
-theorem erdos_939 : (∀ r ≥ 4, (Erdos939Sums r).Nonempty) ↔ answer(sorry) := by
+theorem erdos_939 : answer(sorry) ↔ ∀ r ≥ 4, (Erdos939Sums r).Nonempty := by
   sorry
 
 /--
@@ -47,7 +47,7 @@ If $r≥4$ are there infinitely many sums of $r-2$ coprime $r$-powerful numbers
 that are themselves $r$-powerful?
 -/
 @[category research open, AMS 11]
-theorem erdos_939.variants.infinite : (∀ r ≥ 4, (Erdos939Sums r).Infinite) ↔ answer(sorry) := by
+theorem erdos_939.variants.infinite : answer(sorry) ↔ ∀ r ≥ 4, (Erdos939Sums r).Infinite := by
   sorry
 
 /--
@@ -55,9 +55,9 @@ Are there infinitely many triples of coprime $3$-powerful numbers $a, b, c$ such
 -/
 @[category research open, AMS 11]
 theorem erdos_939.variants.triples :
-    {(a,b,c) | ({a, b, c} : Finset ℕ).Coprime ∧
+    answer(sorry) ↔ {(a,b,c) | ({a, b, c} : Finset ℕ).Coprime ∧
       (3).Full a ∧ (3).Full b ∧ (3).Full c ∧
-      a + b = c}.Infinite ↔ answer(sorry) := by
+      a + b = c}.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/940.lean
+++ b/FormalConjectures/ErdosProblems/940.lean
@@ -32,9 +32,8 @@ has density $0$?
 -/
 @[category research open, AMS 11]
 theorem erdos_940 :
-    (∀ r ≥ 3,
-      {n : ℕ | ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ n = S.sum}.HasDensity 0)
-    ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ r ≥ 3,
+      {n : ℕ | ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ n = S.sum}.HasDensity 0 := by
   sorry
 
 /--
@@ -51,8 +50,8 @@ Is it true that the set of integers which are the sum of at most three cubes has
 -/
 @[category research open, AMS 11]
 theorem erdos_940.variants.three_cubes :
-    {n : ℕ | ∃ (S : Multiset ℕ), S.card ≤ 3 ∧ n = (Multiset.map (· ^ 3) S).sum}.HasDensity 0
-    ↔ answer(sorry) := by
+    answer(sorry) ↔
+    {n : ℕ | ∃ (S : Multiset ℕ), S.card ≤ 3 ∧ n = (Multiset.map (· ^ 3) S).sum}.HasDensity 0 := by
   sorry
 
 
@@ -61,8 +60,8 @@ It is not known if all large integers are the sum of at most $r$-many $r$-powerf
 -/
 @[category research open, AMS 11]
 theorem erdos_940.variants.large_integers :
-    (∀ r ≥ 2, (∀ᶠ x in atTop, ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ x = S.sum))
-    ↔ answer(sorry) := by
+    answer(sorry) ↔
+    ∀ r ≥ 2, (∀ᶠ x in atTop, ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ x = S.sum) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/942.lean
+++ b/FormalConjectures/ErdosProblems/942.lean
@@ -36,10 +36,9 @@ Is there some constant $c > 0$ such that $h(n) < (\log n)^{c + o(1)}$ and, for i
 $h(n) > (\log n)^{c - o(1)}$.
 -/
 @[category research open, AMS 11]
-theorem erdos_942 : (∃ c > 0, ∃ (o : ℕ → ℝ), o =o[atTop] (1 : ℕ → ℝ) ∧
+theorem erdos_942 : answer(sorry) ↔ ∃ c > 0, ∃ (o : ℕ → ℝ), o =o[atTop] (1 : ℕ → ℝ) ∧
     ∀ n > 0, erdos_942.h n < (Real.log n) ^ (c + o n) ∧
-    {n | erdos_942.h n > (Real.log n) ^ (c - o n)}.Infinite)
-    ↔ answer(sorry) := by
+    {n | erdos_942.h n > (Real.log n) ^ (c - o n)}.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/943.lean
+++ b/FormalConjectures/ErdosProblems/943.lean
@@ -30,9 +30,9 @@ namespace Erdos943
 Let $A$ be the set of powerful numbers. Is is true that $1_A\ast 1_A(n)=n^{o(1)}$ for every $n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_943 :
-    (∃ (o : ℕ → ℝ), o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ᶠ n in atTop, (sumRep Powerful n) = (n : ℝ)^(o n)) ↔
-    answer(sorry) := by
+theorem erdos_943 : answer(sorry) ↔
+    ∃ (o : ℕ → ℝ), o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ᶠ n in atTop, (sumRep Powerful n) = (n : ℝ)^(o n)
+    := by
   sorry
 
 end Erdos943

--- a/FormalConjectures/ErdosProblems/944.lean
+++ b/FormalConjectures/ErdosProblems/944.lean
@@ -42,7 +42,7 @@ Let $k \ge 4$ and $r\ge 1$. Must there exist a graph $G$ with chromatic number $
 -/
 @[category research open, AMS 11]
 theorem erdos_944 :
-    (∀ k ≥ 4, ∀ r ≥ 1, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k r) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ k ≥ 4, ∀ r ≥ 1, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k r := by
   sorry
 
 /--
@@ -53,7 +53,7 @@ This was conjectured by Dirac in 1970.
 -/
 @[category research open, AMS 11]
 theorem erdos_944.variants.dirac_conjecture :
-    (∀ k ≥ 4, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ k ≥ 4, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1 := by
   sorry
 
 
@@ -95,7 +95,7 @@ The case $k=4$ and $r=1$ remains open: Are there $4$-critical graphs without any
 -/
 @[category research open, AMS 11]
 theorem erdos_944.dirac_conjecture.k_eq_four :
-    (∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 4 1) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 4 1 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/945.lean
+++ b/FormalConjectures/ErdosProblems/945.lean
@@ -44,7 +44,7 @@ def Erdos945Prop : Prop := ∃ O : ℝ → ℝ, O =O[atTop] (1 : ℝ → ℝ) �
 Is it true that $F(x) \leq (\log x)^{O(1)}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_945 : Erdos945Prop ↔ answer(sorry) := by
+theorem erdos_945 : answer(sorry) ↔ Erdos945Prop := by
   sorry
 
 def Erdos945Constant : Prop :=
@@ -59,7 +59,7 @@ Is there a constant $C > 0$ such that, for all large $x$, every interval $[x, x+
 contains two integers with the same number of divisors?
 -/
 @[category research open, AMS 11]
-theorem erdos_945.variants.constant : Erdos945Constant ↔ answer(sorry) := by
+theorem erdos_945.variants.constant : answer(sorry) ↔ Erdos945Constant := by
   sorry
 
 -- TODO(firsching): show equivalence

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -51,7 +51,7 @@ noncomputable def f (k : ℕ) : ℕ := Nat.find (erdos_961.well_defined k)
 It is conjectured that $f(k) \ll (\log k)^O(1)$.
 -/
 @[category research open, AMS 11]
-theorem erdos_961 : (∃ C > 0, ∀ᶠ k in atTop, f k < (log (k : ℝ)) ^ C) ↔ answer(sorry) := by
+theorem erdos_961 : answer(sorry) ↔ ∃ C > 0, ∀ᶠ k in atTop, f k < (log (k : ℝ)) ^ C := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/97.lean
+++ b/FormalConjectures/ErdosProblems/97.lean
@@ -74,7 +74,7 @@ Does every convex polygon have a vertex with no other 4 vertices equidistant fro
 -/
 @[category research open, AMS 52]
 theorem erdos_97 :
-    (∀ A : Finset ℝ², A.Nonempty → ConvexIndep A → ¬HasNEquidistantProperty 4 A) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ A : Finset ℝ², A.Nonempty → ConvexIndep A → ¬HasNEquidistantProperty 4 A := by
   sorry
 
 /--
@@ -106,8 +106,8 @@ Erdős also conjectured that there is a $k$ for which every convex polygon has a
 with no other $k$ vertices equidistant from it.
 -/
 @[category research open, AMS 52]
-theorem erdos_97.variants.k_equidistant :
-    (∃ k : ℕ, ∀ A : Finset ℝ², A.Nonempty → ConvexIndep A → ¬HasNEquidistantProperty k A) ↔ answer(sorry) := by
+theorem erdos_97.variants.k_equidistant : answer(sorry) ↔
+    ∃ k : ℕ, ∀ A : Finset ℝ², A.Nonempty → ConvexIndep A → ¬HasNEquidistantProperty k A := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/972.lean
+++ b/FormalConjectures/ErdosProblems/972.lean
@@ -35,7 +35,7 @@ Let $\alpha > 1$ be irrational. Are there infinitely many primes $p$
 such that $\lfloor p\alpha \rfloor$ is also prime?
 -/
 @[category research open, AMS 11]
-theorem erdos_972 : (∀ α > 1, Irrational α → (primeSet α).Infinite) ↔ answer(sorry) := by
+theorem erdos_972 : answer(sorry) ↔ ∀ α > 1, Irrational α → (primeSet α).Infinite := by
   sorry
 
 end Erdos972

--- a/FormalConjectures/ErdosProblems/979.lean
+++ b/FormalConjectures/ErdosProblems/979.lean
@@ -32,14 +32,14 @@ Let $k ≥ 2$, and let $f_k(n)$ count the number of solutions to $n = p_1^k + \d
 where the $p_i$ are prime numbers. Is it true that $\limsup f_k(n) = \infty$?
 -/
 @[category research open, AMS 11]
-theorem erdos_979 :
-    (∀ k ≥ 2, Filter.limsup (fun n => (solutionSet n k).encard) Filter.atTop = ⊤) ↔ answer(sorry) := by
+theorem erdos_979 : answer(sorry) ↔
+    ∀ k ≥ 2, Filter.limsup (fun n => (solutionSet n k).encard) Filter.atTop = ⊤ := by
   sorry
 
 /--
 Erdős [Er37b] proved that if $f_2(n)$ counts the number of solutions to $n = p_1^2 + p_2^2$, where $p_1$ and $p_2$ are prime numbers, then $\limsup f_2(n) = \infty$.
 
-[Er37b] Erdős, Paul, On the Sum and Difference of Squares of Primes. J. London Math. Soc. (1937), 133--136. 
+[Er37b] Erdős, Paul, On the Sum and Difference of Squares of Primes. J. London Math. Soc. (1937), 133--136.
 -/
 @[category research solved, AMS 11]
 theorem erdos_979_k2 :

--- a/FormalConjectures/ErdosProblems/985.lean
+++ b/FormalConjectures/ErdosProblems/985.lean
@@ -28,8 +28,8 @@ namespace Erdos985
 Is it true that, for every prime $p$, there is a prime $q \leq p$ which is a primitive root modulo $p$?
 -/
 @[category research open, AMS 11]
-theorem erdos_985 : (∀ᵉ (p : ℕ) (hp_prime : p.Prime) (hp_nontrivial : p ≠ 2),
-    ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1) ↔ answer(sorry) := by
+theorem erdos_985 : answer(sorry) ↔ ∀ᵉ (p : ℕ) (hp_prime : p.Prime) (hp_nontrivial : p ≠ 2),
+    ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1 := by
   sorry
 
 -- TODO: Artin conjectured that 2 is a primitive root for infinitely many primes $p$, which

--- a/FormalConjectures/GreensOpenProblems/1.lean
+++ b/FormalConjectures/GreensOpenProblems/1.lean
@@ -31,10 +31,9 @@ Let $A$ be a set of $n$ positive integers. Does $A$ contain a sum-free set
 of size at least $\frac n 3 + Ω(n)$, where $Ω(n) → ∞$ as $n → ∞$?
 -/
 @[category research open, AMS 5 11]
-theorem green_1 : (∃ Ω : ℕ → ℝ, atTop.Tendsto Ω atTop ∧
+theorem green_1 : answer(sorry) ↔ ∃ Ω : ℕ → ℝ, atTop.Tendsto Ω atTop ∧
      ∀ n, ∀ (A : Finset ℕ), (∀ a ∈ A, 0 < a) → A.card = n →
-     ∃ (S : Finset ℕ), S ⊆ A ∧ IsSumFree S.toSet ∧ ((n : ℝ) / 3) + Ω n ≤ S.card)
-     ↔ answer(sorry) := by
+     ∃ (S : Finset ℕ), S ⊆ A ∧ IsSumFree S.toSet ∧ ((n : ℝ) / 3) + Ω n ≤ S.card := by
   sorry
 
 -- TODO(firsching): add known/related results here.

--- a/FormalConjectures/Mathoverflow/1973.lean
+++ b/FormalConjectures/Mathoverflow/1973.lean
@@ -38,8 +38,8 @@ relating it to `EuclideanSpace ℂ (Fin 3)`?
 -/
 @[category research open, AMS 32]
 theorem mathoverflow_1973 :
-    (∃ atlas : ChartedSpace (EuclideanSpace ℂ (Fin 3)) (unitSphere 6),
-      IsManifold 𝓘(ℂ, EuclideanSpace ℂ (Fin 3)) 1 (unitSphere 6)) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ atlas : ChartedSpace (EuclideanSpace ℂ (Fin 3)) (unitSphere 6),
+      IsManifold 𝓘(ℂ, EuclideanSpace ℂ (Fin 3)) 1 (unitSphere 6) := by
   sorry
 
 end Mathoverflow1973

--- a/FormalConjectures/Mathoverflow/21003.lean
+++ b/FormalConjectures/Mathoverflow/21003.lean
@@ -36,7 +36,7 @@ $f : \mathbb{Q} \times \mathbb{Q} \rightarrow \mathbb{Q}$ is a bijection?
 -/
 @[category research open, AMS 12]
 theorem mathoverflow_21003 :
-    (∃ f : MvPolynomial (Fin 2) ℚ, Function.Bijective fun x ↦ f.eval x) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ f : MvPolynomial (Fin 2) ℚ, Function.Bijective fun x ↦ f.eval x := by
   sorry
 
 end Mathoverflow21003

--- a/FormalConjectures/Mathoverflow/31809.lean
+++ b/FormalConjectures/Mathoverflow/31809.lean
@@ -30,9 +30,9 @@ open CategoryTheory Limits Category Preadditive Pretriangulated
 
 /-- Does there exist a category that is pretriangulated but not triangulated? -/
 @[category research open, AMS 18]
-theorem mathoverflow_31809 : (∀ (C : Type*) [Category C] [Preadditive C]
+theorem mathoverflow_31809 : answer(sorry) ↔ (∀ (C : Type*) [Category C] [Preadditive C]
     [HasZeroObject C] [HasShift C ℤ] [∀ (n : ℤ), (shiftFunctor C n).Additive]
-    [Pretriangulated C], IsTriangulated C) ↔ answer(sorry) := by
+    [Pretriangulated C], IsTriangulated C) := by
   sorry
 
 end Mathoverflow31809

--- a/FormalConjectures/Mathoverflow/34145.lean
+++ b/FormalConjectures/Mathoverflow/34145.lean
@@ -142,14 +142,14 @@ def Configuration.IsPacking (c : Configuration) : Prop :=
 /-- Can a unit square be covered by rectangles of width `1 / (n + 1)` and height `1 / (n + 2)`? -/
 @[category research open, AMS 51]
 theorem rectangles_cover_unit_square :
-    (∃ c : Configuration, ∀ p ∈ unitSquare, ∃ n, p ∈ (c.rect n).toSet) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ c : Configuration, ∀ p ∈ unitSquare, ∃ n, p ∈ (c.rect n).toSet := by
   sorry
 
 /-- Equivalently, can a unit square be packed with rectangles of width `1 / (n + 1)` and height
 `1 / (n + 2)`? -/
 @[category research open, AMS 51]
 theorem rectangles_pack_unit_square :
-    (∃ c : Configuration, (∀ n, (c.rect n).toSet ⊆ unitSquare) ∧ c.IsPacking) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ c : Configuration, (∀ n, (c.rect n).toSet ⊆ unitSquare) ∧ c.IsPacking := by
   sorry
 
 /-- It is known that packing the rectangles into a square of side length `133/132` is possible.

--- a/FormalConjectures/Mathoverflow/347178.lean
+++ b/FormalConjectures/Mathoverflow/347178.lean
@@ -34,10 +34,9 @@ $$\sup_{x \in \mathbb R^n}f(x) = \sup_{x\in \mathbb R^n} f(x+\nabla f(x))$$?
 -/
 @[category research open, AMS 26]
 theorem mathoverflow_347178 :
-    (∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f),
+    answer(sorry) ↔ ∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f),
         (BddAbove (range f) ↔ BddAbove (range (fun x ↦ f (x + gradient f x)))) ∧
-        (⨆ x, (f x : EReal)) = ⨆ x, (f (x + gradient f x) : EReal))
-      ↔ answer(sorry) := by
+        (⨆ x, (f x : EReal)) = ⨆ x, (f (x + gradient f x) : EReal) := by
   sorry
 
 /--
@@ -46,9 +45,8 @@ $\sup_{x \in \mathbb R^n}f(x)$ and $\sup_{x\in \mathbb R^n} f(x+\nabla f(x))$ eq
 -/
 @[category research open, AMS 26]
 theorem mathoverflow_347178.variants.bounded_iff :
-    (∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f),
-        (BddAbove (range f) ↔ BddAbove (range (fun x ↦ f (x + gradient f x)))))
-      ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f),
+        (BddAbove (range f) ↔ BddAbove (range (fun x ↦ f (x + gradient f x)))) := by
   sorry
 
 /--
@@ -58,10 +56,9 @@ hold when both suprema are finite?
 -/
 @[category research open, AMS 26]
 theorem mathoverflow_347178.variants.bounded_only :
-    (∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f)
+    answer(sorry) ↔ ∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f)
         (h : BddAbove (range f)) (h' : BddAbove (range (fun x ↦ f (x + gradient f x)))),
-        (⨆ x, f x) = ⨆ x, f (x + gradient f x))
-      ↔ answer(sorry) := by
+        (⨆ x, f x) = ⨆ x, f (x + gradient f x) := by
   sorry
 
 end Mathoverflow347178

--- a/FormalConjectures/Mathoverflow/347178.lean
+++ b/FormalConjectures/Mathoverflow/347178.lean
@@ -46,7 +46,7 @@ $\sup_{x \in \mathbb R^n}f(x)$ and $\sup_{x\in \mathbb R^n} f(x+\nabla f(x))$ eq
 @[category research open, AMS 26]
 theorem mathoverflow_347178.variants.bounded_iff :
     answer(sorry) ↔ ∀ᵉ (n ≥ 2) (f : ℝ^n → ℝ) (hf : ContDiff ℝ 1 f),
-        (BddAbove (range f) ↔ BddAbove (range (fun x ↦ f (x + gradient f x)))) := by
+        BddAbove (range f) ↔ BddAbove (range fun x ↦ f (x + gradient f x)) := by
   sorry
 
 /--

--- a/FormalConjectures/Mathoverflow/486451.lean
+++ b/FormalConjectures/Mathoverflow/486451.lean
@@ -35,9 +35,9 @@ theorem exists_semiring_unique_left_maximal_not_unique_right_maximal :
 which are not the same as sets. -/
 @[category research open, AMS 16]
 theorem exists_semiring_unique_left_right_maximal_ne :
-    (∃ (R : Type) (_ : Semiring R) (hI : ∃! I : Ideal R, I.IsMaximal)
+    answer(sorry) ↔ ∃ (R : Type) (_ : Semiring R) (hI : ∃! I : Ideal R, I.IsMaximal)
       (hJ : ∃! J : Ideal Rᵐᵒᵖ, J.IsMaximal),
-        (hI.choose : Set R) ≠ MulOpposite.op ⁻¹' hJ.choose) ↔ answer(sorry) := by
+        (hI.choose : Set R) ≠ MulOpposite.op ⁻¹' hJ.choose := by
   sorry
 
 end Mathoverflow486451

--- a/FormalConjectures/Mathoverflow/75792.lean
+++ b/FormalConjectures/Mathoverflow/75792.lean
@@ -182,8 +182,8 @@ theorem Reachable.five_pow_six : Reachable (5^6) 29 :=
 
 /-- Is `5n` the complexity of `5^n` for `0 < n`? Answer: No.-/
 @[category research solved, AMS 11]
-theorem complexity_five_pow : (∀ n : ℕ, 0 < n → complexity (5 ^ n) = 5 * n) ↔ answer(False) := by
-  simp only [iff_false, not_forall]
+theorem complexity_five_pow : answer(False) ↔ ∀ n : ℕ, 0 < n → complexity (5 ^ n) = 5 * n := by
+  simp [false_iff, not_forall]
   exact ⟨6, by decide, fun h ↦ absurd (h ▸ Reachable.five_pow_six.complexity_le) (by decide)⟩
 
 /-- Is `3n` the complexity of `3^n` for `0 < n`? Answer: Yes, by John Selfridge.
@@ -191,12 +191,12 @@ theorem complexity_five_pow : (∀ n : ℕ, 0 < n → complexity (5 ^ n) = 5 * n
 Reference: https://arxiv.org/abs/1207.4841
 -/
 @[category research solved, AMS 11]
-theorem complexity_three_pow : (∀ n : ℕ, 0 < n → complexity (3 ^ n) = 3 * n) ↔ answer(True) := by
+theorem complexity_three_pow : answer(True) ↔ ∀ n : ℕ, 0 < n → complexity (3 ^ n) = 3 * n := by
   sorry
 
 /-- Is `2n` the complexity of `2^n` for `0 < n`? -/
 @[category research open, AMS 11]
-theorem complexity_two_pow : (∀ n : ℕ, 0 < n → complexity (2 ^ n) = 2 * n) ↔ answer(sorry) := by
+theorem complexity_two_pow : answer(sorry) ↔ ∀ n : ℕ, 0 < n → complexity (2 ^ n) = 2 * n := by
   sorry
 
 end Mathoverflow75792

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -204,7 +204,7 @@ theorem beaver_math_olympiad_problem_5 : answer(sorry) ↔
     (a_ini : a 0 = 0) (b_ini : b 0 = 5)
     (a_rec : ∀ n, a (n + 1) = if f (a n) ≤ b n then a n + 1 else a n)
     (b_rec : ∀ n, b (n+1) = if f (a n) ≤ b n then b n - f (a n) else 3 * b n + a n + 5),
-    (∃ i, b i = (f (a i)) - 1) := by
+    ∃ i, b i = f (a i) - 1 := by
   sorry
 
 end BusyBeaverMathOlympiad

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -71,7 +71,7 @@ theorem busy_beaver_math_olympiad_problem_1 :
     (a_rec : ∀ n, a (n + 1) = if b n ≤ a n then a n - b n else 2 * a n + 1)
     (b_ini : b 0 = 2)
     (b_rec : ∀ n, b (n + 1) = if b n ≤ a n then 4 * b n + 2 else b n - a n),
-    (∃ i, a i = b i) := by
+    ∃ i, a i = b i := by
   sorry
 
 /--

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -59,19 +59,19 @@ The first 10 values of $(a_n, b_n)$ are $(1, 2), (3, 1), (2, 6), (5, 4), (1, 18)
 [`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated
-using `↔ answer(sorry)`.
+using `answer(sorry) ↔`.
 
 The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jason Yuen on
 June 25th 2024.
 -/
 @[category research open, AMS 5 11 68]
 theorem busy_beaver_math_olympiad_problem_1 :
-    (∀ᵉ (a : ℕ → ℕ) (b : ℕ → ℕ)
+    answer(sorry) ↔ ∀ᵉ (a : ℕ → ℕ) (b : ℕ → ℕ)
     (a_ini : a 0 = 1)
     (a_rec : ∀ n, a (n + 1) = if b n ≤ a n then a n - b n else 2 * a n + 1)
     (b_ini : b 0 = 2)
     (b_rec : ∀ n, b (n + 1) = if b n ≤ a n then 4 * b n + 2 else b n - a n),
-    (∃ i, a i = b i)) ↔ answer(sorry) := by
+    (∃ i, a i = b i) := by
   sorry
 
 /--
@@ -190,7 +190,7 @@ Does there exist a positive integer $i$ such that $b_i = f(a_i)-1$?
 [`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated
-using `↔ answer(sorry)`.
+using `answer(sorry) ↔`.
 
 The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor mxdys
 on August 7th 2024.
@@ -199,12 +199,12 @@ The correspondence between the machine's halting problem and the below reformula
 in [Rocq](https://github.com/ccz181078/busycoq/blob/BB6/verify/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE.v).
 -/
 @[category research open, AMS 5 11 68]
-theorem beaver_math_olympiad_problem_5
-    (a b f : ℕ → ℕ) (hf : f = fun x ↦ 10 * 2 ^ x - 1)
+theorem beaver_math_olympiad_problem_5 : answer(sorry) ↔
+    ∀ (a b f : ℕ → ℕ), ∀ᵉ (hf : f = fun x ↦ 10 * 2 ^ x - 1)
     (a_ini : a 0 = 0) (b_ini : b 0 = 5)
     (a_rec : ∀ n, a (n + 1) = if f (a n) ≤ b n then a n + 1 else a n)
-    (b_rec : ∀ n, b (n+1) = if f (a n) ≤ b n then b n - f (a n) else 3 * b n + a n + 5) :
-    (∃ i, b i = (f (a i)) - 1) ↔ answer(sorry) := by
+    (b_rec : ∀ n, b (n+1) = if f (a n) ≤ b n then b n - f (a n) else 3 * b n + a n + 5),
+    (∃ i, b i = (f (a i)) - 1) := by
   sorry
 
 end BusyBeaverMathOlympiad

--- a/FormalConjectures/Paper/HartshorneConjecture.lean
+++ b/FormalConjectures/Paper/HartshorneConjecture.lean
@@ -43,7 +43,7 @@ local instance (X : TopologicalSpace.Opens S) :
     ((Opens.grothendieckTopology S).over X)
 
 local instance (X : TopologicalSpace.Opens S) :
-    ((Opens.grothendieckTopology S).over X).WEqualsLocallyBijective (AddCommGrp.{u}):=
+    ((Opens.grothendieckTopology S).over X).WEqualsLocallyBijective (AddCommGrp.{u}) :=
   inferInstance
 
 /--

--- a/FormalConjectures/Paper/Rupert.lean
+++ b/FormalConjectures/Paper/Rupert.lean
@@ -104,7 +104,6 @@ Does the Rupert property hold for every convex polyhedron with nonempty interior
 -/
 @[category research open, AMS 52]
 theorem is_every_convex_polyhedron_rupert :
-    (∀ (vertices : Finset ℝ³),
-       (interior (convexHull ℝ vertices : Set ℝ³)).Nonempty → IsRupert vertices)
-      ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ (vertices : Finset ℝ³),
+       (interior (convexHull ℝ vertices : Set ℝ³)).Nonempty → IsRupert vertices := by
  sorry

--- a/FormalConjectures/Wikipedia/BoundedBurnsideProblem.lean
+++ b/FormalConjectures/Wikipedia/BoundedBurnsideProblem.lean
@@ -30,9 +30,8 @@ $g^n = 1$. Is $G$ necessarily finite?
 -/
 @[category research open, AMS 20]
 theorem bounded_burnside_problem :
-    (∀ (G : Type) [Group G] (fin_gen : Group.FG G)
-      (n : ℕ) (hn : n > 0) (bounded : ∀ g : G, g^n = 1), Finite G) ↔
-    answer(sorry) := by
+    answer(sorry) ↔ ∀ (G : Type) [Group G] (fin_gen : Group.FG G)
+      (n : ℕ) (hn : n > 0) (bounded : ∀ g : G, g^n = 1), Finite G := by
   sorry
 
 end BoundedBurnsideProblem

--- a/FormalConjectures/Wikipedia/Conway99Graph.lean
+++ b/FormalConjectures/Wikipedia/Conway99Graph.lean
@@ -59,8 +59,8 @@ one of the two diagonals of a unique 4-cycle.
 The first condition is equivalent to being locally linear.
 -/
 @[category research open, AMS 5]
-theorem conway99Graph : (∃ G : SimpleGraph (Fin 99),
-    G.LocallyLinear ∧ NonEdgesAreDiagonals G) ↔ answer(sorry) := by
+theorem conway99Graph : answer(sorry) ↔ ∃ G : SimpleGraph (Fin 99),
+    G.LocallyLinear ∧ NonEdgesAreDiagonals G := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/Euclid.lean
+++ b/FormalConjectures/Wikipedia/Euclid.lean
@@ -33,14 +33,14 @@ noncomputable def Euclid (n : ℕ) : ℕ := 1 + ∏ i ∈ Finset.range n, i.nth 
 It is not known whether there is an inifinite number of prime Euclid numbers.
 -/
 @[category research open, AMS 11]
-theorem infinite_prime_euclid_numbers : {n | (Euclid n).Prime}.Infinite ↔ answer(sorry) := by
+theorem infinite_prime_euclid_numbers : answer(sorry) ↔ {n | (Euclid n).Prime}.Infinite := by
   sorry
 
 /--
 It is not known whether every Euclid number is a square-free number.
 -/
 @[category research open, AMS 11]
-theorem euclid_numbers_are_square_free : (∀ n, Squarefree (Euclid n)) ↔ answer(sorry) := by
+theorem euclid_numbers_are_square_free : answer(sorry) ↔ (∀ n, Squarefree (Euclid n)) := by
   sorry
 
 end EuclidNumbers

--- a/FormalConjectures/Wikipedia/EulerBrick.lean
+++ b/FormalConjectures/Wikipedia/EulerBrick.lean
@@ -49,7 +49,7 @@ Is there a perfect Euler brick?
 -/
 @[category research open, AMS 11]
 theorem perfect_euler_brick_existence :
-    (∃ a b c : ℕ+, IsPerfectCuboid a b c) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ a b c : ℕ+, IsPerfectCuboid a b c := by
   sorry
 
 /--
@@ -57,7 +57,7 @@ Is there an Euler brick in $4$-dimensional space?
 -/
 @[category research open, AMS 11]
 theorem four_dim_euler_brick_existence :
-    (∃ sides : Fin 4 → ℕ+, IsEulerHyperBrick 4 sides) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ sides : Fin 4 → ℕ+, IsEulerHyperBrick 4 sides:= by
   sorry
 
 /--
@@ -65,7 +65,7 @@ Is there an Euler brick in $n$-dimensional space for any $n > 3$?
 -/
 @[category research open, AMS 11]
 theorem n_dim_euler_brick_existence :
-    (∀ n > 3, ∃ sides : Fin n → ℕ+, IsEulerHyperBrick n sides) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ n > 3, ∃ sides : Fin n → ℕ+, IsEulerHyperBrick n sides := by
   sorry
 
 end EulerBrick

--- a/FormalConjectures/Wikipedia/Fermat.lean
+++ b/FormalConjectures/Wikipedia/Fermat.lean
@@ -28,28 +28,28 @@ namespace Fermat
 Are Fermat numbers composite for all `n > 4`?
 -/
 @[category research open, AMS 11]
-theorem fermat_number_are_composite : (∀ n > 4, ¬Prime n.fermatNumber) ↔ answer(sorry) := by
+theorem fermat_number_are_composite : answer(sorry) ↔ ∀ n > 4, ¬Prime n.fermatNumber := by
   sorry
 
 /--
 Are there infinitely many Fermat primes?
 -/
 @[category research open, AMS 11]
-theorem infinite_fermat_primes : Infinite {n : ℕ | Prime n.fermatNumber} ↔ answer(sorry) := by
+theorem infinite_fermat_primes : answer(sorry) ↔ Infinite {n : ℕ | Prime n.fermatNumber} := by
   sorry
 
 /--
 Are there infinitely many composite Fermat numbers?
 -/
 @[category research open, AMS 11]
-theorem infinite_fermat_composite : Infinite {n : ℕ | ¬Prime n.fermatNumber} ↔ answer(sorry) := by
+theorem infinite_fermat_composite : answer(sorry) ↔ Infinite {n : ℕ | ¬Prime n.fermatNumber} := by
   sorry
 
 /--
 Are all Fermat numbers are square-free?
 -/
 @[category research open, AMS 11]
-theorem all_fermat_squarefree : (∀ (n : ℕ), Squarefree n.fermatNumber) ↔ answer(sorry) := by
+theorem all_fermat_squarefree : answer(sorry) ↔ (∀ (n : ℕ), Squarefree n.fermatNumber) := by
   sorry
 
 end Fermat

--- a/FormalConjectures/Wikipedia/Fermat.lean
+++ b/FormalConjectures/Wikipedia/Fermat.lean
@@ -49,7 +49,7 @@ theorem infinite_fermat_composite : answer(sorry) ↔ Infinite {n : ℕ | ¬Prim
 Are all Fermat numbers are square-free?
 -/
 @[category research open, AMS 11]
-theorem all_fermat_squarefree : answer(sorry) ↔ (∀ (n : ℕ), Squarefree n.fermatNumber) := by
+theorem all_fermat_squarefree : answer(sorry) ↔ ∀ n : ℕ, Squarefree n.fermatNumber := by
   sorry
 
 end Fermat

--- a/FormalConjectures/Wikipedia/InscribedSquare.lean
+++ b/FormalConjectures/Wikipedia/InscribedSquare.lean
@@ -50,8 +50,8 @@ Does every Jordan curve admit an inscribed square?
 -/
 @[category research open, AMS 51]
 theorem inscribed_square_problem :
-    (∀ (γ : Circle → ℝ²) (hγ : IsEmbedding γ),
-      ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) 1) ↔ answer(sorry) :=
+    answer(sorry) ↔ ∀ (γ : Circle → ℝ²) (hγ : IsEmbedding γ),
+      ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) 1 :=
   sorry
 
 /--
@@ -60,8 +60,8 @@ Does every Jordan curve admit inscribed rectangles of any given aspect ratio?
 -/
 @[category research open, AMS 51]
 theorem inscribed_rectangle_problem :
-    (∀ (γ : Circle → ℝ²) (hγ : IsEmbedding γ) (r : ℝ) (hr : r > 0),
-      ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) r) ↔ answer(sorry) :=
+    answer(sorry) ↔ ∀ (γ : Circle → ℝ²) (hγ : IsEmbedding γ) (r : ℝ) (hr : r > 0),
+      ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) r :=
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/Irrational.lean
+++ b/FormalConjectures/Wikipedia/Irrational.lean
@@ -34,7 +34,7 @@ namespace Irrational
 /-- Are $e$ and $\pi$ algebraically independent? -/
 @[category research open, AMS 33]
 theorem algebraicIndependent_e_pi :
-    AlgebraicIndependent ℚ ![e, π] ↔ answer(sorry) := by
+    answer(sorry) ↔ AlgebraicIndependent ℚ ![e, π] := by
   sorry
 
 /--
@@ -42,7 +42,7 @@ Is $e + \pi$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_e_plus_pi :
-    Irrational (e + π) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (e + π) := by
   sorry
 
 /--
@@ -50,7 +50,7 @@ Is $e \pi$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_e_times_pi :
-    Irrational (e * π) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (e * π) := by
   sorry
 
 /--
@@ -58,7 +58,7 @@ Is $e ^ e$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_e_to_e :
-    Irrational (e ^ e) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (e ^ e) := by
   sorry
 
 /--
@@ -66,7 +66,7 @@ Is $\pi ^ e$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_pi_to_e :
-    Irrational (π ^ e) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (π ^ e) := by
   sorry
 
 /--
@@ -74,7 +74,7 @@ Is $\pi ^ \pi$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_pi_to_pi :
-    Irrational (π ^ π) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (π ^ π) := by
   sorry
 
 /--
@@ -82,7 +82,7 @@ Is $\ln(\pi)$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_ln_pi :
-    Irrational (log π) ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational (log π) := by
   sorry
 
 /--
@@ -90,7 +90,7 @@ Is the Euler-Mascheroni constant $\gamma$ irrational?
 -/
 @[category research open, AMS 33]
 theorem irrational_eulerMascheroniConstant :
-    Irrational eulerMascheroniConstant ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational eulerMascheroniConstant := by
   sorry
 
 /--
@@ -98,7 +98,7 @@ Is the Catalan constant $$G = \sum_{n=0}^∞ (-1)^n / (2n + 1)^2 \approx 0.91596
 -/
 @[category research open, AMS 11 33]
 theorem irrational_catalanConstant :
-    Irrational catalanConstant ↔ answer(sorry) := by
+    answer(sorry) ↔ Irrational catalanConstant := by
   sorry
 
 end Irrational

--- a/FormalConjectures/Wikipedia/LegendreConjecture.lean
+++ b/FormalConjectures/Wikipedia/LegendreConjecture.lean
@@ -34,8 +34,7 @@ Does there always exist at least one prime between consecutive perfect squares?
 -/
 @[category research open, AMS 11]
 theorem legendre_conjecture :
-    (∀ᵉ (n ≥ 1), ∃ p ∈ Set.Ioo (n^2) ((n+1)^2), Prime p)
-      ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ᵉ (n ≥ 1), ∃ p ∈ Set.Ioo (n^2) ((n+1)^2), Prime p := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/LehmerTotient.lean
+++ b/FormalConjectures/Wikipedia/LehmerTotient.lean
@@ -30,7 +30,7 @@ $\varphi(n)$ divides $n - 1$?
 -/
 @[category research open, AMS 11]
 theorem lehmer_totient :
-    (∃ n > 1, ¬Prime n ∧ Nat.totient n ∣ n - 1) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∃ n > 1, ¬Prime n ∧ Nat.totient n ∣ n - 1 := by
   sorry
 
 end LehmerTotient

--- a/FormalConjectures/Wikipedia/MagicSquareOfSquares.lean
+++ b/FormalConjectures/Wikipedia/MagicSquareOfSquares.lean
@@ -33,14 +33,13 @@ and all rows, columns, and diagonals add up to the same value?
 -/
 @[category research open, AMS 11]
 theorem exists_magic_square_squares :
-    (∃ m : Fin 3 → Fin 3 → ℕ, ∃ t : ℕ,
+    answer(sorry) ↔ ∃ m : Fin 3 → Fin 3 → ℕ, ∃ t : ℕ,
        m.Injective2 ∧
        (∀ i j, IsSquare (m i j)) ∧
        ∀ i, ∑ j, m i j = t ∧
        ∀ j, ∑ i, m i j = t ∧
        m 0 0 + m 1 1 + m 2 2 = t ∧
-       m 0 2 + m 1 1 + m 2 0 = t)
-     ↔ answer(sorry) := by
+       m 0 2 + m 1 1 + m 2 0 = t := by
   sorry
 
 end MagicSquareOfSquares

--- a/FormalConjectures/Wikipedia/Mersenne.lean
+++ b/FormalConjectures/Wikipedia/Mersenne.lean
@@ -90,7 +90,7 @@ Are there infinitely many Mersenne primes?
 -/
 @[category research open, AMS 11]
 theorem infinitely_many_mersenne_primes :
-  Set.Infinite { p : ℕ | p.GivesMersennePrime } ↔ answer(sorry) := by
+  answer(sorry) ↔ Set.Infinite { p : ℕ | p.GivesMersennePrime } := by
     sorry
 
 end Mersenne

--- a/FormalConjectures/Wikipedia/NoetherProblem.lean
+++ b/FormalConjectures/Wikipedia/NoetherProblem.lean
@@ -63,9 +63,9 @@ indeterminates over `K`. Is it true that `L/K` has the Noether property?
 Solution: False.
 -/
 @[category research solved, AMS 12 14]
-theorem noether_problem : (∀ (K L ι G : Type)
+theorem noether_problem : answer(sorry) ↔ ∀ (K L ι G : Type)
     [Field K] [Field L] [Fintype ι] [Algebra K L] [IsRationalExtension K L ι],
-    HasNoetherProperty K L ι) ↔ answer(False) := by
+    HasNoetherProperty K L ι := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/NoetherProblem.lean
+++ b/FormalConjectures/Wikipedia/NoetherProblem.lean
@@ -63,7 +63,7 @@ indeterminates over `K`. Is it true that `L/K` has the Noether property?
 Solution: False.
 -/
 @[category research solved, AMS 12 14]
-theorem noether_problem : answer(sorry) ↔ ∀ (K L ι G : Type)
+theorem noether_problem : answer(False) ↔ ∀ (K L ι G : Type)
     [Field K] [Field L] [Fintype ι] [Algebra K L] [IsRationalExtension K L ι],
     HasNoetherProperty K L ι := by
   sorry

--- a/FormalConjectures/Wikipedia/PrimesAndPerfectSquares.lean
+++ b/FormalConjectures/Wikipedia/PrimesAndPerfectSquares.lean
@@ -30,7 +30,7 @@ Are there infinitely many primes $p$ such that $p - 1$ is a perfect square? In o
 -/
 @[category research open, AMS 11]
 theorem infinite_prime_sq_add_one :
-    {n : ℕ | Prime (n^2 + 1)}.Infinite ↔ answer(sorry):= by
+    answer(sorry) ↔ {n : ℕ | Prime (n^2 + 1)}.Infinite := by
   sorry
 
 end PrimesAndPerfectSquares

--- a/FormalConjectures/Wikipedia/RationalDistanceProblem.lean
+++ b/FormalConjectures/Wikipedia/RationalDistanceProblem.lean
@@ -39,7 +39,7 @@ Does there exist a point in the plane at rational distance from all four vertice
 -/
 @[category research open, AMS 11 51]
 theorem rational_distance_problem :
-  (∃ P : ℝ² , ∀ i, ¬ Irrational (dist P (UnitSquareCorners i))) ↔ answer(sorry) := by
-    sorry
+    answer(sorry) ↔ ∃ P : ℝ² , ∀ i, ¬ Irrational (dist P (UnitSquareCorners i)) := by
+  sorry
 
 end RationalDistanceProblem

--- a/FormalConjectures/Wikipedia/SumOfThreeCubes.lean
+++ b/FormalConjectures/Wikipedia/SumOfThreeCubes.lean
@@ -88,7 +88,7 @@ theorem isSumOfThreeCubesRat_any (r : ℚ) : IsSumOfThreeCubes r := by
 `n` is not `4` or `5` mod `9`. -/
 @[category research open, AMS 11]
 theorem isSumOfThreeCubes_iff_mod_9 :
-    (∀ n : ℤ, IsSumOfThreeCubes n ↔ ¬(n ≡ 4 [ZMOD 9] ∨ n ≡ 5 [ZMOD 9])) ↔ answer(sorry) := by
+    answer(sorry) ↔ ∀ n : ℤ, IsSumOfThreeCubes n ↔ ¬(n ≡ 4 [ZMOD 9] ∨ n ≡ 5 [ZMOD 9]) := by
   sorry
 
 end SumOfThreeCubes

--- a/FormalConjectures/Wikipedia/TwinPrimes.lean
+++ b/FormalConjectures/Wikipedia/TwinPrimes.lean
@@ -32,7 +32,7 @@ Are there infinitely many primes p such that p + 2 is prime?
 -/
 @[category research open, AMS 11]
 theorem twin_primes :
-    {p : ℕ | Prime p ∧ Prime (p + 2)}.Infinite ↔ answer(sorry) := by
+    answer(sorry) ↔ {p : ℕ | Prime p ∧ Prime (p + 2)}.Infinite := by
   sorry
 
 end TwinPrimes

--- a/FormalConjectures/Wikipedia/conjecture_1_3_to_2_3.lean
+++ b/FormalConjectures/Wikipedia/conjecture_1_3_to_2_3.lean
@@ -33,12 +33,11 @@ The set of all total order extensions is represented as order preserving
 bijections $P$ of $1, ..., n$.
 -/
 @[category research open, AMS 6]
-theorem conjecture_1_3_to_2_3 : (∀ (P : Type) [Finite P] [PartialOrder P]
+theorem conjecture_1_3_to_2_3 : answer(sorry) ↔ ∀ (P : Type) [Finite P] [PartialOrder P]
     (not_total : ¬ IsTotal P (· ≤ ·)) (total_ext : Set <| OrderHom P ℕ)
     (total_ext_def : ∀ σ, σ ∈ total_ext ↔ Set.range σ = Set.Icc 1 (Nat.card P)),
     ∃ x y : P, ({σ ∈ total_ext | σ x < σ y}.ncard / total_ext.ncard : ℚ)
-      ∈ Set.Icc (1/3) (2/3)) ↔
-    answer(sorry ) := by
+      ∈ Set.Icc (1/3) (2/3) := by
   sorry
 
 end Conjecture_1_3_to_2_3

--- a/README.md
+++ b/README.md
@@ -236,9 +236,12 @@ meaningful solution of the problem is outside of the scope of this repository.
     use `answer(sorry)` in the following way:
     ```lean
     /-- English version: "Does P hold ?" -/
-    theorem myConjecture : P ↔ answer(sorry) := by
+    theorem myConjecture : answer(sorry) ↔ P := by
       sorry
-    ```
+    ```.
+    This way the informal "Does ...", "Are there ..." or "Is it true that ..." corresponds
+    to the `answer(sorry)` in the formalised statement.
+
     If the problem has been solved, `answer(sorry)` should be replaced by
     `answer(True)` or `answer(False)` accordingly.
     If the problem is not stated as a question, the following style is preferred:


### PR DESCRIPTION
This changes occurrences of  `... ↔ .nswer(sorry)` with `answer(sorry) ↔ ...`, which is hopefully less error prone. (In fact we fix some bugs this way here)

Drive-by: adding some line break here and there in order to satisfy the 100 character limit.