### PR TITLE
solve(Wikipedia): WolstenholmePrime 16843 and 2124679 verified (native_decide in test)

### DIFF
--- a/FormalConjectures/Wikipedia/WolstenholmePrime.lean
+++ b/FormalConjectures/Wikipedia/WolstenholmePrime.lean
@@ -47,11 +47,13 @@ Two known Wolstenholme primes: 16843 and 2124679.
 -/
 @[category test, AMS 11]
 theorem wolstenholme_prime_16483 : IsWolstenholmePrime 16843 := by
-  sorry
+  refine ⟨by norm_num, by norm_num, ?_⟩
+  native_decide
 
 @[category test, AMS 11]
 theorem wolstenholme_prime_2124679 : IsWolstenholmePrime 2124679 := by
-  sorry
+  refine ⟨by norm_num, by norm_num, ?_⟩
+  native_decide
 
 /--
 Equivalently, a prime $p > 7$ is a Wolstenholme prime if it divides the numerator of the Bernoulli number $B_{p-3}$.


### PR DESCRIPTION
Proof generated by Claude Sonnet 4.6 in Aletheia style harness and verified via Lean 4 compilation. Proves that 16843 and 2124679 are Wolstenholme primes (p^4 | C(2p,p) - 2) using `native_decide` in `@[category test]` theorems (permitted per sniper doctrine for test-category). Follows the same pattern as prior test-category native_decide PRs.

  Axioms: Lean.ofReduceBool present from native_decide in test helpers. No sorryAx. Permitted for test category.