### PR TITLE
feat(website): send less bytes

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Generate conjectures data for website
         run: |
           mkdir -p site/data
-          lake exe extract_names > site/data/conjectures.json || true
+          lake exe extract_names --exclude=statement,docstring,formalProofKind,formalProofLink,moduleDocstrings > site/data/conjectures.json || true
 
       - name: Extract Verso fragments for website
         run: |

--- a/site/build.js
+++ b/site/build.js
@@ -175,8 +175,13 @@ function processEntry(entry) {
     code,
     name: AMS_SUBJECTS[parseInt(code, 10)] || `AMS ${code}`,
   }));
+  // Pick only the fields the website actually uses. Avoids leaking large
+  // unused fields (statement, docstring, formalProofKind, formalProofLink)
+  // into the client-side JSON. Docstrings come from versoFragments instead.
   return {
-    ...entry,
+    theorem: entry.theorem,
+    module: entry.module,
+    category: entry.category,
     displayTheorem: entry.theorem.replace(/[«»]/g, ''),
     displayModule: entry.module.replace(/[«»]/g, ''),
     githubPath: moduleToGitHubPath(entry.module),


### PR DESCRIPTION
This decreases what is sent in the main .json file: we just exclude stuff that is never displayed.

Raw:    3,595,952 -> 2,856,342  saved 739,610 bytes (20.6%)
Gzip:   523,520 -> 329,005  saved 194,515 bytes (37.2%)
(only approximate, not entirely sure what Gzip settings Github uses (and
why they don't use brotli...)