### PR TITLE
fix(AgohGuiga): congruence condition

### DIFF
--- a/FormalConjectures/Wikipedia/AgohGiuga.lean
+++ b/FormalConjectures/Wikipedia/AgohGiuga.lean
@@ -47,7 +47,7 @@ An integer `p ≥ 2` is prime if and only if we have
 def AgohGiugaCongr : Prop :=
   ∀ p ≥ 2, p.Prime ↔ ∃ (k : ℤ),
   let B := bernoulli' (p - 1)
-  p * B.num + B.den = k * p
+  p * B.num + B.den = k * p^2
 
 /--
 The **Agoh-Giuga Conjecture**, Giuga's formulation.


### PR DESCRIPTION
(issue spotted by Gemini)
We aim to formalize $pB \equiv -1 \pmod p$ where $B$ is a rational number. If we write $B$ as $\frac a b$ in the basic form, then this means that $b$ is divisible by $p$, and $a \equiv -\frac b p \pmod p$, equivalently $ap+b \equiv 0 \pmod {p^2}$. The original formalization wrote only $ap+b \equiv 0 \pmod p$, which is equivalent to $b \equiv 0 \pmod p$.
