### PR TITLE
Add problem 77

### DIFF
--- a/FormalConjectures/GreensOpenProblems/77.lean
+++ b/FormalConjectures/GreensOpenProblems/77.lean
@@ -33,6 +33,13 @@ def unitDisc : Set (ℝ × ℝ) := {p | dist p (0, 0) ≤ 1}
 noncomputable def triangleArea (p₁ p₂ p₃ : ℝ × ℝ) : ℝ :=
   (1/2) * |p₁.1 * (p₂.2 - p₃.2) + p₂.1 * (p₃.2 - p₁.2) + p₃.1 * (p₁.2 - p₂.2)|
 
+/--
+Given $n$ points in the unit disc, must there be a triangle determined by these points with area
+at most $n^{-2 + o(1)}$?
+
+Komlós, Pintz, and Szemerédi showed that the $o(1)$ term is necessary, and proved that there must
+exist a triangle with area at most $n^{-8/7}$.
+-/
 @[category research open, AMS 52 05]
 theorem green_77 :
     answer(sorry) ↔ ∃ (f : ℕ → ℝ), (atTop.Tendsto f (𝓝 0)) ∧


### PR DESCRIPTION
Adds formalization of Ben Green's Open Problem 77 from his open problems collection.

Problem statement: Given n points in the unit disc, must there exist a triangle of area at most n^(-2+o(1))?

What's included:

Definition of unit disc in ℝ²
Triangle area computation using standard cross-product formula
Main conjecture formalized with proper asymptotic notation (ε(n) → 0)
Technical details: The o(1) term is handled by quantifying over all functions ε: ℕ → ℝ that tend to 0, then requiring ∃N such that for all n ≥ N, any n-point configuration contains a triangle with area ≤ n^(-2) · (1 + ε(n)).

AMS categories: 52 (Convex/discrete geometry), 05 (Combinatorics)