### PR TITLE
fix: make `green_58` asymptotic

### DIFF
--- a/FormalConjectures/GreensOpenProblems/58.lean
+++ b/FormalConjectures/GreensOpenProblems/58.lean
@@ -33,7 +33,7 @@ contain a composite number?
 @[category research open, AMS 5 11]
 theorem green_58 :
     answer(sorry) ↔
-      ∀ᵉ (N ≥ (1 : ℕ)) (A ⊆ Finset.Icc 1 N) (B ⊆ Finset.Icc 1 N),
+      ∀ᶠ (N : ℕ) in Filter.atTop, ∀ᵉ (A ⊆ Finset.Icc 1 N) (B ⊆ Finset.Icc 1 N),
         (N : ℝ) ^ (0.49 : ℝ) ≤ (A.card : ℝ) →
         (N : ℝ) ^ (0.49 : ℝ) ≤ (B.card : ℝ) →
         ∃ m ∈ (A + B), m.Composite := by


### PR DESCRIPTION
This question is implicitly asymptotic in `N`, especially given its relation to the inverse Goldbach problem. AlphaProof finds a trivial counterexample with `N = 1, A = {1}, B = {1}` otherwise.