### PR TITLE
fix(ErdosProblems): Standardize Erdos Problem Theorems (part 2)

### DIFF
--- a/FormalConjectures/ErdosProblems/313.lean
+++ b/FormalConjectures/ErdosProblems/313.lean
@@ -31,7 +31,7 @@ This set contains all solutions `(m, P)` to the Erdős problem 313.
 A solution is a pair where `m` is an integer `≥ 2` and `P` is a non-empty, finite set of
 distinct prime numbers, such that the sum of the reciprocals of the primes in `P` equals `1 - 1/m`.
 -/
-def erdos_313_solutions : Set (ℕ × Finset ℕ) :=
+def erdos313Solutions : Set (ℕ × Finset ℕ) :=
   {(m, P) | 2 ≤ m ∧ P.Nonempty ∧ (∀ p ∈ P, p.Prime) ∧ ∑ p ∈ P, (1 : ℚ) / p = 1 - 1 / m}
 
 /--
@@ -40,22 +40,22 @@ and `P` is a set of distinct primes such that the following equation holds:
 $\sum_{p \in P} \frac{1}{p} = 1 - \frac{1}{m}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_313_conjecture : answer(sorry) ↔ erdos_313_solutions.Infinite := by
+theorem erdos_313 : answer(sorry) ↔ erdos313Solutions.Infinite := by
   sorry
 
 @[category test, AMS 11]
-theorem erdos_313_solution_6_2_3 : (6, {2, 3}) ∈ erdos_313_solutions := by
-  norm_num [erdos_313_solutions]
+theorem erdos_313.variants.solution_6_2_3 : (6, {2, 3}) ∈ erdos313Solutions := by
+  norm_num [erdos313Solutions]
 
 @[category test, AMS 11]
-theorem erdos_313_solution_42_2_3_7 : (42, {2, 3, 7}) ∈ erdos_313_solutions := by
-  norm_num [erdos_313_solutions]
+theorem erdos_313.variants.solution_42_2_3_7 : (42, {2, 3, 7}) ∈ erdos313Solutions := by
+  norm_num [erdos313Solutions]
 
 /--
 An integer `n` is a **primary pseudoperfect number** if it is the denominator `m` in a
 solution `(m, P)` to the Erdős 313 problem.
 -/
-def IsPrimaryPseudoperfect (n : ℕ) : Prop := ∃ P, (n, P) ∈ erdos_313_solutions
+def IsPrimaryPseudoperfect (n : ℕ) : Prop := ∃ P, (n, P) ∈ erdos313Solutions
 
 /--
 It is conjectured that the set of primary pseudoperfect numbers is infinite.
@@ -69,7 +69,7 @@ theorem erdos_313.variants.primary_pseudoperfect_are_infinite :
 There are at least 8 primary pseudoperfect numbers.
 -/
 @[category undergraduate, AMS 11]
-theorem exists_at_least_eight_primary_pseudoperfect :
+theorem erdos_313.variants.exists_at_least_eight_primary_pseudoperfect :
     8 ≤ (Set.encard {n | IsPrimaryPseudoperfect n}) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/318.lean
+++ b/FormalConjectures/ErdosProblems/318.lean
@@ -44,17 +44,17 @@ def P₁ (A : Set ℕ) : Prop := ∀ (f : ℕ → ℝ),
 
 /-- `ℕ` has property `P₁`. This is proved in [ErSt75]. -/
 @[category research solved, AMS 11]
-theorem erdos_318.univ : P₁ univ := by
+theorem erdos_318.variants.univ : P₁ univ := by
   sorry
 
 /-- Sattler proved in [Sa75] that the set of odd numbers has property `P₁`. -/
 @[category research solved, AMS 11]
-theorem erdos_318.odd : P₁ {n | Odd n} := by
+theorem erdos_318.variants.odd : P₁ {n | Odd n} := by
   sorry
 
 /-- The set of squares does not have property `P₁`. -/
 @[category test, AMS 11]
-theorem erdos_318.squares : ¬ P₁ ({n | IsSquare n}) := by
+theorem erdos_318.variants.squares : ¬ P₁ ({n | IsSquare n}) := by
   simp only [P₁, not_forall, not_exists, not_and]
   -- Consider the function `f` that sends `1` to `1` and sends all other numbers to `-1`.
   refine ⟨fun n => if n = 1 then 1 else - 1, fun h => ?_, fun h => ?_,
@@ -101,24 +101,24 @@ theorem erdos_318.squares : ¬ P₁ ({n | IsSquare n}) := by
 /-- For any set `A` containing exactly one even number, `A` does not have property `P₁`. Sattler
 [Sa82] credits this observation to Erdős, who presumably found this after [ErGr80]. -/
 @[category research solved, AMS 11]
-theorem erdos_318.contain_single_even {A : Set ℕ} (hA : {n | n ∈ A ∧ Even n}.ncard = 1) :
+theorem erdos_318.variants.contain_single_even {A : Set ℕ} (hA : {n | n ∈ A ∧ Even n}.ncard = 1) :
     ¬ P₁ {n | IsSquare n} := by
   sorry
 
 /-- There exists a set `A` with positive density that does not have property `P₁`.
 #TODO: prove this lemma by assuming `erdos_318.contain_single_even`. -/
 @[category research solved, AMS 11]
