### PR TITLE
prove(OEIS/56777): mod_72_of_comesFromPrimeQuadruple

### DIFF
--- a/FormalConjectures/OEIS/56777.lean
+++ b/FormalConjectures/OEIS/56777.lean
@@ -71,11 +71,68 @@ theorem a_of_comesFromPrimeQuadruple {n : ℕ} (h : ComesFromPrimeQuadruple n) :
 theorem comesFromPrimeQuadruple_of_a {n : ℕ} (h : a n) : ComesFromPrimeQuadruple n := by
   sorry
 
-/-- Numbers coming from prime quadruples satisfy $n \equiv 65 \pmod{72}$. -/
+/-- Numbers coming from prime quadruples satisfy $n \equiv 65 \pmod{72}$.
+
+**Proof sketch:** Any prime quadruple $(p, p+2, p+6, p+8)$ with all entries prime must have
+$p \geq 5$ and $p \equiv 5 \pmod{6}$ (since $p$ is an odd prime with $p \not\equiv 1 \pmod 3$,
+as that would force $3 \mid (p+2)$). Writing $p = 6k+5$, we have
+$p(p+8) = (6k+5)(6k+13) = 36k(k+3) + 65$. Since $k(k+3)$ is always even
+(one of $k, k+3$ is even), we get $p(p+8) = 72m + 65$ for some $m \geq 0$. -/
 @[category undergraduate, AMS 11]
 theorem mod_72_of_comesFromPrimeQuadruple {n : ℕ} (h : ComesFromPrimeQuadruple n) :
     n % 72 = 65 := by
-  sorry
+  obtain ⟨p, hp, hp2, hp6, hp8, hn⟩ := h
+  subst hn
+  -- p ≠ 2: since if p = 2 then p+2 = 4 is not prime
+  have hp_ne2 : p ≠ 2 := by
+    intro heq; subst heq; exact absurd hp2 (by decide)
+  -- p ≠ 3: since if p = 3 then p+6 = 9 = 3² is not prime
+  have hp_ne3 : p ≠ 3 := by
+    intro heq; subst heq; exact absurd hp6 (by decide)
+  -- 2 ∤ p: p is prime and ≠ 2
+  have hp_not2dvd : ¬ 2 ∣ p := by
+    intro h2
+    rcases hp.eq_one_or_self_of_dvd 2 h2 with h | h
+    · norm_num at h
+    · exact hp_ne2 h.symm
+  -- 3 ∤ p: p is prime and ≠ 3
+  have hp_not3dvd : ¬ 3 ∣ p := by
+    intro h3
+    rcases hp.eq_one_or_self_of_dvd 3 h3 with h | h
+    · norm_num at h
+    · exact hp_ne3 h.symm
+  -- 3 ∤ (p+2): p+2 is prime; if 3 ∣ (p+2) then p+2 = 3 so p = 1, contradicting p prime
+  have hp2_not3dvd : ¬ 3 ∣ (p + 2) := by
+    intro h3
+    rcases hp2.eq_one_or_self_of_dvd 3 h3 with h | h
+    · norm_num at h
+    · linarith [hp.two_le]
+  -- p % 2 = 1 (p is odd)
+  have hp_mod2 : p % 2 = 1 := by
+    have h0 : p % 2 ≠ 0 := fun h0 => hp_not2dvd (Nat.dvd_of_mod_eq_zero h0)
+    omega
+  -- p % 3 = 2: neither 0 (3 ∤ p) nor 1 (3 ∤ p+2, since p%3=1 → (p+2)%3=0)
+  have hp_mod3 : p % 3 = 2 := by
+    have h1 : p % 3 ≠ 0 := fun h0 => hp_not3dvd (Nat.dvd_of_mod_eq_zero h0)
+    have h2 : (p + 2) % 3 ≠ 0 := fun h0 => hp2_not3dvd (Nat.dvd_of_mod_eq_zero h0)
+    omega
+  -- Decompose: p = 6k + 5 for k = p / 6
+  set k := p / 6
+  have hp_eq : p = 6 * k + 5 := by omega
+  -- k * (k + 3) is even: if k even then 2 ∣ k; if k odd then k+3 is even so 2 ∣ k+3
+  have h_even : 2 ∣ k * (k + 3) := by
+    rcases Nat.even_or_odd k with ⟨r, hr⟩ | ⟨r, hr⟩
+    · -- k = r + r (even), so 2 ∣ k
+      exact (Nat.dvd_of_mod_eq_zero (by omega)).mul_right (k + 3)
+    · -- k = 2r + 1 (odd), so k + 3 = 2(r+2) is even
+      exact (Nat.dvd_of_mod_eq_zero (by omega)).mul_left k
+  obtain ⟨m, hm⟩ := h_even
+  -- Key identity: (6k+5)(6k+13) = 36·k·(k+3) + 65 = 72m + 65
+  have h_main : p * (p + 8) = 72 * m + 65 := by
+    rw [hp_eq]
+    have step : (6 * k + 5) * (6 * k + 5 + 8) = 36 * (k * (k + 3)) + 65 := by ring
+    linarith
+  omega
 
 /-- Numbers coming from prime quadruples satisfy $n \equiv 9 \pmod{100}$. -/
 @[category undergraduate, AMS 11]


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in Aletheia style harness and verified via Lean 4 compilation. Proves `mod_72_of_comesFromPrimeQuadruple`: if (p, p+2, p+6, p+8) is a prime quadruple then p(p+8) ≡ 65 (mod 72), by showing p = 6k+5 forces p(p+8) = 72m+65 via a short modular arithmetic chain.

  Axioms checked: clean (propext, Classical.choice, Quot.sound). No sorryAx. No native_decide in core theorems.