### PR TITLE
feat(OEIS/280831): the 1680-Conjecture

### DIFF
--- a/FormalConjectures/OEIS/280831.lean
+++ b/FormalConjectures/OEIS/280831.lean
@@ -47,7 +47,7 @@ theorem hasSquareCondition_7 : HasSquareCondition 7 :=
 
 @[category test, AMS 11]
 theorem hasSquareCondition_95 : HasSquareCondition 95 :=
-  ⟨6, 3, 1, 7, by norm_num, ⟨216, by norm_num⟩⟩
+  ⟨6, 3, 1, 7, by norm_num, 216, by norm_num⟩
 
 /--
 **Zhi-Wei Sun's 1680-Conjecture (A280831)**: Any nonnegative integer can be written as


### PR DESCRIPTION
Closes #1488

Adds formalization of Zhi-Wei Sun's 1680-Conjecture from OEIS A280831: any nonnegative integer can be written as x² + y² + z² + w² with x, y, z, w nonnegative integers such that x⁴ + 1680y³z is a square.

Includes:
- Predicate HasSquareCondition
- Three test cases (n = 0, 7, 95) from OEIS examples

References:
- [OEIS A280831](https://oeis.org/A280831)
- Z.-W. Sun, "Refining Lagrange's four-square theorem," *J. Number Theory* **175** (2017), 167-190.
- Z.-W. Sun, "Refining Lagrange's four-square theorem," arXiv:1604.06723 [math.NT], 2016.
