### PR TITLE
fix(ErdosProblems): Standardize Erdos Problem Theorems (part 1)

### DIFF
--- a/FormalConjectures/ErdosProblems/100.lean
+++ b/FormalConjectures/ErdosProblems/100.lean
@@ -47,7 +47,7 @@ theorem erdos_100 :
 
 /-- Stronger conjecture: diameter $\geq n - 1$ for sufficiently large $n$. -/
 @[category research open, AMS 52]
-theorem erdos_100_strong :
+theorem erdos_100.variants.strong :
     ∀ᶠ n in atTop, ∀ A : Finset ℝ²,
       A.card = n →
       DistancesSeparated A →
@@ -57,7 +57,7 @@ theorem erdos_100_strong :
 /-- From [Kanold]: diameter $\geq n^{3/4}$.
 TODO: find reference -/
 @[category research open, AMS 52]
-theorem erdos_100_kanold :
+theorem erdos_100.variants.kanold :
     ∃ C > (0 : ℝ), ∀ᶠ n in atTop, ∀ A : Finset ℝ²,
       A.card = n →
       DistancesSeparated A →
@@ -66,7 +66,7 @@ theorem erdos_100_kanold :
 
 /-- From [GuKa15]: diameter $\gg n / \log n$. -/
 @[category research open, AMS 52]
-theorem erdos_100_guth_katz :
+theorem erdos_100.variants.guth_katz :
     ∃ C > (0 : ℝ), ∀ᶠ n in atTop, ∀ A : Finset ℝ²,
       A.card = n →
       DistancesSeparated A →
@@ -76,7 +76,7 @@ theorem erdos_100_guth_katz :
 /-- From [Piepmeyer]: 9 points with diameter $< 5$.
 TODO: find reference -/
 @[category research open, AMS 52]
-theorem erdos_100_piepmeyer :
+theorem erdos_100.variants.piepmeyer :
     ∃ A : Finset ℝ², A.card = 9 ∧ DistancesSeparated A ∧
       diam (A : Set ℝ²) < 5 := by
   sorry

--- a/FormalConjectures/ErdosProblems/1038.lean
+++ b/FormalConjectures/ErdosProblems/1038.lean
@@ -34,24 +34,7 @@ namespace Erdos1038
 /-- What is the infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such
 that all of its roots are real and contained in `[-1,1]`? -/
 @[category research open, AMS 28]
