### PR TITLE
fix: convert secondary module docstrings to regular comments in EulerBrick

### DIFF
--- a/FormalConjectures/Wikipedia/EulerBrick.lean
+++ b/FormalConjectures/Wikipedia/EulerBrick.lean
@@ -72,7 +72,7 @@ section Cuboid
 
 open Polynomial
 
-/-! **Cuboid conjectures**:
+/-  **Cuboid conjectures**:
 The three Cuboid conjectures ask if certain families of polynomials are always irreducible.
 If all hold, this implies the nonexistence of a perfect Euler brick.
 -/


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.