### PR TITLE
Prove OEIS 56777/358684 and Selfridge pseudoprime tests

### DIFF
--- a/FormalConjectures/OEIS/358684.lean
+++ b/FormalConjectures/OEIS/358684.lean
@@ -118,7 +118,7 @@ theorem five : a 5 = 23 := by
 
 @[category test, AMS 11]
 theorem six : a 6 = 46 := by
-  native_decide
+  decide +native
 
 @[category test, AMS 11]
 theorem seven : a 7 = 73 := by

--- a/FormalConjectures/OEIS/358684.lean
+++ b/FormalConjectures/OEIS/358684.lean
@@ -118,8 +118,7 @@ theorem five : a 5 = 23 := by
 
 @[category test, AMS 11]
 theorem six : a 6 = 46 := by
-  -- AlphaProof failed to close this goal
-  sorry
+  native_decide
 
 @[category test, AMS 11]
 theorem seven : a 7 = 73 := by

--- a/FormalConjectures/OEIS/56777.lean
+++ b/FormalConjectures/OEIS/56777.lean
@@ -75,13 +75,84 @@ theorem comesFromPrimeQuadruple_of_a {n : ℕ} (h : a n) : ComesFromPrimeQuadrup
 @[category undergraduate, AMS 11]
 theorem mod_72_of_comesFromPrimeQuadruple {n : ℕ} (h : ComesFromPrimeQuadruple n) :
     n % 72 = 65 := by
-  sorry
+  obtain ⟨p, hp, hp2, hp6, hp8, rfl⟩ := h
+  have hp5 : 5 ≤ p := by
+    by_contra hlt; push_neg at hlt
+    interval_cases p <;> simp_all (config := { decide := true })
+  have h2 : ¬ (2 ∣ p) := by
+    intro hdvd; cases hp.eq_one_or_self_of_dvd 2 hdvd with | inl h => omega | inr h => omega
+  have h3 : ¬ (3 ∣ p) := by
+    intro hdvd; cases hp.eq_one_or_self_of_dvd 3 hdvd with | inl h => omega | inr h => omega
+  have hmod2 : p % 2 = 1 := by omega
+  have hmod3 : p % 3 = 2 := by
+    have hne1 : p % 3 ≠ 1 := by
+      intro heq
+      have h3dvd : 3 ∣ (p + 2) := ⟨p / 3 + 1, by omega⟩
+      cases hp2.eq_one_or_self_of_dvd 3 h3dvd with | inl h => omega | inr h => omega
+    omega
+  have hmod6 : p % 6 = 5 := by omega
+  set q := p / 6
+  have hp_eq : p = 6 * q + 5 := by omega
+  have hparity : 2 ∣ q * (q + 3) := by
+    rcases Nat.even_or_odd q with ⟨r, hr⟩ | ⟨r, hr⟩
+    · exact dvd_mul_of_dvd_left ⟨r, by omega⟩ _
+    · exact dvd_mul_of_dvd_right ⟨r + 2, by omega⟩ _
+  obtain ⟨k, hk⟩ := hparity
+  have h1 : p * (p + 8) = (6 * q + 5) * (6 * q + 13) := by congr 1 <;> omega
+  have h2 : (6 * q + 5) * (6 * q + 13) = 36 * (q * (q + 3)) + 65 := by ring
+  have h3 : 36 * (q * (q + 3)) = 72 * k := by linarith
+  have hprod : p * (p + 8) = 72 * k + 65 := by linarith
+  omega
 
 /-- Numbers coming from prime quadruples satisfy $n \equiv 9 \pmod{100}$,
 except the first value "65". -/
 @[category undergraduate, AMS 11]
-theorem mod_100_of_comesFromPrimeQuadruple {n : ℕ} (h : 65 < n) (h : ComesFromPrimeQuadruple n) :
+theorem mod_100_of_comesFromPrimeQuadruple {n : ℕ} (h65 : 65 < n) (h : ComesFromPrimeQuadruple n) :
     n % 100 = 9 := by
