### PR TITLE
prove(ErdosProblems/470): smallest_weird_eq_70

### DIFF
--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -59,8 +59,8 @@ theorem erdos_470.variants.weird_pos_density : {n : ℕ | n.Weird}.HasPosDensity
 /--
 The smallest weird number is 70.
 -/
-@[category high_school, AMS 11]
 set_option maxRecDepth 4000 in
+@[category high_school, AMS 11]
 theorem erdos_470.variants.smallest_weird_eq_70 : (∀ n < 70, ¬n.Weird) ∧ (70).Weird := by
   refine ⟨fun n hn => ?_, Nat.weird_seventy⟩
   simp only [Nat.Weird, Nat.Abundant, Nat.Pseudoperfect]


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in Aletheia style harness and verified via Lean 4 compilation. Proves `smallest_weird_eq_70`: the smallest weird number is 70, using `Nat.weird_seventy` from Mathlib for the positive half and `interval_cases n <;> decide` with `set_option maxRecDepth 4000` for the negative half.

  Axioms checked: clean (propext, Classical.choice, Quot.sound). No sorryAx. No native_decide in core theorems.