-theorem erdos_1038.inf (n : ℕ) : answer(sorry) =
-    ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
-    (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
-    volume {x | |f.1.eval x| < 1} := by
-  sorry
-
-/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
-all of its roots are real and contained in `[-1,1]` is `< 1.835`. -/
-@[category research solved, AMS 28]
-theorem erdos_1038.inf_upperBound (n : ℕ) : ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
-    (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
-    volume {x | |f.1.eval x| < 1} < 1.835 := by
-  sorry
-
-/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
-all of its roots are real and contained in `[-1,1]` is `≥ 2 ^ (4 / 3) - 1`. -/
-@[category research solved, AMS 28]
-theorem erdos_1038.inf_lowerBound (n : ℕ) : 2 ^ (4 / 3 : ℝ) - 1 ≤
+theorem erdos_1038.parts.i (n : ℕ) : answer(sorry) =
     ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
     (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
     volume {x | |f.1.eval x| < 1} := by
@@ -61,8 +44,25 @@ theorem erdos_1038.inf_lowerBound (n : ℕ) : 2 ^ (4 / 3 : ℝ) - 1 ≤
 all of its roots are real and contained in `[-1,1]` is `2 * 2 ^ (1 / 2)`. This is proved in
 [Tao25]. -/
 @[category research solved, AMS 28]
-theorem erdos_1038.sup (n : ℕ) : 2 * 2 ^ (1 / 2 : ℝ) =
+theorem erdos_1038.parts.ii (n : ℕ) : 2 * 2 ^ (1 / 2 : ℝ) =
     ⨆ f : {f : Polynomial ℝ // f.Monic ∧
+    (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
+    volume {x | |f.1.eval x| < 1} := by
+  sorry
+
+/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
+all of its roots are real and contained in `[-1,1]` is `< 1.835`. -/
+@[category research solved, AMS 28]
+theorem erdos_1038.variants.inf_upperBound (n : ℕ) : ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
+    (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
+    volume {x | |f.1.eval x| < 1} < 1.835 := by
+  sorry
+
+/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
+all of its roots are real and contained in `[-1,1]` is `≥ 2 ^ (4 / 3) - 1`. -/
+@[category research solved, AMS 28]
+theorem erdos_1038.varaints.inf_lowerBound (n : ℕ) : 2 ^ (4 / 3 : ℝ) - 1 ≤
+    ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
     (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
     volume {x | |f.1.eval x| < 1} := by
   sorry

--- a/FormalConjectures/ErdosProblems/1051.lean
+++ b/FormalConjectures/ErdosProblems/1051.lean
@@ -74,7 +74,7 @@ Erdős [Er88c] notes that if the sequence grows rapidly to infinity (specificall
 $a_{n+1} \geq C \cdot a_n^2$ for some constant $C > 0$), then the series is irrational.
 -/
 @[category research solved, AMS 11]
-theorem erdos_1051.rapid_growth (a : ℕ → ℤ) (h_mono : StrictMono a)
+theorem erdos_1051.variants.rapid_growth (a : ℕ → ℤ) (h_mono : StrictMono a)
     (h_rapid : ∃ C > 0, ∀ n, (a (n + 1) : ℝ) ≥ C * (a n : ℝ) ^ 2) :
     Irrational (ErdosSeries a) := by
   sorry

--- a/FormalConjectures/ErdosProblems/1056.lean
+++ b/FormalConjectures/ErdosProblems/1056.lean
@@ -49,7 +49,7 @@ This is problem A15 in Guy's collection [Gu04], where he reports that in a lette
 Erdős observed that $3 * 4 \equiv 5 * 6 * 7 \equiv 1 \mod 11$.
 -/
 @[category undergraduate, AMS 11]
-theorem erdos_1056_k2 :
+theorem erdos_1056.variants.k2 :
     AllModProdEqualsOne 11 ![3, 5, 8] := by
   unfold AllModProdEqualsOne
   decide
@@ -59,7 +59,7 @@ Makowski [Ma83] found, for $k=3$:
 $2 * 3 * 4 * 5 \equiv 6 * 7 * 8 * 9 * 10 * 11 \equiv 12 * 13 * 14 * 15 \equiv 1 \mod 17$.
 -/
 @[category undergraduate, AMS 11]
-theorem erdos_1056_k3 :
+theorem erdos_1056.variants.k3 :
     AllModProdEqualsOne 17 ![2, 6, 12, 16] := by
   unfold AllModProdEqualsOne
   decide
@@ -69,7 +69,7 @@ Noll and Simmons asked, more generally, whether there are solutions to
 $q_1! \equiv \dots \equiv q_k! \mod p$ for arbitrarily large $k$ (with $q_1 < \dots < q_k$).
 -/
 @[category research open, AMS 11]
-theorem noll_simmons :
+theorem erdos_1056.variants.noll_simmons :
     answer(sorry) ↔ ∀ᶠ k in Filter.atTop,
     ∃ (p : ℕ) (_ : p.Prime) (Q : Fin k → ℕ) (_ : StrictMono Q) (_ : ∀ i, Q i < p),
     ∀ i j : Fin k, (Q i)! ≡ (Q j)! [MOD p] := by

--- a/FormalConjectures/ErdosProblems/1060.lean
+++ b/FormalConjectures/ErdosProblems/1060.lean
@@ -33,12 +33,12 @@ $\log n$.
 -/
 
 @[category research open, AMS 11]
-theorem erdos_1060.bound_one :
+theorem erdos_1060.parts.i :
     ∃ h : ℕ → ℝ,
       h =o[atTop] (fun n ↦ 1 / log (log n)) ∧ ∀ᶠ n in atTop, #{k ≤ n | k * σ 1 k = n} ≤ (n : ℝ) ^ h n := by sorry
 
 @[category research open, AMS 11]
-theorem erdos_1060.bound_two :
+theorem erdos_1060.parts.ii :
     ∃ (C : ℝ), (fun n ↦ (#{k ≤ n | k * σ 1 k = n} : ℝ)) =O[atTop]
       (fun n ↦ log n ^ C) := by sorry
 

--- a/FormalConjectures/ErdosProblems/1062.lean
+++ b/FormalConjectures/ErdosProblems/1062.lean
@@ -39,9 +39,18 @@ open scoped Classical in
 noncomputable def f (n : ℕ) : ℕ :=
   Nat.findGreatest (fun k => ∃ A ⊆ Set.Icc 1 n, ForkFree A ∧ A.ncard = k) n
 
+-- TODO: Add erdos_1062.parts.i: How large can $f(n)$ be?
+
+/-- Erdős asked whether the limiting density `f n / n` exists and, if so, whether it is
+irrational. -/
+@[category research open, AMS 11]
+theorem erdos_1062.parts.ii :
+    (∃ l, Tendsto (fun n => (f n : ℝ) / n) atTop (𝓝 l) ∧ Irrational l) ↔ answer(sorry) := by
+  sorry
+
 /-- The interval `[⌊n/3⌋, n]` is fork-free, and therefore `f n` is at least `⌈2n / 3⌉`. -/
 @[category research solved, AMS 11]
-theorem erdos_1062.lower_bound (n : ℕ) : ⌈(2 * n / 3 : ℝ)⌉₊ ≤ f n := by
+theorem erdos_1062.variants.lower_bound (n : ℕ) : ⌈(2 * n / 3 : ℝ)⌉₊ ≤ f n := by
   classical
   set b : ℕ := n / 3 with hb
   let A : Finset ℕ := .Icc (b + 1) n
@@ -68,15 +77,8 @@ theorem erdos_1062.lower_bound (n : ℕ) : ⌈(2 * n / 3 : ℝ)⌉₊ ≤ f n :=
 /-- Lebensold proved that for large `n`, the function `f n` lies between `0.6725 n` and
 `0.6736 n`. -/
 @[category research solved, AMS 11]
-theorem erdos_1062.lebensold_bounds :
+theorem erdos_1062.variants.lebensold_bounds :
     ∀ᶠ n in atTop, (0.6725 : ℝ) * n ≤ f n ∧ f n ≤ (0.6736 : ℝ) * n := by
-  sorry
-
-/-- Erdős asked whether the limiting density `f n / n` exists and, if so, whether it is
-irrational. -/
-@[category research open, AMS 11]
-theorem erdos_1062.limit_density :
-    (∃ l, Tendsto (fun n => (f n : ℝ) / n) atTop (𝓝 l) ∧ Irrational l) ↔ answer(sorry) := by
   sorry
 
 end Erdos1062

--- a/FormalConjectures/ErdosProblems/1063.lean
+++ b/FormalConjectures/ErdosProblems/1063.lean
@@ -40,6 +40,17 @@ noncomputable def n (k : ℕ) : ℕ :=
     ∀ i < k, i ≠ i0 → (m - i) ∣ m.choose k}
 
 /--
+Estimate $n_k$ by finding a better upper bound.
+-/
+@[category research open, AMS 11]
+theorem erdos_1063.better_upper :
+    let upper_bound : ℕ → ℝ := answer(sorry)
+    (fun k => (n k : ℝ)) =O[atTop] upper_bound ∧
+    upper_bound =o[atTop] fun k =>
+      (k : ℝ) * ((Finset.Icc 1 (k - 1)).lcm (fun n : ℕ => n) : ℝ) := by
+  sorry
+
+/--
 Erdős and Selfridge noted that, for $n \ge 2k$ with $k \ge 2$, at least one of the numbers
 $n - i$ for $0 \le i < k$ fails to divide $\binom{n}{k}$ ([ErSe83]).
 -/
@@ -74,17 +85,6 @@ theorem erdos_1063.variants.cambie_upper_bound {k : ℕ} (hk : 3 ≤ k) :
 theorem erdos_1063.variants.exp_upper_bound :
     ∃ f : ℕ → ℝ, Tendsto f atTop (𝓝 0) ∧
       ∀ k, (n k : ℝ) ≤ exp ((1 + f k) * k) := by
-  sorry
-
-/--
-Estimate $n_k$ by finding a better upper bound.
--/
-@[category research open, AMS 11]
-theorem erdos_1063.better_upper :
-    let upper_bound : ℕ → ℝ := answer(sorry)
-    (fun k => (n k : ℝ)) =O[atTop] upper_bound ∧
-    upper_bound =o[atTop] fun k =>
-      (k : ℝ) * ((Finset.Icc 1 (k - 1)).lcm (fun n : ℕ => n) : ℝ) := by
   sorry
 
 end Erdos1063

--- a/FormalConjectures/ErdosProblems/1065.lean
+++ b/FormalConjectures/ErdosProblems/1065.lean
@@ -33,7 +33,7 @@ in [Unsolved Problems in Number Theory](https://doi.org/10.1007/978-0-387-26677-
 by *Richard K. Guy*
  -/
 @[category research open, AMS 11]
-theorem erdos_1065a :
+theorem erdos_1065.parts.i :
     answer(sorry) ↔ Set.Infinite {p | ∃ q k, p.Prime ∧ q.Prime ∧ p = 2^k * q + 1} := by
   sorry
 
@@ -42,7 +42,7 @@ Are there infinitely many primes $p$ such that $p = 2^k 3^l q + 1$
 for some prime $q$ and $k ≥ 0$, $l ≥ 0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_1065b : answer(sorry) ↔
+theorem erdos_1065.parts.ii : answer(sorry) ↔
     Set.Infinite {p | ∃ q k l, p.Prime ∧ q.Prime ∧ p = 2^k * 3^l * q + 1} := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/1071.lean
+++ b/FormalConjectures/ErdosProblems/1071.lean
@@ -40,7 +40,7 @@ This was formalized in Lean by Alexeev using Aristotle and ChatGPT.
 -/
 @[category research formally solved using lean4 at
 "https://github.com/plby/lean-proofs/blob/main/src/v4.24.0/ErdosProblems/Erdos1071.lean", AMS 52]
-theorem erdos_1071a :
+theorem erdos_1071.parts.i :
     answer(True) ↔ ∃ S : Finset (ℝ² × ℝ²),
       Maximal (fun T : Finset (ℝ² × ℝ²) =>
         (∀ seg ∈ T, dist seg.1 seg.2 = 1 ∧
@@ -51,7 +51,7 @@ theorem erdos_1071a :
 
 /-- Is there a region $R$ with a maximal set of disjoint unit line segments that is countably infinite? -/
 @[category research open, AMS 52]
-theorem erdos_1071b :
+theorem erdos_1071.parts.ii :
     answer(sorry) ↔ ∃ (R : Set ℝ²) (S : Set (ℝ² × ℝ²)),
       S.Countable ∧ S.Infinite ∧
       Maximal (fun T : Set (ℝ² × ℝ²) =>

--- a/FormalConjectures/ErdosProblems/1072.lean
+++ b/FormalConjectures/ErdosProblems/1072.lean
@@ -32,12 +32,12 @@ noncomputable def f (p : ℕ) : ℕ := sInf {n | (n)! + 1 ≡ 0 [MOD p]}
 
 /-- Is it true that there are infinitely many $p$ for which $f(p) = p − 1$? -/
 @[category research open, AMS 11]
-theorem erdos_1072a : answer(sorry) ↔ Set.Infinite {p | p.Prime ∧ f p = p - 1} := by
+theorem erdos_1072.parts.i : answer(sorry) ↔ Set.Infinite {p | p.Prime ∧ f p = p - 1} := by
   sorry
 
 /-- Is it true that $f(p)/p \to 0$ for $p \to \infty$ in a density 1 subset of the primes? -/
 @[category research open, AMS 11]
-theorem erdos_1072b :
+theorem erdos_1072.parts.ii :
     answer(sorry) ↔ ∃ (P : Set ℕ), P ⊆ {p | p.Prime} ∧ P.HasDensity 1 {p | p.Prime} ∧
       Tendsto (fun p => (f p / p : ℝ)) (atTop ⊓ principal P) (𝓝 0) := by
   sorry
@@ -49,7 +49,7 @@ is $o(x/\log x)$.
 Amer. Math. Monthly (2002), 554--559.
 -/
 @[category research open, AMS 11]
-theorem erdos_1072a.variants.littleo :
+theorem erdos_1072.variants.littleo :
     (fun x ↦ (({p | p.Prime ∧ f p = p - 1}.interIcc 0 x).ncard : ℝ)) =o[atTop]
       (fun x ↦ x / Real.log x) := by
   sorry

--- a/FormalConjectures/ErdosProblems/1074.lean
+++ b/FormalConjectures/ErdosProblems/1074.lean
@@ -55,7 +55,7 @@ $$
 $$
 exist? -/
 @[category research open, AMS 11]
-theorem erdos_1074.part8_i_i : answer(sorry) ↔ ∃ c, EHSNumbers.HasDensity c := by
+theorem erdos_1074.parts.i : answer(sorry) ↔ ∃ c, EHSNumbers.HasDensity c := by
   sorry
 
 /-- Let $S$ be the set of all $m\geq 1$ such that there exists a prime $p\not\equiv 1\pmod{m}$ such
@@ -64,7 +64,7 @@ $$
   \lim\frac{|S\cap[1, x]|}{x}?
 $$ -/
 @[category research open, AMS 11]
-theorem erdos_1074.part_i_ii : EHSNumbers.HasDensity answer(sorry) := by
+theorem erdos_1074.parts.ii : EHSNumbers.HasDensity answer(sorry) := by
   sorry
 
 /-- Similarly, if $P$ is the set of all primes $p$ such that there exists an $m$ with
@@ -74,7 +74,7 @@ $$
 $$
 exist? -/
 @[category research open, AMS 11]
-theorem erdos_1074.part_ii_i : answer(sorry) ↔ ∃ c, PillaiPrimes.HasDensity c {p | p.Prime} := by
+theorem erdos_1074.parts.iii : answer(sorry) ↔ ∃ c, PillaiPrimes.HasDensity c {p | p.Prime} := by
   sorry
 
 /-- Similarly, if $P$ is the set of all primes $p$ such that there exists an $m$ with
@@ -83,7 +83,7 @@ $$
   \lim\frac{|P\cap[1, x]|}{\pi(x)}?
 $$ -/
 @[category research open, AMS 11]
-theorem erdos_1074.parts_ii_ii :
+theorem erdos_1074.parts.iv :
     PillaiPrimes.HasDensity answer(sorry) {p | p.Prime} := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/1082.lean
+++ b/FormalConjectures/ErdosProblems/1082.lean
@@ -45,7 +45,7 @@ Let $A\subset \mathbb{R}^2$ be a set of $n$ points with no three on a line.
 Does $A$ determine at least $\lfloor n/2\rfloor$ distinct distances?
 -/
 @[category research open, AMS 51]
-theorem erdos_1082a : answer(sorry) ↔ ∀ (A : Finset ℝ²) (hA_n3c : NonTrilinear A.toSet),
+theorem erdos_1082.parts.i : answer(sorry) ↔ ∀ (A : Finset ℝ²) (hA_n3c : NonTrilinear A.toSet),
     A.card / 2 ≤ distinctDistances A:= by
   sorry
 
@@ -61,8 +61,9 @@ $\mathbb{R}^2$, with no three on a line, such that each point determines only $2
 A smaller counterexample has been formalised here: it comprised of $8$ points, where each point only
 determines $3$ distances.
 -/
-@[category research formally solved using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/0aca4d71095301c0fd2dca32611b7addb2ea735c/FormalConjectures/ErdosProblems/1082.lean", AMS 51]
-theorem erdos_1082b : answer(False) ↔
+@[category research formally solved using formal_conjectures at
+"https://github.com/google-deepmind/formal-conjectures/blob/0aca4d71095301c0fd2dca32611b7addb2ea735c/FormalConjectures/ErdosProblems/1082.lean", AMS 51]
+theorem erdos_1082.parts.ii : answer(False) ↔
     ∀ (A : Finset ℝ²) (hA : A.Nonempty) (hA_n3c : NonTrilinear A.toSet),
     ∃ (a : ℝ²) (ha : a ∈ A), A.card / 2 ≤ distinctDistancesFrom A a - 1 := by
   sorry

--- a/FormalConjectures/ErdosProblems/1101.lean
+++ b/FormalConjectures/ErdosProblems/1101.lean
@@ -55,13 +55,13 @@ def IsGood (u : ℕ → ℕ) : Prop :=
 
 /-- 1. There is NO good sequence with polynomial growth. -/
 @[category research open, AMS 11]
-theorem erdos_1101.polynomial :
+theorem erdos_1101.parts.i :
     ¬ ∃ u, IsGood u ∧ ∃ k : ℕ, (fun n => (u n : ℝ)) =O[atTop] (fun n => (n : ℝ) ^ k) := by
   sorry
 
 /-- 2. There is a good sequence with sub-exponential growth. -/
 @[category research open, AMS 11]
-theorem erdos_1101.subexponential :
+theorem erdos_1101.parts.ii :
     ∃ u, IsGood u ∧ (fun n => Real.log (u n : ℝ)) =o[atTop] (fun n => (n : ℝ)) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/1106.lean
+++ b/FormalConjectures/ErdosProblems/1106.lean
@@ -34,7 +34,8 @@ Let $p(n)$ be the partition number of $n$ and $F(n)$ be the number of distinct p
 $∏_{i= 1} ^ {n} p(n)$, then $F(n)$ tends to infinity when $n$ tends to infinity.
 -/
 @[category research open, AMS 11]
-theorem erdos_1106 : Tendsto (fun n => #(∏ i ∈ Icc 1 n, p i).primeFactors) atTop atTop := by
+theorem erdos_1106.parts.i :
+    answer(sorry) ↔ Tendsto (fun n => #(∏ i ∈ Icc 1 n, p i).primeFactors) atTop atTop := by
   sorry
 
 /--
@@ -42,7 +43,8 @@ Let $p(n)$ be the partition number of $n$ and $F(n)$ be the number of distinct p
 $∏_{i= 1} ^ {n} p(n)$, $F(n)>n$ for sufficiently large $n$.
 -/
 @[category research open, AMS 11]
-theorem erdos_1106_k2 : ∀ᶠ n in atTop, #(∏ i ∈ Icc 1 n, p i).primeFactors > n := by
+theorem erdos_1106.parts.ii :
+    answer(sorry) ↔ ∀ᶠ n in atTop, #(∏ i ∈ Icc 1 n, p i).primeFactors > n := by
   sorry
 
 end Erdos1106

--- a/FormalConjectures/ErdosProblems/1108.lean
+++ b/FormalConjectures/ErdosProblems/1108.lean
@@ -42,7 +42,7 @@ def IsPowerful (n : ℕ) : Prop :=
 For each $k \geq 2$, does the set $A = \left\{ \sum_{n\in S}n! : S\subset \mathbb{N}\text{ finite}\right\}$ of all finite sums of distinct factorials contain only finitely many $k$-th powers?
 -/
 @[category research open, AMS 11]
-theorem erdos_1108.k_th_powers : answer(sorry) ↔ ∀ k ≥ 2,
+theorem erdos_1108.parts.i : answer(sorry) ↔ ∀ k ≥ 2,
     Set.Finite { a | a ∈ FactorialSums ∧ ∃ m : ℕ, m ^ k = a } := by
   sorry
 
@@ -50,7 +50,7 @@ theorem erdos_1108.k_th_powers : answer(sorry) ↔ ∀ k ≥ 2,
 Does the set $A = \left\{ \sum_{n\in S}n! : S\subset \mathbb{N}\text{ finite}\right\}$ of all finite sums of distinct factorials contain only finitely many powerful numbers?
 -/
 @[category research open, AMS 11]
-theorem erdos_1108.powerful_numbers :
+theorem erdos_1108.parts.ii :
      answer(sorry) ↔ {a ∈ FactorialSums | IsPowerful a}.Finite := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/1145.lean
+++ b/FormalConjectures/ErdosProblems/1145.lean
@@ -66,7 +66,7 @@ theorem erdos_1145 : answer(sorry) ↔ Erdos1145Prop := by
 A stronger form of [erdosproblems.com/28].
 -/
 @[category test, AMS 11]
-theorem erdos_1145_implies_erdos_28 : Erdos1145Prop → type_of% Erdos28.erdos_28 := by
+theorem erdos_1145.test_implies_erdos_28 : Erdos1145Prop → type_of% Erdos28.erdos_28 := by
   delta sumRep
   intro h1145 s hs
   rcases hs.exists_le with ⟨m, hm⟩

--- a/FormalConjectures/ErdosProblems/1148.lean
+++ b/FormalConjectures/ErdosProblems/1148.lean
@@ -40,14 +40,14 @@ def Erdos1148Prop (n : ℕ) : Prop :=
 Can every large integer $n$ be written as $n=x^2+y^2-z^2$ with $\max(x^2,y^2,z^2)\leq n$?
 -/
 @[category research open, AMS 11]
-theorem erdos_1148 : ∀ᶠ n in atTop, Erdos1148Prop n := by
+theorem erdos_1148 : answer(sorry) ↔ ∀ᶠ n in atTop, Erdos1148Prop n := by
   sorry
 
 /--
 The largest integer known which cannot be written this way is $6563$.
 -/
 @[category high_school, AMS 11]
-theorem erdos_1148.lower_bound : ¬ Erdos1148Prop 6563 := by
+theorem erdos_1148.variants.lower_bound : ¬ Erdos1148Prop 6563 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1150.lean
+++ b/FormalConjectures/ErdosProblems/1150.lean
@@ -47,7 +47,7 @@ $$\frac{1}{2\pi} \int_0^{2\pi} |P(e^{i\theta})|^2 d\theta = \sum_{k=0}^{n} |a_k|
 since each $|a_k|^2 = 1$.
 -/
 @[category graduate, AMS 12 30]
-theorem erdos_1150.parseval_lower_bound (P : ℂ[X]) (n : ℕ)
+theorem erdos_1150.variants.parseval_lower_bound (P : ℂ[X]) (n : ℕ)
     (hcoeff : ∀ i ≤ P.natDegree, P.coeff i = -1 ∨ P.coeff i = 1)
     (hdeg : P.natDegree = n) :
     ⨆ z : Metric.sphere (0 : ℂ) 1, ‖P.eval (z : ℂ)‖ ≥ Real.sqrt (n + 1) := by

--- a/FormalConjectures/ErdosProblems/13.lean
+++ b/FormalConjectures/ErdosProblems/13.lean
@@ -52,7 +52,7 @@ $a | (b_1 + ... + b_r)$ and $a < \min(b_1, ..., b_r)$, then is it true that
 $|A| \le N/(r+1) + O(1)$?
 -/
 @[category research open, AMS 5 11]
-theorem erdos_13_general : answer(sorry) ↔ ∀ r : ℕ, ∃ C : ℝ, ∀ N : ℕ,
+theorem erdos_13.variants.general : answer(sorry) ↔ ∀ r : ℕ, ∃ C : ℝ, ∀ N : ℕ,
     ∀ A ⊆ Icc 1 N,
     (∀ a ∈ A, ∀ (b : Fin r → ℕ), (∀ i, b i ∈ A) → (∀ i, a < b i) →
       ¬ (a ∣ ∑ i, b i)) →

--- a/FormalConjectures/ErdosProblems/137.lean
+++ b/FormalConjectures/ErdosProblems/137.lean
@@ -53,7 +53,7 @@ $p\mid m(m+1)\cdots (m+n)$ and yet $p^2$ does not divide the right hand side.
 [Er82c] Erdős, Paul, "Miscellaneous problems in number theory". Congr. Numer. (1982), 25-45.,
 -/
 @[category research open, AMS 11]
-theorem erdos_137.multiple_powerful_factors (k : ℕ) : ∀ᶠ n in Filter.atTop,
+theorem erdos_137.variants.multiple_powerful_factors (k : ℕ) : ∀ᶠ n in Filter.atTop,
     ∀ (m : ℕ) (hm : 0 < m),
     letI N := ∏ x ∈ Finset.Ioc m (m + n), x
     ∃ P : Finset ℕ, P.card = k ∧ ∀ p ∈ P, p.Prime ∧

--- a/FormalConjectures/ErdosProblems/14.lean
+++ b/FormalConjectures/ErdosProblems/14.lean
@@ -49,14 +49,14 @@ in exactly one way as the sum of two elements from $A$. Is it true that for all
 $\epsilon > 0$ and large $N$, $|\{1,\ldots,N\} \setminus B| \gg_\epsilon N^{1/2 - \epsilon}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_14a :
+theorem erdos_14.parts.i :
     answer(sorry) ↔ ∀ A, ∀ ε > 0, nonUniqueSumCount A ≫ almostSquareRoot ε := by sorry
 
 /--
 Is it possible that $|\{1,\ldots,N\} \setminus B| = o(N^\frac{1}{2})$?
 -/
 @[category research open, AMS 11]
-theorem erdos_14b :
+theorem erdos_14.parts.ii :
     answer(sorry) ↔ ∃ (A : Set ℕ), IsLittleO atTop (nonUniqueSumCount A) squareRoot := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/152.lean
+++ b/FormalConjectures/ErdosProblems/152.lean
@@ -44,7 +44,7 @@ theorem erdos_152 : answer(sorry) ↔ Tendsto f atTop atTop := by
 
 /-- Must `f n ≫ n ^ 2`? -/
 @[category research open, AMS 5]
-theorem erdos_152.square : answer(sorry) ↔
+theorem erdos_152.variants.square : answer(sorry) ↔
     (fun n => f n : ℕ → ℝ) ≫ (fun n => n ^ 2 : ℕ → ℝ) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/158.lean
+++ b/FormalConjectures/ErdosProblems/158.lean
@@ -53,14 +53,14 @@ namespace Erdos158
 
 /-- Let `A` be an infinite `B₂[2]` set. Must `liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) = 0`? -/
 @[category research open, AMS 5]
-theorem erdos_158.B22 : answer(sorry) ↔ ∀ A : Set ℕ, A.Infinite → B2 2 A →
+theorem erdos_158 : answer(sorry) ↔ ∀ A : Set ℕ, A.Infinite → B2 2 A →
     liminf (fun N : ℕ => (A ∩ .Iio N).ncard * (N : ℝ) ^ (- 1 / 2 : ℝ)) atTop = 0 := by
   sorry
 
 /-- Let `A` be an infinite Sidon set. Then
 `liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) * (log N) ^ (1 / 2) < ∞`. This is proved in [ESS94]. -/
 @[category research solved, AMS 5]
-theorem erdos_158.isSidon' {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
+theorem erdos_158.variants.isSidon' {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
     liminf (fun N ↦ ENNReal.ofReal ((A ∩ .Iio N).ncard * N ^ (- 1 / 2 : ℝ) * log N ^ (1 / 2 : ℝ)))
       atTop < ⊤ := by
   sorry
@@ -68,7 +68,7 @@ theorem erdos_158.isSidon' {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A
 /-- As a corollary of `erdos_158.isSidon'`, we can prove that
 `liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) = 0` for any infinite Sidon set `A`. -/
 @[category research solved, AMS 5]
-theorem erdos_158.isSidon {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
+theorem erdos_158.variants.isSidon {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
     liminf (fun N : ℕ => (A ∩ .Iio N).ncard * (N : ℝ) ^ (- 1 / 2 : ℝ)) atTop = 0 := by
   have := erdos_158.isSidon' hAinf hAsid
   contrapose! this with h

--- a/FormalConjectures/ErdosProblems/158.lean
+++ b/FormalConjectures/ErdosProblems/158.lean
@@ -70,7 +70,7 @@ theorem erdos_158.variants.isSidon' {A : Set ℕ} (hAinf : A.Infinite) (hAsid : 
 @[category research solved, AMS 5]
 theorem erdos_158.variants.isSidon {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
     liminf (fun N : ℕ => (A ∩ .Iio N).ncard * (N : ℝ) ^ (- 1 / 2 : ℝ)) atTop = 0 := by
-  have := erdos_158.isSidon' hAinf hAsid
+  have := erdos_158.variants.isSidon' hAinf hAsid
   contrapose! this with h
   rw [Tendsto.liminf_eq]
   refine ENNReal.tendsto_ofReal_atTop.comp ?_

--- a/FormalConjectures/ErdosProblems/160.lean
+++ b/FormalConjectures/ErdosProblems/160.lean
@@ -49,18 +49,6 @@ theorem erdos_160.known_upper :
 open Real
 
 /--
-The observation of Zachary Hunter in [that question](https://mathoverflow.net/q/410808)
-coupled with the bounds of Kelley-Meka [KeMe23](https://arxiv.org/abs/2302.05537) imply that
-$$h(N) \gg \exp(c(\log N)^{\frac 1 {12}})$$
-for some $c > 0$.
--/
-@[category research solved, AMS 5 51]
-theorem erdos_160.known_lower :
-    ∃ c > 0, (fun (n : ℕ) => exp (c * log (n : ℝ) ^ ((1 : ℝ) / 12)))
-    =O[atTop] fun n => (erdos_160.h n : ℝ):= by
-  sorry
-
-/--
 Estimate $h(n)$ by finding a better upper bound.
 -/
 @[category research open, AMS 5 51]
@@ -80,6 +68,18 @@ theorem erdos_160.better_lower:
     ∀ c > 0,
     (fun (n : ℕ) => exp (c * log n ^ ((1 : ℝ) / 12))) =O[atTop] (fun n => (erdos_160.h n : ℝ)) →
     ∀ c > 0, (fun (n : ℕ) => exp (c * log n ^ ((1 : ℝ) / 12))) =o[atTop] lower_bound := by
+  sorry
+
+/--
+The observation of Zachary Hunter in [that question](https://mathoverflow.net/q/410808)
+coupled with the bounds of Kelley-Meka [KeMe23](https://arxiv.org/abs/2302.05537) imply that
+$$h(N) \gg \exp(c(\log N)^{\frac 1 {12}})$$
+for some $c > 0$.
+-/
+@[category research solved, AMS 5 51]
+theorem erdos_160.variants.known_lower :
+    ∃ c > 0, (fun (n : ℕ) => exp (c * log (n : ℝ) ^ ((1 : ℝ) / 12)))
+    =O[atTop] fun n => (erdos_160.h n : ℝ):= by
   sorry
 
 end Erdos160

--- a/FormalConjectures/ErdosProblems/188.lean
+++ b/FormalConjectures/ErdosProblems/188.lean
@@ -19,7 +19,12 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 188
 
-*Reference:* [erdosproblems.com/188](https://www.erdosproblems.com/188)
+*References:*
+- [erdosproblems.com/188](https://www.erdosproblems.com/188)
+- [EGMRSS75] Erdős, P. and Graham, R. L. and Montgomery, P. and Rothschild, B. L. and Spencer, J.
+  and Straus, E. G., Euclidean {R}amsey theorems. {II}. (1975), 529--557.
+- [Ts17] Tsaturian, Sergei, A {E}uclidean {R}amsey result in the plane. Electron. J. Combin. (2017),
+  Paper No. 4.35, 9.
 -/
 
 namespace Erdos188
@@ -33,6 +38,14 @@ def s := { k : ℕ | ∃ blue : Set ℂ,
     ¬ (∃ bs ⊆ blue, (∃ s, bs.IsAPOfLengthWith k s 1)) }
 
 /--
+What is the smallest $k$ such that $\mathbb{R}^2$ can be red/blue coloured with no pair of red
+points unit distance apart, and no $k$-term arithmetic progression of blue points with distance 1?
+-/
+@[category research open, AMS 5]
+theorem erdos_188 : IsLeast s answer(sorry) := by
+  sorry
+
+/--
 Old and new problems and results in combinatorial number theory by Erdős & Graham (Page 14, 15):
 
 It has been shown that there is a large $M$ so that it is possible to partition $\mathbb{E}^2$ into
@@ -40,7 +53,7 @@ two sets $A$ and $B$ so that $A$ contains no pair of points with distance 1 and 
 of length $M$.
 -/
 @[category research solved, AMS 5]
-theorem erdos_188.nonempty : s.Nonempty := by
+theorem erdos_188.variants.nonempty : s.Nonempty := by
   sorry
 
 /--
@@ -50,15 +63,7 @@ How small can $M$ be made? The only estimate currently known is that $M \le 1000
 In the other direction, it has just been shown by R. Juhász [Ju (79)] that we must have $M \ge 5$.
 -/
 @[category research solved, AMS 5]
-theorem erdos_188.estimate : (∀ k, k ∈ s → 5 ≤ k) ∧ (∃ k ∈ s, k ≤ 10000000) := by
-  sorry
-
-/--
-What is the smallest $k$ such that $\mathbb{R}^2$ can be red/blue coloured with no pair of red
-points unit distance apart, and no $k$-term arithmetic progression of blue points with distance 1?
--/
-@[category research open, AMS 5]
-theorem erdos_188 : IsLeast s answer(sorry) := by
+theorem erdos_188.variants.estimate : (∀ k, k ∈ s → 5 ≤ k) ∧ (∃ k ∈ s, k ≤ 10000000) := by
   sorry
 
 end Erdos188

--- a/FormalConjectures/ErdosProblems/198.lean
+++ b/FormalConjectures/ErdosProblems/198.lean
@@ -78,7 +78,7 @@ theorem erdos_198 : (∀ A : Set ℕ, IsSidon A → (∃ Y, IsAPOfLength Y ⊤ �
 In fact one such sequence is $n! + n$. This was found by AlphaProof. It also found $(n + 1)! + n$.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_198.variant_concrete :  ∃ (A : Set ℕ), A = {n ! + n | n} ∧
+theorem erdos_198.variants.concrete :  ∃ (A : Set ℕ), A = {n ! + n | n} ∧
     IsSidon A ∧ (∀ Y, IsAPOfLength Y ⊤ → (A ∩ Y).Nonempty) := by
   sorry
 


### PR DESCRIPTION
This partially fixes some of the names I listed in #2414 (all files starting with `1`. I'll do this in a few batches just to make it easier to review.

Some notable cases: 

158 contains variants that are no longer on the website. I also don't see them reclassified as separate problems, so not sure where they went.
1102 is originally written as a single problem but in lean is broken into 4 different problems.