### PR TITLE
fix(ErdosProblems): update 1 least_N_5 to formally solved

### DIFF
--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -137,7 +137,7 @@ elements is $13$.
 
 https://oeis.org/A276661
 -/
-@[category research solved, AMS 5 11]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-1-n5/FormalConjectures/ErdosProblems/1.lean", AMS 5 11]
 theorem erdos_1.variants.least_N_5 :
     IsLeast { N | ∃ A, IsSumDistinctSet A N ∧ A.card = 5 } 13 := by
   sorry


### PR DESCRIPTION
Following the pattern established in PR #2421 (Erdos 100), updating the category
attribute to point to my fork where the full proof is hosted.

The proof constructs witness A = {3, 6, 11, 12, 13} and exhaustively verifies
via `decide` that no 5-element subset of {1,...,12} is sum-distinct.

Proof: https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-1-n5/FormalConjectures/ErdosProblems/1.lean