### PR TITLE
feat(GreensOpenProblems): 2

### DIFF
--- a/FormalConjectures/GreensOpenProblems/2.lean
+++ b/FormalConjectures/GreensOpenProblems/2.lean
@@ -16,9 +16,6 @@ limitations under the License.
 
 import FormalConjectures.Util.ProblemImports
 
-open Filter
-open scoped Topology
-
 /-!
 # Ben Green's Open Problem 2
 
@@ -35,6 +32,10 @@ References:
   sum-free sets via large Sidon sets. Colloq. Math., 86(2):171–176, 2000.
   doi:10.4064/cm-86-2-171-176.
 -/
+
+open Filter
+open scoped Topology
+
 namespace Green2
 
 /--


### PR DESCRIPTION
# Description
Let $A \subset \mathbf{Z}$ be a set of $n$ integers. Is there a set $S \subset A$ of size $(\log n)^{100}$ such that the restricted sumset $S \hat{+} S$ is disjoint from $A$?

The _restricted sumset_ of a set $S$, denoted $S \hat{+} S$, is the set $\lbrace s_1 + s_2 : s_1, s_2 \in S, s_1 \neq s_2 \rbrace$.

- Closes #890 
- Added some proven bounds as additional variants

# Testing
:white_check_mark: Builds successfully.
```shell
$ lake build FormalConjectures/GreensOpenProblems/2.lean 
Build completed successfully.
```