### PR TITLE
feat(OEIS/A281976): sum of four squares with square conditions

### DIFF
--- a/FormalConjectures/OEIS/281976.lean
+++ b/FormalConjectures/OEIS/281976.lean
@@ -41,7 +41,7 @@ def IsSumOfFourSquaresWithSquareConditions (n : ℕ) : Prop :=
 
 @[category test, AMS 11]
 theorem isSumOfFourSquaresWithSquareConditions_0 : IsSumOfFourSquaresWithSquareConditions 0 :=
-  ⟨0, 0, 0, 0, by norm_num, by norm_num, ⟨0, by norm_num⟩, ⟨0, by norm_num⟩⟩
+  ⟨0, 0, 0, 0, by norm_num⟩
 
 @[category test, AMS 11]
 theorem isSumOfFourSquaresWithSquareConditions_8 : IsSumOfFourSquaresWithSquareConditions 8 :=


### PR DESCRIPTION
Closes #1485

### Summary
Adds formalization of Zhi-Wei Sun's conjecture from OEIS A281976: any integer $n \geq 0$ can be written as $x^2 + y^2 + z^2 + w^2$ with $x, y, z, w$ nonnegative integers and $z \leq w$, such that both $x$ and $x + 24y$ are squares.

### Changes
- Created `FormalConjectures/OEIS/281976.lean` with:
  - Predicate `IsSumOfFourSquaresWithSquareConditions` defining the representation
  - Five test cases (n = 0, 8, 12, 23, 24) from OEIS examples
  - Main conjecture statement with appropriate attributes
  - References to related papers

### Reference
- [OEIS A281976](https://oeis.org/A281976)
- Main research paper
Zhi-Wei Sun, “Refining Lagrange’s four-square theorem”, Journal of Number Theory 175 (2017), 167–190.
https://doi.org/10.1016/j.jnt.2016.11.008
- Related preprint
Zhi-Wei Sun, “Restricted sums of four squares”, arXiv:1701.05868 [math.NT], 2017.
https://arxiv.org/abs/1701.05868

Please let me know if there's any issue with the PR.