### PR TITLE
fix(ErdosProblems/33)

### DIFF
--- a/FormalConjectures/ErdosProblems/33.lean
+++ b/FormalConjectures/ErdosProblems/33.lean
@@ -41,10 +41,8 @@ for some `a` in `A` and `n ≥ 0`. What is the smallest possible value of
 `lim sup n → ∞ |A ∩ {1, …, N}| / N^(1/2)`?
 -/
 @[category research open, AMS 11]
-theorem erdos_33 : IsLeast
-    { c : EReal | ∃ (A : Set ℕ), AdditiveBasisCondition A ∧
-      Filter.atTop.limsup (fun N => (A.interIcc 1 N).ncard / √N) = c}
-    answer(sorry) := by
+theorem erdos_33 : ⨅ A : {A : Set ℕ | AdditiveBasisCondition A}, Filter.atTop.limsup (fun N =>
+    (A.1.interIcc 1 N).ncard / (√N : EReal)) = answer(sorry) := by
   sorry
 
 /--


### PR DESCRIPTION
Closes #1543

van Doorn's constructions implies that there exists a set `A` such that `lim sup |A ∩ {1, …, N}| / N^(1/2) ≤ (2 * (φ ^ (5 / 2)))`. Hence, the minimum value of `limsup` is less than `(2 * (φ ^ (5 / 2)))`.

Also fixes some typos.