### PR TITLE
chore(ErdosProblems): Remove (easy) lemma which is in mathlib

### DIFF
--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -46,13 +46,6 @@ theorem erdos_730.variants.explicit_pairs :
   sorry
 
 /--
-Show that for all $n$, the binomial coefficient $\binom{2n}{n}$ is even.
--/
-@[category high_school, AMS 11]
-theorem erdos_730.variants.two_div_forall (n : ℕ) (h : 0 < n) : 2 ∣ n.centralBinom := by
-  sorry
-
-/--
 There are examples where $(n, m) ∈ S$ with $m ≠ n + 1$.
 
 (Found by AlphaProof, although it was implicit already in [A129515])


### PR DESCRIPTION
The lemma I removed is (exactly)
```Nat.two_dvd_centralBinom_of_one_le```

https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Nat/Choose/Central.html#Nat.two_dvd_centralBinom_of_one_le