### PR TITLE
fix(ErdosProblems): positivity in `918` variant

### DIFF
--- a/FormalConjectures/ErdosProblems/918.lean
+++ b/FormalConjectures/ErdosProblems/918.lean
@@ -71,7 +71,7 @@ less than $\aleph_k$ vertices has chromatic number $\leq \aleph_0$. -/
 -- Formalisation note: the source is missing the assumption that the graph have ℵₖ vertices
 -- which can be found in [ErHa68b]
 @[category research solved, AMS 5]
-theorem erdos_918.variants.erdos_hajnal (k : ℕ) : ∃ (V : Type u) (G : SimpleGraph V),
+theorem erdos_918.variants.erdos_hajnal (k : ℕ) (hk : 0 < k) : ∃ (V : Type u) (G : SimpleGraph V),
     #V = ℵ_ k ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (W : Set V) (_ : #W < ℵ_ k), (G.induce W).chromaticCardinal ≤ ℵ₀ := by
   sorry


### PR DESCRIPTION
This variant needs `k > 0`, otherwise get a contradiction between having `#V = ℵ_ 0` and `G.chromaticCardinal = ℵ₁`