### PR TITLE
fix(ErdosProblems): update 273 variants.three to formally solved

### DIFF
--- a/FormalConjectures/ErdosProblems/273.lean
+++ b/FormalConjectures/ErdosProblems/273.lean
@@ -34,7 +34,7 @@ theorem erdos_273 : answer(sorry) ↔ ∃ c : StrictCoveringSystem ℤ, ∀ i, �
 /--
 Is there a covering system all of whose moduli are of the form $p-1$ for some primes $p \geq 3$?
 -/
-@[category research solved, AMS 5 11]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-273-variant3/FormalConjectures/ErdosProblems/273.lean", AMS 5 11]
 theorem erdos_273.variants.three : answer(True) ↔ ∃ c : StrictCoveringSystem ℕ, ∀ i, ∃ p, p.Prime ∧ 3 ≤ p ∧
     c.moduli i = Ideal.span {↑(p - 1)} := by
   -- TODO(Paul-Lez): find reference for this and perhaps formalize the proof?


### PR DESCRIPTION
Updates the `@[category]` tag for `erdos_273.variants.three` to formally solved,
pointing to the proof on our fork branch.

Full proof: https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-273-variant3/FormalConjectures/ErdosProblems/273.lean

This follows the same pattern as the merged PR #2421 (Erdős 100).