### PR TITLE
feat: elaboration options for answer(sorry)

### DIFF
--- a/FormalConjectures/Util/Answer.lean
+++ b/FormalConjectures/Util/Answer.lean
@@ -32,7 +32,7 @@ which is a job for human mathematicians, not Lean alone.
 -/
 namespace Google
 
-open Lean Elab Term
+open Lean Elab Meta Term
 
 /-- A type that captures the current setting for the `answer()` elaborator. -/
 inductive AnswerSetting
@@ -40,8 +40,7 @@ inductive AnswerSetting
   | alwaysTrue
   /-- Default mode for `answer(foo)`: just postpones elaboration. -/
   | postpone
-  /-- Elaborate `answer(foo)` by creating an auxiliary definition with value `foo`.
-    **For now, this is experimental** -/
+  /-- Elaborate `answer(foo)` by creating an auxiliary definition with value `foo`. -/
   | withAuxiliary
 deriving Inhabited, ToJson, BEq
 
@@ -88,18 +87,17 @@ def answerElab : TermElab := fun stx expectedType? => do
       let some declName := (← read).declName?
         | throwError "Failed to find the name of the declaration"
       let answerName : Name := declName.str "_answer"
-      let levelParams : List Name := []
+      let levelParamNames : List Name := (collectLevelParams {} exprType).params.toList
       let answerAuxiliaryDecl : DefinitionVal := {
         name := answerName
-        -- TODO(Paul-Lez): For now, let's ignore universes to get a working v0, but fix it later?
-        levelParams := []
+        levelParams := levelParamNames
         type := exprType
         value := expr
         hints := .abbrev
         safety := .safe
       }
       addDecl (.defnDecl answerAuxiliaryDecl) true
-      return mkAnswerAnnotation (.const answerName [])
+      return mkAnswerAnnotation (.const answerName <| levelParamNames.map Level.param)
     | .alwaysTrue =>
       -- If the answer is a `sorry` of type `Prop` then default to `True` in this setting
       if expectedType? == some (Expr.sort .zero) && a == (← `(term| sorry)) then

--- a/FormalConjecturesTest/Util/Answer.lean
+++ b/FormalConjecturesTest/Util/Answer.lean
@@ -25,14 +25,12 @@ set_option google.answer "with_auxiliary"
 
 open Lean Elab Meta
 
-#guard_msgs in
 theorem foo : answer(True) := by
   run_tac Tactic.withMainContext do
     let env ← getEnv
     let some aux := env.find? `foo._answer | throwError "here"
   trivial
 
-#guard_msgs in
 theorem bar : 1 = answer(sorry) := by
   run_tac Tactic.withMainContext do
     let env ← getEnv
@@ -41,14 +39,16 @@ theorem bar : 1 = answer(sorry) := by
   guard_target = 1 = bar._answer
   sorry
 
-
-#guard_msgs in
 theorem bar_symm : answer(sorry) = 1 := by
   run_tac Tactic.withMainContext do
     let env ← getEnv
     let some aux := env.find? `bar._answer | throwError "here"
   -- TODO(Paul-Lez): This will change when I write a delaborator
   guard_target = bar_symm._answer = 1
+  sorry
+
+theorem i_have_some_universes.{u, v} (X : Type u) (Y : Type v) : (X × Y) = answer(sorry) := by
+  guard_target = (X × Y : Type (max u v)) = i_have_some_universes._answer.{u, v}
   sorry
 
 end WithAuxiliary


### PR DESCRIPTION
This PR gives users the option to change the behaviour of `answer(sorry)`. They can either
- have it replace `sorry` by `True` if it's a `Prop` (default behaviour for now), and attach metadata.
- do nothing except attach metadata
- create an auxiliary declaration which is then referenced by the `Expr` that the elaborator produces (together with a metadata annotation).

Note: this also changes the metadata attached to the expressions produced by `answer(sorry)` - I think it's reasonable for us to move to a format that is unique to `answer()` rather than using `mkSaveInfoAnnotation`.