### PR TITLE
feat: Add Pollock's (tetrahedral numbers) conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/PollocksConjecture.lean
+++ b/FormalConjectures/Wikipedia/PollocksConjecture.lean
@@ -66,7 +66,7 @@ theorem pollock_tetrahedral.salzer_levine :
     IsGreatest NotSumOfFourTetrahedral 343867 := by
   sorry
 
-/-- As stated on Wikipedia/OEIS (A000797), the set of exceptions has cardinality `241`. -/
+/-- As stated on Wikipedia/OEIS (A000797), the set of exceptions has cardinality $241$. -/
 @[category high_school, AMS 11]
 theorem pollock_tetrahedral.ncard_exceptions :
     type_of% pollock_tetrahedral.salzer_levine ↔


### PR DESCRIPTION
Adds formalization of Pollock's (tetrahedral numbers) conjecture.

## Changes
- Define `tetrahedral` function: \(T_n = n(n+1)(n+2)/6\)
- Formalize main conjecture: every positive integer is the sum of at most 5 tetrahedral numbers
- Add Salzer-Levine strengthening: the set of integers requiring 5 tetrahedral numbers is finite
- Add references: Wikipedia, OEIS A000797, Dickson, Pollock (1850), Salzer-Levine (1958), MathWorld

Closes #1780