### PR TITLE
feat: add module docstring to ForMathlib

### DIFF
--- a/FormalConjectures/Util/ForMathlib.lean
+++ b/FormalConjectures/Util/ForMathlib.lean
@@ -13,12 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
+import FormalConjecturesForMathlib
+
 /-!
 # ForMathlib (deprecated)
 
 This module is deprecated since 2026-01-08. Use `FormalConjecturesForMathlib` directly.
 -/
-
-import FormalConjecturesForMathlib
 
 deprecated_module (since := "2026-01-08")


### PR DESCRIPTION
Add a module docstring to `FormalConjectures.Util.ForMathlib`.