### PR TITLE
prove(ErdosProblems/707): example_sidon_set

### DIFF
--- a/FormalConjectures/ErdosProblems/707.lean
+++ b/FormalConjectures/ErdosProblems/707.lean
@@ -143,7 +143,13 @@ The set `{1, 2, 4}` is a Sidon set.
 -/
 @[category undergraduate, AMS 5 11]
 theorem erdos_707.variants.example_sidon_set : IsSidon ({1, 2, 4} : Set ℕ) := by
-  sorry
+  intro i₁ hi₁ j₁ hj₁ i₂ hi₂ j₂ hj₂ heq
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hi₁ hj₁ hi₂ hj₂
+  rcases hi₁ with rfl | rfl | rfl <;>
+  rcases hj₁ with rfl | rfl | rfl <;>
+  rcases hi₂ with rfl | rfl | rfl <;>
+  rcases hj₂ with rfl | rfl | rfl <;>
+  simp_all
 
 /--
 The set `{1, 2, 4}` can be embedded in a perfect difference set modulo 7.


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in Aletheia style harness and verified via Lean 4 compilation. Proves `erdos_707.variants.example_sidon_set`: the set {1, 2, 4} is a Sidon set via exhaustive `rcases` + `simp_all` over 3⁴ = 81 cases.

  Axioms checked: clean (propext, Classical.choice, Quot.sound). No sorryAx. No native_decide in core theorems.