### PR TITLE
Prove sum-distinct bound (Erdős 1) and factorial practicality (Erdős 18)

### DIFF
--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -53,7 +53,27 @@ The trivial lower bound is $N \gg 2^n / n$.
 @[category undergraduate, AMS 5 11]
 theorem erdos_1.variants.weaker : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ)
     (_ : IsSumDistinctSet A N), N ≠ 0 → C * 2 ^ A.card / A.card < N := by
-  sorry
+  refine ⟨1/3, by norm_num, ?_⟩
+  intro N A hA hN
+  obtain ⟨hA1, hA2⟩ := hA
+  have key : 2 ^ A.card ≤ A.card * N + 1
+  rw [← Finset.card_powerset A]
+  have h1 : (A.powerset.image (fun S => S.sum id)).card = A.powerset.card
+  refine Finset.card_image_of_injOn ?_
+  intro a ha b hb hab; have h := @hA2 ⟨a, ha⟩ ⟨b, hb⟩; simp at h; exact h hab
+  have h2 : A.powerset.image (fun S => S.sum id) ⊆ Finset.range (A.card * N + 1)
+  intro x; simp only [Finset.mem_image, Finset.mem_range]; rintro ⟨S, hS, rfl⟩
+  exact Nat.lt_add_one_of_le (le_trans (Finset.sum_le_card_nsmul S id N (fun i hi => (Finset.mem_Icc.mp (hA1 (Finset.mem_powerset.mp hS hi))).2)) (Nat.mul_le_mul_right N (Finset.card_le_card (Finset.mem_powerset.mp hS))))
+  rw [← h1]; exact le_trans (Finset.card_le_card h2) (by simp [Finset.card_range])
+  have key_r : (2 : ℝ) ^ A.card ≤ ↑A.card * ↑N + 1 := by exact_mod_cast key
+  have hN_pos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hN)
+  by_cases hc : A.card = 0
+  simp [hc]; positivity
+  have hc_pos : (0 : ℝ) < ↑A.card := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hc)
+  field_simp
+  have h_one_le : (1 : ℝ) ≤ ↑A.card := by exact_mod_cast Nat.pos_of_ne_zero hc
+  have h_one_le_n : (1 : ℝ) ≤ ↑N := by exact_mod_cast Nat.pos_of_ne_zero hN
+  nlinarith
 
 /--
 Erdős and Moser [Er56] proved

--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -53,27 +53,23 @@ The trivial lower bound is $N \gg 2^n / n$.
 @[category undergraduate, AMS 5 11]
 theorem erdos_1.variants.weaker : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ)
     (_ : IsSumDistinctSet A N), N ≠ 0 → C * 2 ^ A.card / A.card < N := by
