### PR TITLE
feat(GreensOpenProblems): 12

### DIFF
--- a/FormalConjectures/GreensOpenProblems/12.lean
+++ b/FormalConjectures/GreensOpenProblems/12.lean
@@ -38,12 +38,10 @@ Note: We interpret indices modulo 5.
 theorem green_12 : answer(sorry) ↔
     ∀ {G : Type*} [AddCommGroup G] [Fintype G] [DecidableEq G],
     ∀ (A : Finset G),
-
     let N := Fintype.card G
     let α := (A.card : ℝ) / N
     let valid_tuples : Finset ((Fin 5 → G) × (Fin 5 → G)) := Finset.univ.filter (fun t =>
       ∀ i : Fin 5, ∀ j ∈ ({i, i + 1, i + 2} : Finset (Fin 5)), t.1 i + t.2 j ∈ A)
-
     (valid_tuples.card : ℝ) ≥ α ^ 15 * (N : ℝ) ^ 10 := by
   sorry
 


### PR DESCRIPTION
# Description
Let $G$ be an abelian group of size $N$, and suppose that $A \subset G$ has density $\alpha$.
Are there at least $\alpha^{15} N^{10}$ tuples $(x_1, \dots, x_5, y_1, \dots, y_5) \in G^{10}$ such that $x_i + y_j \in A$ whenever $j \in \{i, i+1, i+2\}$?

---

- Closes #1547
- I interpreted the indices to wrap-around modulo 5
- Fits nicely in a single block of code, I was surprised I did not need to define intermediate predicates

# Testing
:white_check_mark: Builds successfully
```shell
$ lake build FormalConjectures/GreensOpenProblems/12.lean 
Build completed successfully.
```