### PR TITLE
feat(ErdosProblems): 152

### DIFF
--- a/FormalConjectures/ErdosProblems/152.lean
+++ b/FormalConjectures/ErdosProblems/152.lean
@@ -35,7 +35,7 @@ namespace Erdos152
 ranges over all Sidon sets of size `n`. -/
 noncomputable def f (n : ℕ) : ℕ :=
   ⨅ A : {A : Set ℕ | A.ncard = n ∧ IsSidon A},
-  {s : ℕ | s - 1 ∉ A.1 + A.1 ∧ s ∈ A.1 ∧ s + 1 ∉ A.1 + A.1}.ncard
+  {s : ℕ | s - 1 ∉ A.1 + A.1 ∧ s ∈ A.1 + A.1 ∧ s + 1 ∉ A.1 + A.1}.ncard
 
 /-- Must `lim f n = ∞`? -/
 @[category research open, AMS 5]


### PR DESCRIPTION
Closes #389

Some remarks:

1. In the paper [ESS94] On Sum Sets of Sidon Sets, the authors formulate this conjecture by using limit, which will be equivalent to the formulation on the website. The limit formulation is easier to formalize and this is why I defined the function `f`. This definition of `f` also makes it easier to talk about the growth rate.
2. For the conjecture related to infinite Sidon sets, one needs the results in the PR #1481, so I left it as a TODO.
<img width="1052" height="413" alt="Screenshot 2026-01-06 at 1 40 26 AM" src="https://github.com/user-attachments/assets/28b211a9-0c66-4089-972e-a722939ffc45" />
