### PR TITLE
Prove complexity(1) = 1 and complexity(2) = 2 (MO 75792)

### DIFF
--- a/FormalConjectures/Mathoverflow/75792.lean
+++ b/FormalConjectures/Mathoverflow/75792.lean
@@ -155,12 +155,19 @@ theorem Reachable.complexity {n : ℕ} (hn : 0 < n) : Reachable n (complexity n)
 theorem complexity_zero : complexity 0 = 0 := rfl
 
 @[category test, AMS 11]
-theorem complexity_one : complexity 1 = 1 := by
-  sorry
+theorem complexity_one : complexity 1 = 1 :=
+  Reachable.one.complexity_eq fun n' hn' ↦ by
+    have : n' = 0 := by omega
+    subst this; exact not_reachable_zero_snd 1
 
 @[category test, AMS 11]
-theorem complexity_two : complexity 2 = 2 := by
-  sorry
+theorem complexity_two : complexity 2 = 2 :=
+  (Reachable.add .one .one).complexity_eq fun n' hn' ↦ by
+    interval_cases n'
+    · exact not_reachable_zero_snd 2
+    · rw [reachable_iff_of_two_le 2 1 (by omega)]
+      rintro ⟨m₁, hm₁, m₂, hm₂, n₁, hn₁, n₂, hn₂, h₁, -⟩
+      omega
 
 @[category test, AMS 11]
 theorem Reachable.pow (m n : ℕ) (hm : 0 < m) (hn : 0 < n) : Reachable (m ^ n) (m * n) := by


### PR DESCRIPTION
## Summary
- Prove `complexity_one`: integer complexity of 1 is 1, via Reachable.one + not_reachable_zero_snd
- Prove `complexity_two`: integer complexity of 2 is 2, via Reachable.add + interval_cases lower bound

## Notes
- AI-assisted (Claude for tactic search), manually reviewed and submitted
- Uses existing Reachable API and complexity_eq helper