### PR TITLE
Prove 4 Sidon set theorems (Erdős 42, 44)

### DIFF
--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -65,14 +65,21 @@ The set `{1, 2, 4}` is a maximal Sidon set in `{1, ..., 4}`.
 -/
 @[category undergraduate, AMS 5 11]
 theorem example_maximal_sidon : IsMaximalSidonSetIn {1, 2, 4} 4 := by
-  sorry
+  refine ⟨?_, ?_, ?_⟩
+  · intro x hx; simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx; rcases hx with rfl | rfl | rfl <;> simp [Set.mem_Icc] <;> omega
+  · intro i₁ hi₁ j₁ hj₁ i₂ hi₂ j₂ hj₂ hsum; simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hi₁ hj₁ hi₂ hj₂; rcases hi₁ with rfl | rfl | rfl <;> rcases hj₁ with rfl | rfl | rfl <;> rcases hi₂ with rfl | rfl | rfl <;> rcases hj₂ with rfl | rfl | rfl <;> simp_all <;> omega
+  · intro x hx hxA; simp only [Set.mem_Icc] at hx; obtain ⟨hx1, hx2⟩ := hx; simp only [Set.mem_insert_iff, Set.mem_singleton_iff, not_or] at hxA; obtain ⟨hne1, hne2, hne4⟩ := hxA; have hx3 : x = 3 := (by omega); subst hx3; intro hbad; have := hbad 1 (by simp) 2 (by simp) 3 (by simp) 2 (by simp) (by norm_num); rcases this with ⟨h1, h2⟩ | ⟨h1, h2⟩ <;> omega
 
 /--
 The difference set of `{1, 2, 4}` is `{0, 1, 2, 3}`.
 -/
 @[category undergraduate, AMS 5 11]
 theorem example_difference_set : ({1, 2, 4} : Set ℕ) - {1, 2, 4} = {0, 1, 2, 3} := by
-  sorry
+  ext x
+  simp only [Set.mem_sub, Set.mem_insert_iff, Set.mem_singleton_iff]
+  constructor
+  · rintro ⟨a, ha, b, hb, rfl⟩; rcases ha with rfl | rfl | rfl <;> rcases hb with rfl | rfl | rfl <;> simp <;> omega
+  · rintro (rfl | rfl | rfl | rfl); exacts [⟨1, by decide, 1, by decide, by decide⟩, ⟨2, by decide, 1, by decide, by decide⟩, ⟨4, by decide, 2, by decide, by decide⟩, ⟨4, by decide, 1, by decide, by decide⟩]
 
 /--
 For any maximal Sidon set, the difference set contains 0.
@@ -80,6 +87,11 @@ For any maximal Sidon set, the difference set contains 0.
 @[category undergraduate, AMS 5 11]
 theorem maximal_sidon_contains_zero (A : Set ℕ) (N : ℕ) (hN : 1 ≤ N)
     (hA : IsMaximalSidonSetIn A N) : 0 ∈ A - A := by
-  sorry
+  obtain ⟨hAsub, hAsidon, hAmax⟩ := hA
+  have hne : A.Nonempty
+  · by_contra hemp; rw [Set.not_nonempty_iff_eq_empty] at hemp; exact hAmax (Set.mem_Icc.mpr ⟨le_refl 1, hN⟩) (by rw [hemp]; exact id) (by rw [hemp, Set.empty_union]; exact fun _ hi _ hj _ hk _ hl _ => by simp only [Set.mem_singleton_iff] at hi hj hk hl; subst hi; subst hj; subst hk; subst hl; exact Or.inl ⟨rfl, rfl⟩)
+  obtain ⟨a, ha⟩ := hne
+  have := Set.sub_mem_sub ha ha
+  rwa [Nat.sub_self] at this
 
 end Erdos42

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -62,7 +62,9 @@ The set `{1, 2, 4, 8, 13}` is a Sidon set in `{1, ..., 13}`.
 -/
 @[category undergraduate, AMS 5 11]
 theorem example_sidon_set : IsSidon ({1, 2, 4, 8, 13} : Set ℕ) := by
-  sorry
+  intro i₁ hi₁ j₁ hj₁ i₂ hi₂ j₂ hj₂ hsum
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hi₁ hj₁ hi₂ hj₂
+  rcases hi₁ with rfl | rfl | rfl | rfl | rfl <;> rcases hj₁ with rfl | rfl | rfl | rfl | rfl <;> rcases hi₂ with rfl | rfl | rfl | rfl | rfl <;> rcases hj₂ with rfl | rfl | rfl | rfl | rfl <;> simp_all <;> omega
 
 /--
 For any `N`, there exists a Sidon set of size at least `√N/2`.


### PR DESCRIPTION
## Summary
- Prove `example_maximal_sidon`: `{1, 2, 4}` is maximal Sidon in `{1, ..., 4}` via case analysis
- Prove `example_difference_set`: difference set of `{1, 2, 4}` is `{0, 1, 2, 3}` via Set.sub extensionality
- Prove `maximal_sidon_contains_zero`: any maximal Sidon set has `0 ∈ A - A` via nonemptiness
- Prove `example_sidon_set` (44): `{1, 2, 4, 8, 13}` is Sidon via exhaustive case bash + omega

## Notes
- AI-assisted (Claude for tactic search), manually reviewed and submitted
- Techniques: case analysis on finite set membership, omega for arithmetic