### PR TITLE
feat(FormalConjectures/Util/Linters): ExistsImplication linter

### DIFF
--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -26,11 +26,12 @@ register_option linter.style.existsImplication : Bool := {
   descr := "Detects misformalisations caused by writing ∃ x, P x → Q rather than ∃ x, P x ∧ Q "
 }
 
+/-- Changes and expression of the form `∀ (h1 : Prop1) (h2 : Prop2) ..., Propn` to
+`Prop1 ∧ Prop2 ∧ ... ∧ Propn`. -/
 def forallToAnd (expr : Expr) : MetaM Expr :=
   forallTelescope expr fun vars final => do
     let varsAsProp ← vars.mapM inferType
-    varsAsProp.foldrM (fun var currentBigAnd =>
-      mkAppM ``And #[var, currentBigAnd]) final
+    varsAsProp.foldrM (fun var currentBigAnd => mkAppM ``And #[var, currentBigAnd]) final
 
 /--
 Checks if an expression contains the pattern `∃ x, P x → Q`.

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -75,6 +75,7 @@ def existsImplicationLinter : Linter where
   run := Lean.Elab.Command.Linter.runTermLinter (σ := Unit) linter.style.existsImplication
     fun expr stx => checkExistsArrow expr stx
 
+-- This name is here due to the reappearance of https://github.com/leanprover/lean4/issues/10175.
 initialize zzzzzzz : Unit ← do addLinter existsImplicationLinter
 
 end ExistsImplicationLinter

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -75,7 +75,7 @@ def existsImplicationLinter : Linter where
   run := Lean.Elab.Command.Linter.runTermLinter (σ := Unit) linter.style.existsImplication
     fun expr stx => checkExistsArrow expr stx
 
--- This name is here due to the reappearance of https://github.com/leanprover/lean4/issues/10175.
-initialize zzzzzzz : Unit ← do addLinter existsImplicationLinter
+/-- This name is here due to the reappearance of https://github.com/leanprover/lean4/issues/10175.-/
+initialize zzzThisIsASillyButNecessayNameSeeMyDocstring : Unit ← do addLinter existsImplicationLinter
 
 end ExistsImplicationLinter

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -15,7 +15,16 @@ limitations under the License.
 -/
 
 import FormalConjecturesForMathlib.Tactic.Linter.Term
-import Mathlib
+
+/-! # The Exists Implication Linter
+
+Many misformalisations stem from using a pattern of the form `∃ x, P x → Q` instead of
+`∃ x, P x ∧ Q` (e.g. when formalising something of the form "there is positive `x` such that ...").
+This is almost always incorrect (and trivial to prove) since it then suffices to pick an `x` that
+does not satisfy `P`. This linter flags occurences of this patter to the user and proposes a
+corrected syntax.
+
+-/
 
 open Lean Meta
 

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -75,6 +75,6 @@ def existsImplicationLinter : Linter where
   run := Lean.Elab.Command.Linter.runTermLinter (σ := Unit) linter.style.existsImplication
     fun expr stx => checkExistsArrow expr stx
 
-initialize addLinter existsImplicationLinter
+initialize zzzzzzz : Unit ← do addLinter existsImplicationLinter
 
 end ExistsImplicationLinter

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -1,3 +1,19 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
 import FormalConjecturesForMathlib.Tactic.Linter.Term
 import Mathlib
 
@@ -44,8 +60,10 @@ The `existsImplicationLinter` detects expressions of the form `∃ a, P a → Q`
 user since those are rarely correct.
 -/
 def existsImplicationLinter : Linter where
-  run := Lean.Elab.Command.Linter.runTermLinter (σ := Unit) linter.style.existsImplication fun expr stx => do
-    checkExistsArrow expr stx
+  -- TODO(Paul-Lez): Running in `StateT Unit MetaM Unit` is a bit of a hack.
+  -- Do this with a non-StateT version of `runTermLinter`?
+  run := Lean.Elab.Command.Linter.runTermLinter (σ := Unit) linter.style.existsImplication
+    fun expr stx => checkExistsArrow expr stx
 
 initialize addLinter existsImplicationLinter
 

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -1,0 +1,52 @@
+import FormalConjecturesForMathlib.Tactic.Linter.Term
+import Mathlib
+
+open Lean Meta
+
+namespace ExistsImplicationLinter
+
+register_option linter.style.existsImplication : Bool := {
+  defValue := true
+  descr := "Detects misformalisations caused by writing ∃ x, P x → Q rather than ∃ x, P x ∧ Q "
+}
+
+def forallToAnd (expr : Expr) : MetaM Expr :=
+  forallTelescope expr fun vars final => do
+    let varsAsProp ← vars.mapM inferType
+    varsAsProp.foldrM (fun var currentBigAnd =>
+      mkAppM ``And #[var, currentBigAnd]) final
+
+/--
+Checks if an expression contains the pattern `∃ x, P x → Q`.
+-/
+partial def checkExistsArrow (stx : Syntax) (e : Expr) : MetaM Unit := do
+  match e with
+  | .mdata _ e => checkExistsArrow stx e
+  | .app .. =>
+      -- Check if this is an application of `Exists`
+      if e.isAppOfArity ``Exists 2 then
+        let lam := e.getAppArgs[1]!
+        let .lam _ _ target _ := lam
+          | throwError m!"Encountered an ill-formed existential expression {e}"
+        -- If the inside of the lambda expression is not a forall then we're fine.
+        unless target.isForall do return
+        lambdaTelescope lam fun vars target => do
+          let correctCore ← forallToAnd target
+          let correctLam ← Lean.Meta.mkLambdaFVars vars correctCore
+          let suggestedExpr ← mkAppM ``Exists #[correctLam]
+          Lean.Linter.logLintIf linter.style.existsImplication stx
+              m!"Declaration contains the pattern the expression {e}. \
+                Did you mean {suggestedExpr}?"
+  | _ => pure ()
+
+/--
+The `existsImplicationLinter` detects expressions of the form `∃ a, P a → Q` and flags them to the
+user since those are rarely correct.
+-/
+def existsImplicationLinter : Linter where
+  run := Lean.Elab.Command.Linter.runTermLinter (σ := Unit) linter.style.existsImplication fun expr stx => do
+    checkExistsArrow expr stx
+
+initialize addLinter existsImplicationLinter
+
+end ExistsImplicationLinter

--- a/FormalConjecturesTest/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/ExistsImplicationLinter.lean
@@ -1,3 +1,19 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
 import FormalConjectures.Util.Linters.ExistsImplicationLinter
 
 /--

--- a/FormalConjecturesTest/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/ExistsImplicationLinter.lean
@@ -15,13 +15,12 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.Linters.ExistsImplicationLinter
+import Mathlib
 
 /--
 warning: Declaration contains the pattern the expression ∃ n, n ≠ 0 → False. Did you mean ∃ n, n ≠ 0 ∧ False?
 
 Note: This linter can be disabled with `set_option linter.style.existsImplication false`
----
-info: Nat
 -/
 #guard_msgs in
 theorem this_doesnt_look_good : ∃ n : Nat, n ≠ 0 → False := by
@@ -32,8 +31,6 @@ theorem this_doesnt_look_good : ∃ n : Nat, n ≠ 0 → False := by
 warning: Declaration contains the pattern the expression ∃ n, n ≠ 0 → n ≠ 1 → False. Did you mean ∃ n, n ≠ 0 ∧ n ≠ 1 ∧ False?
 
 Note: This linter can be disabled with `set_option linter.style.existsImplication false`
----
-info: Nat
 -/
 #guard_msgs in
 theorem even_worse : ∃ n : Nat, n ≠ 0 → n ≠ 1 → False := by

--- a/FormalConjecturesTest/Util/Linters/ExistsImplicationLinterTest.lean
+++ b/FormalConjecturesTest/Util/Linters/ExistsImplicationLinterTest.lean
@@ -1,0 +1,29 @@
+import FormalConjectures.Util.Linters.ExistsImplicationLinter
+
+/--
+warning: Declaration contains the pattern the expression ∃ n, n ≠ 0 → False. Did you mean ∃ n, n ≠ 0 ∧ False?
+
+Note: This linter can be disabled with `set_option linter.style.existsImplication false`
+---
+info: Nat
+-/
+#guard_msgs in
+theorem this_doesnt_look_good : ∃ n : Nat, n ≠ 0 → False := by
+  use 0
+  trivial
+
+/--
+warning: Declaration contains the pattern the expression ∃ n, n ≠ 0 → n ≠ 1 → False. Did you mean ∃ n, n ≠ 0 ∧ n ≠ 1 ∧ False?
+
+Note: This linter can be disabled with `set_option linter.style.existsImplication false`
+---
+info: Nat
+-/
+#guard_msgs in
+theorem even_worse : ∃ n : Nat, n ≠ 0 → n ≠ 1 → False := by
+  use 0
+  trivial
+
+#guard_msgs in
+theorem this_is_fine : ∃ n : Nat, n ≠ 0 ∨ False := by
+  sorry


### PR DESCRIPTION
Fixes #2227.

This linter detects misformalisations arising from statements of the form `∃ x, P x → Q` that should have been formalised instead as `∃ x, P x ∧ Q`.
