### PR TITLE
feat: Gourevitch conjecture

### DIFF
--- a/FormalConjectures/Paper/Gourevitch.lean
+++ b/FormalConjectures/Paper/Gourevitch.lean
@@ -38,6 +38,5 @@ theorem gourevitch_series_identity :
     ∑' n : ℕ, ((1 + 14 * n + 76 * n ^ 2 + 168 * n ^ 3) / (2 ^ (20 * n)) : ℝ)
       * Nat.centralBinom n ^ 7 = 32 / (Real.pi ^ 3) := by
   sorry
-  sorry
 
 end Gourevitch


### PR DESCRIPTION
Fixes #1828

This PR formalizes Gourevitch's series identity.

Statement:
∑' n, ((1 + 14 n + 76 n^2 + 168 n^3) / 2^(20 n)) * (Nat.centralBinom n)^7
  = 32 / π^3

Details:
- Adds theorem `gourevitch_series_identity`
- Uses `Nat.centralBinom` for binomial coefficient formulation
- Categorized under `research solved` and `AMS 11 33`
- Includes literature references

References:
- Guillera (2003), Experimental Mathematics
- Au (2025), Journal of Symbolic Computation
