### PR TITLE
feat(extract_names): add module docstrings and restructure JSON output

### DIFF
--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -160,7 +160,7 @@ unsafe def main (args : List String) : IO Unit := do
     let mut moduleDocstrings : List (String × String) := []
     for modName in moduleNames do
       if let some docs := getModuleDoc? env modName then
-        if docs.size > 1 then
+        if docs.size != 1 then
           IO.eprintln s!"WARNING: Module {modName} has {docs.size} module docstrings"
         if docs.size > 0 then
           let combined := "\n\n".intercalate (docs.toList.map (·.doc))


### PR DESCRIPTION
Output is now `{ problems: [...], moduleDocstrings: {...} }` instead of a flat array. Module docstrings are extracted via `getModuleDoc?`. Warns on stderr if a module has multiple or no docstring blocks.