### PR TITLE
feat(GreensOpenProblems): 18

### DIFF
--- a/FormalConjectures/GreensOpenProblems/18.lean
+++ b/FormalConjectures/GreensOpenProblems/18.lean
@@ -36,6 +36,10 @@ namespace Green18
 /--
 The number of triples $(x, y, g)$ in $G^3$ such that $g \neq e$, and $(x, y), (gx, y), (x, gy)$ are
 all in $A$. These are called "naive corners" by [Au16].
+
+Note: the shortened formulation from [Gr26] does not mention $g \neq e$, but this is the original
+statement from [Au16], which ensure non-trivial corners. Note however that [Au16] use more
+generally compact groups and not just finite discrete groups.
 -/
 def numNaiveCorners {G : Type*} [Group G] [Fintype G] [DecidableEq G] (A : Finset (G × G)) : ℕ :=
   ( (univ : Finset (G × G × G)).filter


### PR DESCRIPTION
# Description
Suppose that $G$ is a finite group, and let $A \subset G \times G$ be a subset of density $\alpha$. Is it true that there are $\gg_\alpha |G|^3$ triples $x, y, g$ such that $(x, y), (gx, y), (x, gy)$ all lie in $A$?


- Closes #1553
- Couple clarifications from Green's statement:
    - Added $\exists m_0 \in \mathbb{N}, ..., |G| \ge m_0$ to focus on asymptotic behavior and avoid edge cases on tiny groups.
    - Added $g \neq e$ from Austin's paper, to avoid trivial triples. Not strictly required.
    - Still following Austin's referenced paper, density is taken as "A is $\alpha$-dense, i.e. $|A| \ge \alpha |G|^2$"
- Also added the solved case for "BMZ" corners

# Testing
:white_check_mark: Builds successfully.
```shell
$ lake build FormalConjectures/GreensOpenProblems/18.lean 
Build completed successfully.
```