### PR TITLE
fix(ErdosProblems/274): allow repeated subgroups in the covering

### DIFF
--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -64,7 +64,7 @@ of the cosets.)
 theorem erdos_274.variants.abelian {G : Type*} [Fintype G] [CommGroup G]
     (hG : 1 < Fintype.card G) {ι : Type*} [Fintype ι] (P : Group.ExactCovering G ι)
     (hι : 1 < Fintype.card ι) :
-    ∃ i j, P.parts i ≠ P.parts j ∧ #(P.parts i) = #(P.parts j) := by
+    ∃ i j, i ≠ j ∧ #(P.parts i) = #(P.parts j) := by
   sorry
 
 /--
@@ -77,7 +77,7 @@ indices $[G:G_1], \dots, [G:G_k]$ cannot be distinct.
 @[category research open, AMS 20]
 theorem herzog_schonheim {G : Type*} [Group G] (hG : 1 < ENat.card G) {ι : Type*} [Fintype ι]
     (hι : 1 < Fintype.card ι) (P : Group.ExactCovering G ι) :
-    ∃ i j, P.parts i ≠ P.parts j ∧ (P.parts i).index = (P.parts j).index := by
+    ∃ i j, i ≠ j ∧ (P.parts i).index = (P.parts j).index := by
   sorry
 
 end Erdos274


### PR DESCRIPTION
There may be repetition in the subgroups used in the covering, so asserting there are always two distinct subgroups is too strong. For example, in the group with two elements, the conjecture is seen to be true, but only by using the (repeated) trivial subgroup {1} and representatives {1, 2}.