### PR TITLE
feat(Wikipedia): add Zilber–Pink conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/ZilberPink.lean
+++ b/FormalConjectures/Wikipedia/ZilberPink.lean
@@ -1,0 +1,28 @@
+/-
+Zilber–Pink Conjecture
+
+Informal statement:
+Let X be a mixed Shimura variety or a semiabelian variety over ℂ,
+and let V ⊆ X be a subvariety. Then V contains only finitely many
+maximal atypical subvarieties.
+
+This conjecture is a central open problem in arithmetic geometry,
+generalizing earlier conjectures such as André–Oort and Mordell–Lang.
+
+Formalization status:
+This conjecture is currently not formalizable in mathlib due to the
+absence of major foundational components, including:
+* Shimura varieties (mixed and unmixed)
+* Semiabelian varieties
+* Special subvarieties
+* Atypical subvarieties
+* Mixed Hodge structures
+
+Reference:
+* https://en.wikipedia.org/wiki/Zilber%E2%80%93Pink_conjecture
+-/
+
+@[category research open, AMS 11 14]
+theorem zilber_pink_conjecture :
+  True := by
+  sorry


### PR DESCRIPTION
This PR adds a documented conjecture stub for the Zilber–Pink conjecture
under `FormalConjectures/Wikipedia`.

The contribution does not attempt a formalization. Instead, it:
- records the informal statement of the conjecture,
- provides mathematical context and references,
- and explicitly documents the major missing prerequisites in mathlib
  that currently prevent formalization (e.g. Shimura varieties,
  semiabelian varieties, and atypical subvarieties).

This follows the repository’s goal of tracking important conjectures and
mapping infrastructure gaps for future formalization efforts.

Closes #1824.
