### PR TITLE
fix: remove squarefree assumption from Artin conjecture case

### DIFF
--- a/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
+++ b/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
@@ -57,7 +57,7 @@ abbrev S (a : ℤ) : Set ℕ :=
 
 /--
 **Artin's Constant** is defined to be the product
-$$\prod_{p\ \text{prime}}, \left(1 - \frac{1}{p(p - 1)}\right)$$.
+$$\prod_{p\ \text{prime}} \left(1 - \frac{1}{p(p - 1)}\right)$$.
 -/
 noncomputable def ArtinConstant : ℝ :=
   ∏' p : Nat.Primes, (1 - 1 / (p * (p - 1)) : ℝ)
@@ -176,7 +176,7 @@ then the density of the set $S(a)$ of primes $p$ such that $a$ is a primitive ro
 is given by
 $$C \left(\prod_{p \mid m} \frac{p(p-2)}{(p ^ 2 - p - 1)}\right)
 \left(1 - \prod_{p \mid \gcd(b_0, m)} \frac{1}{2 - p}
-\prod_{p \mid b_0, p\nmid m} \frac{1}{(1 + p - p ^ 2)}\right)$$,
+\prod_{p \mid b_0, p\nmid m} \frac{1}{(1 + p - p ^ 2)}\right),$$
 where $C$ is Artin's constant.
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
+++ b/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
@@ -152,7 +152,7 @@ $$C\prod_{p \mid m} \frac{p(p - 2)}{p^2 - p - 1}$$,
 where $C$ is Artin's constant.
 -/
 @[category research open, AMS 11]
-theorem artin_primitive_roots.variants.part_ii_prime_power_squarefree_not_modeq_one
+theorem artin_primitive_roots.variants.part_ii_power_squarefreePart_not_modeq_one
     (a m b : ℕ) (ha : a = b ^ m) (hb : ∀ u v, 1 < u → b ≠ v^u) (hm₁ : 1 < m)
     (hm₂ : Odd m) (hb' : ¬ b.squarefreePart ≡ 1 [MOD 4]) :
     (S a).HasDensity (ArtinConstant * powCorrectionFactor m) {p | p.Prime} := by
@@ -162,7 +162,7 @@ theorem artin_primitive_roots.variants.part_ii_prime_power_squarefree_not_modeq_
 **Artin's Conjecture on Primitive Roots**, second half, power version, conditional on GRH
 -/
 @[category research solved, AMS 11]
-theorem conditional_artin_primitive_roots.variants.part_ii_prime_power_squarefree_not_modeq_one
+theorem conditional_artin_primitive_roots.variants.part_ii_power_squarefreePart_not_modeq_one
     (a m b : ℕ) (ha : a = b ^ m) (hb : ∀ u v, 1 < u → b ≠ v ^ u) (hm₁ : 1 < m)
     (hm₂ : Odd m) (hb' : ¬ b.squarefreePart ≡ 1 [MOD 4])
     (h : type_of% generalized_riemann_hypothesis) :
@@ -180,7 +180,7 @@ $$C \left(\prod_{p \mid m} \frac{p(p-2)}{(p ^ 2 - p - 1)}\right)
 where $C$ is Artin's constant.
 -/
 @[category research open, AMS 11]
-theorem artin_primitive_roots.variants.part_ii_prime_power_squarefree_modeq_one
+theorem artin_primitive_roots.variants.part_ii_power_squarefreePart_modeq_one
     (a m b : ℕ) (ha : a = b ^ m) (hb : ∀ u v, 1 < u → b ≠ v ^ u) (hm₁ : 1 < m)
     (hm₂ : Odd m) (hb' : b.squarefreePart ≡ 1 [MOD 4]) :
     (S a).HasDensity
@@ -192,7 +192,7 @@ theorem artin_primitive_roots.variants.part_ii_prime_power_squarefree_modeq_one
 **Artin's Conjecture on Primitive Roots**, second half, power version, conditional on GRH.
 -/
 @[category research solved, AMS 11]
-theorem conditional_artin_primitive_roots.variants.part_ii_prime_power_squarefree_modeq_one
+theorem conditional_artin_primitive_roots.variants.part_ii_power_squarefreePart_modeq_one
     (a m b : ℕ) (ha : a = b ^ m) (hb : ∀ u v, 1 < u → b ≠ v ^ u) (hm₁ : 1 < m)
     (hm₂ : Odd m) (hb' : b.squarefreePart ≡ 1 [MOD 4])
     (h : type_of% generalized_riemann_hypothesis) :

--- a/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
+++ b/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
@@ -182,7 +182,7 @@ where $C$ is Artin's constant.
 @[category research open, AMS 11]
 theorem artin_primitive_roots.variants.part_ii_prime_power_squarefree_modeq_one
     (a m b : ℕ) (ha : a = b ^ m) (hb : ∀ u v, 1 < u → b ≠ v ^ u) (hm₁ : 1 < m)
-    (hm₂ : m.primeFactorsList.Nodup) (hm₃ : Odd m) (hb' : b.squarefreePart ≡ 1 [MOD 4]) :
+    (hm₂ : Odd m) (hb' : b.squarefreePart ≡ 1 [MOD 4]) :
     (S a).HasDensity
       (ArtinConstant * powCorrectionFactor m * entanglementFactor b m)
       {p | p.Prime} := by
@@ -194,7 +194,7 @@ theorem artin_primitive_roots.variants.part_ii_prime_power_squarefree_modeq_one
 @[category research solved, AMS 11]
 theorem conditional_artin_primitive_roots.variants.part_ii_prime_power_squarefree_modeq_one
     (a m b : ℕ) (ha : a = b ^ m) (hb : ∀ u v, 1 < u → b ≠ v ^ u) (hm₁ : 1 < m)
-    (hm₂ : m.primeFactorsList.Nodup) (hm₃ : Odd m) (hb' : b.squarefreePart ≡ 1 [MOD 4])
+    (hm₂ : Odd m) (hb' : b.squarefreePart ≡ 1 [MOD 4])
     (h : type_of% generalized_riemann_hypothesis) :
     (S a).HasDensity
       (ArtinConstant * powCorrectionFactor m * entanglementFactor b m)


### PR DESCRIPTION
The assumption that `m` is squarefree is not needed in this variant. Plus naming and doc fixes.