### PR TITLE
fix: convert secondary module docstrings to regular comments in Dickson

### DIFF
--- a/FormalConjectures/Wikipedia/Dickson.lean
+++ b/FormalConjectures/Wikipedia/Dickson.lean
@@ -37,7 +37,7 @@ theorem dickson_conjecture (fs : Finset ℤ[X]) (hfs : ∀ f ∈ fs, f.degree = 
     (hfs' : SchinzelCondition fs) : Infinite {n : ℕ | ∀ f ∈ fs, (f.eval (n : ℤ)).natAbs.Prime} := by
   sorry
 
-/-! ## Special cases -/
+/-  ## Special cases -/
 
 /--
 **Polignac's conjecture**


### PR DESCRIPTION
Convert secondary module docstrings (`/-! ... -/`) to regular multiline comments in `FormalConjectures.Wikipedia.Dickson`.

The main module docstring at the top of the file is preserved. The `/-! ## Special cases -/` section separator is converted to a regular `/-` comment.