### PR TITLE
solve(ErdosProblems): danzer in 97

### DIFF
--- a/FormalConjectures/ErdosProblems/97.lean
+++ b/FormalConjectures/ErdosProblems/97.lean
@@ -86,7 +86,7 @@ Danzer's construction is explained in [Er87b].
 [Er46b] Erdős, P., _On sets of distances of $n$ points_. Amer. Math. Monthly (1946), 248-250.
 [Er87b] Erdős, P., _Some combinatorial and metric problems in geometry_. Intuitive geometry (Siófok, 1985), 167-177.
 -/
-@[category research solved, AMS 52]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-97-danzer/FormalConjectures/ErdosProblems/97.lean", AMS 52]
 theorem erdos_97.variants.three_equidistant :
     ∃ A : Finset ℝ², A.Nonempty ∧ ConvexIndep A ∧ HasNEquidistantProperty 3 A := by
   let A₁ : ℝ² := !₂[(-√3), -1]


### PR DESCRIPTION
Proof generated by Gemini 3.1 pro in Aletheia style harness I made for asiprize.com and verified via Lean 4 compilation. The model extracted the exact algebraic Cartesian coordinates for Danzer's 9-point planar configuration and verified the bounds.

This resolves erdos_97.variants.three_equidistant. The file has been verified locally against the repo's toolchain (rc=0) and HasNEquidistantProperty has been fully proven over the 9 points.

The proof uses a custom Term Rewriting System mapping the Euclidean distances to a finite set D to prevent ring and norm_num timeouts over the radicals. Because of the heavy use of computational reflection (`ring_nf`), the proof is ~1,200 lines long and may time out GitHub Actions CI.

As requested in #2406, I have hosted the full compiled proof on my fork and updated the category tag here to point to it. Axioms checked: clean (propext, Classical.choice, Quot.sound).