### PR TITLE
fix(ErdosProblems): 197

### DIFF
--- a/FormalConjectures/ErdosProblems/197.lean
+++ b/FormalConjectures/ErdosProblems/197.lean
@@ -37,6 +37,4 @@ theorem erdos_197 :
       (∃ g : ℕ ≃ B, ¬HasMonotoneAP (Subtype.val ∘ g) 3) := by
   sorry
 
-
-
 end Erdos197

--- a/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
@@ -241,8 +241,9 @@ def ContainsMonoAPofLength {κ : Type} [Finite κ] {M : Set α}
     ∀ m ∈ ap, coloring m = c
 
 /--
-A function `f : α → β` has a monotone `k`-term arithmetic progression if there exists an
-arithmetic progression `l` of length `k` in `α` such that its image under `f` is sorted.
+A function `f : β → α` has a monotone `k`-term arithmetic progression if there exists a choice
+of indices `b 1 < b 2 < ... < b k` such that the subsequence `f (b i)` forms an increasing or
+decreasing arithmetic progression of length `k`.
 -/
 def HasMonotoneAP {β : Type*} [Preorder β] (f : β → α) (k : ℕ) : Prop :=
   ∃ l : List β, (l.map f).IsAPOfLength k ∧ l.Pairwise (· < ·)


### PR DESCRIPTION
- The previous definition of `HasMonotoneAP` was correct but had a slightly unnatural ordering of types in the formalisation, with `f` being a map from the value type of the sequence to the index type.
- This led to a misformalisation in `erdos_197` where the permutations are maps from index type to value type.
- Rather than use `f.symm` in `erdos_197`, reverse ordering within `HasMonotoneAP` so that it is more natural.