### PR TITLE
fix(OEIS/56777): `mod_100_of_comesFromPrimeQuadruple`

### DIFF
--- a/FormalConjectures/OEIS/56777.lean
+++ b/FormalConjectures/OEIS/56777.lean
@@ -77,7 +77,8 @@ theorem mod_72_of_comesFromPrimeQuadruple {n : ℕ} (h : ComesFromPrimeQuadruple
     n % 72 = 65 := by
   sorry
 
-/-- Numbers coming from prime quadruples satisfy $n \equiv 9 \pmod{100}$. -/
+/-- Numbers coming from prime quadruples satisfy $n \equiv 9 \pmod{100}$,
+except the first value "65". -/
 @[category undergraduate, AMS 11]
 theorem mod_100_of_comesFromPrimeQuadruple {n : ℕ} (h : 65 < n) (h : ComesFromPrimeQuadruple n) :
     n % 100 = 9 := by


### PR DESCRIPTION
we need to exclude the first value in the sequence here