### PR TITLE
fix(ErdosProblems): Standardize Erdos Problem Theorems (part 4)

### DIFF
--- a/FormalConjectures/ErdosProblems/513.lean
+++ b/FormalConjectures/ErdosProblems/513.lean
@@ -36,7 +36,7 @@ noncomputable def ratio (r : ℝ) (f : ℂ → ℂ) : ℝ :=
 /-- Let `f` be a transcendental entire function. What is the greatest possible value of
 `liminf (fun r : ℝ => ratio r f) atTop`? -/
 @[category research open, AMS 30]
-theorem erdos_513.sup : answer(sorry) =
+theorem erdos_513 : answer(sorry) =
     ⨆ f : {f : ℂ → ℂ // Transcendental ℂ[X] f ∧ Differentiable ℂ f},
     (liminf (fun r : ℝ => ratio r f) atTop) := by
   sorry
@@ -44,14 +44,14 @@ theorem erdos_513.sup : answer(sorry) =
 /-- For all transcendental entire function `f`, `liminf (fun r : ℝ => ratio r f) atTop ≤ 2 / π - c`
 for some `c > 0`. This is proved in [ClHa64]. -/
 @[category research solved, AMS 30]
-theorem erdos_513.upper_bound : ∃ c > 0,
+theorem erdos_513.variants.upper_bound : ∃ c > 0,
     ⨆ f : {f : ℂ → ℂ // Transcendental ℂ[X] f ∧ Differentiable ℂ f},
     (liminf (fun r : ℝ => ratio r f) atTop) ≤ 2 / π - c := by
   sorry
 
 /-- For all transcendental entire function `f`, `liminf (fun r : ℝ => ratio r f) atTop > 1 / 2`. -/
 @[category research solved, AMS 30]
-theorem erdos_513.lower_bound :
+theorem erdos_513.variants.lower_bound :
     ⨆ f : {f : ℂ → ℂ // Transcendental ℂ[X] f ∧ Differentiable ℂ f},
     (liminf (fun r : ℝ => ratio r f) atTop) > 1 / 2 := by
   sorry

--- a/FormalConjectures/ErdosProblems/516.lean
+++ b/FormalConjectures/ErdosProblems/516.lean
@@ -43,7 +43,7 @@ noncomputable def ratio (r : ℝ) (f : ℂ → ℂ) : ℝ :=
 /-- Let `f = ∑ aₖzⁿₖ` be an entire function of finite order such that `nₖ / k → ∞`.
 Then `limsup (fun r => ratio r f) atTop = 1`. This is proved in [Fu63]. -/
 @[category research solved, AMS 30]
-theorem erdos_516.limsup_ratio_eq_one_of_hasFabryGaps_ofFiniteOrder {f : ℂ → ℂ} {n : ℕ → ℕ}
+theorem erdos_516 {f : ℂ → ℂ} {n : ℕ → ℕ}
     (hn : HasFabryGaps n) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)
     (hfn : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) (hf : OfFiniteOrder f) :
     limsup (fun r => ratio r f) atTop = 1 := by
@@ -52,7 +52,7 @@ theorem erdos_516.limsup_ratio_eq_one_of_hasFabryGaps_ofFiniteOrder {f : ℂ →
 /-- Let `f = ∑ aₖzⁿₖ` be an entire function such that `nₖ > k (log k) ^ (2 + c)`.
 Then `limsup (fun r => ratio r f) atTop = 1`. This is proved in [Ko65]. -/
 @[category research solved, AMS 30]
-theorem erdos_516.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → ℕ}
+theorem erdos_516.variants.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → ℕ}
     (hn : ∃ c > (0 : ℝ), ∀ k, n k > k * log k ^ (2 + c)) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)
     (hfn : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) :
     limsup (fun r => ratio r f) atTop = 1 := by
