### PR TITLE
Mark erdos_686.variants.four_three as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -80,7 +80,7 @@ The number $4$ cannot be written as
 $$4=\frac{\prod_{1\leq i\leq 2}(m+i)}{\prod_{1\leq i\leq 2}(n+i)}$$
 for $m≥n+2$!
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11]
 theorem erdos_686.variants.four_three :
     ¬ ∃ᵉ (n : ℕ) (m ≥ n + 3),
       (4 : ℚ) = (∏ i ∈ Finset.Icc 1 3, (m + i)) / (∏ i ∈ Finset.Icc 1 3, (n + i)) := by

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -79,6 +79,8 @@ theorem erdos_686.variants.four_two :
 The number $4$ cannot be written as
 $$4=\frac{\prod_{1\leq i\leq 2}(m+i)}{\prod_{1\leq i\leq 2}(n+i)}$$
 for $m≥n+2$!
+
+See [comment section on erdosproblems.com](https://www.erdosproblems.com/forum/thread/686#post-4599)
 -/
 @[category research solved, AMS 11]
 theorem erdos_686.variants.four_three :


### PR DESCRIPTION
Updates the category attribute from open to solved. 

Based on recent discussion N=4 is not representable for k=3.

Reference: https://www.erdosproblems.com/forum/thread/686#post-4599.
