### PR TITLE
fix(ErdosProblems): update 100_piepmeyer to formally solved

### DIFF
--- a/FormalConjectures/ErdosProblems/100.lean
+++ b/FormalConjectures/ErdosProblems/100.lean
@@ -75,7 +75,7 @@ theorem erdos_100_guth_katz :
 
 /-- From [Piepmeyer]: 9 points with diameter $< 5$.
 TODO: find reference -/
-@[category research open, AMS 52]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-100-piepmeyer/FormalConjectures/ErdosProblems/100.lean", AMS 52]
 theorem erdos_100_piepmeyer :
     ∃ A : Finset ℝ², A.card = 9 ∧ DistancesSeparated A ∧
       diam (A : Set ℝ²) < 5 := by


### PR DESCRIPTION
Following the maintainer's feedback on PR #2406, I am updating the category attribute to point to my fork where the 22-minute compilation proof is hosted, to avoid timing out the CI on the main branch while still officially classifying the theorem as formally solved.