### PR TITLE
ErdosProblems/857: add initial conjecture scaffold

### DIFF
--- a/FormalConjectures/ErdosProblems/20.lean
+++ b/FormalConjectures/ErdosProblems/20.lean
@@ -23,41 +23,7 @@ import FormalConjectures.Util.ProblemImports
 * [erdosproblems.com/20](https://www.erdosproblems.com/20)
 * [Wikipedia](https://en.wikipedia.org/wiki/Sunflower_(mathematics))
 -/
-universe u
-
 namespace Erdos20
-
-variable {α : Type}
-
-/--
-A sunflower $F$ with kernel $S$ is a collection of sets in which all possible distinct pairs of sets
-share the same intersection $S$.
--/
-def IsSunflowerWithKernel (F : Set (Set α)) (S : Set α) : Prop :=
-  F.Pairwise (fun A B => A ∩ B = S)
-
-@[category test, AMS 5]
-theorem isSunflowerWithKernel_empty (S : Set α) : IsSunflowerWithKernel {} S := by
-  simp [IsSunflowerWithKernel]
-
-@[category test, AMS 5]
-theorem isSunflowerWithKernel_singleton (S : Set α) (A : Set α) :
-    IsSunflowerWithKernel {A} S := by
-  simp [IsSunflowerWithKernel]
-
-/--
-A sunflower $F$ is a collection of sets in which all possible distinct pairs of sets share the
-same intersection.
--/
-def IsSunflower (F : Set (Set α)) : Prop := ∃ S, IsSunflowerWithKernel F S
-
-@[category test, AMS 5]
-theorem isSunflower_empty : IsSunflower (∅ : Set (Set α)) := by
-  simp [IsSunflower, isSunflowerWithKernel_empty]
-
-@[category test, AMS 5]
-theorem isSunflower_singleton (A : Set α) : IsSunflower {A} := by
-  simp [IsSunflower, isSunflowerWithKernel_singleton]
 
 /--
 Let $f(n,k)$ be minimal such that every $F$ family of $n$-uniform sets with $|F| \ge f(n,k)$

--- a/FormalConjectures/ErdosProblems/857.lean
+++ b/FormalConjectures/ErdosProblems/857.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
+import FormalConjectures.ErdosProblems.«20»
 
 /-!
 # Erdős Problem 857
@@ -30,28 +31,12 @@ open Filter
 
 namespace Erdos857
 
-variable {α : Type}
-
-/--
-A sunflower `F` with kernel `S` is a collection of sets in which all possible distinct pairs
-of sets have intersection `S`.
--/
-def IsSunflowerWithKernel (F : Set (Set α)) (S : Set α) : Prop :=
-  F.Pairwise (fun A B => A ∩ B = S)
-
-/--
-A sunflower is a collection of sets in which all possible distinct pairs have the
-same intersection.
--/
-def IsSunflower (F : Set (Set α)) : Prop :=
-  ∃ S, IsSunflowerWithKernel F S
-
 /--
 `m(n, k)`: minimal sunflower-forcing family size in the non-uniform `[n]` model.
 -/
 noncomputable def m (n k : ℕ) : ℕ :=
   sInf {t : ℕ | ∀ (F : Set (Set (Fin n))), t ≤ F.ncard →
-    ∃ S ⊆ F, S.ncard = k ∧ IsSunflower S}
+    ∃ S ⊆ F, S.ncard = k ∧ Erdos20.IsSunflower S}
 
 /-- Existence of an asymptotic formula for `m(·,k)` up to asymptotic equivalence. -/
 def hasAsymptoticFormula (k : ℕ) : Prop :=

--- a/FormalConjectures/ErdosProblems/857.lean
+++ b/FormalConjectures/ErdosProblems/857.lean
@@ -56,7 +56,7 @@ noncomputable def m (n k : ℕ) : ℕ :=
 /-- Existence of an asymptotic formula for `m(·,k)` up to asymptotic equivalence. -/
 def hasAsymptoticFormula (k : ℕ) : Prop :=
   ∃ g : ℕ → ℝ,
-    Tendsto (fun n : ℕ => (m n k : ℝ) / g n) atTop (𝓝 1)
+    Tendsto (fun n : ℕ => (m n k : ℝ) / g n) atTop (nhds 1)
 
 /--
 Estimate `m(n,k)`, or better give an asymptotic formula.

--- a/FormalConjectures/ErdosProblems/857.lean
+++ b/FormalConjectures/ErdosProblems/857.lean
@@ -1,0 +1,68 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 857
+
+*Reference:* [erdosproblems.com/857](https://www.erdosproblems.com/857)
+
+For fixed `n, k`, let `m(n, k)` be minimal such that every family of subsets of `[n]`
+of size at least `m(n, k)` contains a `k`-sunflower.
+The problem asks to estimate `m(n, k)`, ideally asymptotically.
+-/
+
+open Filter
+
+namespace Erdos857
+
+variable {α : Type}
+
+/--
+A sunflower `F` with kernel `S` is a collection of sets in which all possible distinct pairs
+of sets have intersection `S`.
+-/
+def IsSunflowerWithKernel (F : Set (Set α)) (S : Set α) : Prop :=
+  F.Pairwise (fun A B => A ∩ B = S)
+
+/--
+A sunflower is a collection of sets in which all possible distinct pairs have the
+same intersection.
+-/
+def IsSunflower (F : Set (Set α)) : Prop :=
+  ∃ S, IsSunflowerWithKernel F S
+
+/--
+`m(n, k)`: minimal sunflower-forcing family size in the non-uniform `[n]` model.
+-/
+noncomputable def m (n k : ℕ) : ℕ :=
+  sInf {t : ℕ | ∀ (F : Set (Set (Fin n))), t ≤ F.ncard →
+    ∃ S ⊆ F, S.ncard = k ∧ IsSunflower S}
+
+/-- Existence of an asymptotic formula for `m(·,k)` up to asymptotic equivalence. -/
+def hasAsymptoticFormula (k : ℕ) : Prop :=
+  ∃ g : ℕ → ℝ,
+    Tendsto (fun n : ℕ => (m n k : ℝ) / g n) atTop (𝓝 1)
+
+/--
+Estimate `m(n,k)`, or better give an asymptotic formula.
+-/
+@[category research open, AMS 5]
+theorem erdos_857 : answer(sorry) ↔ ∀ k : ℕ, 3 ≤ k → hasAsymptoticFormula k := by
+  sorry
+
+end Erdos857

--- a/FormalConjectures/ErdosProblems/857.lean
+++ b/FormalConjectures/ErdosProblems/857.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjectures.ErdosProblems.«20»
 
 /-!
 # Erdős Problem 857
@@ -36,7 +35,7 @@ namespace Erdos857
 -/
 noncomputable def m (n k : ℕ) : ℕ :=
   sInf {t : ℕ | ∀ (F : Set (Set (Fin n))), t ≤ F.ncard →
-    ∃ S ⊆ F, S.ncard = k ∧ Erdos20.IsSunflower S}
+    ∃ S ⊆ F, S.ncard = k ∧ IsSunflower S}
 
 /--
 Estimate `m(n,k)`, or better give an asymptotic formula.

--- a/FormalConjectures/ErdosProblems/857.lean
+++ b/FormalConjectures/ErdosProblems/857.lean
@@ -38,16 +38,13 @@ noncomputable def m (n k : ℕ) : ℕ :=
   sInf {t : ℕ | ∀ (F : Set (Set (Fin n))), t ≤ F.ncard →
     ∃ S ⊆ F, S.ncard = k ∧ Erdos20.IsSunflower S}
 
-/-- Existence of an asymptotic formula for `m(·,k)` up to asymptotic equivalence. -/
-def hasAsymptoticFormula (k : ℕ) : Prop :=
-  ∃ g : ℕ → ℝ,
-    Tendsto (fun n : ℕ => (m n k : ℝ) / g n) atTop (nhds 1)
-
 /--
 Estimate `m(n,k)`, or better give an asymptotic formula.
 -/
 @[category research open, AMS 5]
-theorem erdos_857 : answer(sorry) ↔ ∀ k : ℕ, 3 ≤ k → hasAsymptoticFormula k := by
+theorem erdos_857 :
+    let f : ℕ → ℕ → ℝ := answer(sorry)
+    ∀ k : ℕ, 3 ≤ k → Tendsto (fun n : ℕ => (m n k : ℝ) / f k n) atTop (nhds 1) := by
   sorry
 
 end Erdos857

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -39,6 +39,7 @@ public import FormalConjecturesForMathlib.Combinatorics.Additive.VCDim
 public import FormalConjecturesForMathlib.Combinatorics.Basic
 public import FormalConjecturesForMathlib.Combinatorics.LatinSquare
 public import FormalConjecturesForMathlib.Combinatorics.Ramsey
+public import FormalConjecturesForMathlib.Combinatorics.SetFamily.Sunflower
 public import FormalConjecturesForMathlib.Combinatorics.SetFamily.VCDim
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Balanced
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Clique

--- a/FormalConjecturesForMathlib/Combinatorics/SetFamily/Sunflower.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SetFamily/Sunflower.lean
@@ -1,0 +1,54 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Set.Card
+
+@[expose] public section
+
+/-!
+# Sunflowers
+
+This file defines sunflowers of set families.
+-/
+
+variable {α : Type*}
+
+/--
+A sunflower `F` with kernel `S` is a collection of sets in which all possible distinct pairs of sets
+share the same intersection `S`.
+-/
+def IsSunflowerWithKernel (F : Set (Set α)) (S : Set α) : Prop :=
+  F.Pairwise (fun A B => A ∩ B = S)
+
+theorem isSunflowerWithKernel_empty (S : Set α) : IsSunflowerWithKernel {} S := by
+  simp [IsSunflowerWithKernel]
+
+theorem isSunflowerWithKernel_singleton (S : Set α) (A : Set α) :
+    IsSunflowerWithKernel {A} S := by
+  simp [IsSunflowerWithKernel]
+
+/--
+A sunflower `F` is a collection of sets in which all possible distinct pairs of sets share the
+same intersection.
+-/
+def IsSunflower (F : Set (Set α)) : Prop := ∃ S, IsSunflowerWithKernel F S
+
+theorem isSunflower_empty : IsSunflower (∅ : Set (Set α)) := by
+  simp [IsSunflower, isSunflowerWithKernel_empty]
+
+theorem isSunflower_singleton (A : Set α) : IsSunflower {A} := by
+  simp [IsSunflower, isSunflowerWithKernel_singleton]


### PR DESCRIPTION
## Summary

Adds an initial scaffold for **Erdős Problem 857** in `FormalConjectures/ErdosProblems/857.lean`.

Closes #982.

This formalizes the statement layer only, with:

- non-uniform extremal quantity `m (n, k)` over families of subsets of `Fin n`
- shared sunflower definitions moved to `FormalConjecturesForMathlib.Combinatorics.SetFamily.Sunflower`
- main statement `erdos_857` using the repository's `answer(sorry)` pattern for the unknown asymptotic family

## Motivation

`857` is currently missing from `FormalConjectures/ErdosProblems/`.
This PR adds a concise, reviewable formal statement entry point aligned with repository conventions.

## Conventions

- Uses `@[category research open, AMS 5]`.
- Uses `answer(sorry)` for the open problem statement.
- Includes problem reference in the module docstring.
- Avoids importing one conjecture file from another by placing the reusable sunflower API in `FormalConjecturesForMathlib`.

## Verification

- `COPYFILE_DISABLE=1 ~/.elan/bin/lake exe cache get`
- `COPYFILE_DISABLE=1 ~/.elan/bin/lake build FormalConjecturesForMathlib.Combinatorics.SetFamily.Sunflower FormalConjectures.ErdosProblems.«20» FormalConjectures.ErdosProblems.«857»`

## Notes

Opening as a statement scaffold, not a proof of the conjecture.
