### PR TITLE
feat(OEIS/232174): representations with prime conditions

### DIFF
--- a/FormalConjectures/OEIS/232174.lean
+++ b/FormalConjectures/OEIS/232174.lean
@@ -27,8 +27,9 @@ Zhi-Wei Sun has offered a $200 prize for the first proof.
 *References:*
 - [OEIS A232174](https://oeis.org/A232174)
 - Z.-W. Sun, "Conjectures on representations involving primes," in: M. Nathanson (ed.),
-  Combinatorial and Additive Number Theory II: CANT, Springer, 2017, pp. 279-310.
-  (See also arXiv:1211.1588 [math.NT].)
+  Combinatorial and Additive Number Theory II: CANT, Springer Proc. in Math. & Stat.,
+  Vol. 220, Springer, 2017, pp. 279-310. https://arxiv.org/abs/1211.1588
+- D.A. Cox, "Primes of the Form x² + ny²," John Wiley & Sons, 1989.
 -/
 
 namespace OeisA232174
@@ -59,4 +60,3 @@ theorem conjecture (n : ℕ) (hn : 1 < n) : HasPrimeRepresentation n := by
   sorry
 
 end OeisA232174
-


### PR DESCRIPTION
Closes #1490

### Summary
Adds formalization of Zhi-Wei Sun's conjecture from OEIS A232174: any integer $n > 1$ can be written as $x + y$ with $x, y > 0$ such that both $x + ny$ and $x^2 + ny^2$ are prime.

### Changes
- Created `FormalConjectures/OEIS/232174.lean` with:
  - Predicate `HasPrimeRepresentation` defining the representation
  - Three test cases (n = 2, 5, 8) from OEIS examples
  - Main conjecture statement with appropriate attributes

### Reference
- [OEIS A232174](https://oeis.org/A232174)
- Z.-W. Sun, "Conjectures on representations involving primes," arXiv:1211.1588
- D.A. Cox, "Primes of the Form x² + ny²," John Wiley & Sons, 1989.

let me know if any changes are needed. 