### PR TITLE
fix: only replace dots outside guillemets

### DIFF
--- a/site/build.js
+++ b/site/build.js
@@ -111,10 +111,17 @@ const GITHUB_BASE = 'https://github.com/google-deepmind/formal-conjectures/blob/
 // ---------------------------------------------------------------------------
 
 /** Convert a module name to a GitHub file URL. */
+function moduleToGitHubPath(module) {
+  // Replace periods with slashes outside guillemets
+  const withSlashes = module.replace(/«[^»]*»|\./g, (match) =>
+    match[0] === '«' ? match : '/'
+  );
+  // and then strip Lean «guillemets» used to quote numeric/special segments
+  const clean = withSlashes.replace(/[«»]/g, '');
+  return `${clean}.lean`;
+}
 function moduleToGitHubURL(module) {
-  // Strip Lean «guillemets» used to quote numeric/special segments
-  const clean = module.replace(/[«»]/g, '');
-  return `${GITHUB_BASE}/${clean.replace(/\./g, '/')}.lean`;
+  return `${GITHUB_BASE}/${moduleToGitHubPath(module)}`;
 }
 
 /** Extract the source collection from a module name. */
@@ -155,6 +162,7 @@ function processEntry(entry) {
     ...entry,
     theorem,
     module,
+    githubPath: moduleToGitHubPath(entry.module),
     githubUrl: moduleToGitHubURL(entry.module),
     collection: collection.name,
     collectionUrl: collection.url,

--- a/site/src/js/theorem.js
+++ b/site/src/js/theorem.js
@@ -130,7 +130,7 @@ function renderDetail(theorem, siblings) {
       <div class="detail-label">View source</div>
       <div class="detail-value">
         <a href="${FC.escapeHTML(theorem.githubUrl)}" target="_blank" rel="noopener">
-          ${FC.escapeHTML(theorem.module.replace(/\./g, '/'))}.lean on GitHub ↗
+          ${FC.escapeHTML(theorem.githubPath)} on GitHub ↗
         </a>
       </div>
     </div>


### PR DESCRIPTION
ATM, the GitHub URL in pages like https://google-deepmind.github.io/formal-conjectures/theorem/?name=Arxiv.0911.2077.arxiv.id0911_2077.conjecture6_3 is broken. The site script just assumes all the dots need to be replaced in slashes, but in this case the folder is actually called `0911.2077`.

I think this should fix the issue both in the displayed link text and the link target itself. I did split the function into two to be a bit more DRY.

(To be upfront about LLM usage, I asked AI to write the regex, so that's lines 116-118. Everything else by hand. The CLA should be signed under the username `vEnhance`.)