### PR TITLE
feat(GreensOpenProblems): 100

### DIFF
--- a/FormalConjectures/GreensOpenProblems/100.lean
+++ b/FormalConjectures/GreensOpenProblems/100.lean
@@ -39,7 +39,7 @@ and $g \notin N$.
 @[category research open, AMS 20]
 theorem green_100 :
   answer(sorry) ↔
-    ∀ (G : Type*) [Group G],
+    ∀ (G : Type) [Group G],
       (∀ (g : G), g ≠ 1 → ∃ (N : Subgroup G), N.Normal ∧ Finite (G ⧸ N) ∧ g ∉ N) := by
   sorry
 end Green100


### PR DESCRIPTION
This file introduces Green's Open Problem 100, discussing whether every group is well-approximated by finite groups and defining the concept of residual finiteness.

  closes: #1756

Reference: https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.100