### PR TITLE
feat(OEIS): add A239957 - primitive roots of the form k² + 1

### DIFF
--- a/FormalConjectures/OEIS/239957.lean
+++ b/FormalConjectures/OEIS/239957.lean
@@ -36,7 +36,7 @@ form $k^2 + 1$, where $k$ is an integer.
 -/
 @[category research open, AMS 11]
 theorem conjecture (p : ℕ) (hp : p.Prime) :
-    ∃ k : ℤ, 0 < k ^ 2 + 1 ∧ k ^ 2 + 1 < p ∧
+    ∃ k : ℤ, k ^ 2 + 1 < p ∧
       orderOf (k ^ 2 + 1 : ZMod p) = p - 1 := by
   sorry
 


### PR DESCRIPTION
## What is the conjecture

Every prime p has a primitive root 0 < g < p of the form k² + 1, where k is an integer.

Zhi-Wei Sun has offered a prize of RMB 2,000 for the first proof.

## Formalization

The conjecture is formalized as: for every prime p, there exists an integer k such that:
- 0 < k² + 1 < p
- k² + 1 is a primitive root modulo p (i.e., `orderOf (k² + 1 : ZMod p) = p - 1`)

## References

- [OEIS A239957](https://oeis.org/A239957)
- Z.-W. Sun, "New observations on primitive roots modulo primes," arXiv:1405.0290 [math.NT], 2014.

Closes #1487