### PR TITLE
fix(ErdosProblems): 277 

### DIFF
--- a/FormalConjectures/ErdosProblems/277.lean
+++ b/FormalConjectures/ErdosProblems/277.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
   53--61.
 -/
 
-open ArithmeticFunction
+open scoped ArithmeticFunction.sigma
 
 namespace Erdos277
 
@@ -37,10 +37,8 @@ This was answered affirmatively by Haight [Ha79].
 -/
 @[category research solved, AMS 11]
 theorem erdos_277 :
-   answer(True) ↔ ∀ c : ℝ, ∃ n : ℕ, (sigma 1 n : ℝ) > c * n ∧
-      ¬ ∃ (S : Finset (ℤ × ℕ)),
-      (∀ z : ℤ, ∃ s ∈ S, z ≡ s.1 [ZMOD s.2]) ∧
-      (∀ s ∈ S, s.2 ∣ n ∧ 1 < s.2) := by
+   answer(True) ↔ ∀ c : ℝ, ∃ n : ℕ, (σ 1 n : ℝ) > c * n ∧
+      ∀ (m : StrictCoveringSystem ℤ), ∃ i, (n : ℤ) ∉ m.moduli i  := by
   sorry
 
 end Erdos277

--- a/FormalConjecturesForMathlib/NumberTheory/CoveringSystem.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/CoveringSystem.lean
@@ -34,7 +34,8 @@ structure CoveringSystem (R : Type*) [CommSemiring R] where
   residue : ι → R
   moduli : ι → Ideal R
   unionCovers : ⋃ i, ({residue i} : Set R) + (moduli i : Set R) = @Set.univ R
-  non_trivial : ∀ i, moduli i ≠ ⊥
+  ne_bot : ∀ i, moduli i ≠ ⊥
+  ne_top : ∀ i, moduli i ≠ ⊤
 
 /--
 We say a covering system is strict if all the congruence relations that define it are take modulo


### PR DESCRIPTION
- Previous formulation of `erdos_277` was missing the (often implicit) assumption that the moduli must all be distinct, as given in the strictly monotone condition in the [solution paper](https://www.cambridge.org/core/journals/mathematika/article/abs/covering-systems-of-congruences-a-negative-result/1428418132CBD5B6E87BAFE8A5B42640)
- Use `StrictCoveringSystem` from `ForMathlib` to cover this missing assumption
- `CoveringSystem` in `ForMathlib` itself was missing an additional non-triviality condition, that none of the moduli must be `1` (otherwise one gets the original ring as a trivial covering system)
- push negation through `erdos_277` to make it slightly nicer