### PR TITLE
fix(ErdosProblems): update 508 HadwigerNelsonAtLeast4 to formally solved

### DIFF
--- a/FormalConjectures/ErdosProblems/508.lean
+++ b/FormalConjectures/ErdosProblems/508.lean
@@ -71,7 +71,7 @@ The "chromatic number of the plane" is at least 4. This can be
 proven by considering the [Moser-Spindel graph](https://de.wikipedia.org/wiki/Moser-Spindel)
 or the [Golomb graph](https://en.wikipedia.org/wiki/Golomb_graph) graph.
 -/
-@[category research solved, AMS 5]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-508-moser-spindle/FormalConjectures/ErdosProblems/508.lean", AMS 5]
 theorem HadwigerNelsonAtLeast4 : 4 ≤ χ(ℝ²) := by
   sorry
 


### PR DESCRIPTION
Following the pattern established in PR #2421 (Erdos 100), updating the category
attribute to point to my fork where the full Moser Spindle proof is hosted, to
avoid timing out the CI on the main branch.

The complete formal proof constructs the 7-vertex Moser Spindle with exact
algebraic coordinates and proves non-3-colorability via `decide`.

Proof: https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-508-moser-spindle/FormalConjectures/ErdosProblems/508.lean