### PR TITLE
feat(ErdosProblems): 367

### DIFF
--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -26,30 +26,34 @@ import FormalConjectures.Util.ProblemImports
 The problem asks about bounds on products of 2-full parts over short intervals.
 -/
 
+open Asymptotics Filter
+
 namespace Erdos367
 
 /-- Product of primes dividing `n` with exponent exactly one. -/
-noncomputable def exactlyOncePrimeDivisorProduct (n : ℕ) : ℕ :=
+def exactlyOncePrimeDivisorProduct (n : ℕ) : ℕ :=
   (n.factorization.support.filter (fun p => n.factorization p = 1)).prod id
 
 /--
 `B₂(n)` in the Erdős Problem 367 statement:
 `B₂(n) = n / n'`, where `n'` is the product of all primes dividing `n` exactly once.
 -/
-noncomputable def B2 (n : ℕ) : ℕ :=
+def B2 (n : ℕ) : ℕ :=
   n / exactlyOncePrimeDivisorProduct n
 
 /-- Product `∏_{n ≤ m < n+k} B₂(m)`. -/
-noncomputable def intervalB2Product (n k : ℕ) : ℕ :=
+def intervalB2Product (n k : ℕ) : ℕ :=
   (Finset.range k).prod (fun i => B2 (n + i))
 
-/-- Discrete formulation of a `n^(2+o(1))`-type upper bound with integer slack. -/
+/-- Asymptotic formulation of an `n^(2+o(1))`-type upper bound. -/
 def nearlyQuadraticBound (k : ℕ) : Prop :=
-  ∀ s : ℕ, 1 ≤ s → ∃ C : ℕ, ∀ n : ℕ, 1 ≤ n → intervalB2Product n k ≤ C * n ^ (2 + s)
+  ∃ e : ℕ → ℝ,
+    e =o[atTop] (1 : ℕ → ℝ) ∧
+    ∀ᶠ n in atTop, (intervalB2Product n k : ℝ) ≤ (n : ℝ) ^ (2 + e n)
 
 /-- The stronger variant `≪_k n^2`. -/
 def quadraticBound (k : ℕ) : Prop :=
-  ∃ C : ℕ, ∀ n : ℕ, 1 ≤ n → intervalB2Product n k ≤ C * n ^ 2
+  (fun n ↦ (intervalB2Product n k : ℝ)) =O[atTop] fun n ↦ (n : ℝ) ^ (2 : ℝ)
 
 /--
 For fixed `k ≥ 1`, is `∏_{n ≤ m < n+k} B₂(m) ≪ n^(2+o(1))`?
@@ -73,12 +77,12 @@ theorem erdos_367.variants.k_le_two : ∀ k : ℕ, k ≤ 2 → quadraticBound k 
   sorry
 
 /-- `B_r(n)`: product of prime powers `p^a ‖ n` with `a ≥ r`. -/
-noncomputable def Br (r n : ℕ) : ℕ :=
+def Br (r n : ℕ) : ℕ :=
   (n.factorization.support.filter (fun p => r ≤ n.factorization p)).prod
     (fun p => p ^ (n.factorization p))
 
 /-- Product `∏_{n ≤ m < n+k} B_r(m)`. -/
-noncomputable def intervalBrProduct (r n k : ℕ) : ℕ :=
+def intervalBrProduct (r n k : ℕ) : ℕ :=
   (Finset.range k).prod (fun i => Br r (n + i))
 
 /--

