### PR TITLE
fix(Wikipedia): Mahler32

### DIFF
--- a/FormalConjectures/Wikipedia/Mahler32.lean
+++ b/FormalConjectures/Wikipedia/Mahler32.lean
@@ -32,7 +32,7 @@ $$
 -/
 noncomputable def Ω (α : ℝ) : ℝ :=
   sInf {Filter.atTop.limsup (fun n ↦ Int.fract (θ * α ^ n))
-    - Filter.atTop.liminf (fun n ↦ Int.fract (θ * α ^ n)) | (θ : ℝ) (_ : 0 < θ) }
+    - Filter.atTop.liminf (fun n ↦ Int.fract (θ * α ^ n)) | (θ : ℝ) (_ : 0 < θ)}
 
 /-- A Z-number is a real number `x` such that the fractional parts of `x(3/2)^n` are less than
 `1/2` for all positive integers `n`. -/


### PR DESCRIPTION
Use `sInf` instead of `iInf` because `⨅ (θ : ℝ) (_ : 0 < θ)` parses as `⨅ (θ : ℝ), ⨅ (_ : 0 < θ)` allowing the use of `0` as a value for `θ`. 

MWE:
```lean
example : ⨅ (n : ℕ) (_ : 0 < n), n = 0 := by 
  -- goal: ⨅ n, ⨅ (_ : 0 < n), n = 0
  apply IsLeast.csInf_eq
  use ⟨0, by simp⟩ 
  simp [lowerBounds]