### PR TITLE
Add Herzog–Schönheim conjecture alias

### DIFF
--- a/FormalConjectures/Wikipedia/HerzogSchonheimConjecture.lean
+++ b/FormalConjectures/Wikipedia/HerzogSchonheimConjecture.lean
@@ -32,6 +32,7 @@ The actual formalization is in `FormalConjectures.ErdosProblems.«274»`.
 namespace HerzogSchonheimConjecture
 
 @[category research open, AMS 20]
-theorem herzog_schonheim_conjecture : type_of% @Erdos274.herzog_schonheim := by sorry
+theorem herzog_schonheim_conjecture : type_of% @Erdos274.herzog_schonheim := by 
+  sorry
 
 end HerzogSchonheimConjecture


### PR DESCRIPTION
This is an alias for FormalConjectures/ErdosProblems/274.lean 

The alias uses `type_of%` to refer to the canonical statement in
`FormalConjectures/ErdosProblems/274.lean`, without duplicating any logical content. It has the same parameters and assumptions which are mapped to the parameters in the original theorem. Users can work with the Herzog–Schönheim conjecture using this file directly.

Closes #1956

