### PR TITLE
feat(GreensOpenProblems): 31

### DIFF
--- a/FormalConjectures/GreensOpenProblems/31.lean
+++ b/FormalConjectures/GreensOpenProblems/31.lean
@@ -49,7 +49,7 @@ open Filter
 /-- Let $F(N)$ be the largest Sidon subset of $[N]$. -/
 noncomputable def F (N : ℕ) : ℝ := Finset.maxSidonSubsetCard (Finset.Icc 1 N)
 
-/-- Can we improve the lower bound $N^{1/2} + O(1)$? -/
+/-- Can we improve the lower bound $N^{1/2} + O(1)$, at least for infinitely many $N$? -/
 @[category research open, AMS 5 11]
 theorem green_31.lower :
     let ans := (answer(sorry) : ℕ → ℝ)
@@ -57,11 +57,33 @@ theorem green_31.lower :
     ∃ᶠ N in atTop, ans N ≤ F N := by
   sorry
 
-/-- Can we improve the upper bound $N^{1/2} + 0.98183 N^{1/4} + O(1)$ [CHO25]? -/
+/-- Can we improve the lower bound $N^{1/2} + O(1)$, for all sufficiently large $N$? -/
+@[category research open, AMS 5 11]
+theorem green_31.variants.lower_eventually :
+    let ans := (answer(sorry) : ℕ → ℝ)
+    Filter.Tendsto (fun N ↦ ans N - Real.sqrt (N : ℝ)) atTop atTop ∧ -- Break the O(1) barrier
+    ∀ᶠ N in atTop, ans N ≤ F N := by
+  sorry
+
+/--
+Can we improve the upper bound $N^{1/2} + 0.98183 N^{1/4} + O(1)$ [CHO25], at least for infinitely
+many $N$?
+-/
 @[category research open, AMS 5 11]
 theorem green_31.upper :
     let ans := (answer(sorry) : ℕ → ℝ)
     (∃ᶠ N in atTop, F N ≤ ans N) ∧
+    ∃ c < (0.98183 : ℝ), ∃ C : ℝ, ∀ᶠ N in atTop, ans N - Real.sqrt (N : ℝ) ≤ c * (N : ℝ) ^ (4⁻¹ : ℝ) + C := by
+  sorry
+
+/--
+Can we improve the upper bound $N^{1/2} + 0.98183 N^{1/4} + O(1)$ [CHO25], for all sufficiently
+large $N$?
+-/
+@[category research open, AMS 5 11]
+theorem green_31.variants.upper_eventually :
+    let ans := (answer(sorry) : ℕ → ℝ)
+    (∀ᶠ N in atTop, F N ≤ ans N) ∧
     ∃ c < (0.98183 : ℝ), ∃ C : ℝ, ∀ᶠ N in atTop, ans N - Real.sqrt (N : ℝ) ≤ c * (N : ℝ) ^ (4⁻¹ : ℝ) + C := by
   sorry
 


### PR DESCRIPTION
# Description
Write $F(N)$ for the largest Sidon subset of $[N]$. Improve, at least for infinitely many $N$, the bounds $N^{1/2} + O(1) \le F(N) \le N^{1/2} + N^{1/4} + O(1)$.

- Closes #1587.
- Leverages the existing implementation of #205.
- Adds the variants discussed by Green in the comments.
- Implemented with the help of Gemini 3.1 Pro: usually to get a first draft going, and then heavily steered and manually adjusted for style and simplicity.

# Testing
:white_check_mark: Builds fine
```shell
$ lake build FormalConjectures/GreensOpenProblems/31.lean 
Build completed successfully (7976 jobs).
```