### PR TITLE
fix(ErdosProblems): make `510` asymptotic

### DIFF
--- a/FormalConjectures/ErdosProblems/510.lean
+++ b/FormalConjectures/ErdosProblems/510.lean
@@ -26,7 +26,7 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Erdos510
 
-open Real
+open Real Filter
 open scoped Finset
 
 /--
@@ -39,7 +39,7 @@ $$\sum_{n\in A}\cos(n\theta) < -cN^{1/2}?$$
 @[category research open, AMS 11]
 theorem erdos_510 :
     answer(sorry) ↔ ∃ (c : ℝ) (hc : 0 < c),
-      ∀ N > 0, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
+      ∀ᶠ N in atTop, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
       ∃ θ, ∑ n ∈ A, cos (n * θ) < -c * sqrt N := by
   sorry
 
@@ -49,7 +49,7 @@ Ruzsa [Ru04] proved an upper bound of $-\exp(O(\sqrt{\log N})$.
 @[category research solved, AMS 11]
 theorem erdos_510.variant.ruzsa :
     ∃ (c : ℝ) (hc : 0 < c),
-      ∀ N > 0, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
+      ∀ᶠ N in atTop, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
       ∃ θ, ∑ n ∈ A, cos (n * θ) < - exp (c * sqrt (log N)) := by
   sorry
 
@@ -59,7 +59,7 @@ Bedert [Be25c] proved an upper bound of $-c N^{1/7}$.
 @[category research solved, AMS 11]
 theorem erdos_510.variant.bedert :
     ∃ (c : ℝ) (hc : 0 < c),
-      ∀ N > 0, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
+      ∀ᶠ N in atTop, ∀ (A : Finset ℕ), 0 ∉ A → #A = N →
       ∃ θ, ∑ n ∈ A, cos (n * θ) < - c * N ^ (1 / 7 : ℝ) := by
   sorry
 


### PR DESCRIPTION
The original problem concerns only sufficiently large `N`, see https://www.degruyterbrill.com/document/doi/10.1515/crll.1965.217.128/html