### PR TITLE
fix(ErdosProblems): 455 

### DIFF
--- a/FormalConjectures/ErdosProblems/455.lean
+++ b/FormalConjectures/ErdosProblems/455.lean
@@ -23,7 +23,7 @@ import FormalConjectures.Util.ProblemImports
  - [Ri76] Richter, Bernd, Über die Monotonie von Differenzenfolgen. Acta Arith. (1976), 225-227.
 -/
 
-open Filter
+open Filter ENNReal
 
 namespace Erdos455
 
@@ -41,7 +41,7 @@ theorem erdos_455: answer(sorry) ↔ ∀ q : ℕ → ℕ, StrictMono q →
 @[category research solved, AMS 11]
 theorem erdos_455.liminf : ∀ q : ℕ → ℕ, StrictMono q →
     (∀ n, (q n).Prime ∧ q (n + 2) - q (n + 1) ≥ q (n + 1) - q n) →
-    liminf (fun n : ℕ => (q n : ℝ) / n ^ 2) atTop > 0.352 := by
+    liminf (fun n : ℕ => (q n : ℝ≥0∞) / n ^ 2) atTop > 0.352 := by
   sorry
 
 end Erdos455


### PR DESCRIPTION
need to cast `liminf` to an extended real type due to junk value of `0` for unbounded sequences