@@ -61,7 +61,7 @@ theorem erdos_516.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → ℕ}
 /-- Is it true that for all entire functions `f = ∑ aₖzⁿₖ` such that `∑' 1 / nₖ < ∞`,
 `limsup (fun r => ratio r f) atTop = 1`? -/
 @[category research open, AMS 30]
-theorem erdos_516.limsup_ratio_eq_one_of_hasFejerGaps : answer(sorry) ↔
+theorem erdos_516.variants.limsup_ratio_eq_one_of_hasFejerGaps : answer(sorry) ↔
     ∀ {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFejerGaps n) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)
     (hfn : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)),
     limsup (fun r => ratio r f) atTop = 1 := by

--- a/FormalConjectures/ErdosProblems/517.lean
+++ b/FormalConjectures/ErdosProblems/517.lean
@@ -32,7 +32,7 @@ namespace Erdos517
 /-- If `f(z) = ∑ aₖzⁿₖ` is an entire function (with `aₖ ≠ 0` for all `k`) such that `nₖ / k → ∞`,
 is it true that `f` assumes every value infinitely often? -/
 @[category research open, AMS 30]
-theorem erdos_517.fabry : answer(sorry) ↔ ∀ {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFabryGaps n)
+theorem erdos_517 : answer(sorry) ↔ ∀ {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFabryGaps n)
     {a : ℕ → ℂ} (ha : ∀ k, a k ≠ 0) (hf : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) (z : ℂ),
     {x : ℂ | f x = z}.Infinite := by
   sorry
