### PR TITLE
fix(ErdosProblems/978): add missing hypotheses and fix conditions

### DIFF
--- a/FormalConjectures/ErdosProblems/978.lean
+++ b/FormalConjectures/ErdosProblems/978.lean
@@ -34,8 +34,8 @@ namespace Erdos978
 degree `k` of `f` is larger than `2` and is not equal to a power of `2`. Then the set of `n` such
 that `f n` is `(k - 1)`-th power free is infinite, and this is proved in [Er53]. -/
 @[category research solved, AMS 11]
-theorem erdos_978.variants.sub_one {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 2)
-    (hp : ¬ ∃ l : ℕ, f.natDegree = 2 ^ l) (hlc : 0 < f.leadingCoeff) :
+theorem erdos_978.variants.sub_one {f : ℤ[X]} (hi : Irreducible f) (hd : 2 < f.natDegree)
+    (hp : ∀ (x : ℕ), f.natDegree ≠ 2 ^ x) (hlc : 0 < f.leadingCoeff) :
     {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))}.Infinite := by
   sorry
 
@@ -44,17 +44,17 @@ degree `k` of `f` is larger than `2`, is not equal to a power of `2`, and `f n` 
 `(k - 1)`-th power divisors other than `1`. Then the set of `n` such that `f n` is `(k - 1)`-th
 power free has positive density, and this is proved in [Ho67]. -/
 @[category research solved, AMS 11]
-theorem erdos_978.parts.i {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 2)
-    (hp2 : ¬ ∃ l : ℕ, f.natDegree = 2 ^ l) (hlc : 0 < f.leadingCoeff)
-    (hp : ¬ ∃ p : ℕ, p.Prime ∧ ∀ n : ℕ, (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
+theorem erdos_978.parts.i {f : ℤ[X]} (hi : Irreducible f) (hd : 2 < f.natDegree)
+    (hp2 : ∀ (x : ℕ), f.natDegree ≠ 2 ^ x) (hlc : 0 < f.leadingCoeff)
+    (hp : ∀ (p : ℕ), p.Prime → ∃ n : ℕ, ¬ (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
     HasPosDensity {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))} := by
   sorry
 
 /-- If the degree `k` of `f` is larger than or equal to `9`, then the set of `n` such that `f n` is
 `(k - 2)`-th power free has infinitely many elements. This result is proved in [Br11]. -/
 @[category research solved, AMS 11]
-theorem erdos_978.variants.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree ≥ 9)
-    (hp : ¬ ∃ p : ℕ, p.Prime ∧ ∀ n : ℕ, (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
+theorem erdos_978.variants.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : 9 ≤ f.natDegree)
+    (hp : ∀ (p : ℕ), p.Prime → ∃ n : ℕ, ¬ (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
     {n : ℕ | Powerfree (f.natDegree - 2) (f.eval (n : ℤ))}.Infinite := by
   sorry
 


### PR DESCRIPTION
- Add positive leading coefficient (`0 < f.leadingCoeff`) to `sub_one`
  and `sub_one_density`, matching the original references [Er53] and [Ho67]
- Add power-of-two degree exclusion to  `sub_one_density` and the open conjecture `parts.ii`
- Require `k > 3` (not `k > 2`) in `parts.ii`, since X^3 - 2 is a
  counterexample (identified by AlphaProof)
- Rename `sub_two'` → `parts.ii` to follow naming convention
- Update docstrings to reflect all changes