### PR TITLE
feat(ErdosProblems): 1071

### DIFF
--- a/FormalConjectures/ErdosProblems/1071.lean
+++ b/FormalConjectures/ErdosProblems/1071.lean
@@ -32,7 +32,8 @@ namespace Erdos1071
 def SegmentsDisjoint (seg1 seg2 : ℝ² × ℝ²) : Prop :=
   segment ℝ seg1.1 seg1.2 ∩ segment ℝ seg2.1 seg2.2 ⊆ {seg1.1, seg1.2, seg2.1, seg2.2}
 
-/-- Can a finite set of disjoint unit segments in a unit square be maximal? -/
+/-- Can a finite set of disjoint unit segments in a unit square be maximal?
+Solved affirmatively by [Da85], who gave an explicit construction. -/
 @[category research solved, AMS 52]
 theorem erdos_1071a :
     answer(True) ↔ ∃ S : Finset (ℝ² × ℝ²),


### PR DESCRIPTION
Add formalization of Erdős Problem 1071

Formalizes both parts:
- Part (a): Finite maximal set in unit square (solved by Danzer)
- Part (b): Countably infinite maximal set in some region (open)

Uses mathlib's segment and dist primitives with simple helper definitions.

closes #1111 