### PR TITLE
chore: wrong year

### DIFF
--- a/FormalConjectures/Wikipedia/Toronto.lean
+++ b/FormalConjectures/Wikipedia/Toronto.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
In my PR #1776 which was opened and merged yesterday, I put 2025 instead of 2026