### PR TITLE
fix(ErdosProblems/859): make density vary in `t`

### DIFF
--- a/FormalConjectures/ErdosProblems/859.lean
+++ b/FormalConjectures/ErdosProblems/859.lean
@@ -38,7 +38,7 @@ from above by `1 / log (t) ^ c₄` for some positive constants `c₃` and `c₄`
 -/
 @[category research solved, AMS 11]
 theorem erdos_859.variants.erdos_upper_lower_bounds : ∃ᵉ (c₃ > (0 : ℝ)) (c₄ > (0 : ℝ)) (t₀ : ℕ),
-    ∀\^f t in atTop, ∃ dₜ : ℝ, (DivisorSumSet t).HasDensity dₜ ∧
+    ∀ᶠ t in atTop, ∃ dₜ : ℝ, (DivisorSumSet t).HasDensity dₜ ∧
     1 / Real.log t ^ c₃ < dₜ ∧ dₜ < 1 / Real.log t ^ c₄ := by
   sorry
 


### PR DESCRIPTION
- The LHS of the previous version was a constant function within the asymptotic equivalence. It needs to vary with t.
- Fix typing of some constants which were previously inferred as Nat

Closes #1542