### PR TITLE
feat(GreensOpenProblems): 48, 49, 50

### DIFF
--- a/FormalConjectures/GreensOpenProblems/49.lean
+++ b/FormalConjectures/GreensOpenProblems/49.lean
@@ -37,9 +37,9 @@ of size at most $|A|$?
 This problem is resolved by the Polynomial Freiman–Ruzsa theorem (Gowers, Green, Manners, and Tao, 2023).
 -/
 @[category research solved, AMS 05 11]
-theorem green_49 : answer(True) ↔
-  ∃ C > 0,
-    ∀ (n : ℕ) (K : ℝ) (A : Finset (Fin n → ZMod 2)),
+theorem green_49 :
+    answer(True) ↔ ∃ C > 0,
+      ∀ (n : ℕ) (K : ℝ) (A : Finset (Fin n → ZMod 2)),
       1 ≤ K →
       ((A + A).card : ℝ) ≤ K * A.card →
       ∃ V : Submodule (ZMod 2) (Fin n → ZMod 2),

--- a/FormalConjectures/GreensOpenProblems/50.lean
+++ b/FormalConjectures/GreensOpenProblems/50.lean
@@ -37,14 +37,14 @@ Suppose that $A \subset \mathbb{F}_2^n$ be a set of density $\alpha$.
 Does $10A$ contain a coset of some subspace of dimension at least $n - O(\log(1/\alpha))$?
 -/
 @[category research open, AMS 05 11]
-theorem green_50 : answer(sorry) ↔
-  ∃ C > 0,
-    ∀ (n : ℕ) (α : ℝ) (A : Finset (Fin n → ZMod 2)),
-      0 < α →
-      (A.card : ℝ) = α * (2 ^ n : ℝ) →
-      ∃ V : Submodule (ZMod 2) (Fin n → ZMod 2),
-        (n : ℝ) - C * Real.log (1 / α) ≤ (Module.finrank (ZMod 2) V : ℝ) ∧
-        ∃ x, ∀ v ∈ V, x + v ∈ iteratedSum A 10 := by
+theorem green_50 :
+    answer(sorry) ↔ ∃ C > 0,
+      ∀ (n : ℕ) (α : ℝ) (A : Finset (Fin n → ZMod 2)),
+        0 < α →
+        (A.card : ℝ) = α * (2 ^ n : ℝ) →
+          ∃ V : Submodule (ZMod 2) (Fin n → ZMod 2),
+            (n : ℝ) - C * Real.log (1 / α) ≤ (Module.finrank (ZMod 2) V : ℝ) ∧
+            ∃ x, ∀ v ∈ V, x + v ∈ iteratedSum A 10 := by
   sorry
 
 end Green50


### PR DESCRIPTION
## Add Ben Green’s Open Problems 48, 49, and 50

This PR adds formalizations of **Ben Green’s Open Problems 48, 49, and 50** to
`FormalConjectures/GreensOpenProblems`.

- Problem 48 is recorded as **open**, following Green’s informal inverse small sieve question.
- Problem 49 is recorded as **solved**, following the Polynomial Freiman–Ruzsa theorem.
- Problem 50 is recorded as **open**, using the standard `answer(sorry)` pattern.

Closes #1604, #1605, and #1606.