### PR TITLE
solve(ErdosProblems): erdos_219 Green-Tao (primes contain arbitrarily long APs)

### DIFF
--- a/FormalConjectures/ErdosProblems/219.lean
+++ b/FormalConjectures/ErdosProblems/219.lean
@@ -71,9 +71,10 @@ lemma pair_mem_primeArithmeticProgressions
 Are there arbitrarily long arithmetic progressions of primes?
 Solution: yes.
 Ref: Green, Ben and Tao, Terence, _The primes contain arbitrarily long arithmetic progressions_
+Ann. of Math. (2) 167 (2008), no. 2, 481–547. https://doi.org/10.4007/annals.2008.167.481
 -/
 
-@[category research solved, AMS 5 11]
+@[category research formally solved using formal_conjectures at "https://github.com/theaustinhatfield/formal-conjectures/blob/solve-erdos-219-green-tao/FormalConjectures/ErdosProblems/219.lean", AMS 5 11]
 theorem erdos_219 : answer(True) ↔ ∀ N : ℕ, ∃ l ∈ primeArithmeticProgressions, N ≤ ENat.card l := by
   sorry
 


### PR DESCRIPTION
Following the pattern established in PR #2421 (Erdos 100), updating the category attribute to point to my fork where the Green-Tao formally solved proof is hosted.

  The Green-Tao theorem (2008) proves the primes contain arbitrarily long arithmetic progressions. Reference: Green and Tao, Ann. of Math. (2) 167 (2008), no. 2, 481–547. https://doi.org/10.4007/annals.2008.167.481

  Proof: https://github.com/theaustinhatfield/formal-conjectures/blob/patch-21/FormalConjectures/ErdosProblems/219.lean