### PR TITLE
feat(GreensOpenProblems): 58

### DIFF
--- a/FormalConjectures/GreensOpenProblems/58.lean
+++ b/FormalConjectures/GreensOpenProblems/58.lean
@@ -26,9 +26,6 @@ open scoped Pointwise
 
 namespace Green58
 
-/- The analytic lower bound on the size of the sets in the conjecture. Here `((49 : ℝ) / 100)` is
-`0.49`. -/
-
 /--
 Suppose $A, B ⊆ \{1, \dots, N\}$ both have size at least $N^{0.49}$. Must the sumset $A + B$
 contain a composite number?


### PR DESCRIPTION
This adds the Lean formalization of Green’s Open Problem 58, asking whether subsets of {1,…,N} of size at least N^{0.49} must have a composite element in A + B.

Closes #1663.