### PR TITLE
Fix issue: OEIS A185636

### DIFF
--- a/FormalConjectures/NumberTheory/A185636.lean
+++ b/FormalConjectures/NumberTheory/A185636.lean
@@ -1,0 +1,21 @@
+/-
+Conjecture: (OEIS A185636, Zhi-Wei Sun)
+For each n ∈ ℕ, there exists k ∈ {0, ..., n} such that both n + k and n + k^2 are prime.
+
+Reference: https://oeis.org/A185636
+Status: Open (as of January 2026)
+Prize: $100 offered by Zhi-Wei Sun (see his homepage)
+Numerical evidence: Verified for large n, no counterexamples known.
+
+Prerequisites: Basic number theory, primality.
+-/
+
+import data.nat.prime
+
+open nat
+
+/-- 
+For every natural number n, there exists k ≤ n such that both n + k and n + k^2 are prime.
+-/
+conjecture sun_A185636 :
+  ∀ n : ℕ, ∃ k : ℕ, k ≤ n ∧ prime (n + k) ∧ prime (n + k^2)

--- a/FormalConjecturesForMathlib/NumberTheory/A185636.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/A185636.lean
@@ -1,0 +1,21 @@
+/-
+Conjecture: (OEIS A185636, Zhi-Wei Sun)
+For each n ∈ ℕ, there exists k ∈ {0, ..., n} such that both n + k and n + k^2 are prime.
+
+Reference: https://oeis.org/A185636
+Status: Open (as of January 2026)
+Prize: $100 offered by Zhi-Wei Sun (see his homepage)
+Numerical evidence: Verified for large n, no counterexamples known.
+
+Prerequisites: Basic number theory, primality.
+-/
+
+import data.nat.prime
+
+open nat
+
+/-- 
+For every natural number n, there exists k ≤ n such that both n + k and n + k^2 are prime.
+-/
+conjecture sun_A185636 :
+  ∀ n : ℕ, ∃ k : ℕ, k ≤ n ∧ prime (n + k) ∧ prime (n + k^2)


### PR DESCRIPTION
fixes  #1492

Added Zhi-Wei Sun’s conjecture (OEIS A185636) to the repository as a new Lean file in FormalConjectures/NumberTheory. 
The file includes the formal statement, references, status, and prerequisites. 
The conjecture asserts that for every n ≥ 1, there exists
 k ∈ {0, ..., n} such that both n + k and n + k² are prime.

How I solved this issue:

1. Located the correct directory for number theory conjectures.
2. Created A185636.lean with a clear docstring, OEIS link, and Lean statement.
3. Followed repository conventions for formatting and metadata.