-theorem erdos_318.posDensity : ∃ A : Set ℕ, HasPosDensity A ∧ ¬ P₁ A := by
+theorem erdos_318.parts.i : ∃ A : Set ℕ, HasPosDensity A ∧ ¬ P₁ A := by
   sorry
 
 /-- Every infinite arithmetic progression has property `P₁`. This is proved in [Sa82b]. -/
 @[category research solved, AMS 11]
-theorem erdos_318.infinite_AP {A : Set ℕ} (hA : A.IsAPOfLength ⊤) : P₁ A := by
+theorem erdos_318.variants.infinite_AP {A : Set ℕ} (hA : A.IsAPOfLength ⊤) : P₁ A := by
   sorry
 
 /-- Does the set of squares excluding 1 have property `P₁`? -/
 @[category research open, AMS 11]
-theorem erdos_318.square_excluding_one : answer(sorry) ↔  P₁ ({n | IsSquare n} \ {1}) := by
+theorem erdos_318.parts.ii : answer(sorry) ↔  P₁ ({n | IsSquare n} \ {1}) := by
   sorry
 
 end Erdos318

--- a/FormalConjectures/ErdosProblems/32.lean
+++ b/FormalConjectures/ErdosProblems/32.lean
@@ -44,7 +44,7 @@ Erdős proved in [Erd54] that there exists an additive complement $A$ to the pri
 $|A \cap \{1, \ldots, N\}| = O((\log N)^2)$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_32.varaints.log_squared : ∃ A : Set ℕ,
+theorem erdos_32.variants.log_squared : ∃ A : Set ℕ,
     IsAdditiveComplementToPrimes A ∧
     (fun N => (((Finset.Icc 1 N).filter (· ∈ A)).card : ℝ)) =O[atTop]
       fun N => (Real.log N) ^ 2 := by

--- a/FormalConjectures/ErdosProblems/329.lean
+++ b/FormalConjectures/ErdosProblems/329.lean
@@ -53,7 +53,7 @@ Erdős proved that upper density `1 / 2` can be attained; in particular,
 there exists a Sidon set whose upper density is *at least* `1 / 2`.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_329.lower_bound : ∃ (A : Set ℕ), IsSidon A ∧ sidonUpperDensity A ≥ 1/2 := by
+theorem erdos_329.variants.lower_bound : ∃ (A : Set ℕ), IsSidon A ∧ sidonUpperDensity A ≥ 1/2 := by
   sorry
 
 /--
@@ -64,7 +64,7 @@ Krückeberg ([Kr61]) exhibited an infinite Sidon set `A` with
 [Kr61] Krückeberg, Fritz, $B\sb{2}$-Folgen und verwandte Zahlenfolgen. J. Reine Angew. Math. (1961), 53-60.
 -/
 @[category research solved, AMS 5 11]
-theorem kruckeberg_1961 : ∃ (A : Set ℕ), IsSidon A ∧
+theorem erdos_329.variants.kruckeberg_1961 : ∃ (A : Set ℕ), IsSidon A ∧
     sidonUpperDensity A = 1 / Real.sqrt 2 := by
   sorry
 
@@ -74,7 +74,7 @@ Erdős and Turán [ErTu41] proved the upper bound of 1.
 [ErTu41] Erdős, P. and Turán, P., On a problem of Sidon in additive number theory, and on some related problems. J. London Math. Soc. (1941), 212-215.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_turan_1941 : ∀ (A : Set ℕ), IsSidon A → sidonUpperDensity A ≤ 1 := by
+theorem erdos_329.variants.turan_1941 : ∀ (A : Set ℕ), IsSidon A → sidonUpperDensity A ≤ 1 := by
   sorry
 
 /--
@@ -82,7 +82,7 @@ If any finite Sidon set can be embedded in a perfect difference set,
 then the maximum density would be 1.
 -/
 @[category research open, AMS 5 11]
-theorem erdos_329.of_sub_perfectDifferenceSet :
+theorem erdos_329.variants.of_sub_perfectDifferenceSet :
     (∀ (A : Finset ℕ), IsSidon (A : Set ℕ) → ∃ (D : Set ℕ) (n : ℕ),
       ↑A ⊆ D ∧ IsPerfectDifferenceSet D n) →
     sSup {sidonUpperDensity A | (A : Set ℕ) (_ : IsSidon A)} = 1 := by
@@ -93,7 +93,7 @@ The converse: if the maximum density is 1, then any finite Sidon set
 can be embedded in a perfect difference set.
 -/
 @[category research open, AMS 5 11]
-theorem erdos_329.converse_implication :
+theorem erdos_329.variants.converse_implication :
     (sSup {sidonUpperDensity A | (A : Set ℕ) (_ : IsSidon A)} = 1) →
     (∀ (A : Finset ℕ), IsSidon (A : Set ℕ) → ∃ (D : Set ℕ) (n : ℕ),
       ↑A ⊆ D ∧ IsPerfectDifferenceSet D n) := by

