### PR TITLE
Prove g_k positivity (Erdős 400) and 6563 bound (Erdős 1148)

### DIFF
--- a/FormalConjectures/ErdosProblems/1148.lean
+++ b/FormalConjectures/ErdosProblems/1148.lean
@@ -46,9 +46,22 @@ theorem erdos_1148 : answer(sorry) ↔ ∀ᶠ n in atTop, Erdos1148Prop n := by
 /--
 The largest integer known which cannot be written this way is $6563$.
 -/
+private instance (n : ℕ) : Decidable (Erdos1148Prop n) :=
+  decidable_of_iff
+    (∃ x ∈ Finset.range (Nat.sqrt n + 1), ∃ y ∈ Finset.range (Nat.sqrt n + 1),
+      ∃ z ∈ Finset.range (Nat.sqrt n + 1),
+      n = x ^ 2 + y ^ 2 - z ^ 2 ∧ x ^ 2 ≤ n ∧ y ^ 2 ≤ n ∧ z ^ 2 ≤ n)
+    (by
+      constructor
+      · rintro ⟨x, -, y, -, z, -, h⟩; exact ⟨x, y, z, h⟩
+      · rintro ⟨x, y, z, h1, h2, h3, h4⟩
+        refine ⟨x, Finset.mem_range.mpr ?_, y, Finset.mem_range.mpr ?_,
+                z, Finset.mem_range.mpr ?_, h1, h2, h3, h4⟩
+        all_goals (simp only [Nat.lt_succ_iff]; exact Nat.le_sqrt'.mpr ‹_›))
+
 @[category high_school, AMS 11]
 theorem erdos_1148.variants.lower_bound : ¬ Erdos1148Prop 6563 := by
-  sorry
+  native_decide
 
 /--
 The weaker property: $n = x^2 + y^2 - z^2$ such that $\max(x^2, y^2, z^2) \leq n + 2\sqrt{n}$.

--- a/FormalConjectures/ErdosProblems/1148.lean
+++ b/FormalConjectures/ErdosProblems/1148.lean
@@ -61,7 +61,7 @@ private instance (n : ℕ) : Decidable (Erdos1148Prop n) :=
 
 @[category high_school, AMS 11]
 theorem erdos_1148.variants.lower_bound : ¬ Erdos1148Prop 6563 := by
-  native_decide
+  decide +native
 
 /--
 The weaker property: $n = x^2 + y^2 - z^2$ such that $\max(x^2, y^2, z^2) \leq n + 2\sqrt{n}$.

--- a/FormalConjectures/ErdosProblems/400.lean
+++ b/FormalConjectures/ErdosProblems/400.lean
@@ -71,6 +71,33 @@ theorem erdos_400.variants.upper_bound (k : ℕ) (hk : k ≥ 2) :
 /-- For $k \ge 2$, $g_k(n) > 0$. We show this by choosing $a = (n, 1, 0, \ldots, 0)$. -/
 @[category test, AMS 11]
 theorem erdos_400.variants.g_pos (k n : ℕ) (h: k ≥ 2) : 0 < g k n := by
-  sorry
+  obtain ⟨k', rfl⟩ : ∃ k', k = k' + 2 := ⟨k - 2, by omega⟩
+  simp only [g]
+  -- Witness: a(0) = n, a(1) = 1, a(i) = 0 for i ≥ 2
+  set a : Fin (k' + 2) → ℕ := fun i =>
+    if (i : ℕ) = 0 then n else if (i : ℕ) = 1 then 1 else 0 with ha_def
+  have h_prod : ∏ i : Fin (k' + 2), (a i)! = n ! := by
+    rw [Fin.prod_univ_succ]; simp [ha_def]
+    rw [Fin.prod_univ_succ]; simp [ha_def]
+  have h_sum : ∑ i : Fin (k' + 2), a i = n + 1 := by
+    rw [Fin.sum_univ_succ]; simp [ha_def]
+  -- 1 is in the set
+  have hmem : 1 ∈ {(∑ i, b i) - n | (b : Fin (k' + 2) → ℕ) (_ : ∏ i, (b i)! ∣ n !)} :=
+    ⟨a, h_prod ▸ dvd_refl n !, by omega⟩
+  -- The set is bounded above by (k'+2) * n!
+  have hbdd : BddAbove {(∑ i, b i) - n | (b : Fin (k' + 2) → ℕ) (_ : ∏ i, (b i)! ∣ n !)} := by
+    refine ⟨(k' + 2) * n !, ?_⟩
+    rintro x ⟨b, hb, rfl⟩
+    calc (∑ i, b i) - n
+        ≤ ∑ i, b i := Nat.sub_le _ _
+      _ ≤ ∑ i : Fin (k' + 2), (b i)! :=
+          Finset.sum_le_sum fun i _ => Nat.self_le_factorial _
+      _ ≤ Finset.univ.card • n ! := by
+          apply Finset.sum_le_card_nsmul; intro i _
+          exact le_trans (Finset.single_le_prod' (fun j _ =>
+            Nat.one_le_iff_ne_zero.mpr (Nat.factorial_ne_zero _))
+            (Finset.mem_univ i)) (Nat.le_of_dvd (Nat.factorial_pos n) hb)
+      _ = (k' + 2) * n ! := by simp [Finset.card_fin, smul_eq_mul]
+  exact Nat.lt_of_lt_of_le Nat.one_pos (le_csSup hbdd hmem)
 
 end Erdos400


### PR DESCRIPTION
## Summary
- Prove `g_pos`: g_k(n) > 0 for k ≥ 2, via explicit witness a = (n, 1, 0, ..., 0)
- Prove `lower_bound`: 6563 cannot be written as x² + y² - z², via native_decide
- Add Decidable instance for Erdos1148Prop to enable native_decide

## Notes
- AI-assisted (Claude for tactic search), manually reviewed and submitted
- Erdős 400: constructive witness with BddAbove proof
- Erdős 1148: Decidable instance bounds search space to √n, then kernel evaluation