### PR TITLE
feat(ErdosProblems): Collatz conjecture

### DIFF
--- a/FormalConjectures/ErdosProblems/1135.lean
+++ b/FormalConjectures/ErdosProblems/1135.lean
@@ -18,7 +18,7 @@ import FormalConjectures.Wikipedia.CollatzConjecture
 /-!
 # Erdős Problem 1135
 
-*Reference:*
+*References:*
 * [erdosproblems.com/1135](__https://www.erdosproblems.com/1135__)
 * [Gu04] Guy, Richard K., Unsolved problems in number theory.  (2004), xviii+437.
 * [La10] Lagarias, Jeffrey C., The {$3x+1$} problem: an overview.  (2010), 3--29.


### PR DESCRIPTION
Import the Collatz conjecture for Erdős Problem 1135. This was done so that it appears as formalised on the erdos website, although it's the same as the Collatz Conjecture under the Wikipedia directory, due to the way the repo is setup, this had to be done.

Closes #1625

Note: I am aware this isn't a problem proposed by Erdos, however he did offer a prize for it and is also mentioned on the website as the 1135th problem.
