### PR TITLE
fix(ErdosProblems): update 885 k_eq_2 and k_eq_3 to formally solved

### DIFF
--- a/FormalConjectures/ErdosProblems/885.lean
+++ b/FormalConjectures/ErdosProblems/885.lean
@@ -52,7 +52,7 @@ theorem erdos_885 : answer(sorry) ↔ ∀ k ≥ 1,
 /--
 Erdős and Rosenfeld [ErRo97] proved this is true for $k=2$.
 -/
-@[category research solved, AMS 11]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-885-k2-k3/FormalConjectures/ErdosProblems/885.lean", AMS 11]
 theorem erdos_885.variants.k_eq_2 :
     ∃ Ns : Finset ℕ,
       (∀ n ∈ Ns, 1 ≤ n) ∧
@@ -63,7 +63,7 @@ theorem erdos_885.variants.k_eq_2 :
 /--
 Jiménez-Urroz [Ji99] proved this for $k=3$.
 -/
-@[category research solved, AMS 11]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-885-k2-k3/FormalConjectures/ErdosProblems/885.lean", AMS 11]
 theorem erdos_885.variants.k_eq_3 :
     ∃ Ns : Finset ℕ,
       (∀ n ∈ Ns, 1 ≤ n) ∧


### PR DESCRIPTION
Following the pattern established in PR #2421 (Erdos 100), updating the category
attributes to point to my fork where the full proofs are hosted.

- k=2: Verified using witnesses {10, 70} with D(10) ∩ D(70) = {3, 9}.
- k=3: Verified using witnesses {112, 952, 3240} with intersection {6, 54, 111}.

Proof: https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-885-k2-k3/FormalConjectures/ErdosProblems/885.lean