### PR TITLE
fix(ErdosProblems): 204 

### DIFF
--- a/FormalConjectures/ErdosProblems/204.lean
+++ b/FormalConjectures/ErdosProblems/204.lean
@@ -42,7 +42,8 @@ Adenwalla [Ad25] has proved there are no such $n$.
 theorem erdos_204 : answer(False) ↔ ∃ (n : ℕ) (a : ℕ → ℤ),
     let D := {d : ℕ | d ∣ n ∧ d > 1}
     (∀ x : ℤ, ∃ d ∈ D, x ≡ a d [ZMOD d]) ∧
-    (∀ d ∈ D, ∀ d' ∈ D, ∀ x : ℤ, x ≡ a d [ZMOD d] → x ≡ a d' [ZMOD d'] → Nat.gcd d d' = 1) := by
+    (∀ d ∈ D, ∀ d' ∈ D, d ≠ d' → (∃ x : ℤ, x ≡ a d [ZMOD d] → x ≡ a d' [ZMOD d']) →
+      Nat.gcd d d' = 1) := by
   sorry
 
 end Erdos204


### PR DESCRIPTION
- `d` and `d'` need to be distinct otherwise `d.gcd d' = 1` is a contradiction. 
- existential quantifier needed for `x` 