### PR TITLE
fix(OEIS): A006697 fix gen func and provide solution

### DIFF
--- a/FormalConjectures/OEIS/6697.lean
+++ b/FormalConjectures/OEIS/6697.lean
@@ -117,7 +117,7 @@ for a formal proof of the generating function using this definition.
 Hence, a formalization of [arXiv:1605.02361](https://arxiv.org/abs/1605.02361)
 would complete a formal proof as below.
 -/
-@[category research solved, AMS 68]
+@[category research solved, formal_proof using lean4 at "https://github.com/AxiomMath/gdm-formal-conjectures/blob/main/OeisA6697/solution.lean", AMS 68]
 theorem conjecture (n : ℕ) :
     a n = coeff (R := ℚ) n
       ((1 - X)⁻¹ + X * (1 - X)⁻¹ ^ 2 * ((1 - X)⁻¹ - ∑' k, X ^ (2 ^ (k + 1) + k))) := by


### PR DESCRIPTION
-  The Allouche-Shallit paper cited in the OEIS entry also provides a formula for a(n) given by $a_n = \sum_{i=0}^{n} \min(2^i,n-i+1)$. If one uses this instead as the definition of a(n), the conjecture becomes straightforward to prove.
- The OGF actually listed on the OEIS does not appear to match the sequence; it is off by a small normalization.  Indeed, letting X=0 we see the original OGF has value 3, but a(0)=1. This change corrects the listed OGF to match what I think is the correct generating function.


