### PR TITLE
feat(ErdosProblems): 507

### DIFF
--- a/FormalConjectures/ErdosProblems/507.lean
+++ b/FormalConjectures/ErdosProblems/507.lean
@@ -32,7 +32,7 @@ import FormalConjectures.Util.ProblemImports
 -/
 
 open Asymptotics Filter Topology
-open scoped Classical EuclideanGeometry
+open scoped EuclideanGeometry
 
 namespace Erdos507
 
@@ -48,7 +48,7 @@ $\alpha(n)$ is the supremum of `minTriangleArea S` over all sets `S` of $n$ poin
 -/
 noncomputable def α (n : ℕ) : ℝ :=
   sSup (minTriangleArea '' { S : Finset ℝ² |
-    S.card = n ∧ ↑S ⊆ Metric.closedBall (0 : ℝ²) 1 ∧ ¬ Collinear ℝ (↑S : Set ℝ²) })
+    S.card = n ∧ ↑S ⊆ Metric.closedBall (0 : ℝ²) 1 ∧ ¬ Collinear ℝ (S : Set ℝ²) })
 
 /--
 Current best lower bound [KPS82].


### PR DESCRIPTION
# Description
Let $\alpha(n)$ be such that every set of $n$ points in the unit disk contains three points which determine a triangle of area at most $\alpha(n)$. Estimate $\alpha(n)$.

- Closes #760
- Added additional known bounds from the literature
- Tried to leverage `Finset` as much as possible to ligthen the proof burden

# Testing
:white_check_mark: Builds successfully
```shell
$ lake build FormalConjectures/ErdosProblems/507.lean 
Build completed successfully.
```