### PR TITLE
fix: convert secondary module docstrings to regular comments in Green.35

### DIFF
--- a/FormalConjectures/GreensOpenProblems/35.lean
+++ b/FormalConjectures/GreensOpenProblems/35.lean
@@ -65,7 +65,7 @@ theorem green_35.upper :
     (∀ p, 1 < p → c p ≤ ub p) ∧ ub ∞ < 0.7505 := by
   sorry
 
-/-! Known bounds and comparisons. -/
+/-  Known bounds and comparisons. -/
 namespace variants
 
 /-- Lower bound for $c(2)$ from Green's first paper ([Gr01]); the constant is `sqrt(4/7)` (about 0.7559). -/


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.