### PR TITLE
fix: convert secondary module docstrings to regular comments in VCDimConvex

### DIFF
--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -29,7 +29,7 @@ and conjectures that every convex set in ℝⁿ⁺¹ has finite VCₙ dimension.
 
 open scoped EuclideanGeometry Pointwise
 
-/-! ### What's known in the literature -/
+/-  ### What's known in the literature -/
 
 /-- Every convex set in $\mathbb R^2$ has VC dimension at most 3. -/
 @[category research solved, AMS 5 52]
@@ -41,14 +41,14 @@ lemma hasAddVCDimAtMost_three_of_convex_r2 {C : Set ℝ²} (hC : Convex ℝ C) :
 lemma exists_infinite_convex_r3_shatters :
     ∃ A C : Set ℝ³, A.Infinite ∧ Convex ℝ C ∧ Shatters {t +ᵥ C | t : ℝ³} A := sorry
 
-/-! ### What's not in the literature -/
+/-  ### What's not in the literature -/
 
 /-- There exists a set of infinite $\mathrm{VC}_n$ dimension in $\mathbb R^{n + 2}$. -/
 @[category research solved, AMS 5 52]
 lemma exists_convex_rn_add_two_vc_n_forall_not_hasAddVCNDimAtMost (n : ℕ) :
     ∃ C : Set (Fin (n + 2) → ℝ), Convex ℝ C ∧ ∀ d, ¬ HasAddVCNDimAtMost C n d := sorry
 
-/-! ### Conjectures -/
+/-  ### Conjectures -/
 
 /-- Every convex set in $\mathbb R^3$ has $\mathrm{VC}_2$ dimension at most 1. -/
 @[category research open, AMS 5 52]


### PR DESCRIPTION
Convert secondary module docstrings to regular multiline comments in . The main module docstring is preserved.