### PR TITLE
fix(ErdosProblems/38): use weak additive basis notion in erdos_38

### DIFF
--- a/FormalConjectures/ErdosProblems/38.lean
+++ b/FormalConjectures/ErdosProblems/38.lean
@@ -19,7 +19,10 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 38
 
-*Reference:* [erdosproblems.com/38](https://www.erdosproblems.com/38)
+*Reference:*
+- [erdosproblems.com/38](https://www.erdosproblems.com/38)
+- [Er56](Erdős, P., Problems and results in additive number theory.
+  Colloque sur la Théorie des Nombres, Bruxelles, 1955 (1956), 127-137.)
 -/
 
 open Classical Set Pointwise
@@ -34,6 +37,11 @@ and every $N$ there exists $b \in B$ such that
   \lvert (A \cup (A+b)) \cap \{1, \ldots, N\} \rvert \geq (\alpha + f(\alpha)) N
 \]
 where $f(\alpha) > 0$ for $0 < \alpha < 1$?
+
+Note: here Erdős seems to use a slightly weaker notion of an additive basis (see [Er56] at the top
+of page 135). In particular, for this problem, a set is an additive basis of order $k$ if every
+natural number can be written as a sum of _at most_ $k$ elements of the set, rather than as a sum of
+_precisely_ $k$ elements.
 -/
 @[category research open, AMS 11]
 theorem erdos_38 : answer(sorry) ↔

--- a/FormalConjecturesForMathlib/Combinatorics/Additive/Basis.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Additive/Basis.lean
@@ -19,6 +19,14 @@ import Mathlib.Algebra.Group.Pointwise.Set.BigOperators
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 
+/-! # Bases
+
+References:
+- [Er56](Erdős, P., Problems and results in additive number theory.
+  Colloque sur la Théorie des Nombres, Bruxelles, 1955 (1956), 127-137.)
+
+-/
+
 open Filter
 open scoped Pointwise
 
@@ -185,6 +193,8 @@ lemma isAsymptoticMulBasisOfOrder_iff_prod_atTop :
     IsAsymptoticMulBasisOfOrder A n ↔
       ∀ᶠ a in atTop, ∃ f : Fin n → M, (∀ i, f i ∈ A) ∧ ∏ i, f i = a := by
   simp [isAsymptoticMulBasisOfOrder_iff_prod, cofinite_eq_atTop]
+
+-- Note: the terminology _weak basis_ is non-standard. This notion is used in [Er56] p135.
 
 /-- A set `A : Set M` is a weak multiplicative basis of order `n` if any element `a : M`
 can be expressed as a product of at most `n` elements lying in `A`. -/


### PR DESCRIPTION
Based on https://combinatorica.hu/~p_erdos/1956-17.pdf (top of page 138 - this is the document the problem is sourced from) it seems that the notion of additive bases Erdos had in mind was a little weaker than what this problem was formalised with