### PR TITLE
fix(ErdosProblems): 786

### DIFF
--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -73,7 +73,7 @@ theorem erdos_786.parts.i.example (A : Set ℕ) (hA : A = { n | n % 4 = 2 }) :
 
 /--
 `consecutivePrimesFrom p k` gives the set of `k + 1` consecutive primes that are at least `p` in
-size. If `p` is prime then this is the set of `k + 1` consectuve primes `p, p_1, ..., p_k`-/
+size. If `p` is prime then this is the set of `k + 1` consecutive primes `p, p_1, ..., p_k`-/
 noncomputable def consecutivePrimesFrom (p : ℕ) (k : ℕ) : Finset ℕ :=
     (Finset.range (k + 1)).image (Nat.nth (fun q ↦ q.Prime ∧ p ≤ q))
 


### PR DESCRIPTION
- Fix order of quantifiers in Selfridge example because the length `k` of the sequence is determined by the magnitude of the primes. If we take `k = 1` before the primes themselves, then very large primes will never straddle `1` in their sums of reciprocals, giving a contradiction.
- Redefine `consecutivePrimes` in order to formalise this interpretation.
- The condition that `A` is the set of numbers with only one prime from the sequence dividing it requires multiplicity one as well. 
- Fix constraints on `eps`
- Add a TODO since the updated website mentions that repetitions may be allowed in `Set.IsMulCardSet`, although both versions are open.