### PR TITLE
fix: convert secondary module docstrings to regular comments in Green.24

### DIFF
--- a/FormalConjectures/GreensOpenProblems/24.lean
+++ b/FormalConjectures/GreensOpenProblems/24.lean
@@ -53,7 +53,7 @@ Conjectured in [Aa19] p.579: $\left({1}{3} + o(1)\right) n^2$.
 theorem green_24 : ∀ n, max013AffineTranslates n = answer(sorry) := by
   sorry
 
-/-! A collection of associated bounds and conjectured values. -/
+/-  A collection of associated bounds and conjectured values. -/
 
 namespace variants
 


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.