### PR TITLE
solve(ErdosProblems): trivial upper bound F(n) ≤ n + √n in 385

### DIFF
--- a/FormalConjectures/ErdosProblems/385.lean
+++ b/FormalConjectures/ErdosProblems/385.lean
@@ -33,7 +33,28 @@ noncomputable def F (n : ℕ) : ℕ := sSup {m + m.minFac | (m < n) (_ : m.Compo
 /-- Note that trivially $F(n) \leq n + \sqrt{n}$. -/
 @[category test, AMS 11]
 theorem trivial_ub (n : ℕ) : F n ≤ n + √n := by
-  sorry
+  -- First prove the ℕ-valued bound: F n ≤ n + Nat.sqrt n
+  have key : F n ≤ n + Nat.sqrt n := by
+    simp only [F]
+    rcases Set.eq_empty_or_nonempty {m + m.minFac | (m < n) (_ : m.Composite)} with hempty | hne
+    · simp only [hempty, csSup_empty]; exact bot_le
+    · apply csSup_le hne
+      rintro x ⟨m, hm, hcomp, rfl⟩
+      have hpos : 0 < m := Nat.lt_trans Nat.zero_lt_one hcomp.1
+      have hminFac_sq : m.minFac ^ 2 ≤ m := Nat.minFac_sq_le_self hpos hcomp.2
+      have hminFac_le : m.minFac ≤ Nat.sqrt n := by
+        rw [Nat.le_sqrt]
+        calc m.minFac * m.minFac = m.minFac ^ 2 := (sq m.minFac).symm
+          _ ≤ m := hminFac_sq
+          _ ≤ n := Nat.le_of_lt hm
+      have hm_le : m ≤ n - 1 := Nat.le_sub_one_of_lt hm
+      omega
+  -- Cast to ℝ, using Nat.sqrt n ≤ Real.sqrt n
+  calc (F n : ℝ) ≤ (n + Nat.sqrt n : ℕ) := by exact_mod_cast key
+    _ = (n : ℝ) + (Nat.sqrt n : ℝ) := by push_cast; ring
+    _ ≤ (n : ℝ) + Real.sqrt n := by
+        gcongr
+        exact Real.nat_sqrt_le_real_sqrt
 
 /-- Let $F(n) := \max\{m + p(m) \mid  \textrm{$m < n$ composite}\}\}$ where $p(m)$ is the least
 prime divisor of $m$. Is it true that $F(n)>n$ for all sufficiently large $n$? -/


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in Aletheia style harness and verified via Lean 4 compilation. Proves `trivial_ub`: for all n, F(n) ≤ n + √n, where F(n) = sup{m + p(m) | m < n composite} and p(m) is the least prime factor of m. For any composite m < n, p(m)² ≤ m (since p(m) is the smallest prime factor), so p(m) ≤ sqrt(m) ≤ sqrt(n), therefore m + p(m) ≤ (n-1) + sqrt(n) ≤ n + sqrt(n).

  Axioms checked: clean (propext, Classical.choice, Quot.sound). No sorryAx. No native_decide in core theorems.