-  sorry
+  obtain ⟨p, hp, hp2, hp6, hp8, rfl⟩ := h
+  have hp5 : 5 ≤ p := by
+    by_contra hlt; push_neg at hlt
+    interval_cases p <;> simp_all (config := { decide := true })
+  have h2 : ¬ (2 ∣ p) := by
+    intro hdvd; cases hp.eq_one_or_self_of_dvd 2 hdvd with | inl h => omega | inr h => omega
+  have h3 : ¬ (3 ∣ p) := by
+    intro hdvd; cases hp.eq_one_or_self_of_dvd 3 hdvd with | inl h => omega | inr h => omega
+  have h5 : ¬ (5 ∣ p) := by
+    intro hdvd; cases hp.eq_one_or_self_of_dvd 5 hdvd with | inl h => omega | inr h =>
+      -- p = 5 → p*(p+8) = 65, but 65 < n = p*(p+8) is impossible
+      subst h; omega
+  have hmod30 : p % 30 = 11 := by
+    have hmod2 : p % 2 = 1 := by omega
+    have hmod3 : p % 3 = 2 := by
+      have : p % 3 ≠ 1 := by
+        intro heq; have : 3 ∣ (p + 2) := ⟨p / 3 + 1, by omega⟩
+        cases hp2.eq_one_or_self_of_dvd 3 this with | inl h => omega | inr h => omega
+      omega
+    have hmod5 : p % 5 = 1 := by
+      have hne2 : p % 5 ≠ 2 := by
+        intro heq; have : 5 ∣ (p + 8) := ⟨p / 5 + 2, by omega⟩
+        cases hp8.eq_one_or_self_of_dvd 5 this with | inl h => omega | inr h => omega
+      have hne3 : p % 5 ≠ 3 := by
+        intro heq; have : 5 ∣ (p + 2) := ⟨p / 5 + 1, by omega⟩
+        cases hp2.eq_one_or_self_of_dvd 5 this with | inl h => omega | inr h => omega
+      have hne4 : p % 5 ≠ 4 := by
+        intro heq; have : 5 ∣ (p + 6) := ⟨p / 5 + 2, by omega⟩
+        cases hp6.eq_one_or_self_of_dvd 5 this with | inl h => omega | inr h => omega
+      omega
+    omega
+  set q := p / 30
+  have hp_eq : p = 30 * q + 11 := by omega
+  -- p*(p+8) = (30q+11)(30q+19) = 900*q*(q+1) + 30*(11+19)*q + 209
+  -- = 900*q*(q+1) + 900*q + 209 ... let me just compute with ring
+  have hparity : 2 ∣ q * (q + 1) := by
+    rcases Nat.even_or_odd q with ⟨r, hr⟩ | ⟨r, hr⟩
+    · exact dvd_mul_of_dvd_left ⟨r, by omega⟩ _
+    · exact dvd_mul_of_dvd_right ⟨r + 1, by omega⟩ _
+  obtain ⟨k, hk⟩ := hparity
+  have h1 : p * (p + 8) = (30 * q + 11) * (30 * q + 19) := by congr 1 <;> omega
+  have h2 : (30 * q + 11) * (30 * q + 19) = 900 * (q * (q + 1)) + 209 := by ring
+  have h3 : 900 * (q * (q + 1)) = 1800 * k := by linarith
+  have hprod : p * (p + 8) = 1800 * k + 209 := by linarith
+  omega
 
 end OeisA56777

--- a/FormalConjectures/Wikipedia/Selfridge.lean
+++ b/FormalConjectures/Wikipedia/Selfridge.lean
@@ -80,7 +80,7 @@ This test does not work.
 theorem selfridge_conjecture.variants.exist_pseudo_counterexample :
     ∃ n : ℕ, IsPseudoSelfridge n ∧ ¬ n.Prime := by
   use 6601
-  sorry
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩ <;> native_decide
 
 /--
 Selfridge's test variant:
@@ -92,7 +92,7 @@ The number $6601$ is a conterexample to this test satisfying $6601 ≡ 1 \mod 5$
 @[category high_school, AMS 11]
 theorem selfridge_conjecture.variants.pseudo_counterexample :
     IsPseudoSelfridge 6601 ∧ ¬ (6601).Prime ∧ 6601 ≡ 1 [MOD 5] := by
-  sorry
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_, ?_⟩ <;> native_decide
 
 /--
 Selfridge's test variant:
@@ -104,7 +104,7 @@ The number $30889$ is a conterexample to this test satisfying $30889 ≡ - 1 \mo
 @[category high_school, AMS 11]
 theorem selfridge_conjecture.variants.pseudo_counterexample' :
     IsPseudoSelfridge 30889 ∧ ¬ (30889).Prime ∧ 30889 ≡ 4 [MOD 5] := by
-  sorry
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_, ?_⟩ <;> native_decide
 
 end PrimalityTesting
 

--- a/FormalConjectures/Wikipedia/Selfridge.lean
+++ b/FormalConjectures/Wikipedia/Selfridge.lean
@@ -80,7 +80,7 @@ This test does not work.
 theorem selfridge_conjecture.variants.exist_pseudo_counterexample :
     ∃ n : ℕ, IsPseudoSelfridge n ∧ ¬ n.Prime := by
   use 6601
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩ <;> native_decide
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩ <;> decide +native
 
 /--
 Selfridge's test variant:
@@ -92,7 +92,7 @@ The number $6601$ is a conterexample to this test satisfying $6601 ≡ 1 \mod 5$
 @[category high_school, AMS 11]
 theorem selfridge_conjecture.variants.pseudo_counterexample :
     IsPseudoSelfridge 6601 ∧ ¬ (6601).Prime ∧ 6601 ≡ 1 [MOD 5] := by
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_, ?_⟩ <;> native_decide
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_, ?_⟩ <;> decide +native
 
 /--
 Selfridge's test variant:
@@ -104,7 +104,7 @@ The number $30889$ is a conterexample to this test satisfying $30889 ≡ - 1 \mo
 @[category high_school, AMS 11]
 theorem selfridge_conjecture.variants.pseudo_counterexample' :
     IsPseudoSelfridge 30889 ∧ ¬ (30889).Prime ∧ 30889 ≡ 4 [MOD 5] := by
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_, ?_⟩ <;> native_decide
+  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_, ?_⟩ <;> decide +native
 
 end PrimalityTesting
 


### PR DESCRIPTION
## Summary
- Prove `mod_72_of_comesFromPrimeQuadruple`: p(p+8) ≡ 65 mod 72 for prime quadruples, via CRT decomposition (p ≡ 5 mod 6)
- Prove `mod_100_of_comesFromPrimeQuadruple`: p(p+8) ≡ 9 mod 100 for p > 5, via p ≡ 11 mod 30 analysis
- Prove `a 6 = 46` (OEIS A358684) via native_decide
- Prove 3 Selfridge pseudoprime tests (6601 and 30889 witnesses) via native_decide

## Notes
- AI-assisted (Claude for tactic search), manually reviewed and submitted
- OEIS 56777: prime residue class + parity of quadratic form
- Selfridge/358684: kernel computation via native_decide