### PR TITLE
fix: convert secondary module docstrings to regular comments in Erdos.1135

### DIFF
--- a/FormalConjectures/ErdosProblems/1135.lean
+++ b/FormalConjectures/ErdosProblems/1135.lean
@@ -28,7 +28,7 @@ import FormalConjectures.Wikipedia.CollatzConjecture
 
 namespace Erdos1135
 
-/-!The **Collatz conjecture** states that for any positive integer $n$, there exists a natural
+/-The **Collatz conjecture** states that for any positive integer $n$, there exists a natural
 number $m$ such that the $m$-th term of the sequence is 1.
 -/
 @[category research open, AMS 11 37]


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.