### PR TITLE
fix: convert secondary module docstrings to regular comments in Erdos.329

### DIFF
--- a/FormalConjectures/ErdosProblems/329.lean
+++ b/FormalConjectures/ErdosProblems/329.lean
@@ -99,7 +99,7 @@ theorem erdos_329.variants.converse_implication :
       ↑A ⊆ D ∧ IsPerfectDifferenceSet D n) := by
   sorry
 
-/-! ## Related results and examples -/
+/-  ## Related results and examples -/
 
 /--
 It is possible to construct a Sidon set with positive density.


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.