### PR TITLE
fix: convert secondary module docstrings to regular comments in AgohGiuga

### DIFF
--- a/FormalConjectures/Wikipedia/AgohGiuga.lean
+++ b/FormalConjectures/Wikipedia/AgohGiuga.lean
@@ -23,7 +23,7 @@ open scoped Nat
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Agoh-Giuga_conjecture)
 -/
-/-!
+/-
 
 The **Agoh-Giuga Conjecture**.
 


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.