### PR TITLE
Feat(FormalConjecturesForMathlib): add general infrastructure for term linters.

### DIFF
--- a/FormalConjecturesForMathlib/Lean/Elab/InfoTree/Util.lean
+++ b/FormalConjecturesForMathlib/Lean/Elab/InfoTree/Util.lean
@@ -1,3 +1,19 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
 import Lean
 
 /-! # InfoTree utils

--- a/FormalConjecturesForMathlib/Tactic/Linter/Term.lean
+++ b/FormalConjecturesForMathlib/Tactic/Linter/Term.lean
@@ -1,3 +1,19 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
 import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util
 
 open Lean Meta Elab Command


### PR DESCRIPTION
Co-authored-by: Eric Weiser <efw@google.com>