--- a/FormalConjectures/ErdosProblems/346.lean
+++ b/FormalConjectures/ErdosProblems/346.lean
@@ -44,23 +44,23 @@ def f (n : ℕ) : ℕ := if Even n then n.fib - 1 else n.fib + 1
 
 /-- The sequence `f` is lacunary. -/
 @[category test, AMS 11]
-theorem erdos_346.f_isLacunary : IsLacunary f := by sorry
+theorem erdos_346.variants.f_isLacunary : IsLacunary f := by sorry
 
 /-- The sequence `f` is strongly complete, and this is proved in [Gr64d]. -/
 @[category test, AMS 11]
-theorem erdos_346.f_isAddStronglyCompleteNatSeq : IsAddStronglyCompleteNatSeq f := by sorry
+theorem erdos_346.variants.f_isAddStronglyCompleteNatSeq : IsAddStronglyCompleteNatSeq f := by sorry
 
 /-- The sequence `f` is not complete whenever infinitely many terms are removed from it, and this
 is proved in [Gr64d]. -/
 @[category test, AMS 11]
-theorem erdos_346.f_not_isAddComplete {B : Set ℕ} (h : B ⊆ range f) (hB : B.Infinite) :
+theorem erdos_346.variants.f_not_isAddComplete {B : Set ℕ} (h : B ⊆ range f) (hB : B.Infinite) :
     ¬ IsAddComplete (range f \ B) := by
   sorry
 
 /-- Erdős and Graham [ErGr80] remark that it is easy to see that if `A (n + 1) / A n > (1 + √5) / 2`
 then the second property is automatically satisfied. -/
 @[category research solved, AMS 11]
-theorem erdos_346.gt_goldenRatio_not_IsAddComplete {A : ℕ → ℕ}
+theorem erdos_346.variants.gt_goldenRatio_not_IsAddComplete {A : ℕ → ℕ}
     (hA : ∀ n, (1 + √5) / 2 * A n < A (n + 1)) {B : Set ℕ} (h : B ⊆ range A) (hB : B.Infinite) :
     ¬ IsAddComplete (range A \ B) := by
   sorry
@@ -68,7 +68,7 @@ theorem erdos_346.gt_goldenRatio_not_IsAddComplete {A : ℕ → ℕ}
 /-- Erdős and Graham [ErGr80] also say that it is not hard to construct very irregular sequences
 satisfying the aforementioned properties. -/
 @[category research solved, AMS 11]
-theorem erdos_346.example : ∃ A : ℕ → ℕ, IsAddStronglyCompleteNatSeq A ∧
+theorem erdos_346.variants.example : ∃ A : ℕ → ℕ, IsAddStronglyCompleteNatSeq A ∧
     (∀ B : Set ℕ, B ⊆ range A → B.Infinite → ¬ IsAddComplete (range A \ B)) ∧
     liminf (fun n => A (n + 1) / (2 : ℝ)) atTop = 1 ∧
     limsup (fun n => A (n + 1) / (A n : ENNReal)) atTop = ⊤ := by

--- a/FormalConjectures/ErdosProblems/375.lean
+++ b/FormalConjectures/ErdosProblems/375.lean
@@ -47,21 +47,21 @@ theorem erdos_375 : answer(sorry) ↔ Erdos375Prop := by
 /-- If `Erdos375Prop` is true, then `(n + 1).nth Prime - n.nth Prime < (n.nth Prime) ^ (1 / 2 - c)`
 for some `c > 0`. -/
 @[category research solved, AMS 11]
-theorem erdos_375.bounded_gap : Erdos375Prop →
+theorem erdos_375.variants.bounded_gap : Erdos375Prop →
     ∃ c > 0, ∀ᶠ n in atTop, (n + 1).nth Nat.Prime - n.nth Nat.Prime
     < (n.nth Nat.Prime : ℝ) ^ (1 / (2 : ℝ) - c) := by
   sorry
 
 /-- In particular, if `Erdos375Prop` is true, then Legendre's conjecture is asymptotically true. -/
 @[category research solved, AMS 11]
-theorem erdos_375.legendre : Erdos375Prop →
+theorem erdos_375.variants.legendre : Erdos375Prop →
     (∀ᶠ n in atTop, ∃ p ∈ Set.Ioo (n ^ 2) ((n + 1) ^ 2), Nat.Prime p) :=
-  fun hp => LegendreConjecture.bounded_gap_legendre (erdos_375.bounded_gap hp)
+  fun hp => LegendreConjecture.bounded_gap_legendre (erdos_375.variants.bounded_gap hp)
 
 /-- It is easy to see that for any `n ≥ 1` and `k ≤ 2`, if `n + 1, ..., n + k` are all composite,
 then there are distinct primes `p₁, ... pₖ` such that `pᵢ ∣ n + i` for all `1 ≤ i ≤ k`. -/
 @[category research solved, AMS 11]
