### PR TITLE
fix(ErdosProblems): take `n` sufficiently large in `erdos_1004.EPS87_theorem`

### DIFF
--- a/FormalConjectures/ErdosProblems/1004.lean
+++ b/FormalConjectures/ErdosProblems/1004.lean
@@ -44,7 +44,7 @@ Here we state the existence of such a constant c.
 @[category research solved, AMS 11]
 theorem erdos_1004.EPS87_theorem :
     answer(True) ↔ ∃ (c : ℝ) (hc : c > 0),
-      ∀ (n K : ℕ), n > 0 → IsDistinctTotientRun n K →
+      ∀ᶠ n in atTop, ∀ (K : ℕ), IsDistinctTotientRun n K →
         (K : ℝ) ≤ (n : ℝ) / Real.exp (c * (Real.log n) ^ (1/3 : ℝ)) := by
   sorry
 


### PR DESCRIPTION
Should be eventually, as it is in the main variant.