### PR TITLE
fix(GreenOpenProblems): 16

### DIFF
--- a/FormalConjectures/GreensOpenProblems/16.lean
+++ b/FormalConjectures/GreensOpenProblems/16.lean
@@ -38,14 +38,14 @@ def SolutionFree (A : Finset ℕ) : Prop :=
 
 /-- The maximum size of a solution-free subset of $[N]$. -/
 noncomputable def f (N : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ SolutionFree A ∧ A.card = k}
+  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Icc 1 N ∧ SolutionFree A ∧ A.card = k}
 
 /-- What is the largest subset of $[N]$ with no solution to $x + 3y = 2z + 2w$ in distinct integers $x, y, z, w$? -/
 @[category research open, AMS 5 11]
 theorem green_16 (N : ℕ) :
-    ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ SolutionFree A ∧
+    ∃ A : Finset ℕ, A ⊆ Icc 1 N ∧ SolutionFree A ∧
       A.card = answer(sorry) ∧
-      MaximalFor (fun B => B ⊆ range (N + 1) ∧ SolutionFree B) Finset.card A := by
+      MaximalFor (fun B => B ⊆ Icc 1 N ∧ SolutionFree B) Finset.card A := by
   sorry
 
 /-- From [Ruzsa] $f(N) \gg N^{1/2}$. -/
@@ -69,18 +69,18 @@ theorem green_16_conjectured_lower_bound :
 /-- A set has no nontrivial solution to $x + 2y + 3z = x' + 2y' + 3z'$. -/
 def ZhaoSolutionFree (A : Finset ℕ) : Prop :=
   ∀ x y z x' y' z', x ∈ A → y ∈ A → z ∈ A → x' ∈ A → y' ∈ A → z' ∈ A →
-    x + 2 * y + 3 * z = x' + 2 * y' + 3 * z' →
-    x = x' ∧ y = y' ∧ z = z'
+    [x, y, z, x', y', z'].Nodup →
+    x + 2 * y + 3 * z ≠ x' + 2 * y' + 3 * z'
 
 /-- The maximum size of a Zhao-solution-free subset of $[N]$. -/
 noncomputable def g (N : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ ZhaoSolutionFree A ∧ A.card = k}
+  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Icc 1 N ∧ ZhaoSolutionFree A ∧ A.card = k}
 
 /-- From [Yufei Zhao]: Is there a subset of $\{1, \ldots, N\}$ of size
 $N^{1/3 - o(1)}$ with no nontrivial solutions to $x + 2y + 3z = x' + 2y' + 3z'$? -/
 @[category research open, AMS 5 11]
 theorem zhao_question :
-    ∃ h : ℕ → ℝ, Tendsto h atTop (𝓝 0) ∧ ∀ᶠ N in atTop, (g N : ℝ) ≥ (N : ℝ) ^ (1 / 3 - h N) := by
+    ¬∃ h : ℕ → ℝ, Tendsto h atTop (𝓝 0) ∧ ∀ᶠ N in atTop, (g N : ℝ) ≥ (N : ℝ) ^ (1 / 3 - h N) := by
   sorry
 
 end Green16


### PR DESCRIPTION
- Use `Icc` instead of `range`, since notation $[N]$ is for $\{1, \dots, N\}$. In this case, the inclusion of `0` would change likely change whether `A` is solution free or not, as it changes the equation to something else.
- Fix `ZhaoSolutionFree`, it now matches `SolutionFree`. In particular, AlphaProof showed that the prior formalisation was contradictory for any set of size $> 1$, because one can take any two $x\neq y$ in the set and use $(x, x, y)$ for the LHS and $(y, y, x)$ for the RHS. 