### PR TITLE
fix(ErdosProblems): 274 

### DIFF
--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -47,6 +47,7 @@ structure Group.ExactCovering (G : Type*) [Group G] (ι : Type*) [Fintype ι] wh
 
 /--
 If `G` is a group then can there exist an exact covering of `G` by more than one cosets of
+Does there exist a group `G` with an exact covering by more than one cosets of
 different sizes? (i.e. each element is contained in exactly one of the cosets.)
 -/
 @[category research open, AMS 20]


### PR DESCRIPTION
Use existential quantifier instead of universal. This is false if `G` has prime order, since the only exact coverings of size `> 1` are `p`-copies of `{1}`, which all have the same size.