### PR TITLE
solve(ErdosProblems): compute M(1)=1 M(2)=1 M(3)=2 M(4)=2 M(5)=3 in 36

### DIFF
--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -28,6 +28,8 @@ open Filter
 
 namespace Erdos36
 
+set_option maxRecDepth 100000
+
 /--
 The number of solutions to the equation $a - b = k$, for $a \in A$ and $b \in B$.
 This represents the "overlap" between sets $A$ and $B$ for a given difference $k$.
@@ -52,6 +54,100 @@ noncomputable def M (n : ℕ) : ℕ :=
     (_union : A ∪ B = Finset.Icc (1 : ℤ) (2 * n))
     (_same_card : A.card = B.card)}
 
+/-! ## Core helper lemmas -/
+
+/-- Overlap A B k ≤ A.card: the map (a,b) ↦ a is injective on the filter. -/
+private lemma overlap_le_card_left (A B : Finset ℤ) (k : ℤ) : Overlap A B k ≤ A.card := by
+  simp only [Overlap]
+  apply Finset.card_le_card_of_injOn Prod.fst
+  · intro ⟨a, b⟩ h
+    simp [Finset.mem_product, and_assoc] at h
+    exact h.1
+  · intro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
+    simp [Finset.mem_product, and_assoc] at h₁ h₂
+    exact Prod.ext heq (by linarith [h₁.2.2, h₂.2.2])
+
+/-- A computable version of MaxOverlap: sup over the finite set of differences. -/
+private def maxOverlapComp (A B : Finset ℤ) : ℕ :=
+  ((A ×ˢ B).image (fun p : ℤ × ℤ => p.1 - p.2)).sup (Overlap A B)
+
+/-- The computable version equals MaxOverlap. -/
+private lemma maxOverlapComp_eq (A B : Finset ℤ) : maxOverlapComp A B = MaxOverlap A B := by
+  simp only [maxOverlapComp, MaxOverlap]
+  apply Nat.le_antisymm
+  · apply Finset.sup_le
+    intro k hk
+    simp only [Finset.mem_image, Finset.mem_product] at hk
+    obtain ⟨⟨a, b⟩, hmem, rfl⟩ := hk
+    exact le_ciSup ⟨A.card, fun m ⟨i, hi⟩ => hi ▸ overlap_le_card_left A B i⟩ (a - b)
+  · apply ciSup_le
+    intro k
+    by_cases hk : k ∈ (A ×ˢ B).image (fun p : ℤ × ℤ => p.1 - p.2)
+    · exact Finset.le_sup hk
+    · have hov : Overlap A B k = 0 := by
+        simp only [Overlap]
+        rw [show ((A.product B).filter fun (a, b) => a - b = k) =
+            (A ×ˢ B).filter (fun p : ℤ × ℤ => p.1 - p.2 = k) from rfl,
+            Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+        intro ⟨a, b⟩ hmem heq
+        exact hk (Finset.mem_image.mpr ⟨(a, b), hmem, heq⟩)
+      omega
+
+/-- MaxOverlap A B ≥ 1 when both are nonempty. -/
+private lemma one_le_maxOverlap {A B : Finset ℤ} (hA : A.Nonempty) (hB : B.Nonempty) :
+    1 ≤ MaxOverlap A B := by
+  obtain ⟨a, ha⟩ := hA
+  obtain ⟨b, hb⟩ := hB
+  simp only [MaxOverlap]
+  have hbdd : BddAbove (Set.range (Overlap A B)) :=
+    ⟨A.card, fun m ⟨i, hi⟩ => hi ▸ overlap_le_card_left A B i⟩
+  calc 1 ≤ Overlap A B (a - b) := by
+          simp only [Overlap]
+          rw [Nat.one_le_iff_ne_zero, ← Nat.pos_iff_ne_zero]
+          exact Finset.card_pos.mpr
+            ⟨(a, b), Finset.mem_filter.mpr ⟨Finset.mem_product.mpr ⟨ha, hb⟩, by ring⟩⟩
+    _ ≤ ⨆ i, Overlap A B i := le_ciSup hbdd (a - b)
+
+/-- When A and B are disjoint with A ∪ B = S, we have B = S \ A. -/
+private lemma B_eq_sdiff {A B S : Finset ℤ} (hD : Disjoint A B) (hU : A ∪ B = S) :
+    B = S \ A := by
+  ext x
+  constructor
+  · intro hx
+    exact Finset.mem_sdiff.mpr
+      ⟨hU ▸ Finset.mem_union_right A hx, Finset.disjoint_right.mp hD hx⟩
+  · intro hx
+    have : x ∈ A ∪ B := hU ▸ (Finset.mem_sdiff.mp hx).1
+    exact (Finset.mem_union.mp this).resolve_left (Finset.mem_sdiff.mp hx).2
+
+/-- For valid splits of {1,...,2n}, both A and B have cardinality n. -/
+private lemma split_card {n : ℕ} {A B : Finset ℤ}
+    (hD : Disjoint A B) (hU : A ∪ B = Finset.Icc (1:ℤ) (2*↑n)) (hC : A.card = B.card) :
+    A.card = n ∧ B.card = n := by
+  have hcard : (Finset.Icc (1:ℤ) (2*↑n)).card = 2 * n := by rw [Int.card_Icc]; omega
+  have hAB := Finset.card_union_of_disjoint hD
+  rw [hU, hcard] at hAB
+  exact ⟨by omega, by rw [← hC]; omega⟩
+
+/-- Lower bound for M n via finite enumeration through maxOverlapComp. -/
+private lemma lower_bound_via_comp {n lb : ℕ}
+    (hcheck : ∀ A ∈ (Finset.Icc (1:ℤ) (2*↑n)).powerset.filter (fun A => A.card = n),
+      lb ≤ maxOverlapComp A (Finset.Icc 1 (2*↑n) \ A))
+    {A B : Finset ℤ} (hD : Disjoint A B) (hU : A ∪ B = Finset.Icc (1:ℤ) (2*↑n))
+    (hC : A.card = B.card) : lb ≤ MaxOverlap A B := by
+  have ⟨hAcard, _⟩ := split_card hD hU hC
+  have hAsub : A ⊆ Finset.Icc (1:ℤ) (2*↑n) := hU ▸ Finset.subset_union_left
+  rw [B_eq_sdiff hD hU, ← maxOverlapComp_eq]
+  apply hcheck
+  simp [Finset.mem_powerset, Finset.mem_filter, hAsub, hAcard]
+
+/-!
+## M 1 = 1
+-/
+
+private lemma maxOverlap_1_2 : MaxOverlap ({1} : Finset ℤ) {2} = 1 := by
+  rw [← maxOverlapComp_eq]; decide
+
 /--
 This example calculates the value of $M 1$. The set is $\{1, 2\}$, so the only partition is
 $A = \{1\}, B = \{2\}$ (or vice versa). The possible differences are $1 - 2 = -1$ and $2 - 1 = 1$.
@@ -61,23 +157,88 @@ Thus, $M 1 = 1$.
 -/
 @[category test, AMS 5 11]
 theorem M_one : M 1 = 1 := by
-  sorry
+  apply Nat.le_antisymm
+  · apply Nat.sInf_le
+    exact ⟨{1}, {2}, by decide, by decide, by decide, maxOverlap_1_2⟩
+  · apply le_csInf
+    · exact ⟨_, {1}, {2}, by decide, by decide, by decide, rfl⟩
+    · rintro x ⟨A, B, hD, hU, hC, rfl⟩
+      have ⟨hAcard, hBcard⟩ := split_card hD hU hC
+      exact one_le_maxOverlap (Finset.card_pos.mp (by omega)) (Finset.card_pos.mp (by omega))
+
+/-!
+## M 2 = 1
+-/
+
+private lemma maxOverlap_14_23 : MaxOverlap ({1, 4} : Finset ℤ) {2, 3} = 1 := by
+  rw [← maxOverlapComp_eq]; decide
 
 @[category test, AMS 5 11]
 theorem M_two : M 2 = 1 := by
-  sorry
+  apply Nat.le_antisymm
+  · apply Nat.sInf_le
+    exact ⟨{1, 4}, {2, 3}, by decide, by decide, by decide, maxOverlap_14_23⟩
+  · apply le_csInf
+    · exact ⟨_, {1, 4}, {2, 3}, by decide, by decide, by decide, rfl⟩
+    · rintro x ⟨A, B, hD, hU, hC, rfl⟩
+      have ⟨hAcard, hBcard⟩ := split_card hD hU hC
+      exact one_le_maxOverlap (Finset.card_pos.mp (by omega)) (Finset.card_pos.mp (by omega))
+
+/-!
+## M 3 = 2
+The optimal split is A={1,4,6}, B={2,3,5}.
+-/
+
+private lemma maxOverlap_146_235 : MaxOverlap ({1, 4, 6} : Finset ℤ) {2, 3, 5} = 2 := by
+  rw [← maxOverlapComp_eq]; decide
 
 @[category test, AMS 5 11]
 theorem M_three : M 3 = 2 := by
-  sorry
+  apply Nat.le_antisymm
+  · apply Nat.sInf_le
+    exact ⟨{1, 4, 6}, {2, 3, 5}, by decide, by decide, by decide, maxOverlap_146_235⟩
+  · apply le_csInf
+    · exact ⟨_, {1, 4, 6}, {2, 3, 5}, by decide, by decide, by decide, rfl⟩
+    · rintro x ⟨A, B, hD, hU, hC, rfl⟩
+      exact lower_bound_via_comp (n := 3) (lb := 2) (by decide) hD hU hC
+
+/-!
+## M 4 = 2
+The optimal split is A={2,3,4,6}, B={1,5,7,8}.
+-/
+
+private lemma maxOverlap_2346_1578 : MaxOverlap ({2, 3, 4, 6} : Finset ℤ) {1, 5, 7, 8} = 2 := by
+  rw [← maxOverlapComp_eq]; decide
 
 @[category test, AMS 5 11]
 theorem M_four : M 4 = 2 := by
-  sorry
+  apply Nat.le_antisymm
+  · apply Nat.sInf_le
+    exact ⟨{2, 3, 4, 6}, {1, 5, 7, 8}, by decide, by decide, by decide, maxOverlap_2346_1578⟩
+  · apply le_csInf
+    · exact ⟨_, {2, 3, 4, 6}, {1, 5, 7, 8}, by decide, by decide, by decide, rfl⟩
+    · rintro x ⟨A, B, hD, hU, hC, rfl⟩
+      exact lower_bound_via_comp (n := 4) (lb := 2) (by decide) hD hU hC
+
+/-!
+## M 5 = 3
+The optimal split is A={1,2,3,5,6}, B={4,7,8,9,10}.
+-/
+
+private lemma maxOverlap_12356_4_7_8_9_10 : MaxOverlap ({1, 2, 3, 5, 6} : Finset ℤ)
+    {4, 7, 8, 9, 10} = 3 := by
+  rw [← maxOverlapComp_eq]; decide
 
 @[category test, AMS 5 11]
 theorem M_five : M 5 = 3 := by
-  sorry
+  apply Nat.le_antisymm
+  · apply Nat.sInf_le
+    exact ⟨{1, 2, 3, 5, 6}, {4, 7, 8, 9, 10}, by decide, by decide, by decide,
+            maxOverlap_12356_4_7_8_9_10⟩
+  · apply le_csInf
+    · exact ⟨_, {1, 2, 3, 5, 6}, {4, 7, 8, 9, 10}, by decide, by decide, by decide, rfl⟩
+    · rintro x ⟨A, B, hD, hU, hC, rfl⟩
+      exact lower_bound_via_comp (n := 5) (lb := 3) (by decide) hD hU hC
 
 /--
 The quotient of the minimum maximum overlap $M(N)$ by $N$. The central question of the


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in OpenCode and verified via Lean 4 compilation. Proves five `@[category test]` theorems computing M(1)=1, M(2)=1, M(3)=2, M(4)=2, M(5)=3 for the Minimum Overlap Problem (Erdős Problem 36). Introduces a computable bridge `maxOverlapComp` proved equal to `MaxOverlap` via `maxOverlapComp_eq`. Upper bounds use explicit optimal partitions verified by `decide`. Lower bounds use exhaustive enumeration over all C(2n,n) partitions via `native_decide` in `@[category test]` helpers.

  Axioms checked: clean (propext, Classical.choice, Quot.sound). No sorryAx. No native_decide in core theorems (only in `@[category test]` helpers as permitted).