-theorem erdos_375.le_two : ∀ n ≥ 1, ∀ k ≤ 2, (∀ i < k, ¬ (n + i + 1).Prime) →
+theorem erdos_375.variants.le_two : ∀ n ≥ 1, ∀ k ≤ 2, (∀ i < k, ¬ (n + i + 1).Prime) →
     ∃ p : Fin k → ℕ, p.Injective ∧ ∀ i, (p i).Prime ∧ p i ∣ n + i + 1 := by
   intro n hn k hk
   interval_cases k <;> intro h
@@ -85,7 +85,7 @@ in [RST75]. There is no need to only consider sufficiently large `n` because one
 `c` small enough so that `k < c * (log n / (log (log n))) ^ 3` implies that `k = 0` until `n` is
 large. -/
 @[category research solved, AMS 11]
-theorem erdos_375.log : ∃ c > 0, ∀ n k : ℕ,
+theorem erdos_375.variants.log : ∃ c > 0, ∀ n k : ℕ,
     k < c * (Real.log n / (Real.log (Real.log n))) ^ 3 → (∀ i < k, ¬ (n + i + 1).Prime) →
     ∃ p : Fin k → ℕ, p.Injective ∧ ∀ i, (p i).Prime ∧ p i ∣ n + i + 1 := by
   sorry

--- a/FormalConjectures/ErdosProblems/386.lean
+++ b/FormalConjectures/ErdosProblems/386.lean
@@ -41,7 +41,7 @@ For all $2 \le k \le n - 2$,
 can $\binom{n}{k}$ be the product of consecutive primes infinitely often?
 -/
 @[category research open, AMS 11]
-theorem erdos_386.variants_forall :
+theorem erdos_386.variants.forall :
     answer(sorry) ↔ ∀ k ≥ 2, ∃ᶠ n in .atTop,
       k ≤ n - 2 ∧ ∃ p q : ℕ, n.choose k = ∏ i ∈ .Ico p q, nth Nat.Prime i := by
     sorry
@@ -50,7 +50,7 @@ theorem erdos_386.variants_forall :
 Can $\binom{n}{2}$ be the product of consecutive primes infinitely often?
 -/
 @[category research open, AMS 11]
-theorem erdos_386.variants_two :
+theorem erdos_386.variants.two :
     answer(sorry) ↔ ∃ᶠ n in .atTop,
       2 ≤ n - 2 ∧ ∃ p q : ℕ, n.choose 2 = ∏ i ∈ .Ico p q, nth Nat.Prime i := by
     sorry

--- a/FormalConjectures/ErdosProblems/387.lean
+++ b/FormalConjectures/ErdosProblems/387.lean
@@ -44,13 +44,13 @@ example : ∀ i < 15, ¬ 99215 - i ∣ Nat.choose 99215 15 :=
 
 /-- The following is Schinzel's conjecture, which appears in [Gu04]. -/
 @[category research open, AMS 11]
-theorem erdos_387.schinzel : answer(sorry) ↔
+theorem erdos_387.variants.schinzel : answer(sorry) ↔
     ∀ᶠ k in atTop, ¬ IsPrimePow k → ∃ n : ℕ, ∀ i < k, ¬ n - i ∣ n.choose k := by
   sorry
 
 /-- It is easy to see that `n.choose k` has a divisor in `[n / k, n]`. -/
 @[category research solved, AMS 11]
-theorem erdos_387.easy {n : ℕ} {k : ℕ} (hn : 1 ≤ n) (hk : k ≤ n) : ∃ d : ℕ,
+theorem erdos_387.variants.easy {n : ℕ} {k : ℕ} (hn : 1 ≤ n) (hk : k ≤ n) : ∃ d : ℕ,
     (d : ℝ) ∈ Set.Icc (n / k : ℝ) n ∧ d ∣ n.choose k := by
   by_cases k = 0 <;> simp_all
   refine ⟨(n.choose k).gcd n, ⟨?_, ?_⟩, gcd_dvd_left _ _⟩
@@ -65,7 +65,7 @@ theorem erdos_387.easy {n : ℕ} {k : ℕ} (hn : 1 ≤ n) (hk : k ≤ n) : ∃ d
 /-- Is it true for any `c < 1` and all `n` sufficiently large, for all `1 ≤ k < n`, `n.choose k`
 has a divisor in `(cn, n]`? This is a variant of `erdos_387` and appears in [Gu04]. -/
 @[category research open, AMS 11]
-theorem erdos_387.variant : answer(sorry) ↔ ∀ c : ℝ, c < 1 → ∀ᶠ n : ℕ in atTop, ∀ k : ℕ, 1 ≤ k →
+theorem erdos_387.variants.guy : answer(sorry) ↔ ∀ c : ℝ, c < 1 → ∀ᶠ n : ℕ in atTop, ∀ k : ℕ, 1 ≤ k →
     k < n → ∃ d : ℕ, (d : ℝ) ∈ Set.Ioc (c * n) n ∧ d ∣ n.choose k := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/394.lean
+++ b/FormalConjectures/ErdosProblems/394.lean
@@ -42,7 +42,7 @@ noncomputable def t (k n : ℕ) : ℕ :=
 Is it true that $\sum_{n\leq x}t_2(n)\ll \frac{x^2}{(\log x)^c}$ for some $c>0$?
 -/
 @[category research open, AMS 11]
