### PR TITLE
fix: convert secondary module docstrings to regular comments in CatchUpConjecture

### DIFF
--- a/FormalConjectures/Paper/CatchUpConjecture.lean
+++ b/FormalConjectures/Paper/CatchUpConjecture.lean
@@ -89,7 +89,7 @@ def Outcome.best (os : List Outcome) : Outcome :=
     | _,     _     => .loss) .loss
 
 
-/-!
+/-
 Define the recursive game value functions.
 -/
 


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.