--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -1,0 +1,99 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 367
+
+*References:*
+- [erdosproblems.com/367](https://www.erdosproblems.com/367)
+- [ErGr80] P. Erdős and R. L. Graham, *Old and New Problems and Results in Combinatorial Number Theory*, L'Enseignement Mathématique (1980).
+
+The problem asks about bounds on products of 2-full parts over short intervals.
+-/
+
+namespace Erdos367
+
+/-- Product of primes dividing `n` with exponent exactly one. -/
+noncomputable def exactlyOncePrimeDivisorProduct (n : ℕ) : ℕ :=
+  (n.factorization.support.filter (fun p => n.factorization p = 1)).prod id
+
+/--
+`B₂(n)` in the Erdős Problem 367 statement:
+`B₂(n) = n / n'`, where `n'` is the product of all primes dividing `n` exactly once.
+-/
+noncomputable def B2 (n : ℕ) : ℕ :=
+  n / exactlyOncePrimeDivisorProduct n
+
+/-- Product `∏_{n ≤ m < n+k} B₂(m)`. -/
+noncomputable def intervalB2Product (n k : ℕ) : ℕ :=
+  (Finset.range k).prod (fun i => B2 (n + i))
+
+/-- Discrete formulation of a `n^(2+o(1))`-type upper bound with integer slack. -/
+def nearlyQuadraticBound (k : ℕ) : Prop :=
+  ∀ s : ℕ, 1 ≤ s → ∃ C : ℕ, ∀ n : ℕ, 1 ≤ n → intervalB2Product n k ≤ C * n ^ (2 + s)
+
+/-- The stronger variant `≪_k n^2`. -/
+def quadraticBound (k : ℕ) : Prop :=
+  ∃ C : ℕ, ∀ n : ℕ, 1 ≤ n → intervalB2Product n k ≤ C * n ^ 2
+
+/--
+For fixed `k ≥ 1`, is `∏_{n ≤ m < n+k} B₂(m) ≪ n^(2+o(1))`?
+-/
+@[category research open, AMS 11]
+theorem erdos_367.parts.i : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k → nearlyQuadraticBound k := by
+  sorry
+
+/--
+Or perhaps even `∏_{n ≤ m < n+k} B₂(m) ≪_k n^2`?
+-/
+@[category research open, AMS 11]
+theorem erdos_367.parts.ii : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k → quadraticBound k := by
+  sorry
+
+/--
+The page notes the easy range `k ≤ 2`; this variant captures that solved subregime.
+-/
+@[category research solved, AMS 11]
+theorem erdos_367.variants.k_le_two : ∀ k : ℕ, k ≤ 2 → quadraticBound k := by
+  sorry
+
+/-- `B_r(n)`: product of prime powers `p^a ‖ n` with `a ≥ r`. -/
+noncomputable def Br (r n : ℕ) : ℕ :=
+  (n.factorization.support.filter (fun p => r ≤ n.factorization p)).prod
+    (fun p => p ^ (n.factorization p))
+
+/-- Product `∏_{n ≤ m < n+k} B_r(m)`. -/
+noncomputable def intervalBrProduct (r n k : ℕ) : ℕ :=
+  (Finset.range k).prod (fun i => Br r (n + i))
+
+/--
+Discrete limsup-unbounded formulation for the variant in the additional text.
+-/
+def brRatioUnbounded (r k : ℕ) : Prop :=
+  ∀ A : ℕ, ∃ n : ℕ, 1 ≤ n ∧ A * n ≤ intervalBrProduct r n k
+
+/--
+Variant question from the additional text: for fixed `r, k ≥ 2`, does there exist `ε > 0`
+with unbounded `limsup` behavior for `∏ B_r(m) / n^(1+ε)`?
+-/
+@[category research open, AMS 11]
+theorem erdos_367.variants.higher_full_parts : answer(sorry) ↔
+    ∀ r k : ℕ, 3 ≤ r → 2 ≤ k → brRatioUnbounded r k := by
+  sorry
+
+end Erdos367

--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -30,62 +30,73 @@ open Asymptotics Filter
 
 namespace Erdos367
 
-/-- `B r n` is the `r`-full part of `n`: the product of prime powers `p^a ‖ n` with `a ≥ r`. -/
+/-- `B r n` is the $r$-full part of $n$: the product of prime powers $p^a \| n$ with $a \geq r$. -/
 def B (r n : ℕ) : ℕ :=
-  (n.factorization.support.filter (fun p => r ≤ n.factorization p)).prod
-    (fun p => p ^ (n.factorization p))
+  ∏ i ∈ n.factorization.support.filter (r ≤ n.factorization ·), i ^ n.factorization i
 
 /--
-`B₂(n) = n / n'`, where `n'` is the product of all primes dividing `n` exactly once,
-equivalently the `2`-full part of `n`.
+$B_2(n) = n / n'$, where $n'$ is the product of all primes dividing $n$ exactly once,
+equivalently the $2$-full part of $n$.
 -/
 abbrev B₂ (n : ℕ) : ℕ := B 2 n
 
-/-- Product `∏_{n ≤ m < n+k} B_r(m)`. -/
+/-- Product $\prod_{n \leq m < n+k} B_r(m)$. -/
 def intervalBProduct (r n k : ℕ) : ℕ :=
-  (Finset.range k).prod (fun i => B r (n + i))
+  ∏ i ∈ Finset.range k, B r (n + i)
 
-/-- Asymptotic formulation of an `n^(2+o(1))`-type upper bound. -/
+/-- Asymptotic formulation of an $n^{2+o(1)}$-type upper bound. -/
 def nearlyQuadraticBound (k : ℕ) : Prop :=
   ∃ e : ℕ → ℝ,
     e =o[atTop] (1 : ℕ → ℝ) ∧
     ∀ᶠ n in atTop, (intervalBProduct 2 n k : ℝ) ≤ (n : ℝ) ^ (2 + e n)
 
-/-- The stronger variant `≪_k n^2`. -/
+/-- The stronger variant $\ll_k n^2$. -/
 def quadraticBound (k : ℕ) : Prop :=
   (fun n ↦ (intervalBProduct 2 n k : ℝ)) =O[atTop] fun n ↦ (n : ℝ) ^ (2 : ℝ)
 
 /--
-For fixed `k ≥ 1`, is `∏_{n ≤ m < n+k} B₂(m) ≪ n^(2+o(1))`?
+Let $B_2(n)$ be the $2$-full part of $n$. Is it true that, for every fixed $k \geq 1$,
+$\prod_{n \leq m < n+k} B_2(m) \ll n^{2+o(1)}$?
 -/
 @[category research open, AMS 11]
 theorem erdos_367.parts.i : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k → nearlyQuadraticBound k := by
   sorry
 
 /--
-Or perhaps even `∏_{n ≤ m < n+k} B₂(m) ≪_k n^2`?
+Or perhaps even $\prod_{n \leq m < n+k} B_2(m) \ll_k n^2$?
 -/
 @[category research open, AMS 11]
 theorem erdos_367.parts.ii : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k → quadraticBound k := by
   sorry
 
 /--
-The page notes the easy range `k ≤ 2`; this variant captures that solved subregime.
+van Doorn notes that for $k \leq 2$ we trivially have
+$\prod_{n \leq m < n+k} B_2(m) \ll n^2$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_367.variants.k_le_two : ∀ k : ℕ, k ≤ 2 → quadraticBound k := by
   sorry
 
 /--
-Discrete limsup-unbounded formulation for the `B_r` variant.
+van Doorn also notes that the quadratic bound fails for all $k \geq 3$, and in fact
+$\prod_{n \leq m < n+3} B_2(m) \gg n^2 \log n$ infinitely often.
+-/
+@[category research solved, AMS 11]
+theorem erdos_367.variants.k_ge_three_lower :
+    ∃ c > (0 : ℝ), ∀ᶠ (n : ℕ) in atTop,
+      c * ((n : ℝ) ^ 2 * Real.log (n : ℝ)) ≤ (intervalBProduct 2 n 3 : ℝ) := by
+  sorry
+
+/--
+Discrete limsup-unbounded formulation for the $B_r$ variant.
 -/
 def brRatioUnbounded (r k : ℕ) : Prop :=
   ∀ A : ℕ, ∃ n : ℕ, 1 ≤ n ∧ A * n ≤ intervalBProduct r n k
 
 /--
-Variant question from the additional text: for fixed `r ≥ 3`, `k ≥ 2`, does there exist
-`ε > 0`
-with unbounded `limsup` behavior for `∏ B_r(m) / n^(1+ε)`?
+It would also be interesting to find upper and lower bounds for the analogous product with $B_r$
+for $r \geq 3$. Is it true that, for every fixed $r \geq 3$, $k \geq 2$, and $\epsilon > 0$,
+$\limsup \frac{\prod_{n \leq m < n+k} B_r(m)}{n^{1+\epsilon}} \to \infty$?
 -/
 @[category research open, AMS 11]
 theorem erdos_367.variants.higher_full_parts : answer(sorry) ↔

--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -30,30 +30,30 @@ open Asymptotics Filter
 
 namespace Erdos367
 
-/-- Product of primes dividing `n` with exponent exactly one. -/
-def exactlyOncePrimeDivisorProduct (n : ℕ) : ℕ :=
-  (n.factorization.support.filter (fun p => n.factorization p = 1)).prod id
+/-- `B r n` is the `r`-full part of `n`: the product of prime powers `p^a ‖ n` with `a ≥ r`. -/
+def B (r n : ℕ) : ℕ :=
+  (n.factorization.support.filter (fun p => r ≤ n.factorization p)).prod
+    (fun p => p ^ (n.factorization p))
 
 /--
-`B₂(n)` in the Erdős Problem 367 statement:
-`B₂(n) = n / n'`, where `n'` is the product of all primes dividing `n` exactly once.
+`B₂(n) = n / n'`, where `n'` is the product of all primes dividing `n` exactly once,
+equivalently the `2`-full part of `n`.
 -/
-def B2 (n : ℕ) : ℕ :=
-  n / exactlyOncePrimeDivisorProduct n
+abbrev B₂ (n : ℕ) : ℕ := B 2 n
 
-/-- Product `∏_{n ≤ m < n+k} B₂(m)`. -/
-def intervalB2Product (n k : ℕ) : ℕ :=
-  (Finset.range k).prod (fun i => B2 (n + i))
+/-- Product `∏_{n ≤ m < n+k} B_r(m)`. -/
+def intervalBProduct (r n k : ℕ) : ℕ :=
+  (Finset.range k).prod (fun i => B r (n + i))
 
 /-- Asymptotic formulation of an `n^(2+o(1))`-type upper bound. -/
 def nearlyQuadraticBound (k : ℕ) : Prop :=
   ∃ e : ℕ → ℝ,
     e =o[atTop] (1 : ℕ → ℝ) ∧
-    ∀ᶠ n in atTop, (intervalB2Product n k : ℝ) ≤ (n : ℝ) ^ (2 + e n)
+    ∀ᶠ n in atTop, (intervalBProduct 2 n k : ℝ) ≤ (n : ℝ) ^ (2 + e n)
 
 /-- The stronger variant `≪_k n^2`. -/
 def quadraticBound (k : ℕ) : Prop :=
-  (fun n ↦ (intervalB2Product n k : ℝ)) =O[atTop] fun n ↦ (n : ℝ) ^ (2 : ℝ)
+  (fun n ↦ (intervalBProduct 2 n k : ℝ)) =O[atTop] fun n ↦ (n : ℝ) ^ (2 : ℝ)
 
 /--
 For fixed `k ≥ 1`, is `∏_{n ≤ m < n+k} B₂(m) ≪ n^(2+o(1))`?
@@ -76,23 +76,15 @@ The page notes the easy range `k ≤ 2`; this variant captures that solved subre
 theorem erdos_367.variants.k_le_two : ∀ k : ℕ, k ≤ 2 → quadraticBound k := by
   sorry
 
-/-- `B_r(n)`: product of prime powers `p^a ‖ n` with `a ≥ r`. -/
-def Br (r n : ℕ) : ℕ :=
-  (n.factorization.support.filter (fun p => r ≤ n.factorization p)).prod
-    (fun p => p ^ (n.factorization p))
-
-/-- Product `∏_{n ≤ m < n+k} B_r(m)`. -/
-def intervalBrProduct (r n k : ℕ) : ℕ :=
-  (Finset.range k).prod (fun i => Br r (n + i))
-
 /--
-Discrete limsup-unbounded formulation for the variant in the additional text.
+Discrete limsup-unbounded formulation for the `B_r` variant.
 -/
 def brRatioUnbounded (r k : ℕ) : Prop :=
-  ∀ A : ℕ, ∃ n : ℕ, 1 ≤ n ∧ A * n ≤ intervalBrProduct r n k
+  ∀ A : ℕ, ∃ n : ℕ, 1 ≤ n ∧ A * n ≤ intervalBProduct r n k
 
 /--
-Variant question from the additional text: for fixed `r, k ≥ 2`, does there exist `ε > 0`
+Variant question from the additional text: for fixed `r ≥ 3`, `k ≥ 2`, does there exist
+`ε > 0`
 with unbounded `limsup` behavior for `∏ B_r(m) / n^(1+ε)`?
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -49,9 +49,11 @@ theorem erdos_367.parts.i : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k →
 
 /--
 Or perhaps even $\prod_{n \leq m < n+k} B_2(m) \ll_k n^2$?
+
+van Doorn notes in the comments that this fails for all $k \geq 3$.
 -/
-@[category research open, AMS 11]
-theorem erdos_367.parts.ii : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k →
+@[category research solved, AMS 11]
+theorem erdos_367.parts.ii : answer(False) ↔ ∀ k : ℕ, 1 ≤ k →
     (fun n ↦ ((∏ m ∈ .Ico n (n + k), B 2 m : ℕ) : ℝ)) =O[atTop]
       fun n ↦ (n : ℝ) ^ (2 : ℝ) := by
   sorry

--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
+import FormalConjecturesUtil
 
 /-!
 # Erdős Problem 367
@@ -22,85 +22,73 @@ import FormalConjectures.Util.ProblemImports
 *References:*
 - [erdosproblems.com/367](https://www.erdosproblems.com/367)
 - [ErGr80] P. Erdős and R. L. Graham, *Old and New Problems and Results in Combinatorial Number Theory*, L'Enseignement Mathématique (1980).
-
-The problem asks about bounds on products of 2-full parts over short intervals.
 -/
 
 open Asymptotics Filter
 
 namespace Erdos367
 
-/-- `B r n` is the $r$-full part of $n$: the product of prime powers $p^a \| n$ with $a \geq r$. -/
-def B (r n : ℕ) : ℕ :=
-  ∏ i ∈ n.factorization.support.filter (r ≤ n.factorization ·), i ^ n.factorization i
-
 /--
-$B_2(n) = n / n'$, where $n'$ is the product of all primes dividing $n$ exactly once,
-equivalently the $2$-full part of $n$.
+`B r n` is the $r$-full part of $n$: the product of prime powers $p^a \| n$ with $a \geq r$.
 -/
-abbrev B₂ (n : ℕ) : ℕ := B 2 n
-
-/-- Product $\prod_{n \leq m < n+k} B_r(m)$. -/
-def intervalBProduct (r n k : ℕ) : ℕ :=
-  ∏ i ∈ Finset.range k, B r (n + i)
-
-/-- Asymptotic formulation of an $n^{2+o(1)}$-type upper bound. -/
-def nearlyQuadraticBound (k : ℕ) : Prop :=
-  ∃ e : ℕ → ℝ,
-    e =o[atTop] (1 : ℕ → ℝ) ∧
-    ∀ᶠ n in atTop, (intervalBProduct 2 n k : ℝ) ≤ (n : ℝ) ^ (2 + e n)
-
-/-- The stronger variant $\ll_k n^2$. -/
-def quadraticBound (k : ℕ) : Prop :=
-  (fun n ↦ (intervalBProduct 2 n k : ℝ)) =O[atTop] fun n ↦ (n : ℝ) ^ (2 : ℝ)
+def B (r n : ℕ) : ℕ :=
+  ∏ i ∈ n.factorization.support with r ≤ n.factorization i, i ^ n.factorization i
 
 /--
-Let $B_2(n)$ be the $2$-full part of $n$. Is it true that, for every fixed $k \geq 1$,
+Let $B_2(n)$ be the $2$-full part of $n$ (that is, $B_2(n)=n/n'$ where $n'$ is the product of all
+primes that divide $n$ exactly once). Is it true that, for every fixed $k \geq 1$,
 $\prod_{n \leq m < n+k} B_2(m) \ll n^{2+o(1)}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_367.parts.i : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k → nearlyQuadraticBound k := by
+theorem erdos_367.parts.i : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k →
+    ∃ e : ℕ → ℝ,
+      e =o[atTop] (1 : ℕ → ℝ) ∧
+      ∀ᶠ n in atTop,
+        ((∏ m ∈ .Ico n (n + k), B 2 m : ℕ) : ℝ) ≤ (n : ℝ) ^ (2 + e n) := by
   sorry
 
 /--
 Or perhaps even $\prod_{n \leq m < n+k} B_2(m) \ll_k n^2$?
 -/
 @[category research open, AMS 11]
-theorem erdos_367.parts.ii : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k → quadraticBound k := by
+theorem erdos_367.parts.ii : answer(sorry) ↔ ∀ k : ℕ, 1 ≤ k →
+    (fun n ↦ ((∏ m ∈ .Ico n (n + k), B 2 m : ℕ) : ℝ)) =O[atTop]
+      fun n ↦ (n : ℝ) ^ (2 : ℝ) := by
   sorry
 
 /--
-van Doorn notes that for $k \leq 2$ we trivially have
+van Doorn notes in the comments that for $k \leq 2$ we trivially have
 $\prod_{n \leq m < n+k} B_2(m) \ll n^2$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_367.variants.k_le_two : ∀ k : ℕ, k ≤ 2 → quadraticBound k := by
+theorem erdos_367.variants.k_le_two : ∀ k : ℕ, k ≤ 2 →
+    (fun n ↦ ((∏ m ∈ .Ico n (n + k), B 2 m : ℕ) : ℝ)) =O[atTop]
+      fun n ↦ (n : ℝ) ^ (2 : ℝ) := by
   sorry
 
 /--
-van Doorn also notes that the quadratic bound fails for all $k \geq 3$, and in fact
+But this fails for all $k \geq 3$, and in fact
 $\prod_{n \leq m < n+3} B_2(m) \gg n^2 \log n$ infinitely often.
 -/
 @[category research solved, AMS 11]
 theorem erdos_367.variants.k_ge_three_lower :
-    ∃ c > (0 : ℝ), ∀ᶠ (n : ℕ) in atTop,
-      c * ((n : ℝ) ^ 2 * Real.log (n : ℝ)) ≤ (intervalBProduct 2 n 3 : ℝ) := by
+    ∃ c > (0 : ℝ), ∃ᶠ (n : ℕ) in atTop,
+      c * ((n : ℝ) ^ 2 * Real.log (n : ℝ)) ≤
+        ((∏ m ∈ .Ico n (n + 3), B 2 m : ℕ) : ℝ) := by
   sorry
 
 /--
-Discrete limsup-unbounded formulation for the $B_r$ variant.
--/
-def brRatioUnbounded (r k : ℕ) : Prop :=
-  ∀ A : ℕ, ∃ n : ℕ, 1 ≤ n ∧ A * n ≤ intervalBProduct r n k
-
-/--
 It would also be interesting to find upper and lower bounds for the analogous product with $B_r$
-for $r \geq 3$. Is it true that, for every fixed $r \geq 3$, $k \geq 2$, and $\epsilon > 0$,
+for $r \geq 3$, where $B_r(n)$ is the $r$-full part of $n$ (that is, the product of prime powers
+$p^a \mid n$ such that $p^{a+1} \nmid n$ and $a \geq r$). Is it true that, for every fixed
+$r,k \geq 2$ and $\epsilon > 0$,
 $\limsup \frac{\prod_{n \leq m < n+k} B_r(m)}{n^{1+\epsilon}} \to \infty$?
 -/
 @[category research open, AMS 11]
 theorem erdos_367.variants.higher_full_parts : answer(sorry) ↔
-    ∀ r k : ℕ, 3 ≤ r → 2 ≤ k → brRatioUnbounded r k := by
+    ∀ r k : ℕ, 3 ≤ r → 2 ≤ k → ∀ ε : ℝ, 0 < ε →
+      atTop.limsup (fun n ↦
+        ((∏ m ∈ .Ico n (n + k), B r m : ℕ) / (n : ℝ) ^ (1 + ε) |>.toEReal)) = ⊤ := by
   sorry
 
 end Erdos367


### PR DESCRIPTION
Formalize the statement of **Erdos Problem 367** with:
- `B2` modeled as
  `n / (product of primes dividing n with exponent exactly one)`
- interval products `∏_{n ≤ m < n+k} B₂(m)`
- two main problem parts:
  - `erdos_367.parts.i`
  - `erdos_367.parts.ii`
- additional-text variants:
  - `erdos_367.variants.k_le_two`
  - `erdos_367.variants.higher_full_parts`

If preferred, I can split the `higher_full_parts` variant into a follow-up PR and keep this PR strictly to the two main parts plus the `k ≤ 2` variant.
