### PR TITLE
fix(HilbertProblems): `17`

### DIFF
--- a/FormalConjectures/HilbertProblems/17.lean
+++ b/FormalConjectures/HilbertProblems/17.lean
@@ -63,6 +63,7 @@ theorem f_not_sum_of_squares :
 /--
 For the polynomial version, Hilbert showed that every nonnegative homogeneous polynomial in
 $n$ variables of degree $2d$ can be written as a sum of squares of polynomials if and only if
+- $n = 1$
 - $n = 2$
 - $d = 1$
 - $(n, d) = (3, 2)$.


### PR DESCRIPTION
- `n = 0` cases need to be excluded, plus `d = 0` in the homogeneous case (tests demonstrate why these cases are trivially true)
- Looking at the [table](https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem#Motivation) on the Wikipedia page `n = 1` (and any `d`) also needs to be allowed as solution (although the wiki text is missing this).
- `IsHomogenous` expects degree as parameter rather than the number of variables, so the clause `f.IsHomogeneous n → f.totalDegree = 2 * d` is a contradiction for any `n` and `2 * d` distinct.