-  refine ⟨1/3, by norm_num, ?_⟩
-  intro N A hA hN
-  obtain ⟨hA1, hA2⟩ := hA
-  have key : 2 ^ A.card ≤ A.card * N + 1
-  rw [← Finset.card_powerset A]
-  have h1 : (A.powerset.image (fun S => S.sum id)).card = A.powerset.card
-  refine Finset.card_image_of_injOn ?_
-  intro a ha b hb hab; have h := @hA2 ⟨a, ha⟩ ⟨b, hb⟩; simp at h; exact h hab
-  have h2 : A.powerset.image (fun S => S.sum id) ⊆ Finset.range (A.card * N + 1)
-  intro x; simp only [Finset.mem_image, Finset.mem_range]; rintro ⟨S, hS, rfl⟩
-  exact Nat.lt_add_one_of_le (le_trans (Finset.sum_le_card_nsmul S id N (fun i hi => (Finset.mem_Icc.mp (hA1 (Finset.mem_powerset.mp hS hi))).2)) (Nat.mul_le_mul_right N (Finset.card_le_card (Finset.mem_powerset.mp hS))))
-  rw [← h1]; exact le_trans (Finset.card_le_card h2) (by simp [Finset.card_range])
-  have key_r : (2 : ℝ) ^ A.card ≤ ↑A.card * ↑N + 1 := by exact_mod_cast key
-  have hN_pos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hN)
-  by_cases hc : A.card = 0
-  simp [hc]; positivity
-  have hc_pos : (0 : ℝ) < ↑A.card := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hc)
-  field_simp
-  have h_one_le : (1 : ℝ) ≤ ↑A.card := by exact_mod_cast Nat.pos_of_ne_zero hc
-  have h_one_le_n : (1 : ℝ) ≤ ↑N := by exact_mod_cast Nat.pos_of_ne_zero hN
-  nlinarith
+  refine ⟨1/3, by norm_num, fun N A ⟨hA1, hA2⟩ hN => ?_⟩
+  have key : 2 ^ A.card ≤ A.card * N + 1 := by
+    rw [← Finset.card_powerset]
+    exact (Finset.card_le_card_of_injOn (Finset.sum · id)
+      (fun S hS => Finset.mem_range.mpr <| Nat.lt_add_one_of_le <|
+        (Finset.sum_le_card_nsmul S id N fun i hi =>
+          (Finset.mem_Icc.mp (hA1 (Finset.mem_powerset.mp hS hi))).2).trans
+          (Nat.mul_le_mul_right N (Finset.card_le_card (Finset.mem_powerset.mp hS))))
+      (fun a ha b hb hab => by
+        have := @hA2 ⟨a, ha⟩ ⟨b, hb⟩ hab; simp at this; exact this)).trans_eq
+      (Finset.card_range _)
+  rcases eq_or_ne A.card 0 with hc | hc
+  · simp [hc]; positivity
+  · rw [div_lt_iff₀ (Nat.cast_pos.mpr (Nat.pos_of_ne_zero hc))]
+    nlinarith [show (2 : ℝ) ^ A.card ≤ ↑A.card * ↑N + 1 from by exact_mod_cast key,
+      show (1 : ℝ) ≤ ↑A.card from by exact_mod_cast Nat.pos_of_ne_zero hc,
+      show (1 : ℝ) ≤ (N : ℝ) from by exact_mod_cast Nat.pos_of_ne_zero hN]
 
 /--
 Erdős and Moser [Er56] proved

--- a/FormalConjectures/ErdosProblems/18.lean
+++ b/FormalConjectures/ErdosProblems/18.lean
@@ -82,7 +82,37 @@ theorem practicalH_le_divisors (n : ℕ) (hn : Nat.IsPractical n) :
 /-- $h(n!)$ is well-defined since $n!$ is practical for $n ≥ 1$. -/
 @[category undergraduate, AMS 11]
 theorem factorial_isPractical (n : ℕ) : Nat.IsPractical n.factorial := by
