### PR TITLE
fix(ErdosProblems): Standardize Erdos Problem Theorems (part 5)

### DIFF
--- a/FormalConjectures/ErdosProblems/848.lean
+++ b/FormalConjectures/ErdosProblems/848.lean
@@ -73,7 +73,7 @@ $A ⊆ \{n : n ≡ 18 \pmod{25}\}$.
 A complete formal Lean 4 proof is available at:
 https://github.com/The-Obstacle-Is-The-Way/erdos-banger -/
 @[category research formally solved using lean4 at "https://github.com/The-Obstacle-Is-The-Way/erdos-banger/blob/1cc2ac8e9d70516e979733c6ea5c4d2eb652d1f5/formal/lean/Erdos/848.lean", AMS 11]
-theorem erdos_848_asymptotic : ∀ᶠ N in Filter.atTop, Erdos848For N := by
+theorem erdos_848.variants.asymptotic : ∀ᶠ N in Filter.atTop, Erdos848For N := by
   sorry
 
 end Erdos848

--- a/FormalConjectures/ErdosProblems/853.lean
+++ b/FormalConjectures/ErdosProblems/853.lean
@@ -40,7 +40,7 @@ integer $t$ such that $d_n = t$ has no solutions for $n \le x$.
 Is it true that $r(x) \to \infty$?
 -/
 @[category research open, AMS 11]
-theorem erdos_853 : atTop.Tendsto r atTop := by
+theorem erdos_853.parts.i : atTop.Tendsto r atTop := by
   sorry
 
 /--
@@ -49,7 +49,7 @@ integer $t$ such that $d_n = t$ has no solutions for $n \le x$.
 
 Is it true that $r(x) / \log x \to \infty$? -/
 @[category research open, AMS 11]
-theorem erdos_853_strong :
+theorem erdos_853.parts.ii :
     atTop.Tendsto (fun n ↦ r n / Real.log n) atTop := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/886.lean
+++ b/FormalConjectures/ErdosProblems/886.lean
@@ -52,7 +52,7 @@ Erdős and Rosenfeld [ErRo97] proved that there are infinitely many $n$ such tha
 four divisors of $n$ in $(n^{1/2},n^{1/2}+16n^{1/4})$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_886_variants_rosenfeld_infinite :
+theorem erdos_886.variants.rosenfeld_infinite :
     Set.Infinite {n | 4 ≤ (Erdos886Divisors n (1/4) 16).card} := by
   sorry
 
@@ -61,7 +61,7 @@ Erdős and Rosenfeld [ErRo97] proved that, for any constant $C>0$, all large $n$
 $1+C^2$ many divisors in $[n^{1/2}, n^{1/2}+Cn^{1/4}]$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_886_variants_rosenfeld_bound :
+theorem erdos_886.variants.rosenfeld_bound :
     ∀ C > 0, ∀ᶠ (n : ℕ) in atTop,
     ((divisors n).filter (fun (d : ℕ) =>
       (n : ℝ) ^ (1 / 2 : ℝ) ≤ (d : ℝ) ∧ (d : ℝ) ≤ (n : ℝ) ^ (1 / 2 : ℝ) + C * (n : ℝ) ^ (1 / 4 : ℝ))).card

--- a/FormalConjectures/ErdosProblems/887.lean
+++ b/FormalConjectures/ErdosProblems/887.lean
@@ -32,7 +32,7 @@ Is there an absolute constant $K$ such that, for every $C > 0$, if $n$ is suffic
 $n$ has at most $K$ divisors in $(n^{\frac{1}{2}}, n^{\frac{1}{2}} + C n^{\frac{1}{4}})$.
 -/
 @[category research open, AMS 11]
-theorem erdos_887 : ∀ C > (0 : ℝ), ∀ᶠ n in atTop,
+theorem erdos_887.parts.i : ∀ C > (0 : ℝ), ∀ᶠ n in atTop,
     #{ d ∈ Ioo ⌊√n⌋ ⌈√n + C * n^((1 : ℝ) / 4)⌉ | d ∣ n } ≤ answer(sorry) := by
   sorry
 
@@ -41,7 +41,7 @@ Is there an absolute constant $K$ such that, for every $C > 0$, if $n$ is suffic
 $n$ has at most $K$ divisors in $(n^{\frac{1}{2}}, n^{\frac{1}{2}} + C n^{\frac{1}{4}})$.
 -/
 @[category research open, AMS 11]
