### PR TITLE
fix: simplify mirror files to import-only

### DIFF
--- a/FormalConjectures/ErdosProblems/1135.lean
+++ b/FormalConjectures/ErdosProblems/1135.lean
@@ -13,24 +13,32 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
+
 import FormalConjectures.Wikipedia.CollatzConjecture
 
 /-!
 # Erdős Problem 1135
 
+The Collatz conjecture states that for any positive integer $n$, there exists a natural
+number $m$ such that the $m$-th term of the sequence is 1.
+
 *References:*
-* [erdosproblems.com/1135](__https://www.erdosproblems.com/1135__)
-* [Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.
-* [La10] Lagarias, Jeffrey C., The {$3x+1$} problem: an overview. (2010), 3--29.
-* [La16] Lagarias, Jeffrey C., Erd\H os, {K}larner, and the {$3x+1$} problem. Amer. Math. Monthly (2016), 753--776.
-* [La85] Lagarias, Jeffrey C., The {$3x+1$} problem and its generalizations. Amer. Math. Monthly (1985), 3--23.
+- [erdosproblems.com/1135](https://www.erdosproblems.com/1135)
+- [Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.
+- [La10] Lagarias, Jeffrey C., The {$3x+1$} problem: an overview. (2010), 3--29.
+- [La16] Lagarias, Jeffrey C., Erdős, Klarner, and the {$3x+1$} problem. Amer. Math. Monthly
+  (2016), 753--776.
+- [La85] Lagarias, Jeffrey C., The {$3x+1$} problem and its generalizations. Amer. Math. Monthly
+  (1985), 3--23.
+
+This file points to the canonical formalization in
+`FormalConjectures.Wikipedia.CollatzConjecture`.
 -/
 
 namespace Erdos1135
 
-/-The **Collatz conjecture** states that for any positive integer $n$, there exists a natural
-number $m$ such that the $m$-th term of the sequence is 1.
--/
+/-- The Collatz conjecture states that for any positive integer $n$, there exists a natural
+number $m$ such that the $m$-th term of the sequence is 1. -/
 @[category research open, AMS 11 37]
 theorem erdos_1135 : type_of% CollatzConjecture.collatz_conjecture := by sorry
 

--- a/FormalConjectures/ErdosProblems/20.lean
+++ b/FormalConjectures/ErdosProblems/20.lean
@@ -19,7 +19,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 20
 
-*Reference:* [erdosproblems.com/20](https://www.erdosproblems.com/20)
+*References:*
+* [erdosproblems.com/20](https://www.erdosproblems.com/20)
+* [Wikipedia](https://en.wikipedia.org/wiki/Sunflower_(mathematics))
 -/
 universe u
 

--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -20,8 +20,12 @@ import FormalConjectures.Util.ProblemImports
 # Erdős Problem 274
 
 *References:*
-[erdosproblems.com/274](https://www.erdosproblems.com/274)
-[Wikipedia](https://en.wikipedia.org/wiki/Herzog%E2%80%93Sch%C3%B6nheim_conjecture)
+* [erdosproblems.com/274](https://www.erdosproblems.com/274)
+* [Wikipedia](https://en.wikipedia.org/wiki/Herzog%E2%80%93Sch%C3%B6nheim_conjecture)
+* [arXiv:1803.08301](https://arxiv.org/abs/1803.08301)
+* [arXiv:1803.03569](https://arxiv.org/abs/1803.03569)
+* [PMC7247885](https://pmc.ncbi.nlm.nih.gov/articles/PMC7247885/)
+* [arXiv:1804.11103](https://arxiv.org/abs/1804.11103)
 -/
 
 open scoped Pointwise Cardinal

--- a/FormalConjectures/ErdosProblems/341.lean
+++ b/FormalConjectures/ErdosProblems/341.lean
@@ -18,7 +18,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 341
 
-*Reference:* [erdosproblems.com/341](https://www.erdosproblems.com/341)
+*References:*
+* [erdosproblems.com/341](https://www.erdosproblems.com/341)
+* [Ben Green's Open Problem 7](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.1)
 -/
 
 open Nat Set Filter

--- a/FormalConjectures/ErdosProblems/510.lean
+++ b/FormalConjectures/ErdosProblems/510.lean
@@ -20,6 +20,7 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/510](https://www.erdosproblems.com/510)
+- [Ben Green's Open Problem 81](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.11)
 - [Ru04] Ruzsa, Imre Z., Negative values of cosine sums. Acta Arith. (2004), 179-186.
 - [Be25c] B. Bedert, Polynomial bounds for the Chowla Cosine Problem. arXiv:2509.05260 (2025).
 -/

--- a/FormalConjectures/ErdosProblems/689.lean
+++ b/FormalConjectures/ErdosProblems/689.lean
@@ -18,7 +18,9 @@ import FormalConjectures.Util.ProblemImports
 
 /-!
 # Erdős Problem 689
-*Reference:* [erdosproblems.com/689](https://www.erdosproblems.com/689)
+*References:*
+* [erdosproblems.com/689](https://www.erdosproblems.com/689)
+* [Ben Green's Open Problem 45](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.45)
 -/
 
 namespace Erdos689

--- a/FormalConjectures/GreensOpenProblems/45.lean
+++ b/FormalConjectures/GreensOpenProblems/45.lean
@@ -14,24 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
 import FormalConjectures.ErdosProblems.«689»
 
 /-!
 # Ben Green's Open Problem 45
 
-Can we pick residue classes $a_p(mod p)$, one for each prime `p ⩽ N`,
-such that every integer `⩽ N` lies in at least 10 of them?
+Can we pick residue classes $a_p \pmod{p}$, one for each prime $p \leq N$,
+such that every integer $\leq N$ lies in at least 10 of them?
 
 *References:*
 - [Ben Green's Open Problem 45](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.45)
 - [erdosproblems.com/689](https://www.erdosproblems.com/689)
+
+This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«689»`.
 -/
-
-namespace Green45
-
-@[category research open, AMS 11]
-theorem green_45 : type_of% Erdos689.erdos_689 := by
-  sorry
-
-end Green45

--- a/FormalConjectures/GreensOpenProblems/63.lean
+++ b/FormalConjectures/GreensOpenProblems/63.lean
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
-import FormalConjectures.Util.ProblemImports
+
 import FormalConjectures.ErdosProblems.«424»
 
 /-!
@@ -22,15 +22,9 @@ import FormalConjectures.ErdosProblems.«424»
 Let $A$ be the smallest set containing $2$ and $3$ and such that $a_1a_2 - 1 \in A$
 if $a_1, a_2 \in A$. Does $A$ have positive density?
 
-*Reference:*
- - [Ben Green's Open Problem 63](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.8 Problem 63)
- - [erdosproblems.com/424](https://www.erdosproblems.com/424)
+*References:*
+- [Ben Green's Open Problem 63](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.8)
+- [erdosproblems.com/424](https://www.erdosproblems.com/424)
+
+This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«424»`.
 -/
-
-namespace Green63
-
-@[category research open, AMS 11]
-theorem green_63 : type_of% Erdos424.erdos_424 := by
-  sorry
-
-end Green63

--- a/FormalConjectures/GreensOpenProblems/7.lean
+++ b/FormalConjectures/GreensOpenProblems/7.lean
@@ -14,23 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
 import FormalConjectures.ErdosProblems.«341»
 
 /-!
 # Ben Green's Open Problem 7
 
 *References:*
- - [Ben Green's Open Problem 81](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.1 Problem 7)
- - [erdosproblems.com/341](https://www.erdosproblems.com/341)
+- [Ben Green's Open Problem 7](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.1)
+- [erdosproblems.com/341](https://www.erdosproblems.com/341)
+
+This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«341»`.
 -/
-
-namespace Green7
-
--- TODO: Add Green's Open Problem 7
-
-@[category research open, AMS 11]
-theorem green_7.variants.queneau : type_of% Erdos341.erdos_341 := by
-  sorry
-
-end Green7

--- a/FormalConjectures/GreensOpenProblems/81.lean
+++ b/FormalConjectures/GreensOpenProblems/81.lean
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
-import FormalConjectures.Util.ProblemImports
+
 import FormalConjectures.ErdosProblems.«510»
 
 /-!
@@ -23,14 +23,8 @@ Let $A$ be a set of size $n$ integers. Is there some absolute constant $c > 0$ a
 such that $\sum_{a \in A} \cos(a \theta) \leq - c \sqrt{n}$?
 
 *References:*
- - [Ben Green's Open Problem 81](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.11 Problem 81)
- - [erdosproblems.com/510](https://www.erdosproblems.com/510)
+- [Ben Green's Open Problem 81](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.11)
+- [erdosproblems.com/510](https://www.erdosproblems.com/510)
+
+This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«510»`.
 -/
-
-namespace Green81
-
-@[category research open, AMS 11]
-theorem green_81 : type_of% Erdos510.erdos_510 := by
-  sorry
-
-end Green81

--- a/FormalConjectures/Wikipedia/BrocardProblem.lean
+++ b/FormalConjectures/Wikipedia/BrocardProblem.lean
@@ -26,15 +26,3 @@ $n = 4, 5, 7$.
 
 This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«398»`.
 -/
-
-namespace BrocardProblem
-
-/--
-This Wikipedia entry points to the canonical formalization of Brocard's problem
-in `FormalConjectures.ErdosProblems.«398»`.
--/
-@[category research open, AMS 11]
-theorem brocard_problem : type_of% @Erdos398.erdos_398 := by
-  sorry
-
-end BrocardProblem

--- a/FormalConjectures/Wikipedia/CollatzConjecture.lean
+++ b/FormalConjectures/Wikipedia/CollatzConjecture.lean
@@ -19,7 +19,15 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Collatz conjecture
 
-*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Collatz_conjecture)
+*References:*
+* [Wikipedia](https://en.wikipedia.org/wiki/Collatz_conjecture)
+* [erdosproblems.com/1135](https://www.erdosproblems.com/1135)
+* [Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.
+* [La10] Lagarias, Jeffrey C., The {$3x+1$} problem: an overview. (2010), 3--29.
+* [La16] Lagarias, Jeffrey C., Erdős, Klarner, and the {$3x+1$} problem. Amer. Math. Monthly
+  (2016), 753--776.
+* [La85] Lagarias, Jeffrey C., The {$3x+1$} problem and its generalizations. Amer. Math. Monthly
+  (1985), 3--23.
 -/
 
 namespace CollatzConjecture

--- a/FormalConjectures/Wikipedia/ErdosRadoSunflowerConjecture.lean
+++ b/FormalConjectures/Wikipedia/ErdosRadoSunflowerConjecture.lean
@@ -14,26 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
 import FormalConjectures.ErdosProblems.«20»
 
 /-!
 # Erdős–Rado sunflower conjecture
 
 This file is a Wikipedia-facing entry point for the formalization in
-`FormalConjectures/ErdosProblems/20.lean`.
+`FormalConjectures.ErdosProblems.«20»`.
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Sunflower_(mathematics))
 -/
-
-namespace ErdosRadoSunflowerConjecture
-
-/--
-This Wikipedia entry points to the canonical formalization of the Erdős-Rado sunflower
-conjecture in `FormalConjectures.ErdosProblems.«20»`.
--/
-@[category research open, AMS 05]
-theorem erdos_rado_sunflower_conjecture : type_of% @Erdos20.erdos_20 := by
-  sorry
-
-end ErdosRadoSunflowerConjecture

--- a/FormalConjectures/Wikipedia/HadwigerNelson.lean
+++ b/FormalConjectures/Wikipedia/HadwigerNelson.lean
@@ -27,15 +27,3 @@ the same color.
 
 This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«508»`.
 -/
-
-namespace HadwigerNelson
-
-/--
-This Wikipedia entry points to the canonical formalization of the
-Hadwiger-Nelson problem in `FormalConjectures.ErdosProblems.«508»`.
--/
-@[category research open, AMS 52]
-theorem hadwiger_nelson_problem : type_of% @Erdos508.HadwigerNelsonProblem := by
-  sorry
-
-end HadwigerNelson

--- a/FormalConjectures/Wikipedia/HappyEndingProblem.lean
+++ b/FormalConjectures/Wikipedia/HappyEndingProblem.lean
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
 import FormalConjectures.ErdosProblems.«107»
 
 /-!
@@ -28,15 +27,3 @@ contain $n$ that form a convex polygon.
 
 This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«107»`.
 -/
-
-namespace HappyEndingProblem
-
-/--
-This Wikipedia entry points to the canonical formalization of the happy ending
-problem in `FormalConjectures.ErdosProblems.«107»`.
--/
-@[category research open, AMS 52]
-theorem happy_ending_problem : type_of% @Erdos107.erdos_107 := by
-  sorry
-
-end HappyEndingProblem

--- a/FormalConjectures/Wikipedia/HerzogSchonheimConjecture.lean
+++ b/FormalConjectures/Wikipedia/HerzogSchonheimConjecture.lean
@@ -19,7 +19,7 @@ import FormalConjectures.ErdosProblems.«274»
 /-!
 # Herzog–Schönheim conjecture
 
-The actual formalization is in `FormalConjectures.ErdosProblems.«274»`.
+This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«274»`.
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Herzog%E2%80%93Sch%C3%B6nheim_conjecture)
@@ -28,11 +28,3 @@ The actual formalization is in `FormalConjectures.ErdosProblems.«274»`.
 - [PMC7247885](https://pmc.ncbi.nlm.nih.gov/articles/PMC7247885/)
 - [arXiv:1804.11103](https://arxiv.org/abs/1804.11103)
 -/
-
-namespace HerzogSchonheimConjecture
-
-@[category research open, AMS 20]
-theorem herzog_schonheim_conjecture : type_of% @Erdos274.herzog_schonheim := by 
-  sorry
-
-end HerzogSchonheimConjecture

--- a/FormalConjectures/Wikipedia/MinimalOverlapProblem.lean
+++ b/FormalConjectures/Wikipedia/MinimalOverlapProblem.lean
@@ -28,15 +28,3 @@ $a \in A$, $b \in B$, divided by $n$.
 
 This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«36»`.
 -/
-
-namespace MinimalOverlapProblem
-
-/--
-This Wikipedia entry points to the canonical formalization of the minimum overlap
-problem in `FormalConjectures.ErdosProblems.«36»`.
--/
-@[category research open, AMS 5 11]
-theorem minimum_overlap_problem : type_of% @Erdos36.erdos_36 := by
-  sorry
-
-end MinimalOverlapProblem

--- a/FormalConjectures/Wikipedia/NoThreeInLineProblem.lean
+++ b/FormalConjectures/Wikipedia/NoThreeInLineProblem.lean
@@ -14,26 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
 import FormalConjectures.GreensOpenProblems.«72»
 
 /-!
 # No-three-in-line problem
 
 This file is a Wikipedia-facing entry point for the formalization in
-`FormalConjectures/GreensOpenProblems/72.lean`.
+`FormalConjectures.GreensOpenProblems.«72»`.
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/No-three-in-line_problem)
 -/
-
-namespace NoThreeInLineProblem
-
-/--
-This Wikipedia entry points to the canonical formalization of the no-three-in-line problem in
-`FormalConjectures.GreensOpenProblems.«72»`.
--/
-@[category research open, AMS 05 52]
-theorem no_three_in_line_problem : type_of% @Green72.no_three_in_line := by
-  sorry
-
-end NoThreeInLineProblem


### PR DESCRIPTION
Remove duplicate `type_of%` theorems from mirror files, keeping only the import and module docstring. Move references from mirror files to their canonical imports so no links are lost.