### PR TITLE
feat(OEIS): A067220

### DIFF
--- a/FormalConjectures/OEIS/67720.lean
+++ b/FormalConjectures/OEIS/67720.lean
@@ -47,22 +47,22 @@ theorem a_2 : a 2 := by
 /-- $4$ is in the sequence A067720. -/
 @[category test, AMS 11]
 theorem a_4 : a 4 := by
-  unfold a; decide
+  simp +decide only [a]
 
 /-- $6$ is in the sequence A067720. -/
 @[category test, AMS 11]
 theorem a_6 : a 6 := by
-  unfold a; decide
+  simp +decide only [a]
 
 /-- $8$ is in the sequence A067720. -/
 @[category test, AMS 11]
 theorem a_8 : a 8 := by
-  unfold a; decide
+  simp +decide only [a]
 
 /-- $10$ is in the sequence A067720. -/
 @[category test, AMS 11]
 theorem a_10 : a 10 := by
-  unfold a; decide
+  simp +decide only [a]
 
 /-- If $k + 1$ and $k^2 + 1$ are both prime, then $k$ is in the sequence. -/
 @[category undergraduate, AMS 11]


### PR DESCRIPTION
Resolves #1456.

# **Conjectures associated with A067720**

A067720 lists numbers $k$ such that $\varphi(k^2 + 1) = k \cdot \varphi(k + 1)$,
where $\varphi$ is Euler's totient function.

The sequence exhibits a strong connection to primes: for almost all terms $k$,
$k + 1$ is prime. The conjecture states that $k = 8$ is the only exception.

*References:* [oeis.org/A067720](https://oeis.org/A067720)

 Note: I'm using Claude + Opus for supervised formalization tasks. Claude has no permission to use git on my machine.