### PR TITLE
fix: disable copyright linter on FormalConjectures/All.lean

### DIFF
--- a/FormalConjectures/Util/Linters/CopyrightLinter.lean
+++ b/FormalConjectures/Util/Linters/CopyrightLinter.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 import Mathlib.Tactic.Linter.Header
+import Mathlib.Data.String.Defs
 
 open Lean Elab Meta Command Syntax
 
@@ -58,8 +59,13 @@ register_option linter.style.copyright : Bool := {
   descr := "enable the copyright header style linter"
 }
 
+
+
 /-- The copyright linter ensures that every file has the right copyright header. -/
 def copyrightLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  -- The formal-conjectures CI uses a global import file called `All.lean` but we don't want
+  -- to run this linter there.
+  if (← getFileName).endsWith "FormalConjectures/All.lean" then return
   let source := (← getFileMap).source
   -- Get the syntax corresponding to the first character in the file since that's where the warning
   -- message will be logged.

--- a/FormalConjectures/Util/Linters/CopyrightLinter.lean
+++ b/FormalConjectures/Util/Linters/CopyrightLinter.lean
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 import Mathlib.Tactic.Linter.Header
-import Mathlib.Data.String.Defs
 
 open Lean Elab Meta Command Syntax
 


### PR DESCRIPTION
This PR adds a check in the copyright linter to avoid running it on `FormalConjectures/All.lean` since this throws an error
message every time we run CI.