### PR TITLE
fix: convert secondary module docstrings to regular comments in Erdos.42

### DIFF
--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -58,7 +58,7 @@ theorem erdos_42.variants.constructive : answer(sorry) ↔
   sorry
 
 
-/-! ## Related results and examples -/
+/-  ## Related results and examples -/
 
 /--
 The set `{1, 2, 4}` is a maximal Sidon set in `{1, ..., 4}`.


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.