### PR TITLE
fix: convert secondary module docstrings to regular comments in Catalan

### DIFF
--- a/FormalConjectures/Wikipedia/Catalan.lean
+++ b/FormalConjectures/Wikipedia/Catalan.lean
@@ -48,7 +48,7 @@ theorem pillais_conjecture (a b c : ℕ) (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) 
 
 end Catalan
 
-/-! ## Lebesgue-Nagell equation -/
+/-  ## Lebesgue-Nagell equation -/
 
 namespace LebesgueNagell
 


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.