### PR TITLE
solve(ErdosProblems): example_sidon_set in 44

### DIFF
--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -62,7 +62,13 @@ The set `{1, 2, 4, 8, 13}` is a Sidon set in `{1, ..., 13}`.
 -/
 @[category undergraduate, AMS 5 11]
 theorem example_sidon_set : IsSidon ({1, 2, 4, 8, 13} : Set ℕ) := by
-  sorry
+  intro i₁ hi₁ j₁ hj₁ i₂ hi₂ j₂ hj₂ heq
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hi₁ hj₁ hi₂ hj₂
+  rcases hi₁ with rfl | rfl | rfl | rfl | rfl <;>
+  rcases hj₁ with rfl | rfl | rfl | rfl | rfl <;>
+  rcases hi₂ with rfl | rfl | rfl | rfl | rfl <;>
+  rcases hj₂ with rfl | rfl | rfl | rfl | rfl <;>
+  simp_all
 
 /--
 For any `N`, there exists a Sidon set of size at least `√N/2`.


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in Aletheia style harness and verified via Lean 4 compilation. Proves `Erdos44.example_sidon_set`: the set {1, 2, 4, 8, 13} (the first 5 terms of the Mian-Chowla sequence) is a Sidon set. The proof uses exhaustive case analysis: `rcases` over all 5⁴ = 625 combinations of element membership, closed by `simp_all` which applies `omega` to refute impossible sum equalities and confirms valid pairings.

  Axioms checked: clean (propext, Classical.choice, Quot.sound). No sorryAx. No native_decide in core theorems.