### PR TITLE
feat: add optimization constants

### DIFF
--- a/FormalConjectures/OptimizationConstants/1a.lean
+++ b/FormalConjectures/OptimizationConstants/1a.lean
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
-
 import FormalConjectures.Util.ProblemImports
 
 /-!


### PR DESCRIPTION
See the discussion at
https://leanprover.zulipchat.com/#narrow/channel/524981-Formal-conjectures/topic/Optimization.20constants/with/570016079

It is probably useful if there is a somewhat standard way to phrase the open question (what is lower and upper bound etc) and this is likely a good place to discuss this. Namely how many of the theorems/conjectures ```c1a_le```, ```c1a_ge```, ```c1a_eq``` do we want etc?

(Maybe also add optimization constants to the readme, next the green and erdos problems? as well as a tag for PRs)

Once/If this PR is merged, I will try to make the optimization constants [repository](https://github.com/teorth/optimizationproblems) link to this, similar as it is done for Erdos problems.