### PR TITLE
feat: add module docstring to CopyrightLinter

### DIFF
--- a/FormalConjectures/Util/Linters/CopyrightLinter.lean
+++ b/FormalConjectures/Util/Linters/CopyrightLinter.lean
@@ -15,6 +15,13 @@ limitations under the License.
 -/
 import Mathlib.Tactic.Linter.Header
 
+/-!
+# The copyright linter
+
+This file implements a linter that checks that every file in the project
+has the correct copyright header.
+-/
+
 open Lean Elab Meta Command Syntax
 
 namespace CopyrightLinter


### PR DESCRIPTION
Add a module docstring to `FormalConjectures.Util.Linters.CopyrightLinter`.