### PR TITLE
feat(OEIS): A087719

### DIFF
--- a/FormalConjectures/OEIS/87719.lean
+++ b/FormalConjectures/OEIS/87719.lean
@@ -72,9 +72,6 @@ theorem a_three : a 3 = 57 := by
   intro m hm
   interval_cases m <;> decide
 
-/-- The formula value. -/
-def formula (n : ℕ) : ℕ := 3 ^ n + 3 * 2 ^ n + 6
-
 /-- Conjecture: a(n) = 3^n + 3 * 2^n + 6 for n ≥ 1. -/
 @[category research formally solved using lean4 at "https://github.com/google-deepmind/formal-conjectures/pull/1894/commits/7a286754f623759d69a3dd18f482c53c1d70959b", AMS 11]
 theorem a_formula {n : ℕ} (hn : n ≥ 1) : a n = 3 ^ n + 3 * 2 ^ n + 6 := by


### PR DESCRIPTION
Resolves #1460.

# Conjectures associated with A087719

Define $\varsigma(n)$ the smallest prime factor of $n$ (`Nat.minFac`). Let $a_n$ be the least
number such that the count of numbers $k \le a_n$ with $k > \varsigma(k)^n$ exceeds the count
of numbers with $k \le \varsigma(k)^n$.

The conjecture states that $a_n = 3^n + 3 \cdot 2^n + 6$ for $n \ge 1$.

*References:* [oeis.org/A087719](https://oeis.org/A087719)

Note: I'm using Claude + Opus for supervised formalization tasks. Claude has no permission to use git on my machine.