### PR TITLE
feat(ErdosProblems): 195

### DIFF
--- a/FormalConjectures/ErdosProblems/195.lean
+++ b/FormalConjectures/ErdosProblems/195.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjecturesForMathlib.Combinatorics.AP.Basic
 
 /-!
 # Erdős Problem 195

--- a/FormalConjectures/ErdosProblems/195.lean
+++ b/FormalConjectures/ErdosProblems/195.lean
@@ -1,0 +1,61 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 195
+
+*References:*
+- [erdosproblems.com/195](https://www.erdosproblems.com/195)
+- [Ad22] Adenwalla, S., Avoiding Monotone Arithmetic Progressions in Permutations of Integers.
+  arXiv:2211.04451 (2022).
+- [Ge19] Geneson, Jesse, Forbidden arithmetic progressions in permutations of subsets of the
+  integers. Discrete Math. (2019), 1489-1491.
+-/
+
+namespace Erdos195
+
+open Function Set
+
+/-- A permutation `f` of `ℤ` has a monotone $k$-term AP if there is an AP `l`
+such that its image under `f` is sorted. -/
+def HasMonotoneAP (f : ℤ ≃ ℤ) (k : ℕ) : Prop :=
+  ∃ l : List ℤ, l.IsAPOfLength k ∧ ((l.map f).Sorted (· < ·) ∨ (l.map f).Sorted (· > ·))
+
+/--
+What is the largest $k$ such that in any permutation of $\mathbb{Z}$ there must exist a
+monotone $k$-term arithmetic progression $x_1 < \cdots < x_k$?
+-/
+@[category research open, AMS 5]
+theorem erdos_195 :
+    answer(sorry) = sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by sorry
+
+/--
+Geneson [Ge19] proved that k ≤ 5.
+-/
+@[category research solved, AMS 5]
+theorem erdos_195.variant.leq_5_bound :
+    5 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by sorry
+
+/--
+Adenwalla [Ad22] proved that k ≤ 4.
+-/
+@[category research solved, AMS 5]
+theorem erdos_195.variant.leq_4_bound :
+    4 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by sorry
+
+end Erdos195

--- a/FormalConjectures/ErdosProblems/195.lean
+++ b/FormalConjectures/ErdosProblems/195.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
+import FormalConjecturesForMathlib.Combinatorics.AP.Basic
 
 /-!
 # Erdős Problem 195
@@ -29,33 +30,29 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Erdos195
 
-open Function Set
-
-/-- A permutation `f` of `ℤ` has a monotone $k$-term AP if there is an AP `l`
-such that its image under `f` is sorted. -/
-def HasMonotoneAP (f : ℤ ≃ ℤ) (k : ℕ) : Prop :=
-  ∃ l : List ℤ, l.IsAPOfLength k ∧ ((l.map f).Sorted (· < ·) ∨ (l.map f).Sorted (· > ·))
-
 /--
 What is the largest $k$ such that in any permutation of $\mathbb{Z}$ there must exist a
 monotone $k$-term arithmetic progression $x_1 < \cdots < x_k$?
 -/
 @[category research open, AMS 5]
 theorem erdos_195 :
-    answer(sorry) = sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by sorry
+    answer(sorry) = sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by
+  sorry
 
 /--
 Geneson [Ge19] proved that k ≤ 5.
 -/
 @[category research solved, AMS 5]
 theorem erdos_195.variant.leq_5_bound :
-    5 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by sorry
+    5 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by
+  sorry
 
 /--
 Adenwalla [Ad22] proved that k ≤ 4.
 -/
 @[category research solved, AMS 5]
 theorem erdos_195.variant.leq_4_bound :
-    4 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by sorry
+    4 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by
+  sorry
 
 end Erdos195

--- a/FormalConjectures/ErdosProblems/196.lean
+++ b/FormalConjectures/ErdosProblems/196.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
+import FormalConjecturesForMathlib.Combinatorics.AP.Basic
 
 /-!
 # Erdős Problem 196
@@ -25,8 +26,7 @@ namespace Erdos196
 
 /-- Must every permutation of $\mathbb{N}$, contain a monotone 4-term arithmetic progression?-/
 @[category research open, AMS 5 11]
-theorem erdos_196 : answer(sorry) ↔ ∀ (f : ℕ ≃ ℕ), ∃ (a : List ℕ),
-    ((a.Sorted (· < · )) ∨ (a.Sorted (· > · ))) ∧ (a.map f).IsAPOfLength 4 := by
+theorem erdos_196 : answer(sorry) ↔ ∀ (f : ℕ ≃ ℕ), HasMonotoneAP f 4 := by
   sorry
 
 end Erdos196

--- a/FormalConjectures/ErdosProblems/196.lean
+++ b/FormalConjectures/ErdosProblems/196.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjecturesForMathlib.Combinatorics.AP.Basic
 
 /-!
 # Erdős Problem 196

--- a/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
@@ -233,3 +233,11 @@ def ContainsMonoAPofLength {κ : Type} [Finite κ] {M : Set α}
     (coloring : M → κ) (k : ℕ) : Prop :=
   ∃ c : κ, ∃ ap : Set M, ((·.1) '' ap).IsAPOfLength k ∧
     ∀ m ∈ ap, coloring m = c
+
+/--
+A function `f : α → β` has a monotone `k`-term arithmetic progression if there exists an
+arithmetic progression `l` of length `k` in `α` such that its image under `f` is sorted
+(either strictly increasing or strictly decreasing).
+-/
+def HasMonotoneAP {β : Type*} [Preorder β] (f : α → β) (k : ℕ) : Prop :=
+  ∃ l : List α, l.IsAPOfLength k ∧ ((l.map f).Sorted (· < ·) ∨ (l.map f).Sorted (· > ·))

--- a/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
@@ -46,7 +46,7 @@ A list version of `Set.IsAPOfLengthWith`. Useful when order preservation is requ
 when considering images under arbitrary functions.
 -/
 def List.IsAPOfLengthWith (s : List α) (l : ℕ) (a d : α) : Prop :=
-  s = (List.range l).map fun n ↦ a + n • d
+  s = (List.range l).map (fun n ↦ a + n • d) ∨ s = (List.range l).reverse.map (fun n ↦ a + n • d)
 
 namespace Set.IsAPOfLengthWith
 
@@ -74,8 +74,7 @@ namespace List.IsAPOfLengthWith
 variable {s : List α} {l : ℕ} {a d : α}
 
 theorem length (h : s.IsAPOfLengthWith l a d) : s.length = l := by
-  rw [IsAPOfLengthWith] at h
-  simp [h]
+  cases h <;> simp_all
 
 /-- An arithmetic progression with first term `a` and difference `d` is of length zero if and only
 if `s` is empty. -/
@@ -236,8 +235,7 @@ def ContainsMonoAPofLength {κ : Type} [Finite κ] {M : Set α}
 
 /--
 A function `f : α → β` has a monotone `k`-term arithmetic progression if there exists an
-arithmetic progression `l` of length `k` in `α` such that its image under `f` is sorted
-(either strictly increasing or strictly decreasing).
+arithmetic progression `l` of length `k` in `α` such that its image under `f` is sorted.
 -/
 def HasMonotoneAP {β : Type*} [Preorder β] (f : α → β) (k : ℕ) : Prop :=
-  ∃ l : List α, l.IsAPOfLength k ∧ ((l.map f).Sorted (· < ·) ∨ (l.map f).Sorted (· > ·))
+  ∃ l : List α, l.IsAPOfLength k ∧ (l.map f).Sorted (· < ·)


### PR DESCRIPTION
Closes #416 

I kept the formalization of the weaker bound of \leq 5 because I assume that we eventually want both the proof for \leq 4 and \leq 5 formalized as future training data, but let me know if it's not necessary and we should remove it.