### PR TITLE
feat(GreensOpenProblems): 24

### DIFF
--- a/FormalConjectures/GreensOpenProblems/24.lean
+++ b/FormalConjectures/GreensOpenProblems/24.lean
@@ -54,6 +54,7 @@ theorem green_24 : ∀ n, max013AffineTranslates n = answer(sorry) := by
   sorry
 
 /-! A collection of associated bounds and conjectured values. -/
+
 namespace variants
 
 /-- From [Aa19] p.577: the trivial upper bound is $n^2$ (non asymptotic) -/


### PR DESCRIPTION
# Description

If $A$ is a set of $n$ integers, what is the maximum number of affine translates of the set $\lbrace 0,1,3 \rbrace$ that $A$ can contain?

- Also includes known bounds and conjectures
- Closes #1559.

**References:**
- [Green, Ben. "100 open problems." (2024).](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.24)
- [Aa19] Aaronson, James. "Maximising the number of solutions to a linear equation in a set of integers."
  Bulletin of the London Mathematical Society 51.4 (2019): 577-594.
- [HaL28] Hardy, G. H., and J. E. Littlewood. "Notes on the theory of series (VIII): an inequality."
  Journal of the London Mathematical Society 1.2 (1928): 105-110.

# Testing
:white_check_mark: Builds successfully
```shell
$ lake build FormalConjectures/GreensOpenProblems/24.lean 
Build completed successfully.
```