### PR TITLE
fix(ErdosProblems/289): assume intervals are non-overlapping

### DIFF
--- a/FormalConjectures/ErdosProblems/289.lean
+++ b/FormalConjectures/ErdosProblems/289.lean
@@ -33,10 +33,10 @@ $$
 -/
 @[category research open, AMS 11]
 theorem erdos_289 : answer(sorry) ↔
-    (∀ᶠ k : ℕ in atTop, ∃ I : Fin k → Finset ℕ,
-      (∀ i, 2 ≤ #(I i) ∧ ∃ a b, I i = Finset.Icc a b) ∧
-      (∀ i j, i ≠ j → ∀ x ∈ I i, ∀ y ∈ I j, x + 1 < y ∨ y + 1 < x) ∧
-      ∑ i, ∑ n ∈ I i, (n⁻¹ : ℚ) = 1) := by
+    (∀ᶠ k : ℕ in atTop, ∃ I : Fin k → ℕ × ℕ,
+    (∀ i, (I i).1 < (I i).2) ∧
+    (∀ i j, i ≠ j → (I i).2 < (I j).1 ∨ (I j).2 < (I i).1) ∧
+    ∑ i, ∑ n ∈ .Icc (I i).1 (I i).2, (n⁻¹ : ℚ) = 1) := by
   sorry
 
 end Erdos289


### PR DESCRIPTION
I think the suggestion here https://www.erdosproblems.com/forum/thread/289#post-2245  makes sense, but I don't `0<a` is necessary.

Closes #1539
