### PR TITLE
feat(ErdosProblems/686): prove a solved variant and add some open variants

### DIFF
--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -76,14 +76,36 @@ theorem erdos_686.variants.four_two :
   by_cases hc : m < 2 * (n + 1) <;> nlinarith
 
 /--
+The number $4$ cannot be written as
+$$4=\frac{\prod_{1\leq i\leq 2}(m+i)}{\prod_{1\leq i\leq 2}(n+i)}$$
+for $m≥n+2$!
+-/
+@[category research solved, AMS 11]
+theorem erdos_686.variants.four_three :
+    ¬ ∃ᵉ (n : ℕ) (m ≥ n + 3),
+      (4 : ℚ) = (∏ i ∈ Finset.Icc 1 3, (m + i)) / (∏ i ∈ Finset.Icc 1 3, (n + i)) := by
+  sorry
+
+/--
 Can $9$ be written as
 $$9=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
 for some $k≥2$ and $m≥n+k$?
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11]
 theorem erdos_686.variants.nine :
-    answer(sorry) ↔ ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+    answer(True) ↔ ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
       (9 : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
+  sorry
+
+/--
+Can $25$ be written as
+$$25=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
+for some $k≥2$ and $m≥n+k$?
+-/
+@[category research open, AMS 11]
+theorem erdos_686.variants.twenty_five :
+    answer(sorry) ↔ ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+      (25 : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -30,8 +30,52 @@ for some $k≥2$ and $m≥n+k$?
 -/
 @[category research open, AMS 11]
 theorem erdos_686 :
-    answer(sorry) ↔ ∀ N ≥ 2, ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+    answer(sorry) ↔ ∀ N ≥ (2 : ℕ), ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
       (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
+  sorry
+
+/--
+Can every square $N≥2$ be written as
+$$N=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
+for some $k≥2$ and $m≥n+k$?
+-/
+@[category research open, AMS 11]
+theorem erdos_686.variants.square :
+    answer(sorry) ↔ ∀ N ≥ (2 : ℕ),  (IsSquare N) → ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+      (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
+  sorry
+
+/--
+Can $4$ be written as
+$$4=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
+for some $k≥2$ and $m≥n+k$?
+-/
+@[category research open, AMS 11]
+theorem erdos_686.variants.four :
+    answer(sorry) ↔ ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+      (4 : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
+  sorry
+
+/--
+Can $4$ be written as
+$$4=\frac{\prod_{1\leq i\leq 2}(m+i)}{\prod_{1\leq i\leq 2}(n+i)}$$
+for $m≥n+2$?
+-/
+@[category research open, AMS 11]
+theorem erdos_686.variants.four_two :
+    answer(sorry) ↔ ∃ᵉ (n : ℕ) (m ≥ n + 2),
+      (4 : ℚ) = (∏ i ∈ Finset.Icc 1 2, (m + i)) / (∏ i ∈ Finset.Icc 1 2, (n + i)) := by
+  sorry
+
+/--
+Can $9$ be written as
+$$9=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
+for some $k≥2$ and $m≥n+k$?
+-/
+@[category research open, AMS 11]
+theorem erdos_686.variants.nine :
+    answer(sorry) ↔ ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+      (9 : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
   sorry
 
 /--
@@ -40,22 +84,63 @@ $$N=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
 for some $k≥2$ and $m≥n+k$?
 -/
 @[category research solved, AMS 11]
-theorem erdos_686.variants.non_square (N : ℕ) (h_n_ge_2 : N ≥ 2) (h_not_square : ¬ ∃ s, s * s = N) : ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k), (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
-  exists(2),by valid
-  field_simp only [ Finset.prod_Icc_succ_top,Finset.Icc_self, Finset.prod_singleton]
-  by_cases h:{n|∃k,N*( (n + 1) *(n+2)) = (k + 1) *(k+2)}.Nonempty
-  · obtain ⟨rfl⟩ :=h_n_ge_2.eq_or_lt
-    · exact (mod_cast if a:∃ a ∈ Finset.range 30,∃n ∈ Finset.range 30,_ then a.imp fun a s=>s.2.imp fun and=>And.right else (by tauto))
-    obtain ⟨A, B⟩ :=eq_or_ne N (3)
-    · exact (mod_cast if a:∃ a ∈ Finset.range 30,∃n ∈ Finset.range 30,_ then a.imp fun and μ=>μ.2.imp fun and=>And.right else (by tauto))
-    exact h.mono fun and=>.imp fun a s=>mod_cast (by use (by nlinarith only[pow_three and,s,show N>3by valid]))
+theorem erdos_686.variants.non_square :
+    answer(True) ↔ ∀ N ≥ (2 : ℕ), (¬ IsSquare N) → ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
+      (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
+  refine ⟨fun _ N hN_ge_2 hN_not_square => ?_, fun _ => trivial⟩
+
+  have hN_not_square' : ¬ ∃ s, s * s = N := fun ⟨s, hs⟩ => hN_not_square ⟨s, hs.symm⟩
+
+  -- 1. Setup the existence for k = 2 and simplify the products
+  exists 2, by valid
+  field_simp only [Finset.prod_Icc_succ_top, Finset.Icc_self, Finset.prod_singleton]
+
+  -- 2. Case split on the existence of solutions for small bounds
+  by_cases h : {n | ∃ k, N * ((n + 1) * (n + 2)) = (k + 1) * (k + 2)}.Nonempty
+  · obtain rfl | hN_lt := hN_ge_2.eq_or_lt
+    · exact mod_cast
+        if a : ∃ a ∈ Finset.range 30, ∃ n ∈ Finset.range 30, _ then
+          a.imp fun a s => s.2.imp fun and => And.right
+        else
+          by tauto
+
+    obtain rfl | hN_ne_3 := eq_or_ne N 3
+    · exact mod_cast
+        if a : ∃ a ∈ Finset.range 30, ∃ n ∈ Finset.range 30, _ then
+          a.imp fun and μ => μ.2.imp fun and => And.right
+        else
+          by tauto
+
+    exact h.mono fun and =>
+      .imp fun a s =>
+        mod_cast (by use (by nlinarith only [pow_three and, s, show N > 3 by valid]))
+
+  -- 3. Reduce the general case to Pell's Equation
   convert (Pell.exists_of_not_isSquare _)
-  show@@_ ↔¬ IsSquare (N*4 : ℤ) →_
-  · use mod_cast h.elim ∘.imp (by tauto), (. (mod_cast h_not_square ∘.rec (by use. /2,by norm_num[←., true,Nat.div_mul_div_comm _, ((2).pow_dvd_pow_iff two_ne_zero).1, false,sq])) |>.elim ↑? _)
-    use fun and⟨A, B, _⟩=>absurd (eq_add_of_sub_eq B) ( A.natAbs_sq▸and.natAbs_sq▸mod_cast fun and=>(h) ? _)
-    obtain ⟨l, _⟩ | ⟨a, _⟩ := ( (by ·bound : ℤ)).natAbs.even_or_odd
-    · exact ( absurd (and.trans (by rw [mul_right_comm]) |>.symm.trans (by rw [ (by valid :),sq, add_mul])) (by valid ) )
-    match a with|0=>field_simp[*]at and | S+1=>use A.natAbs+ S,N* A.natAbs+ S,by nlinarith only[‹_›▸and]
+  show @@_ ↔ ¬ IsSquare (N * 4 : ℤ) → _
+  · use
+      mod_cast h.elim ∘ .imp (by tauto),
+      (. (mod_cast hN_not_square' ∘ .rec (by
+          use . / 2
+          norm_num [←., true, Nat.div_mul_div_comm _, ((2).pow_dvd_pow_iff two_ne_zero).1, false, sq]))
+        |>.elim ↑? _)
+
+    use fun and ⟨A, B, _⟩ =>
+      absurd
+        (eq_add_of_sub_eq B)
+        (A.natAbs_sq ▸ and.natAbs_sq ▸ mod_cast fun and => h ?_)
+
+    -- Parity analysis
+    obtain ⟨l, hl⟩ | ⟨a, ha⟩ := ((by · bound : ℤ)).natAbs.even_or_odd
+    · exact absurd
+        (and.trans (by rw [mul_right_comm]) |>.symm.trans (by rw [(by valid :), sq, add_mul]))
+        (by valid)
+
+    match a with
+    | 0 => field_simp [*] at and
+    | S + 1 =>
+        use A.natAbs + S, N * A.natAbs + S, by nlinarith only [‹_› ▸ and]
+
   omega
 
 -- TODO: also formalize the follow-up question:

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -34,6 +34,30 @@ theorem erdos_686 :
       (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
   sorry
 
+/--
+Can every non-square $N≥2$ be written as
+$$N=\frac{\prod_{1\leq i\leq k}(m+i)}{\prod_{1\leq i\leq k}(n+i)}$$
+for some $k≥2$ and $m≥n+k$?
+-/
+@[category research solved, AMS 11]
+theorem erdos_686.variants.non_square (N : ℕ) (h_n_ge_2 : N ≥ 2) (h_not_square : ¬ ∃ s, s * s = N) : ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k), (N : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
+  exists(2),by valid
+  field_simp only [ Finset.prod_Icc_succ_top,Finset.Icc_self, Finset.prod_singleton]
+  by_cases h:{n|∃k,N*( (n + 1) *(n+2)) = (k + 1) *(k+2)}.Nonempty
+  · obtain ⟨rfl⟩ :=h_n_ge_2.eq_or_lt
+    · exact (mod_cast if a:∃ a ∈ Finset.range 30,∃n ∈ Finset.range 30,_ then a.imp fun a s=>s.2.imp fun and=>And.right else (by tauto))
+    obtain ⟨A, B⟩ :=eq_or_ne N (3)
+    · exact (mod_cast if a:∃ a ∈ Finset.range 30,∃n ∈ Finset.range 30,_ then a.imp fun and μ=>μ.2.imp fun and=>And.right else (by tauto))
+    exact h.mono fun and=>.imp fun a s=>mod_cast (by use (by nlinarith only[pow_three and,s,show N>3by valid]))
+  convert (Pell.exists_of_not_isSquare _)
+  show@@_ ↔¬ IsSquare (N*4 : ℤ) →_
+  · use mod_cast h.elim ∘.imp (by tauto), (. (mod_cast h_not_square ∘.rec (by use. /2,by norm_num[←., true,Nat.div_mul_div_comm _, ((2).pow_dvd_pow_iff two_ne_zero).1, false,sq])) |>.elim ↑? _)
+    use fun and⟨A, B, _⟩=>absurd (eq_add_of_sub_eq B) ( A.natAbs_sq▸and.natAbs_sq▸mod_cast fun and=>(h) ? _)
+    obtain ⟨l, _⟩ | ⟨a, _⟩ := ( (by ·bound : ℤ)).natAbs.even_or_odd
+    · exact ( absurd (and.trans (by rw [mul_right_comm]) |>.symm.trans (by rw [ (by valid :),sq, add_mul])) (by valid ) )
+    match a with|0=>field_simp[*]at and | S+1=>use A.natAbs+ S,N* A.natAbs+ S,by nlinarith only[‹_›▸and]
+  omega
+
 -- TODO: also formalize the follow-up question:
 -- “If $n$ and $k$ are fixed then can one say anything about the set of integers so represented?”
 

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -93,7 +93,8 @@ theorem erdos_686.variants.non_square :
 
   -- 1. Setup the existence for k = 2 and simplify the products
   exists 2, by valid
-  field_simp only [Finset.prod_Icc_succ_top, Finset.Icc_self, Finset.prod_singleton]
+  field_simp
+  simp [Finset.prod_Icc_succ_top, Finset.Icc_self, Finset.prod_singleton]
 
   -- 2. Case split on the existence of solutions for small bounds
   by_cases h : {n | ∃ k, N * ((n + 1) * (n + 2)) = (k + 1) * (k + 2)}.Nonempty
@@ -102,24 +103,27 @@ theorem erdos_686.variants.non_square :
         if a : ∃ a ∈ Finset.range 30, ∃ n ∈ Finset.range 30, _ then
           a.imp fun a s => s.2.imp fun and => And.right
         else
-          by tauto
+          by exact (a (by native_decide)).elim
 
     obtain rfl | hN_ne_3 := eq_or_ne N 3
     · exact mod_cast
         if a : ∃ a ∈ Finset.range 30, ∃ n ∈ Finset.range 30, _ then
           a.imp fun and μ => μ.2.imp fun and => And.right
         else
-          by tauto
+          by exact (a (by native_decide)).elim
 
     exact h.mono fun and =>
       .imp fun a s =>
-        mod_cast (by use (by nlinarith only [pow_three and, s, show N > 3 by valid]))
+        mod_cast (by refine ⟨by
+            nlinarith only [pow_three and, s, show N > 3 by valid], ?_⟩; push_cast [s.symm]; field_simp)
 
   -- 3. Reduce the general case to Pell's Equation
   convert (Pell.exists_of_not_isSquare _)
   show @@_ ↔ ¬ IsSquare (N * 4 : ℤ) → _
   · use
-      mod_cast h.elim ∘ .imp (by tauto),
+      mod_cast h.elim ∘ .imp (fun n ⟨m, hle, heq⟩ => ⟨m, by
+        push_cast at heq; rw [eq_div_iff (by positivity : ((n : ℚ) + 1) * (↑n + 2) ≠ 0)] at heq
+        exact_mod_cast heq⟩),
       (. (mod_cast hN_not_square' ∘ .rec (by
           use . / 2
           norm_num [←., true, Nat.div_mul_div_comm _, ((2).pow_dvd_pow_iff two_ne_zero).1, false, sq]))
@@ -137,7 +141,7 @@ theorem erdos_686.variants.non_square :
         (by valid)
 
     match a with
-    | 0 => field_simp [*] at and
+    | 0 => simp_all
     | S + 1 =>
         use A.natAbs + S, N * A.natAbs + S, by nlinarith only [‹_› ▸ and]
 

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -57,15 +57,23 @@ theorem erdos_686.variants.four :
   sorry
 
 /--
-Can $4$ be written as
+The number $4$ cannot be written as
 $$4=\frac{\prod_{1\leq i\leq 2}(m+i)}{\prod_{1\leq i\leq 2}(n+i)}$$
-for $m≥n+2$?
+for $m≥n+2$!
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11]
 theorem erdos_686.variants.four_two :
-    answer(sorry) ↔ ∃ᵉ (n : ℕ) (m ≥ n + 2),
+    ¬ ∃ᵉ (n : ℕ) (m ≥ n + 2),
       (4 : ℚ) = (∏ i ∈ Finset.Icc 1 2, (m + i)) / (∏ i ∈ Finset.Icc 1 2, (n + i)) := by
-  sorry
+  simp only [Finset.prod_Icc_succ_top (by decide : 1 ≤ 2), Finset.Icc_self,
+    Finset.prod_singleton]
+  push_neg
+  intro n m hm
+  rw [ne_eq, eq_div_iff (by positivity : (↑((n + 1) * (n + (1 + 1))) : ℚ) ≠ 0)]
+  push_cast
+  intro h
+  have h' : 4 * ((n + 1) * (n + 2)) = (m + 1) * (m + 2) := by exact_mod_cast h
+  by_cases hc : m < 2 * (n + 1) <;> nlinarith
 
 /--
 Can $9$ be written as

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -80,7 +80,7 @@ The number $4$ cannot be written as
 $$4=\frac{\prod_{1\leq i\leq 2}(m+i)}{\prod_{1\leq i\leq 2}(n+i)}$$
 for $m≥n+2$!
 -/
-@[category research solved, AMS 11]
+@[category research open, AMS 11]
 theorem erdos_686.variants.four_three :
     ¬ ∃ᵉ (n : ℕ) (m ≥ n + 3),
       (4 : ℚ) = (∏ i ∈ Finset.Icc 1 3, (m + i)) / (∏ i ∈ Finset.Icc 1 3, (n + i)) := by


### PR DESCRIPTION
Includes a AlphaProof formal proof for the solved non-square variant. It is cleaned up for maintainability, but the raw output is in the PR history.

This PR also adds several new open variants and fixes a casting bug.

Joint work with @mo271. 