### PR TITLE
fix: convert secondary module docstrings to regular comments in Selfridge

### DIFF
--- a/FormalConjectures/Wikipedia/Selfridge.lean
+++ b/FormalConjectures/Wikipedia/Selfridge.lean
@@ -110,7 +110,7 @@ end PrimalityTesting
 
 section FermatNumbers
 
-/-!
+/-
 # Selfridge's conjectures about Fermat numbers
 -/
 


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.