### PR TITLE
fix(ErdosProblems/189): avoid trapezoids

### DIFF
--- a/FormalConjectures/ErdosProblems/189.lean
+++ b/FormalConjectures/ErdosProblems/189.lean
@@ -63,7 +63,7 @@ theorem erdos_189.variants.square :
       (fun a b c d ↦
         line[ℝ, a, b].direction ⟂ line[ℝ, b, c].direction ∧
         line[ℝ, b, c].direction ⟂ line[ℝ, c, d].direction ∧
-        line[ℝ, c, d].direction ⟂ line[ℝ, d, a].direction
+        line[ℝ, c, d].direction ⟂ line[ℝ, d, a].direction ∧
         dist a b = dist b c)
       (fun a b c d ↦ dist a b * dist b c) := by
   sorry


### PR DESCRIPTION
by adding an extra condition. I suppose we could also fix it with `dist a b = dist c d`, I just picked the one that was also used by Boris Alexeev.

fixes #1541