-  sorry
+  induction n with | zero => ?_ | succ n ih => ?_
+  intro m hm; simp only [Nat.factorial_zero] at hm; interval_cases m
+  exact ⟨∅, by simp, by simp⟩
+  exact ⟨{1}, by simp, by simp⟩
+  simp only [Nat.IsPractical] at ih ⊢
+  intro m hm
+  have h_sub : n.factorial.divisors ⊆ (n + 1).factorial.divisors := Nat.divisors_subset_of_dvd (Nat.factorial_ne_zero _) (Nat.factorial_dvd_factorial (Nat.le_succ n))
+  by_cases hle : m ≤ n.factorial
+  exact subsetSums_mono (by exact_mod_cast h_sub) (ih m hle)
+  push_neg at hle
+  rw [Nat.factorial_succ] at hm
+  set q := m / (n + 1)
+  set r := m % (n + 1)
+  have h_div : m = (n + 1) * q + r := (Nat.div_add_mod m (n + 1)).symm
+  have h_r_bound : r < n + 1 := Nat.mod_lt m (Nat.succ_pos n)
+  have h_r_le : r ≤ n := by omega
+  have h_q_le : q ≤ n.factorial := Nat.div_le_of_le_mul (by linarith)
+  obtain ⟨B, hB_sub, hB_sum⟩ := ih q h_q_le
+  have hB_pos : ∀ d ∈ B, 0 < d := fun d hd => by have := hB_sub hd; simp [Nat.mem_divisors] at this; exact Nat.pos_of_dvd_of_pos this.1 (Nat.factorial_pos n)
+  by_cases hr : r = 0
+  simp only [hr, Nat.add_zero] at h_div
+  simp only [subsetSums, Set.mem_setOf_eq]
+  refine ⟨B.image (· * (n + 1)), ?_, ?_⟩
+  intro x; simp only [Finset.coe_image, Set.mem_image]; rintro ⟨d, hd, rfl⟩; have h := Nat.dvd_of_mem_divisors (by exact_mod_cast hB_sub hd : d ∈ n.factorial.divisors); exact Nat.mem_divisors.mpr ⟨by rw [mul_comm d, Nat.factorial_succ]; exact mul_dvd_mul_left _ h, Nat.factorial_ne_zero _⟩
+  rw [h_div, Finset.sum_image (fun a _ b _ h => mul_right_cancel₀ (by omega : (n+1:ℕ) ≠ 0) h)]; simp [Finset.mul_sum, mul_comm, hB_sum]
+  simp only [subsetSums, Set.mem_setOf_eq]
+  refine ⟨B.image (· * (n + 1)) ∪ {r}, ?_, ?_⟩
+  intro x; simp only [Finset.coe_union, Finset.coe_image, Finset.coe_singleton, Set.mem_union, Set.mem_image, Set.mem_singleton_iff]; rintro (⟨d, hd, rfl⟩ | rfl)
+  have h := Nat.dvd_of_mem_divisors (by exact_mod_cast hB_sub hd : d ∈ n.factorial.divisors); exact Nat.mem_divisors.mpr ⟨by rw [mul_comm d, Nat.factorial_succ]; exact mul_dvd_mul_left _ h, Nat.factorial_ne_zero _⟩
+  exact Nat.mem_divisors.mpr ⟨(Nat.dvd_factorial (by omega) h_r_le).trans (Nat.factorial_dvd_factorial (Nat.le_succ n)), Nat.factorial_ne_zero _⟩
+  rw [h_div, Finset.sum_union (by rw [Finset.disjoint_left]; intro x hx hxr; simp only [Finset.mem_singleton] at hxr; rw [Finset.mem_image] at hx; obtain ⟨d, hd, rfl⟩ := hx; have hd_pos := hB_pos d hd; have : n + 1 ≤ d * (n + 1) := le_mul_of_one_le_left (Nat.zero_le _) hd_pos; omega), Finset.sum_singleton, Finset.sum_image (fun a _ b _ h => mul_right_cancel₀ (by omega : (n+1:ℕ) ≠ 0) h)]; simp [Finset.mul_sum, mul_comm, hB_sum]
 
 /- ### Erdős's Conjectures -/
 

--- a/FormalConjectures/ErdosProblems/18.lean
+++ b/FormalConjectures/ErdosProblems/18.lean
@@ -82,37 +82,46 @@ theorem practicalH_le_divisors (n : ℕ) (hn : Nat.IsPractical n) :
 /-- $h(n!)$ is well-defined since $n!$ is practical for $n ≥ 1$. -/
 @[category undergraduate, AMS 11]
 theorem factorial_isPractical (n : ℕ) : Nat.IsPractical n.factorial := by