-theorem erdos_887.variant_i : ∃ K, ∀ C > (0 : ℝ), ∀ᶠ n in atTop,
+theorem erdos_887.parts.ii : ∃ K, ∀ C > (0 : ℝ), ∀ᶠ n in atTop,
     #{ d ∈ Ioo ⌊√n⌋ ⌈√n + C * n^((1 : ℝ) / 4)⌉ | d ∣ n } ≤ K := by
   sorry
 
@@ -50,7 +50,7 @@ A question of Erdős and Rosenfeld, who proved that there are infinitely many $n
 in $(n^{\frac{1}{2}}, n^{\frac{1}{2}} + n^{\frac{1}{4}})$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_887.variant_ii :
+theorem erdos_887.variants.rosenfeld_infinite :
     Infinite {n : ℤ | (#{ d ∈ Ioo ⌊√n⌋ ⌈√n + n^((1 : ℝ) / 4)⌉ | d ∣ n } = 4)} := by
   sorry
 
@@ -59,7 +59,7 @@ Erdős and Rosenfeld, ask whether $4$ is the best possible $K$ for the infinitud
 with $K$ divisors in $(n^{\frac{1}{2}}, n^{\frac{1}{2}} + n^{\frac{1}{4}})$.
 -/
 @[category research open, AMS 11]
-theorem erdos_887.variant_iii :
+theorem erdos_887.variants.rosenfeld_4 :
     IsGreatest
       {K | Infinite {n : ℤ | (#{ d ∈ Ioo ⌊√n⌋ ⌈√n + n^((1 : ℝ) / 4)⌉ | d ∣ n } = K)}} 4 := by
   sorry

--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -46,10 +46,10 @@ theorem erdos_888 : ∀ n, Nat.findGreatest (p n) n = (answer(sorry) : ℕ → �
 
 /--`|A|=o(n)`. -/
 @[category research solved, AMS 11]
-theorem erdos_888_Sárközy : (fun n ↦ (Nat.findGreatest (p n) n : ℝ)) =o[atTop] (Nat.cast : ℕ → ℝ) := by
+theorem erdos_888.variants.sarkozy : (fun n ↦ (Nat.findGreatest (p n) n : ℝ)) =o[atTop] (Nat.cast : ℕ → ℝ) := by
   sorry
 
 /-- The primes show that `|A| ≫ n/log n` is possible. -/
 @[category research solved, AMS 11]
-theorem erdos_888_primes : (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ )) ≫ (fun n : ℕ ↦ n / (n : ℝ).log) := by
+theorem erdos_888.variants.primes : (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ )) ≫ (fun n : ℕ ↦ n / (n : ℝ).log) := by
   sorry

--- a/FormalConjectures/ErdosProblems/944.lean
+++ b/FormalConjectures/ErdosProblems/944.lean
@@ -94,7 +94,7 @@ theorem erdos_944.variants.dirac_conjecture.k_ge_five (k : ℕ) (hk : 5 ≤ k) :
 The case $k=4$ and $r=1$ remains open: Are there $4$-critical graphs without any critical edges?
 -/
 @[category research open, AMS 11]
-theorem erdos_944.dirac_conjecture.k_eq_four :
+theorem erdos_944.variants.dirac_conjecture.k_eq_four :
     answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 4 1 := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/945.lean
+++ b/FormalConjectures/ErdosProblems/945.lean
@@ -67,7 +67,7 @@ theorem erdos_945.variants.constant : answer(sorry) ↔ Erdos945Constant := by
 The two ways of phrasing the conjecture are equivalent.
 -/
 @[category undergraduate, AMS 11]
-theorem erdos_945.equivalence : Erdos945Prop ↔ Erdos945Constant := by
+theorem erdos_945.variants.equivalence : Erdos945Prop ↔ Erdos945Constant := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/951.lean
+++ b/FormalConjectures/ErdosProblems/951.lean
@@ -37,7 +37,7 @@ def Erdos951_prop (a : ℕ → ℝ) : Prop :=
 
 /-- If `a` has property `Erdos951_prop` and `1 < a 0`, then `a` is a set of Beurling prime numbers. -/
 @[category API, AMS 11]
-theorem erdos_951.isBeurlingPrimes {a : ℕ → ℝ} (ha : 1 < a 0)
+theorem erdos_951.variants.isBeurlingPrimes {a : ℕ → ℝ} (ha : 1 < a 0)
     (hm : StrictMono a) (he : Erdos951_prop a) :
     IsBeurlingPrimes a := by
   refine ⟨ha, hm, tendsto_atTop_atTop.2 fun x => ?_⟩

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -40,7 +40,7 @@ theorem erdos_961.sylvester_schur (k : ℕ) (hk : 0 < k) : Erdos961Prop k k := b
   sorry
 
 @[category test, AMS 11]
-theorem erdos_961.sylvester_schur_1_1 : Erdos961Prop 1 1 := by
+theorem erdos_961.variants.sylvester_schur_1_1 : Erdos961Prop 1 1 := by
   intro m hm
   use m
   constructor
@@ -52,7 +52,7 @@ theorem erdos_961.sylvester_schur_1_1 : Erdos961Prop 1 1 := by
     exact ⟨p, (Nat.mem_primeFactorsList hm0).mpr ⟨hp, hpm⟩, hp.two_le⟩
 
 @[category research solved, AMS 11]
-theorem erdos_961.well_defined (k : ℕ) (hk : 0 < k): ∃ n, Erdos961Prop k n := by
+theorem erdos_961.variants.well_defined (k : ℕ) (hk : 0 < k): ∃ n, Erdos961Prop k n := by
   use k
   exact erdos_961.sylvester_schur k hk
 
@@ -74,7 +74,7 @@ theorem erdos_961 : answer(sorry) ↔ ∃ C > 0, ∀ᶠ k in atTop, f k < (log (
 Erdos [Er55d] proved $f(k) < 3 \frac{k}{\log k}$ for sufficiently large $k$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_961.erdos_upper_bound :
+theorem erdos_961.variants.erdos_upper_bound :
     ∀ᶠ k in atTop, f k < 3 * k / log k := by
   sorry
 
@@ -83,7 +83,7 @@ Jutila [Ju74], and Ramachandra--Shorey [RaSh73] proved a stronger upper bound
 $f(k) \ll \frac{\log \log \log k}{\log \log k} \frac{k}{\log k}$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_961.jutila_ramachandra_shorey_upper_bound :
+theorem erdos_961.variants.jutila_ramachandra_shorey_upper_bound :
     (fun k => (f k : ℝ)) =O[atTop] fun k => log (log (log k)) / log (log k) * (k / log k) := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -61,7 +61,7 @@ For $k$, let $f(k)$ be the minimal $n$ such that every set of $n$ consecutive in
 an integer divisible by a prime $>k$, i.e. not $(k+1)$-smooth.
 -/
 noncomputable def f (k : ℕ) : ℕ :=
-  if hk : 0 < k then Nat.find (erdos_961.well_defined k hk) else 0
+  if hk : 0 < k then Nat.find (erdos_961.variants.well_defined k hk) else 0
 
 /--
 It is conjectured that $f(k) \ll (\log k)^O(1)$.

--- a/FormalConjectures/ErdosProblems/965.lean
+++ b/FormalConjectures/ErdosProblems/965.lean
@@ -49,7 +49,7 @@ theorem erdos_965 :
 In fact, in both [Ko16] and [SWCol] a generalized example for $k$-sums is constructed.
 -/
 @[category research solved, AMS 03 05]
-theorem erdos_965.generalization : answer(False) ↔
+theorem erdos_965.variants.generalization : answer(False) ↔
      ∀ᵉ (k ≥ 2), ∀ f : ℝ → Fin 2, ∃ A : Set ℝ, ¬ A.Countable ∧ ∀ s t : Finset ℝ,
       ↑s ⊆ A → ↑t ⊆ A → s.card = k → t.card = k → f (s.sum id) = f (t.sum id) := by
   sorry

--- a/FormalConjectures/ErdosProblems/978.lean
+++ b/FormalConjectures/ErdosProblems/978.lean
@@ -34,7 +34,7 @@ namespace Erdos978
 `2` and is not equal to a power of `2`. Then the set of `n` such that `f n` is `(k - 1)`-th power
 free is infinite, and this is proved in [Er53]. -/
 @[category research solved, AMS 11]
-theorem erdos_978.sub_one {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 2)
+theorem erdos_978.variants.sub_one {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 2)
     (hp : ¬ ∃ l : ℕ, f.natDegree = 2 ^ l) :
     {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))}.Infinite := by
   sorry
@@ -43,7 +43,7 @@ theorem erdos_978.sub_one {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 
 `2`, and `f n` have no fixed `(k - 1)`-th power divisors other than `1`. Then the set of `n` such
 that `f n` is `(k - 1)`-th power free has positive density, and this is proved in [Ho67]. -/
 @[category research solved, AMS 11]
-theorem erdos_978.sub_one_density {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 2)
+theorem erdos_978.parts.i {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree > 2)
     (hp : ¬ ∃ p : ℕ, p.Prime ∧ ∀ n : ℕ, (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
     HasPosDensity {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))} := by
   sorry
@@ -51,7 +51,7 @@ theorem erdos_978.sub_one_density {f : ℤ[X]} (hi : Irreducible f) (hd : f.natD
 /-- If the degree `k` of `f` is larger than or equal to `9`, then the set of `n` such that `f n` is
 `(k - 2)`-th power free has infinitely many elements. This result is proved in [Br11]. -/
 @[category research solved, AMS 11]
-theorem erdos_978.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree ≥ 9)
+theorem erdos_978.variants.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree ≥ 9)
     (hp : ¬ ∃ p : ℕ, p.Prime ∧ ∀ n : ℕ, (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
     {n : ℕ | Powerfree (f.natDegree - 2) (f.eval (n : ℤ))}.Infinite := by
   sorry
@@ -59,14 +59,14 @@ theorem erdos_978.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : f.natDegree �
 /-- Is it true that the set of `n` such that `f n` is `(k - 2)`-th power free has infinitely many
 elements? -/
 @[category research open, AMS 11]
-theorem erdos_978.sub_two' : answer(sorry) ↔ ∀ {f : ℤ[X]}, Irreducible f → f.natDegree > 2 →
+theorem erdos_978.parts.ii : answer(sorry) ↔ ∀ {f : ℤ[X]}, Irreducible f → f.natDegree > 2 →
     (¬ ∃ p : ℕ, p.Prime ∧ ∀ n : ℕ, (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) →
     {n : ℕ | Powerfree (f.natDegree - 2) (f.eval (n : ℤ))}.Infinite := by
   sorry
 
 /-- Does `n ^ 4 + 2` represent infinitely many squarefree numbers? -/
 @[category research open, AMS 11]
-theorem erdos_978.squarefree : answer(sorry) ↔ {n : ℕ | Squarefree (n ^ 4 + 2)}.Infinite := by
+theorem erdos_978.parts.iii : answer(sorry) ↔ {n : ℕ | Squarefree (n ^ 4 + 2)}.Infinite := by
   sorry
 
 end Erdos978

--- a/FormalConjectures/ErdosProblems/979.lean
+++ b/FormalConjectures/ErdosProblems/979.lean
@@ -42,7 +42,7 @@ Erdős [Er37b] proved that if $f_2(n)$ counts the number of solutions to $n = p_
 [Er37b] Erdős, Paul, On the Sum and Difference of Squares of Primes. J. London Math. Soc. (1937), 133--136.
 -/
 @[category research solved, AMS 11]
-theorem erdos_979_k2 :
+theorem erdos_979.variants.k2 :
     Filter.limsup (fun n => (solutionSet n 2).encard) Filter.atTop = ⊤ := by
   sorry
 
@@ -50,7 +50,7 @@ theorem erdos_979_k2 :
 Erdős (unpublished)
 -/
 @[category research solved, AMS 11]
-theorem erdos_979_k3 :
+theorem erdos_979.variants.k3 :
     Filter.limsup (fun n => (solutionSet n 3).encard) Filter.atTop = ⊤ := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/996.lean
+++ b/FormalConjectures/ErdosProblems/996.lean
@@ -39,7 +39,7 @@ namespace Erdos996
 sequences `n`, if `‖f - fₖ‖₂ = O(1 / log log log k ^ C)`, then for almost every `x`,
 `lim ∑ k ∈ Finset.range N, f (n k • x)) / N = ∫ t, f t ∂t`? -/
 @[category research open, AMS 42]
-theorem erdos_996.log3 : answer(sorry) ↔
+theorem erdos_996 : answer(sorry) ↔
     ∃ (C : ℝ), 0 < C ∧ ∀ (f : Lp ℂ 2 (haarAddCircle (T := 1))) (n : ℕ → ℕ),
     IsLacunary n →
     (fun k => (eLpNorm (fourierPartial f k) 2 (haarAddCircle (T := 1))).toReal) =O[atTop]
@@ -51,7 +51,7 @@ theorem erdos_996.log3 : answer(sorry) ↔
 
 /-- The following theorem is proved in [Ma66]. -/
 @[category research solved, AMS 42]
-theorem erdos_996.log2 : ∀ (C : ℝ), 0.5 < C →
+theorem erdos_996.variants.log2 : ∀ (C : ℝ), 0.5 < C →
     ∀ (f : Lp ℂ 2 (haarAddCircle (T := 1))) (n : ℕ → ℕ),
     IsLacunary n →
     (fun k => (eLpNorm (fourierPartial f k) 2 (haarAddCircle (T := 1))).toReal) =O[atTop]


### PR DESCRIPTION
Closes #2414 

This should be the final one. Hopefully, the script that was checked in should run and show no differences between this repository and the Erdos Problems website.