### PR TITLE
feat(GreensOpenProblems): 77

### DIFF
--- a/FormalConjectures/GreensOpenProblems/77.lean
+++ b/FormalConjectures/GreensOpenProblems/77.lean
@@ -36,7 +36,7 @@ determined by them?
 theorem green_77 :
     answer(sorry) ↔
     ∃ (o : ℕ → ℝ), Tendsto o atTop (𝓝 0) ∧
-      α ≪ (fun n ↦ (n : ℝ) ^ (-(2 : ℝ) + o n)) := by
+      α ≪ fun n ↦ n ^ (-2 + o n) := by
   sorry
 
 end Green77


### PR DESCRIPTION
# Description
Given $n$ points in the unit disc, must there be a triangle of area at most $n^{-2+o(1)}$ determined by them?

- Closes #1732 
- **Depends on the tools defined in #2169 :warning:**

# Testing
:white_check_mark: Builds successfully.
```shell
$ lake build FormalConjectures/GreensOpenProblems/77.lean 
Build completed successfully.
```