### PR TITLE
fix(Answer): restore strict type-checking for answer() in alwaysTrue …

### DIFF
--- a/FormalConjectures/Util/Answer.lean
+++ b/FormalConjectures/Util/Answer.lean
@@ -103,7 +103,7 @@ def answerElab : TermElab := fun stx expectedType? => do
       if expectedType? == some (Expr.sort .zero) && a == (← `(term| sorry)) then
         return .const `True []
       else
-        elabTermAndAnnotate a expectedType?
+        elabTermAndAnnotate a expectedType? true
   | _ => Elab.throwUnsupportedSyntax
 
 -- TODO: add delaborator (for the auxiliary declaration mode!)


### PR DESCRIPTION
…mode

The refactoring of `answerElab` to support AnswerSetting modes inadvertently changed the `alwaysTrue` non-`sorry` path from `postponeElabTerm (strict)` to `elabTerm (permissive)`.
This caused `answer(wrong_type)` to silently succeed instead of producing a type mismatch error.

Pass postpone := true to elabTermAndAnnotate to restore the original behavior.