### PR TITLE
solve(ErdosProblems): mehta variant for n=4 in 389

### DIFF
--- a/FormalConjectures/ErdosProblems/389.lean
+++ b/FormalConjectures/ErdosProblems/389.lean
@@ -39,7 +39,7 @@ theorem erdos_389 : answer(sorry) ↔
 Bhavik Mehta has computed the minimal such $k$ for $1 \leq n \leq 18$.
 For example, the minimal $k$ for $n = 4$ is $207$.
 -/
-@[category high_school, AMS 11]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-389-mehta/FormalConjectures/ErdosProblems/389.lean", AMS 11]
 theorem erdos_389.variants.mehta_four :
     IsLeast
       { k | 1 ≤ k ∧ ∏ i ∈ Finset.range k, (4 + i) ∣ ∏ i ∈ Finset.range k, (4 + k + i) }


### PR DESCRIPTION
Proof generated by Gemini 3.1 pro in Aletheia style harness I made for asiprize.com and verified via Lean 4 compilation.

This resolves the `erdos_389.variants.mehta_four` variant. The file has been verified locally against the repo's toolchain (rc=0) via the zero-trust `comparator`.

I proved this using a custom structurally recursive product function (`my_prod`) to bypass the recursion limits that the default `decide` hits when expanding `Finset.prod` over the large factorials (~417!). The positive case (k=207) and the negative case (evaluating k < 207 via a List map) both evaluate instantly in the kernel.

As requested in #2406, I have hosted the full compiled proof on my fork and updated the category tag here to point to it. Axioms checked: clean.