### PR TITLE
feat(ErdosProblems): Add Erdos README

### DIFF
--- a/FormalConjectures/ErdosProblems/README.md
+++ b/FormalConjectures/ErdosProblems/README.md
@@ -1,0 +1,52 @@
+# Erdős Problems
+
+The official list of Erdős problems can be found at [erdosproblems.com](https://www.erdosproblems.com), managed by Thomas Bloom.
+
+The purpose of this README is to standardize Lean formalization rules for Erdős problems. These standards will make it easier for new contributors to navigate the various formalizations within this repository.
+
+## Naming Theorems
+
+An Erdős problem usually consists of two parts:
+1. **The main problem(s)**: The text within the red or green box on the website.
+2. **The additional text**: The text provided below the red or green box.
+
+### Main Problem(s)
+Main problems may be presented as single questions, multi-part questions, requests for boundary estimates, or descriptions of functional behavior. Use the following naming standards for each case:
+
+* **Single Questions**
+    Use the format: `erdos_{N}`
+
+* **Multi-part Questions**
+    Use the convention: `erdos_{N}.parts.i`, `erdos_{N}.parts.ii`, etc.
+    *(Note: In this case, there will not be a standalone `erdos_{N}` theorem.)*
+
+* **Estimate Questions**
+    The standard pattern is: `erdos_{N}.lower_bound` and `erdos_{N}.upper_bound`
+    *Note: If a strict equality is proven, use `erdos_{N}`.*
+
+* **Behavioral Descriptions**
+    We do not currently have a standardized example for this case.
+
+### Additional Text
+For variants found in the additional text, the naming convention is:
+`erdos_{N}.variants.{name}`
+
+Choose a name that is descriptive of the variant. A common case is when the variant is a solved case for the main problem, but only for `k \geq 2`. In this case, the name could be `erdos_{N}.variants.k_geq_2`. Another common case is when a variant of the main problem is conjectured by another author. In this case, the name could be `erdos_{N}.variants.{author}`.
+
+## Docstrings
+Please keep docstrings as close as possible to the text on the Erdős Problems website. You should generally be able to copy and paste the LaTeX statements into the docstrings with only minor formatting adjustments.
+
+## References
+
+If the website lists references, include them at the top of the file and reference them via their citation. You can copy these directly from the "View the LaTeX source" section of the website.
+An example of this would be:
+
+**Example**:
+```
+*References:*
+- [erdosproblems.com/{N}](https://www.erdosproblems.com/{N})
+- [Va99] Various, Some of Paul's favorite problems. Booklet produced for the conference "Paul Erdős
+  and his mathematics", Budapest, July 1999 (1999).
+```
+
+Even if only a single reference exists, please use the plural heading `References`.

--- a/FormalConjectures/ErdosProblems/README.md
+++ b/FormalConjectures/ErdosProblems/README.md
@@ -5,7 +5,6 @@ The official list of Erdős problems can be found at [erdosproblems.com](https:/
 The purpose of this README is to standardize Lean formalization rules for Erdős problems. These standards will make it easier for new contributors to navigate the various formalizations within this repository.
 
 ## Naming Theorems
-
 An Erdős problem usually consists of two parts:
 1. **The main problem(s)**: The text within the red or green box on the website.
 2. **The additional text**: The text provided below the red or green box.
@@ -37,7 +36,6 @@ Choose a name that is descriptive of the variant. A common case is when the vari
 Please keep docstrings as close as possible to the text on the Erdős Problems website. You should generally be able to copy and paste the LaTeX statements into the docstrings with only minor formatting adjustments.
 
 ## References
-
 If the website lists references, include them at the top of the file and reference them via their citation. You can copy these directly from the "View the LaTeX source" section of the website.
 An example of this would be:
 

--- a/FormalConjectures/ErdosProblems/README.md
+++ b/FormalConjectures/ErdosProblems/README.md
@@ -46,5 +46,3 @@ An example of this would be:
 - [Va99] Various, Some of Paul's favorite problems. Booklet produced for the conference "Paul Erdős
   and his mathematics", Budapest, July 1999 (1999).
 ```
-
-Even if only a single reference exists, please use the plural heading `References`.


### PR DESCRIPTION
This is a follow up to the discussion in https://github.com/google-deepmind/formal-conjectures/pull/2327#issuecomment-3941030097

This is a quick draft I put together, so feel free to fix anything you see fit.

The one thing I added that we haven't really talked about is the References section that I put below. 

This is really just a massive nit of mine, but this is kind of a common pattern in software engineering where you have a singular/plural word to describe a list of things, but you should really just commit to using the plural despite having a single item in the list. It'll allow for easier templating and formatting down the road as well.