### PR TITLE
docs: exclude `ForMathlib` subdir in historical growth plot

### DIFF
--- a/docbuild/scripts/plot_growth.py
+++ b/docbuild/scripts/plot_growth.py
@@ -59,7 +59,7 @@ def get_file_counts_over_time(start_date, columns):
           files = tree_result.stdout.strip().split('\n')
 
           # Only care about lean files in `FormalConjectures` subdir
-          subdir_pattern = re.compile(r'^FormalConjectures/.*\.lean')
+          subdir_pattern = re.compile(r'^FormalConjectures/(?!ForMathlib/).*\.lean')
 
           file_count = len([f for f in files if f and subdir_pattern.match(f)])
           data.append([datetime.fromtimestamp(timestamp), file_count])


### PR DESCRIPTION
Following #1507 the `ForMathlib` directory no longer resides within `FormalConjectures` so it is not included in the growth plot from the 6th January. This PR propagates this backwards in the growth plot, since we presumably only want to count files containing conjectures.