### PR TITLE
feat(GreensOpenProblems): 45

### DIFF
--- a/FormalConjectures/GreensOpenProblems/45.lean
+++ b/FormalConjectures/GreensOpenProblems/45.lean
@@ -27,3 +27,11 @@ such that every integer `⩽ N` lies in at least 10 of them?
 - [Ben Green's Open Problem 45](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.45)
 - [erdosproblems.com/689](https://www.erdosproblems.com/689)
 -/
+
+namespace Green45
+
+@[category research open, AMS 11]
+theorem green_45 : type_of% Erdos689.erdos_689 := by
+  sorry
+
+end Green45


### PR DESCRIPTION
Formalizes Ben Green's Open Problem 45: Can we pick residue classes $a_p(mod p)$, one for each prime `p ⩽ N`,
such that every integer `⩽ N` lies in at least 10 of them?

Closes #1601 
