### PR TITLE
chore: Standardize OEIS references

### DIFF
--- a/FormalConjectures/ErdosProblems/313.lean
+++ b/FormalConjectures/ErdosProblems/313.lean
@@ -21,7 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/313](https://www.erdosproblems.com/313)
-- OEIS: [A54377](https://oeis.org/A54377) (Primary pseudoperfect numbers)
+- [A54377](https://oeis.org/A54377) (Primary pseudoperfect numbers)
 -/
 
 namespace Erdos313

--- a/FormalConjectures/ErdosProblems/413.lean
+++ b/FormalConjectures/ErdosProblems/413.lean
@@ -21,7 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/413](https://www.erdosproblems.com/413)
-- [OEIS A5236](https://oeis.org/A5236)
+- [A5236](https://oeis.org/A5236)
 
 Erdős called a natural number `n` a *barrier* for `ω`, the number of distinct prime divisors,
 if `m + ω(m) ≤ n` for all `m < n`. He believed there should be infinitely many such barriers, and

--- a/FormalConjectures/OEIS/231201.lean
+++ b/FormalConjectures/OEIS/231201.lean
@@ -24,7 +24,7 @@ Number of ways to write $n = x+y$, for $x,y > 0$ such that $2^x + y$ is prime.
 Zhi-Wei Sun has offered a $1000 prize for the first proof.
 
 *References:*
-- [OEIS A231201](https://oeis.org/A231201)
+- [A231201](https://oeis.org/A231201)
 - Zhi-Wei Sun, "Table of n, a(n) for n = 1..10000",
   "Write n = k + m with 2^k + m prime", a message to Number Theory List, Nov. 16, 2013,
   "On a^n+ bn modulo m", arXiv:1312.1166 [math.NT], 2013-2014,

--- a/FormalConjectures/OEIS/232174.lean
+++ b/FormalConjectures/OEIS/232174.lean
@@ -25,7 +25,7 @@ $x^2 + ny^2$ are prime.
 Zhi-Wei Sun has offered a $200 prize for the first proof.
 
 *References:*
-- [OEIS A232174](https://oeis.org/A232174)
+- [A232174](https://oeis.org/A232174)
 - Z.-W. Sun, "Conjectures on representations involving primes," in: M. Nathanson (ed.),
   Combinatorial and Additive Number Theory II: CANT, Springer Proc. in Math. & Stat.,
   Vol. 220, Springer, 2017, pp. 279-310. https://arxiv.org/abs/1211.1588

--- a/FormalConjectures/OEIS/239957.lean
+++ b/FormalConjectures/OEIS/239957.lean
@@ -24,7 +24,7 @@ Every prime $p$ has a primitive root $0 < g < p$ of the form $k^2 + 1$, where $k
 Zhi-Wei Sun has offered a prize of RMB 2,000 for the first proof.
 
 *References:*
-- [OEIS A239957](https://oeis.org/A239957)
+- [A239957](https://oeis.org/A239957)
 - Z.-W. Sun, "New observations on primitive roots modulo primes," arXiv:1405.0290 [math.NT], 2014.
 -/
 

--- a/FormalConjectures/OEIS/280831.lean
+++ b/FormalConjectures/OEIS/280831.lean
@@ -25,7 +25,7 @@ integers such that $x^4 + 1680 y^3 z$ is a square.
 Zhi-Wei Sun has offered a prize of 1,680 RMB for the first proof.
 
 *References:*
-- [OEIS A280831](https://oeis.org/A280831)
+- [A280831](https://oeis.org/A280831)
 - Z.-W. Sun, "Refining Lagrange's four-square theorem," *J. Number Theory* **175** (2017), 167-190.
 - Z.-W. Sun, "Refining Lagrange's four-square theorem," arXiv:1604.06723 [math.NT], 2016.
 -/

--- a/FormalConjectures/OEIS/281976.lean
+++ b/FormalConjectures/OEIS/281976.lean
@@ -25,7 +25,7 @@ integers and $z \leq w$, such that both $x$ and $x + 24y$ are squares.
 Zhi-Wei Sun has offered a $2,400 prize for the first proof.
 
 *References:*
-- [OEIS A281976](https://oeis.org/A281976)
+- [A281976](https://oeis.org/A281976)
 - Z.-W. Sun, "Refining Lagrange's four-square theorem," *J. Number Theory* **175** (2017), 167-190.
   https://doi.org/10.1016/j.jnt.2016.11.008
 - Z.-W. Sun, "Restricted sums of four squares," *arXiv:1701.05868* [math.NT], 2017.

--- a/FormalConjectures/OEIS/287616.lean
+++ b/FormalConjectures/OEIS/287616.lean
@@ -24,8 +24,8 @@ nonnegative integers.
 
 Zhi-Wei Sun has offered a USD 135 prize for the first proof of this conjecture.
 
-*References:* 
-- [OEIS A287616](https://oeis.org/A287616)
+*References:*
+- [A287616](https://oeis.org/A287616)
 - Zhi-Wei Sun, "Universal sums of three quadratic polynomials", arXiv:1502.03056 [math.NT]
 -/
 

--- a/FormalConjectures/OEIS/303656.lean
+++ b/FormalConjectures/OEIS/303656.lean
@@ -25,7 +25,7 @@ nonnegative integers.
 Zhi-Wei Sun has offered a $3,500 prize for the first proof.
 
 *References:*
-- [OEIS A303656](https://oeis.org/A303656)
+- [A303656](https://oeis.org/A303656)
 - Z.-W. Sun, "Restricted sums of four squares," arXiv preprint:
   https://arxiv.org/abs/1701.05868v10
 - Z.-W. Sun, "Refining Lagrange's four-square theorem," Journal of Number Theory:

--- a/FormalConjectures/OEIS/306477.lean
+++ b/FormalConjectures/OEIS/306477.lean
@@ -27,7 +27,7 @@ Zhi-Wei Sun has offered a $2,468 prize for the first proof (or $2,468 RMB for a 
 The conjecture has been verified for all $n$ up to $1.2 \times 10^{12}$ by Yaakov Baruch (March 2019).
 
 *References:*
-- [OEIS A306477](https://oeis.org/A306477)
+- [A306477](https://oeis.org/A306477)
 - [mathoverflow/323541](https://mathoverflow.net/questions/323541): Z.-W. Sun, "Positive integers written as C(w,2) + C(x,4) + C(y,6) + C(z,8) with w,x,y,z in {2,3,...},", Feb. 19, 2019.
 -/
 

--- a/FormalConjectures/OEIS/308734.lean
+++ b/FormalConjectures/OEIS/308734.lean
@@ -25,7 +25,7 @@ where $a, b, c, d, x, y$ are nonnegative integers.
 Zhi-Wei Sun has offered a $2,500 prize for the first proof.
 
 *References:*
-- [OEIS A308734](https://oeis.org/A308734)
+- [A308734](https://oeis.org/A308734)
 - Z.-W. Sun, "Refining Lagrange's four-square theorem," *J. Number Theory* **175** (2017), 167-190.
   https://doi.org/10.1016/j.jnt.2016.11.008
 - Z.-W. Sun, "Restricted sums of four squares," *Int. J. Number Theory* **15** (2019), 1863-1893.

--- a/FormalConjectures/OEIS/41.lean
+++ b/FormalConjectures/OEIS/41.lean
@@ -23,7 +23,7 @@ Name: "No powers as partition numbers"
 
 There are no partition numbers $p(k)$ of the form $x^m$, with $x,m$ integers $>1$.
 
-*Reference*: [OEIS A41](https://oeis.org/A41)
+*Reference*: [A41](https://oeis.org/A41)
 -/
 
 /-- The `n`-th partition number. -/

--- a/FormalConjectures/OEIS/56777.lean
+++ b/FormalConjectures/OEIS/56777.lean
@@ -27,7 +27,7 @@ $\sigma(n+12) = \sigma(n) + 12$.
 The conjectures state identities connecting A56777 and prime quadruples (A7530), as
 well as congruences satisfied by the members of A56777.
 
-*References:* [oeis.org/A56777](https://oeis.org/A56777)
+*References:* [A56777](https://oeis.org/A56777)
 -/
 
 namespace OeisA56777

--- a/FormalConjectures/OEIS/63880.lean
+++ b/FormalConjectures/OEIS/63880.lean
@@ -29,7 +29,7 @@ The conjectures state that all members satisfy $n \equiv 108 \pmod{216}$, and th
 primitive terms (those whose proper divisors aren't in the sequence) are powerful numbers,
 with $108$ being the only primitive term.
 
-*References:* [oeis.org/A063880](https://oeis.org/A063880)
+*References:* [A063880](https://oeis.org/A063880)
 -/
 
 namespace OeisA63880

--- a/FormalConjectures/OEIS/6697.lean
+++ b/FormalConjectures/OEIS/6697.lean
@@ -27,7 +27,7 @@ $$\sum_{n \geq 0} a_n x^n = 1 + \frac{1}{1-x} + \frac{1}{(1-x)^2}\left(\frac{1}{
   \sum_{k \geq 1} x^{2^k + k - 1}\right).$$
 
 *References:*
-- [OEIS A6697](https://oeis.org/A6697)
+- [A6697](https://oeis.org/A6697)
 - J.-P. Allouche and J. Shallit, "On the subword complexity of the fixed point of a → aab, b → b,
   and generalizations," arXiv:1605.02361 [math.CO], 2016.
 - N. J. A. Sloane and Simon Plouffe, *The Encyclopedia of Integer Sequences*, Academic Press, 1995.

--- a/FormalConjectures/OEIS/67720.lean
+++ b/FormalConjectures/OEIS/67720.lean
@@ -24,7 +24,7 @@ where $\varphi$ is Euler's totient function.
 The sequence exhibits a strong connection to primes: for almost all terms $k$,
 $k + 1$ is prime. The conjecture states that $k = 8$ is the only exception.
 
-*References:* [oeis.org/A067720](https://oeis.org/A067720)
+*References:* [A067720](https://oeis.org/A067720)
 -/
 
 open Nat

--- a/FormalConjectures/OEIS/87719.lean
+++ b/FormalConjectures/OEIS/87719.lean
@@ -26,7 +26,7 @@ of numbers with $k \le \varsigma(k)^n$.
 
 The conjecture states that $a_n = 3^n + 3 \cdot 2^n + 6$ for $n \ge 1$.
 
-*References:* [oeis.org/A087719](https://oeis.org/A087719)
+*References:* [A087719](https://oeis.org/A087719)
 -/
 
 namespace OeisA87719

--- a/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
+++ b/FormalConjectures/Wikipedia/ArtinPrimitiveRootsConjecture.lean
@@ -41,7 +41,7 @@ Note that Artin's conjecture has been proved subject to the Generalized Riemann 
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Artin%27s_conjecture_on_primitive_roots)
-- [OEIS](https://oeis.org/A85397)
+- [A85397](https://oeis.org/A85397)
 - [LMS14](https://arxiv.org/pdf/1112.4816) Lenstra, H.W. et al. "Character sums for primitive root densities" _arXiv:1112.4816_ [math.NT] (2014).
 - [Ho67] Hooley, C. "On Artin's conjecture." _Journal für die reine und angewandte Mathematik_ 225 (1967): 209-220.
 -/

--- a/FormalConjectures/Wikipedia/Pell.lean
+++ b/FormalConjectures/Wikipedia/Pell.lean
@@ -21,7 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
  - [Wikipedia](https://en.wikipedia.org/wiki/Pell_number#Primes_and_squares)
- - [OEIS A86383](https://oeis.org/A86383)
+ - [A86383](https://oeis.org/A86383)
 
 The Pell numbers $P_n$ are defined by $P_0 = 0$,
 $P_1 = 1$, $P_{n+2} = 2*P_{n+1} + P_n$. [OEIS A129](https://oeis.org/A129)

--- a/FormalConjectures/Wikipedia/PollocksConjecture.lean
+++ b/FormalConjectures/Wikipedia/PollocksConjecture.lean
@@ -23,7 +23,7 @@ Every positive integer is the sum of at most 5 tetrahedral numbers.
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Pollock%27s_conjectures)
-- [OEIS A797](https://oeis.org/A797)
+- [A797](https://oeis.org/A797)
 - L. E. Dickson, *History of the Theory of Numbers, Vol. II: Diophantine Analysis*, Dover (2005), pp. 22–23
 - Frederick Pollock, *On the extension of the principle of Fermat's theorem on the polygonal numbers to the higher order of series whose ultimate differences are constant*, Abstracts of the Papers Communicated to the Royal Society of London **5** (1850), 922–924
 - H. E. Salzer and N. Levine, *Table of integers not exceeding 100000 that are not expressible as the sum of four tetrahedral numbers*, Math. Comp. **12** (1958), 141–144

--- a/FormalConjectures/Wikipedia/WoodalPrimes.lean
+++ b/FormalConjectures/Wikipedia/WoodalPrimes.lean
@@ -20,7 +20,7 @@ import FormalConjectures.Util.ProblemImports
 
 References:
 * [Wikipedia/Woodall Number](https://en.wikipedia.org/wiki/Woodall_number#Woodall_primes)
-* [OEIS/A2234](https://oeis.org/A2234)
+* [A2234](https://oeis.org/A2234)
 
 -/
 


### PR DESCRIPTION
As per [#Formal conjectures > Referencing OEIS @ 💬](https://leanprover.zulipchat.com/#narrow/channel/524981-Formal-conjectures/topic/Referencing.20OEIS/near/571129136), trying to make these references consistent with one another.