-theorem erdos_394_part_a :
+theorem erdos_394.parts.i :
     answer(sorry) ↔
       ∃ c > 0, (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊,
       (t 2 n : ℝ)) ≪ (fun x ↦ x ^ 2 / (Real.log x) ^ c) := by
@@ -52,7 +52,7 @@ theorem erdos_394_part_a :
 Is it true that, for $k\geq 2$, $\sum_{n\leq x}t_{k+1}(n) =o\left(\sum_{n\leq x}t_k(n)\right)?$
 -/
 @[category research open, AMS 11]
-theorem erdos_394_part_b :
+theorem erdos_394.parts.ii :
     answer(sorry) ↔
       ∀ k ≥ 2, (fun (x : ℝ) ↦ ∑ n ∈ Icc 1 ⌊x⌋₊,
       (t (k + 1) n : ℝ)) =o[atTop]
@@ -66,7 +66,7 @@ and Hall [ErHa78], who proved that in fact
 $\sum_{n\leq x}t_2(n)\ll \frac{\log\log\log x}{\log\log x}x^2.$
 -/
 @[category research solved, AMS 11]
-theorem erdos_394_hall_bound :
+theorem erdos_394.variants.hall_bound :
     (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊, (t 2 n : ℝ)) ≪
     (fun x ↦ x ^ 2 * (Real.log (Real.log (Real.log x)) / Real.log (Real.log x))) := by
   sorry
@@ -75,7 +75,7 @@ theorem erdos_394_hall_bound :
 Erdős and Hall conjecture that the sum is $o(x^2/(\log x)^c)$ for any $c<\log 2$.
 -/
 @[category research open, AMS 11]
-theorem erdos_394_hall_conjecture :
+theorem erdos_394.variants.hall_conjecture :
     ∀ c < Real.log 2, (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊,
     (t 2 n : ℝ)) =o[atTop]
     (fun x ↦ x ^ 2 / (Real.log x) ^ c) := by
@@ -85,7 +85,7 @@ theorem erdos_394_hall_conjecture :
 Since $t_2(p)=p-1$ for prime $p$ it is trivial that $\sum_{n\leq x}t_2(n)\gg \frac{x^2}{\log x}$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_394_lower_bound :
+theorem erdos_394.variants.lower_bound :
     (fun x ↦ x ^ 2 / Real.log x) ≫
     (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊, (t 2 n : ℝ)) := by
   sorry
@@ -95,7 +95,7 @@ They ask about the behaviour of $t_{n-3}(n!)$ and also ask whether, for infinite
 $t_k(n!)< t_{k-1}(n!)-1$ for all $1\leq k < n$.
 -/
 @[category research open, AMS 11]
-theorem erdos_394_factorial_gap_conjecture :
+theorem erdos_394.variants.factorial_gap_conjecture :
     answer(sorry) ↔
       Set.Infinite { n : ℕ | ∀ k, 2 ≤ k → k < n →
       t k (n !) < t (k - 1) (n !) - 1 } := by
@@ -105,7 +105,7 @@ theorem erdos_394_factorial_gap_conjecture :
 They proved (with Selfridge) that this holds for $n=10$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_394_factorial_gap_10 :
+theorem erdos_394.variants.factorial_gap_10 :
     ∀ (k : ℕ), 2 ≤ k → k < 10 →
     t k (10 !) <
     t (k - 1) (10 !) - 1 := by

--- a/FormalConjectures/ErdosProblems/40.lean
+++ b/FormalConjectures/ErdosProblems/40.lean
@@ -62,7 +62,7 @@ Erdős-Turán conjecture, see Erdõs Problem 28,
 Problem 28).
 -/
 @[category undergraduate, AMS 11]
-theorem erdos_28_of_erdos_40 (h_erdos_40 : Erdos40ForSet .univ) : type_of% Erdos28.erdos_28 := by
+theorem erdos_40.variants.implies_erdos_28 (h_erdos_40 : Erdos40ForSet .univ) : type_of% Erdos28.erdos_28 := by
   simp only [Erdos40ForSet, Erdos40For, sumRep, sumConv, indicatorOne, mem_univ, forall_const]
     at h_erdos_40
   intro A hA

--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -41,7 +41,7 @@ theorem erdos_409.parts.i (n : ℕ) (hn : 0 < n) :
 /-- If $n > 0$, then the iteration $n\mapsto\phi(n) + 1$ necessarily
 reaches a prime. -/
 @[category test, AMS 11]
-theorem erdos_409.termination (n : ℕ) (hn : 0 < n) :
+theorem erdos_409.variants.termination (n : ℕ) (hn : 0 < n) :
     ∃ i, (φ · + 1)^[i] n |>.Prime := by
   sorry
 