@@ -40,7 +40,7 @@ theorem erdos_517.fabry : answer(sorry) ↔ ∀ {f : ℂ → ℂ} {n : ℕ → �
 /-- If `f(z) = ∑ aₖzⁿₖ` is an entire function (with `aₖ ≠ 0` for all `k`) such that `∑ 1 / nₖ < ∞`,
 then `f` assumes every value infinitely often. This theorem is proved in [Bi28]. -/
 @[category research solved, AMS 30]
-theorem erdos_517.fejer {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFejerGaps n) {a : ℕ → ℂ}
+theorem erdos_517.variants.fejer {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFejerGaps n) {a : ℕ → ℂ}
     (ha : ∀ k, a k ≠ 0) (hf : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) (z : ℂ) :
     {x : ℂ | f x = z}.Infinite := by
   sorry

--- a/FormalConjectures/ErdosProblems/567.lean
+++ b/FormalConjectures/ErdosProblems/567.lean
@@ -57,7 +57,7 @@ def H5 : SimpleGraph (Fin 5) :=
 Is $Q_3$ (the 3-dimensional hypercube) Ramsey size linear?
 -/
 @[category research open, AMS 05]
-theorem erdos_567_Q3 : answer(sorry) ↔ IsRamseySizeLinear Q3 := by
+theorem erdos_567.parts.i : answer(sorry) ↔ IsRamseySizeLinear Q3 := by
   sorry
 
 /--
@@ -66,7 +66,7 @@ theorem erdos_567_Q3 : answer(sorry) ↔ IsRamseySizeLinear Q3 := by
 Is $K_{3,3}$ Ramsey size linear?
 -/
 @[category research open, AMS 05]
-theorem erdos_567_K33 : answer(sorry) ↔ IsRamseySizeLinear K33 := by
+theorem erdos_567.parts.ii : answer(sorry) ↔ IsRamseySizeLinear K33 := by
   sorry
 
 /--
@@ -75,7 +75,7 @@ theorem erdos_567_K33 : answer(sorry) ↔ IsRamseySizeLinear K33 := by
 Is $H_5$ ($C_5$ with two vertex-disjoint chords) Ramsey size linear?
 -/
 @[category research open, AMS 05]
-theorem erdos_567_H5 : answer(sorry) ↔ IsRamseySizeLinear H5 := by
+theorem erdos_567.parts.iii : answer(sorry) ↔ IsRamseySizeLinear H5 := by
   sorry
 
 end Erdos567

--- a/FormalConjectures/ErdosProblems/680.lean
+++ b/FormalConjectures/ErdosProblems/680.lean
@@ -35,7 +35,7 @@ p(n+k)>k^2+1,
 where $p(m)$ denotes the least prime factor of $m$?
 -/
 @[category research open, AMS 11]
-theorem erdos_680 :
+theorem erdos_680.parts.i :
     answer(sorry) ↔ ∀ᶠ (n : ℕ) in .atTop, ∃ k ≠ 0, (n + k).minFac > k^2 + 1 := by
   sorry
 
@@ -44,7 +44,7 @@ Can one prove this is false if we replace $k^2+1$ by $e^{(1+\epsilon)\sqrt{k}}+C
 $\epsilon>0$, where $C_\epsilon>0$ is some constant?
 -/
 @[category research open, AMS 11]
-theorem erdos_680.variant : answer(sorry) ↔ ∀ ε > 0, ∃ C > 0,
+theorem erdos_680.parts.ii : answer(sorry) ↔ ∀ ε > 0, ∃ C > 0,
     ¬ ∀ᶠ (n : ℕ) in Filter.atTop, ∃ k ≠ 0,
     Nat.minFac (n + k) > exp ((1 + ε) * √k) + C := by
   sorry

--- a/FormalConjectures/ErdosProblems/69.lean
+++ b/FormalConjectures/ErdosProblems/69.lean
@@ -44,7 +44,7 @@ $$
 $$
 -/
 @[category research solved, AMS 11]
-theorem erdos_69.specialisation_of_erdos_257 :
+theorem erdos_69.variants.specialisation_of_erdos_257 :
     let A := { n : ℕ | n.Prime }
     ∑' n, ω (n + 2) / (2 ^ (n + 2) : ℝ) = ∑' p : A, 1 / (2 ^ p.1 - 1) := by
   sorry

--- a/FormalConjectures/ErdosProblems/697.lean
+++ b/FormalConjectures/ErdosProblems/697.lean
@@ -45,19 +45,19 @@ noncomputable def δ (m : ℕ) (α : ℝ) : ℝ := (density_exists m α).choose
 $lim_{m\rightarrow\infty} \delta (m, \alpha) = 0$ for $\alpha < 1$.
 #TODO: prove this theorem. -/
 @[category research solved, AMS 11]
-theorem erdos_697.delta_lt (m : ℕ) (α : ℝ) : δ m α < (m ^ α + 1) / m := by
+theorem erdos_697.variants.delta_lt (m : ℕ) (α : ℝ) : δ m α < (m ^ α + 1) / m := by
   sorry
 
 /-- Let $\beta = \frac{1}{\log 2}$. Then $lim_{m\rightarrow\infty} \delta (m, \alpha) = 0$ if
 $\alpha < \beta$. This is proved in [Ha92]. -/
 @[category research solved, AMS 11]
-theorem erdos_697.beta_lt {α : ℝ} (hα : 1 / log (2 : ℝ) < α) : Tendsto (δ · α) atTop (𝓝 0) := by
+theorem erdos_697.parts.i {α : ℝ} (hα : 1 / log (2 : ℝ) < α) : Tendsto (δ · α) atTop (𝓝 0) := by
   sorry
 
 /-- $lim_{m\rightarrow\infty} \delta (m, \alpha) = 1$ if $\beta < \alpha$.
 This is proved in [Ha92]. -/
 @[category research solved, AMS 11]
-theorem erdos_697.lt_beta {α : ℝ} (hα : α < 1 / log (2 : ℝ)) : Tendsto (δ · α) atTop (𝓝 1) := by
+theorem erdos_697.parts.ii {α : ℝ} (hα : α < 1 / log (2 : ℝ)) : Tendsto (δ · α) atTop (𝓝 1) := by
   sorry
 
 end Erdos697

--- a/FormalConjectures/ErdosProblems/707.lean
+++ b/FormalConjectures/ErdosProblems/707.lean
@@ -86,7 +86,7 @@ cannot be extended to a perfect difference set modulo $p^2+p+1$
 for any prime $p$.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_707.counterexample_prime (A : Set ℕ) (hA : A = {1, 2, 4, 8}) :
+theorem erdos_707.variants.counterexample_prime (A : Set ℕ) (hA : A = {1, 2, 4, 8}) :
    Finite A ∧ IsSidon A ∧
    ∀ (B : Set ℕ) (p : ℕ),
     Prime p → A ⊆ B → ¬IsPerfectDifferenceSet B (p ^ 2 + p + 1) := by
@@ -98,7 +98,7 @@ Alexeev and Mixon [arxiv/2510.19804] have disproved this conjecture, showing tha
 extended to any perfect difference set.
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_707.counterexample_mian_chowla (A : Set ℕ) (hA : A = {1, 2, 4, 8, 13}) :
+theorem erdos_707.variants.counterexample_mian_chowla (A : Set ℕ) (hA : A = {1, 2, 4, 8, 13}) :
    Finite A ∧ IsSidon A ∧
    ∀ (B : Set ℕ) (n : ℕ), A ⊆ B → ¬IsPerfectDifferenceSet B n := by
   sorry
@@ -111,7 +111,7 @@ was given as $\{-8, -6, 0, 1, 4\}$, but this can be shifted to natural numbers
 as pointed out in [arxiv/2510.19804].
 -/
 @[category research solved, AMS 5 11]
-theorem erdos_707.counterexample_hall (A : Set ℕ) (hA : A = {1, 3, 9, 10, 13}) :
+theorem erdos_707.variants.counterexample_hall (A : Set ℕ) (hA : A = {1, 3, 9, 10, 13}) :
    Finite A ∧ IsSidon A ∧
    ∀ (B : Set ℕ) (n : ℕ), A ⊆ B → ¬IsPerfectDifferenceSet B n := by
   sorry

--- a/FormalConjectures/ErdosProblems/723.lean
+++ b/FormalConjectures/ErdosProblems/723.lean
@@ -39,7 +39,7 @@ theorem erdos_723 :
 These always exist if $n$ is a prime power.
 -/
 @[category research solved, AMS 5]
-theorem erdos_723.prime_pow_is_projplane_order :
+theorem erdos_723.variants.prime_power_is_projplane_order :
     ∀ n, IsPrimePow n → ∃ (P L : Type) (_ : Membership P L) (_ : Fintype P) (_ : Fintype L)
       (pp : ProjectivePlane P L), pp.order = n := by
   sorry
@@ -48,7 +48,7 @@ theorem erdos_723.prime_pow_is_projplane_order :
 This conjecture has been proved for $n \leq 11$.
 -/
 @[category research solved, AMS 5]
-theorem erdos_723.leq_11 {P L : Type} [Membership P L] [Fintype P] [Fintype L] :
+theorem erdos_723.variants.leq_11 {P L : Type} [Membership P L] [Fintype P] [Fintype L] :
     ∀ pp : ProjectivePlane P L, pp.order ≤ 11 → IsPrimePow pp.order := by
   sorry
 
@@ -56,7 +56,7 @@ theorem erdos_723.leq_11 {P L : Type} [Membership P L] [Fintype P] [Fintype L] :
 It is open whether there exists a projective plane of order 12.
 -/
 @[category research open, AMS 5]
-theorem erdos_723.eq_12 : answer(sorry) ↔
+theorem erdos_723.variants.eq_12 : answer(sorry) ↔
     ∃ (P L : Type) (_ : Membership P L) (_ : Fintype P) (_ : Fintype L) (pp : ProjectivePlane P L),
       pp.order = 12 := by
   sorry
@@ -66,7 +66,7 @@ Bruck and Ryser have proved that if $n \equiv 1 (\mod 4)$ or $n \equiv 2 (\mod 4
 the sum of two squares.
 -/
 @[category research solved, AMS 5]
-theorem bruck_ryser {P L : Type} [Membership P L] [Fintype P] [Fintype L]
+theorem erdos_723.variants.bruck_ryser {P L : Type} [Membership P L] [Fintype P] [Fintype L]
     (n : ℕ) (pp : ProjectivePlane P L) (hpp : pp.order = n) :
     (n ≡ 1 [MOD 4] ∨ n ≡ 2 [MOD 4]) → ∃ a b, n = a ^ 2 + b ^ 2 := by
   sorry

--- a/FormalConjectures/ErdosProblems/727.lean
+++ b/FormalConjectures/ErdosProblems/727.lean
@@ -39,7 +39,7 @@ It is open even for $k = 2$.
 Let $k = 2$. Does $((n+k)!)^2∣(2n)!$ hold for infinitely many n?
 -/
 @[category research open, AMS 11]
-theorem erdos_727_variants.k_2 :
+theorem erdos_727.variants.k_2 :
     letI k := 2
     answer(sorry) ↔ Set.Infinite {n : ℕ | (Nat.factorial (n + k)) ^ 2 ∣ Nat.factorial (2 * n)} := by
   sorry
@@ -50,7 +50,7 @@ Balakran proved this holds for $k = 1$.
 Let $k = 1$. Does $((n+k)!)^2∣(2n)!$ for infinitely many $n$?
 -/
 @[category research solved, AMS 11]
-theorem erdos_727_variants.k_1 :
+theorem erdos_727.variants.k_1 :
     letI k := 1
     answer(True) ↔ Set.Infinite {n : ℕ | (n + k)! ^ 2 ∣ (2 * n)!} := by
   sorry
@@ -60,7 +60,7 @@ Erdős, Graham, Ruzsa, and Straus observe that the method of Balakran can be fur
 that there are infinitely many $n$ such that $(n+k)!(n+1)!∣(2n)!$
 -/
 @[category research solved, AMS 11]
-theorem erdos_727_variants.k_1_2 (k : ℕ) (hk : 2 ≤ k) :
+theorem erdos_727.variants.k_1_2 (k : ℕ) (hk : 2 ≤ k) :
     Set.Infinite {n : ℕ |
       (Nat.factorial (n + k)) * (Nat.factorial (n + 1)) ∣ Nat.factorial (2 * n)} := by
   sorry

--- a/FormalConjectures/ErdosProblems/741.lean
+++ b/FormalConjectures/ErdosProblems/741.lean
@@ -35,7 +35,7 @@ Can one always decompose $A=A_1\sqcup A_2$ such that $A_1+A_1$ and $A_2+A_2$
 both have positive density?
 -/
 @[category research open, AMS 5]
-theorem erdos_741.density : answer(sorry) ↔ ∀ A : Set ℕ, HasPosDensity (A + A) → ∃ A₁ A₂,
+theorem erdos_741.parts.i : answer(sorry) ↔ ∀ A : Set ℕ, HasPosDensity (A + A) → ∃ A₁ A₂,
     A = A₁ ∪ A₂ ∧ Disjoint A₁ A₂ ∧ HasPosDensity (A₁ + A₁)
     ∧ HasPosDensity (A₂ + A₂) := by
   sorry
@@ -46,7 +46,7 @@ Is there a basis $A$ of order $2$ such that if $A=A_1\sqcup A_2$ then $A_1+A_1$ 
 cannot both have bounded gaps?
  -/
 @[category research open, AMS 5]
-theorem erdos_741.basis : answer(sorry) ↔ ∃ A : Set ℕ, IsAddBasisOfOrder (A ∪ {0}) 2 ∧ ∀ A₁ A₂,
+theorem erdos_741.parts.ii : answer(sorry) ↔ ∃ A : Set ℕ, IsAddBasisOfOrder (A ∪ {0}) 2 ∧ ∀ A₁ A₂,
     A = A₁ ∪ A₂ → Disjoint A₁ A₂ → ¬ (IsSyndetic (A₁ + A₁) ∧ IsSyndetic (A₂ + A₂)) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/757.lean
+++ b/FormalConjectures/ErdosProblems/757.lean
@@ -43,12 +43,12 @@ theorem erdos_757 {A : Set ℝ} :
 
 /-- The supremum is strictly larger than `1 / 2`, which is proved in [GyLe95]. -/
 @[category research solved, AMS 5]
-theorem erdos_757.lowerBound {A : Set ℝ} : 1 / (2 : ℝ) < sSup {c | IsAdmissible c} := by
+theorem erdos_757.variants.lowerBound {A : Set ℝ} : 1 / (2 : ℝ) < sSup {c | IsAdmissible c} := by
   sorry
 
 /-- In [GyLe95], the authors also prove that the supremum is smaller than `3 / 5`. -/
 @[category research solved, AMS 5]
-theorem erdos_757.upperBound {A : Set ℝ} : sSup {c | IsAdmissible c} < 3 / (5 : ℝ) := by
+theorem erdos_757.variants.upperBound {A : Set ℝ} : sSup {c | IsAdmissible c} < 3 / (5 : ℝ) := by
   sorry
 
 end Erdos757

--- a/FormalConjectures/ErdosProblems/770.lean
+++ b/FormalConjectures/ErdosProblems/770.lean
@@ -44,31 +44,31 @@ theorem Nat.Prime.h_eq_add_one {n : ℕ} (hn : 2 < n) : h n = n + 1 ↔ (n + 1).
 
 /-- For odd `n`, the values of `h n` form an unbounded set. -/
 @[category test, AMS 11]
-theorem odd_h_unbounded : Unbounded (· ≤ ·) (ENat.toNat '' (h '' Odd)):= by
+theorem erdos_770.variants.odd_h_unbounded : Unbounded (· ≤ ·) (ENat.toNat '' (h '' Odd)):= by
   sorry
 
 
 /-- For every prime `p`, does the density of integers with `h n = p` exist? -/
 @[category research open, AMS 11]
-theorem erdos_770.density : answer(sorry) ↔ ∀ p : ℕ, p.Prime → ∃ a, HasDensity {n | h n = p} a := by
+theorem erdos_770.parts.i : answer(sorry) ↔ ∀ p : ℕ, p.Prime → ∃ a, HasDensity {n | h n = p} a := by
   sorry
 
 /-- Does `liminf h n = ∞`? -/
 @[category research open, AMS 11]
-theorem erdos_770.liminf : answer(sorry) ↔ liminf h atTop = ⊤ := by
+theorem erdos_770.parts.ii : answer(sorry) ↔ liminf h atTop = ⊤ := by
   sorry
 
 /-- Is it true that if `p` is the greatest prime such that `p - 1 ∣ n` and `p > n ^ ε`, then
 `h n = p`? -/
 @[category research open, AMS 11]
-theorem erdos_770.prime : answer(sorry) ↔ ∀ ε > 0, ∀ᶠ n in atTop,
+theorem erdos_770.parts.iii : answer(sorry) ↔ ∀ ε > 0, ∀ᶠ n in atTop,
     let p := sSup {m : ℕ | m.Prime ∧ m - 1 ∣ n}
     p > (n : ℝ) ^ (ε : ℝ) → h n = p := by
   sorry
 
 /-- It is probably true that `h n = 3` for infinitely many `n`. -/
 @[category research open, AMS 11]
-theorem erdos_770.three : {n | h n = 3}.Infinite := by
+theorem erdos_770.variants.three : {n | h n = 3}.Infinite := by
   sorry
 
 end Erdos770


### PR DESCRIPTION
Renames some of the theorems listed in #2414 

This covers all files that start with `5` through `7`.