-  induction n with | zero => ?_ | succ n ih => ?_
-  intro m hm; simp only [Nat.factorial_zero] at hm; interval_cases m
-  exact ⟨∅, by simp, by simp⟩
-  exact ⟨{1}, by simp, by simp⟩
-  simp only [Nat.IsPractical] at ih ⊢
-  intro m hm
-  have h_sub : n.factorial.divisors ⊆ (n + 1).factorial.divisors := Nat.divisors_subset_of_dvd (Nat.factorial_ne_zero _) (Nat.factorial_dvd_factorial (Nat.le_succ n))
-  by_cases hle : m ≤ n.factorial
-  exact subsetSums_mono (by exact_mod_cast h_sub) (ih m hle)
-  push_neg at hle
-  rw [Nat.factorial_succ] at hm
-  set q := m / (n + 1)
-  set r := m % (n + 1)
-  have h_div : m = (n + 1) * q + r := (Nat.div_add_mod m (n + 1)).symm
-  have h_r_bound : r < n + 1 := Nat.mod_lt m (Nat.succ_pos n)
-  have h_r_le : r ≤ n := by omega
-  have h_q_le : q ≤ n.factorial := Nat.div_le_of_le_mul (by linarith)
-  obtain ⟨B, hB_sub, hB_sum⟩ := ih q h_q_le
-  have hB_pos : ∀ d ∈ B, 0 < d := fun d hd => by have := hB_sub hd; simp [Nat.mem_divisors] at this; exact Nat.pos_of_dvd_of_pos this.1 (Nat.factorial_pos n)
-  by_cases hr : r = 0
-  simp only [hr, Nat.add_zero] at h_div
-  simp only [subsetSums, Set.mem_setOf_eq]
-  refine ⟨B.image (· * (n + 1)), ?_, ?_⟩
-  intro x; simp only [Finset.coe_image, Set.mem_image]; rintro ⟨d, hd, rfl⟩; have h := Nat.dvd_of_mem_divisors (by exact_mod_cast hB_sub hd : d ∈ n.factorial.divisors); exact Nat.mem_divisors.mpr ⟨by rw [mul_comm d, Nat.factorial_succ]; exact mul_dvd_mul_left _ h, Nat.factorial_ne_zero _⟩
-  rw [h_div, Finset.sum_image (fun a _ b _ h => mul_right_cancel₀ (by omega : (n+1:ℕ) ≠ 0) h)]; simp [Finset.mul_sum, mul_comm, hB_sum]
-  simp only [subsetSums, Set.mem_setOf_eq]
-  refine ⟨B.image (· * (n + 1)) ∪ {r}, ?_, ?_⟩
-  intro x; simp only [Finset.coe_union, Finset.coe_image, Finset.coe_singleton, Set.mem_union, Set.mem_image, Set.mem_singleton_iff]; rintro (⟨d, hd, rfl⟩ | rfl)
-  have h := Nat.dvd_of_mem_divisors (by exact_mod_cast hB_sub hd : d ∈ n.factorial.divisors); exact Nat.mem_divisors.mpr ⟨by rw [mul_comm d, Nat.factorial_succ]; exact mul_dvd_mul_left _ h, Nat.factorial_ne_zero _⟩
-  exact Nat.mem_divisors.mpr ⟨(Nat.dvd_factorial (by omega) h_r_le).trans (Nat.factorial_dvd_factorial (Nat.le_succ n)), Nat.factorial_ne_zero _⟩
-  rw [h_div, Finset.sum_union (by rw [Finset.disjoint_left]; intro x hx hxr; simp only [Finset.mem_singleton] at hxr; rw [Finset.mem_image] at hx; obtain ⟨d, hd, rfl⟩ := hx; have hd_pos := hB_pos d hd; have : n + 1 ≤ d * (n + 1) := le_mul_of_one_le_left (Nat.zero_le _) hd_pos; omega), Finset.sum_singleton, Finset.sum_image (fun a _ b _ h => mul_right_cancel₀ (by omega : (n+1:ℕ) ≠ 0) h)]; simp [Finset.mul_sum, mul_comm, hB_sum]
+    induction n with
+  | zero =>
+    intro m hm; simp at hm; interval_cases m
+    · exact ⟨∅, by simp, by simp⟩
+    · exact ⟨{1}, by simp, by simp⟩
+  | succ n ih =>
+    intro m hm
+    by_cases hle : m ≤ n.factorial
+    · exact subsetSums_mono (by exact_mod_cast (Nat.divisors_subset_of_dvd
+        (Nat.factorial_ne_zero _) (Nat.factorial_dvd_factorial n.le_succ))) (ih m hle)
+    · push_neg at hle; rw [Nat.factorial_succ] at hm
+      set q := m / (n + 1); set r := m % (n + 1)
+      have h_div : m = (n + 1) * q + r := (Nat.div_add_mod m (n + 1)).symm
+      have h_r_lt : r < n + 1 := Nat.mod_lt m (Nat.succ_pos n)
+      obtain ⟨B, hB_sub, hB_sum⟩ := ih q (Nat.div_le_of_le_mul (by linarith))
+      have hdvd : ∀ d ∈ B, d * (n + 1) ∈ (n + 1).factorial.divisors := fun d hd => by
+        refine Nat.mem_divisors.mpr ⟨?_, Nat.factorial_ne_zero _⟩
+        rw [mul_comm, Nat.factorial_succ]
+        exact mul_dvd_mul_left _ (Nat.dvd_of_mem_divisors (by exact_mod_cast hB_sub hd))
+      have hB'_sum : (B.image (· * (n + 1))).sum id = (n + 1) * q := by
+        rw [Finset.sum_image (fun a _ b _ h => mul_right_cancel₀ (by omega) h)]
+        simp [Finset.mul_sum, mul_comm, hB_sum]
+      by_cases hr : r = 0
+      · rw [show m = (B.image (· * (n + 1))).sum id from by rw [hB'_sum]; omega]
+        exact ⟨_, fun x hx => by
+          obtain ⟨d, hd, rfl⟩ := Finset.mem_image.mp hx; exact hdvd d hd, rfl⟩
+      · have h_disj : Disjoint (B.image (· * (n + 1))) {r} := by
+          rw [Finset.disjoint_singleton_right, Finset.mem_image]; rintro ⟨d, hd, hdr⟩
+          have : 0 < d := Nat.pos_of_dvd_of_pos
+            (Nat.dvd_of_mem_divisors (by exact_mod_cast hB_sub hd)) (Nat.factorial_pos n)
+          have := le_mul_of_one_le_left (Nat.zero_le (n + 1)) this
+          omega
+        rw [show m = (B.image (· * (n + 1)) ∪ {r}).sum id from by
+          rw [Finset.sum_union h_disj, Finset.sum_singleton, hB'_sum, id_eq]; exact h_div]
+        exact ⟨_, fun x hx => by
+          rcases Finset.mem_union.mp hx with h | h
+          · obtain ⟨d, hd, rfl⟩ := Finset.mem_image.mp h; exact hdvd d hd
+          · rw [Finset.mem_singleton.mp h]; exact Nat.mem_divisors.mpr
+              ⟨(Nat.dvd_factorial (by omega) (by omega)).trans
+                (Nat.factorial_dvd_factorial n.le_succ), Nat.factorial_ne_zero _⟩, rfl⟩
 
 /- ### Erdős's Conjectures -/
 


### PR DESCRIPTION
## Summary
- Prove `erdos_1.variants.weaker`: ∃ C > 0, C·2^|A|/|A| < N for sum-distinct sets, via pigeonhole on powerset sums
- Prove `factorial_isPractical`: n! is practical for all n, via induction with Euclidean division by (n+1)

## Notes
- AI-assisted (Claude for tactic search), manually reviewed and submitted
- Erdős 1: witness C = 1/3, injective powerset→range counting, ℕ→ℝ cast arithmetic
- Erdős 18: divisor subset sums, scaled quotient + remainder decomposition