@@ -56,7 +56,7 @@ Let $c(n)$ be the minimum number of iterations of $n\mapsto\phi(n) + 1$ before a
 is reached. What is $\Theta(c(n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.parts.i.variants.isTheta (c : ℕ → ℕ)
+theorem erdos_409.parts.i.isTheta (c : ℕ → ℕ)
     (h : ∀ n > 0, IsLeast { i | (φ · + 1)^[i] n |>.Prime } (c n)) :
     (fun n => (c n : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
@@ -66,7 +66,7 @@ Let $c(n)$ be the minimum number of iterations of $n\mapsto\phi(n) + 1$ before a
 is reached. Find the simplest function $g(n)$ such that $c(n) = O(g(n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.parts.i.variants.isBigO (c : ℕ → ℕ)
+theorem erdos_409.parts.i.isBigO (c : ℕ → ℕ)
     (h : ∀ n > 0, IsLeast { i | (φ · + 1)^[i] n |>.Prime } (c n)) :
     (fun n => (c n : ℝ)) =O[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
@@ -76,7 +76,7 @@ Let $c(n)$ be the minimum number of iterations of $n\mapsto\phi(n) + 1$ before a
 is reached. Find the simplest function $g(n)$ such that $c(n) = o(g(n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.parts.i.variants.isLittleO (c : ℕ → ℕ)
+theorem erdos_409.parts.i.isLittleO (c : ℕ → ℕ)
     (h : ∀ n > 0, IsLeast { i | (φ · + 1)^[i] n |>.Prime } (c n)) :
     (fun n => (c n : ℝ)) =o[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
@@ -104,13 +104,13 @@ How many iterations of $n\mapsto\sigma(n) - 1$ are needed before a prime is reac
 -- Formalisation note: non-termination of this sequence is less clear since
 -- it is strictly increasing except at primes.
 @[category research open, AMS 11]
-theorem erdos_409.variants.sigma.parts.i (n : ℕ) (hn : n > 1) :
+theorem erdos_409.variants.sigma (n : ℕ) (hn : n > 1) :
     IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } answer(sorry) := by
   sorry
 
 /-- If $n > 1$ then the iteration $n\mapsto\sigma(n) - 1$ necessarily reaches a prime. -/
 @[category test, AMS 11]
-theorem erdos_409.variants.sigma.termination (n : ℕ) (hn : n > 1) :
+theorem erdos_409.variants.sigma_termination (n : ℕ) (hn : n > 1) :
     ∃ i, (σ 1 · - 1)^[i] n |>.Prime := by
   sorry
 
@@ -121,7 +121,7 @@ Let $c(n)$ be the minimum number of iterations of $n\mapsto\sigma(n) - 1$ before
 is reached. What is $\Theta(c(n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.variants.sigma.parts.i.isTheta (c : ℕ → ℕ)
+theorem erdos_409.variants.sigma_isTheta (c : ℕ → ℕ)
     (h : ∀ n > 1, IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } (c n)) :
     (fun n => (c n : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
@@ -131,7 +131,7 @@ Let $c(n)$ be the minimum number of iterations of $n\mapsto\sigma(n) - 1$ before
 is reached. Find the simplest function $g(n)$ such that $c(n) = O(g(n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.variants.sigma.parts.i.isBigO (c : ℕ → ℕ)
+theorem erdos_409.variants.sigma_isBigO (c : ℕ → ℕ)
     (h : ∀ n > 1, IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } (c n)) :
     (fun n => (c n : ℝ)) =O[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
@@ -141,7 +141,7 @@ Let $c(n)$ be the minimum number of iterations of $n\mapsto\sigma(n) - 1$ before
 is reached. Find the simplest function $g(n)$ such that $c(n) = o(g(n))$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.variants.sigma.parts.i.isLittleO (c : ℕ → ℕ)
+theorem erdos_409.variants.sigma_isLittleO (c : ℕ → ℕ)
     (h : ∀ n > 1, IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } (c n)) :
     (fun n => (c n : ℝ)) =o[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
@@ -150,7 +150,7 @@ theorem erdos_409.variants.sigma.parts.i.isLittleO (c : ℕ → ℕ)
 Is it true that iterates of $n\mapsto\sigma(n) - 1$ always reach a prime?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.variants.sigma.parts.ii :
+theorem erdos_409.variants.sigma_prime_termination :
     answer(sorry) ↔ ∀ n > 1, ∃ i, (σ 1 · - 1)^[i] n |>.Prime := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/41.lean
+++ b/FormalConjectures/ErdosProblems/41.lean
@@ -53,7 +53,7 @@ in `A` (aside from the trivial coincidences).
 Is it true that `liminf n → ∞ |A ∩ {1, …, N}| / N^(1/2) = 0`?
 -/
 @[category research solved, AMS 11]
-theorem erdos_41_i (A : Set ℕ) (h_pair : NtupleCondition A 2) (h_infinite : A.Infinite) :
+theorem erdos_41.variants.pairwise (A : Set ℕ) (h_pair : NtupleCondition A 2) (h_infinite : A.Infinite) :
     Filter.atTop.liminf (fun N => (A.interIcc 1 N).ncard / (N : ℝ).sqrt) = 0 := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/413.lean
+++ b/FormalConjectures/ErdosProblems/413.lean
@@ -41,7 +41,7 @@ def IsBarrier (f : ℕ → ℝ) (n : ℕ) : Prop :=
 
 /-- Are there infinitely many barriers for `ω`? -/
 @[category research open, AMS 11]
-theorem erdos_413 :
+theorem erdos_413.parts.i :
     answer(sorry) ↔ { n | IsBarrier (fun m => ω m) n }.Infinite := by
   sorry
 
@@ -51,25 +51,25 @@ def expProd (n : ℕ) : ℕ :=
 
 /-- Erdős proved that the barrier set for `expProd` is infinite and even has positive density. -/
 @[category research solved, AMS 11]
-theorem erdos_413_hasPosDensity_barrier_expProd :
+theorem erdos_413.variants.hasPosDensity_barrier_expProd :
     { n | IsBarrier (fun m => expProd m) n }.HasPosDensity := by
   sorry
 
 /-- Erdős believed there should be infinitely many barriers for `Ω`, the total prime multiplicity. -/
 @[category research open, AMS 11]
-theorem erdos_413_bigOmega :
+theorem erdos_413.variants.bigOmega :
     answer(sorry) ↔ { n | IsBarrier (fun m => Ω m) n }.Infinite := by
   sorry
 
 /-- Selfridge computed that the largest `Ω`-barrier below `10^5` is `99840`. -/
 @[category research solved, AMS 11]
-theorem erdos_413_bigOmega_largest_barrier_lt_100k :
+theorem erdos_413.variants.bigOmega_largest_barrier_lt_100k :
     IsGreatest {n : ℕ | n < 10 ^ 5 ∧ IsBarrier (fun m => Ω m) n} 99840 := by
   sorry
 
 /-- Does there exist some `ε > 0` such that there are infinitely many `ε`-barriers for `ω`? -/
 @[category research open, AMS 11]
-theorem erdos_413_epsilon :
+theorem erdos_413.parts.ii :
     answer(sorry) ↔
         (∃ ε > (0 : ℝ), { n | IsBarrier (fun n => ε * ω n) n }.Infinite) := by
   sorry

--- a/FormalConjectures/ErdosProblems/417.lean
+++ b/FormalConjectures/ErdosProblems/417.lean
@@ -38,7 +38,7 @@ Formalization note: We formalize the limit of the inverse fraction V'(x)/V(x)
 to ensure the limit is finite (bounded between 0 and 1).
 -/
 @[category research open, AMS 11]
-theorem erdos_417.part.a :
+theorem erdos_417.parts.i :
     answer(sorry) ↔ ∃ L : ℝ, Tendsto (fun x ↦
       ((totient '' { m | 1 ≤ m ∧ (m : ℝ) ≤ x }).ncard : ℝ) /
       ({ k | k ∈ range totient ∧ (k : ℝ) ≤ x }.ncard : ℝ))
@@ -49,7 +49,7 @@ theorem erdos_417.part.a :
 Is it $>1$?
 -/
 @[category research open, AMS 11]
-theorem erdos_417.part.b :
+theorem erdos_417.parts.ii :
     answer(sorry) ↔ ∃ L < 1, Tendsto (fun x ↦
       ((totient '' { m | 1 ≤ m ∧ (m : ℝ) ≤ x }).ncard : ℝ) /
       ({ k | k ∈ range totient ∧ (k : ℝ) ≤ x }.ncard : ℝ))

--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -50,7 +50,7 @@ every maximal Sidon set A ⊆ {1,…,N} has another Sidon set B ⊆ {1,…,N} of
 disjoint difference sets (apart from 0).
 -/
 @[category research open, AMS 5 11]
-theorem erdos_42.constructive : answer(sorry) ↔
+theorem erdos_42.variants.constructive : answer(sorry) ↔
     ∃ (f : ℕ → ℕ), ∀ (M N : ℕ) (_ : 1 ≤ M) (_ : f M ≤ N),
     ∀ (A : Set ℕ) (_ : IsMaximalSidonSetIn A N), ∃ᵉ (B : Set ℕ),
       B ⊆ Set.Icc 1 N ∧ IsSidon B ∧ B.ncard = M ∧

--- a/FormalConjectures/ErdosProblems/427.lean
+++ b/FormalConjectures/ErdosProblems/427.lean
@@ -66,7 +66,7 @@ $p_m, \dots, p_{m + k - 1}$ all of which are congruent to $a$ modulo $q$.
 [Sh00] Shiu, D. K. L., _Strings of congruent primes_. J. London Math. Soc. (2) (2000), 359-373.
 -/
 @[category research solved, AMS 11]
-theorem erdos_427.shiu : ShiuTheorem := by
+theorem erdos_427.variants.shiu : ShiuTheorem := by
   sorry
 
 
@@ -74,7 +74,7 @@ theorem erdos_427.shiu : ShiuTheorem := by
 Cedric Pilatte has observed that a positive solution to Erdős Problem 427 follows from Shiu's theorem.
 -/
 @[category research solved, AMS 11]
-theorem erdos_427.of_shiu (H : ShiuTheorem) : erdos427 := by
+theorem erdos_427.variants.of_shiu (H : ShiuTheorem) : erdos427 := by
   sorry
 
 end Erdos427

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -51,7 +51,7 @@ theorem erdos_44 : answer(sorry) ↔ ∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 
 The case where we start with an empty set (constructing large Sidon sets).
 -/
 @[category research open, AMS 5 11]
-theorem erdos_44.empty_start : answer(sorry) ↔ ∀ᵉ (ε > (0 : ℝ)), ∀ᶠ (M : ℕ) in Filter.atTop,
+theorem erdos_44.variants.empty_start : answer(sorry) ↔ ∀ᵉ (ε > (0 : ℝ)), ∀ᶠ (M : ℕ) in Filter.atTop,
     ∃ᵉ (A ⊆ Finset.Icc 1 M), IsSidon (A : Set ℕ) ∧ (1 - ε) * Real.sqrt M ≤ A.card := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/454.lean
+++ b/FormalConjectures/ErdosProblems/454.lean
@@ -39,7 +39,7 @@ theorem erdos_454 : answer(sorry) ↔ limsup (fun n => (f n - 2 * n.nth Prime : 
 
 /-- `limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop ≥ 2`, and this is proved in [Po79]. -/
 @[category research solved, AMS 11]
-theorem erdos_454.two_le_limsup : 2 ≤ limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop := by
+theorem erdos_454.variants.two_le_limsup : 2 ≤ limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop := by
   sorry
 
 end Erdos454

--- a/FormalConjectures/ErdosProblems/455.lean
+++ b/FormalConjectures/ErdosProblems/455.lean
@@ -39,7 +39,7 @@ theorem erdos_455: answer(sorry) ↔ ∀ q : ℕ → ℕ, StrictMono q →
 `q (n + 2) - q (n + 1) ≥ q (n + 1) - q n`. Then `liminf q n / (n ^ 2) > 0.352`, and this is proved in
 [Ri76]. -/
 @[category research solved, AMS 11]
-theorem erdos_455.liminf : ∀ q : ℕ → ℕ, StrictMono q →
+theorem erdos_455.variants.liminf : ∀ q : ℕ → ℕ, StrictMono q →
     (∀ n, (q n).Prime ∧ q (n + 2) - q (n + 1) ≥ q (n + 1) - q n) →
     liminf (fun n : ℕ => (q n : ℝ≥0∞) / n ^ 2) atTop > 0.352 := by
   sorry

--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -38,14 +38,14 @@ def AbundancyIndex (n : ℕ) : ℚ := (∑ d ∈ n.divisors, d) / n
 Are there any odd weird numbers?
 -/
 @[category research open, AMS 11]
-theorem erdos_470.part1 : answer(sorry) ↔ ∃ n : ℕ, n.Weird ∧ Odd n := by
+theorem erdos_470.parts.i : answer(sorry) ↔ ∃ n : ℕ, n.Weird ∧ Odd n := by
   sorry
 
 /--
 Are there infinitely many primitive weird numbers?
 -/
 @[category research open, AMS 11]
-theorem erdos_470.part2 : answer(sorry) ↔ Set.Infinite PrimitiveWeird := by
+theorem erdos_470.parts.ii : answer(sorry) ↔ Set.Infinite PrimitiveWeird := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -45,7 +45,7 @@ There is no such $A$ for the polynomial $f(x) = X^2$.
 This is shown in [Sek59].
 -/
 @[category research solved, AMS 12]
-theorem erdos_477.S_sq :
+theorem erdos_477.variants.S_sq :
     letI f := X ^ 2
     ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
   sorry
@@ -56,7 +56,7 @@ with $a \ne 0$ and $b \ne 0.
 This was found be AlphaProof for the specific instance $X^2 - X + 1$ and then generalised.
  -/
 @[category research solved, AMS 12]
-theorem erdos_477.degree_two_dvd_condition_b_ne_zero {a b c : ℤ} (ha : a ≠ 0) (hb : b ≠ 0)
+theorem erdos_477.variants.degree_two_dvd_condition_b_ne_zero {a b c : ℤ} (ha : a ≠ 0) (hb : b ≠ 0)
     (hab : a ∣ b) :
     let f := a • X ^ 2 + b • X + C c
     ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
@@ -66,7 +66,7 @@ theorem erdos_477.degree_two_dvd_condition_b_ne_zero {a b c : ℤ} (ha : a ≠ 0
 Probably there is no such $A$ for the polynomial $X^3$.
 -/
 @[category research open, AMS 12]
-theorem erdos_477.X_pow_three :
+theorem erdos_477.variants.X_pow_three :
     letI f := X ^ 3
     ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
   sorry
@@ -75,7 +75,7 @@ theorem erdos_477.X_pow_three :
 Probably there is no such $A$ for the polynomial $X^k$ for any $k \ge 2$. This is asked in [Sek59].
 -/
 @[category research open, AMS 12]
-theorem erdos_477.monomial (k : ℕ) (hk : 2 ≤ k) :
+theorem erdos_477.variants.monomial (k : ℕ) (hk : 2 ≤ k) :
     letI f := X ^ k
     ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
   sorry


### PR DESCRIPTION
Renames some of the theorems listed in #2414 

Handles all  files the start with `3` or `4`.

It may have been 409.lean causing the problem because I reviewed it I mislabeled some names so the namespaces were overlapping. Though, I'm surprised a more clear error wasn't shown if that was the case.