### PR TITLE
fix(ErdosProblems): 951

### DIFF
--- a/FormalConjectures/ErdosProblems/951.lean
+++ b/FormalConjectures/ErdosProblems/951.lean
@@ -30,12 +30,14 @@ open Filter
 
 namespace Erdos951
 
-/-- A sequence `a : ℕ → ℝ` is said to have property `Erdos951_prop` if for any pair of distinct
-Beuring integers `x, y`, `|x - y| ≥ 1`. -/
+/-- A sequence `a : ℕ → ℝ` is said to have property `Erdos951Prop` if for any pair of distinct
+finitely supported sequences `k l : ℕ →₀ ℕ` their corresponding Beurling integers are of distance
+at least one apart. -/
 def Erdos951Prop (a : ℕ → ℝ) : Prop :=
   ∀ (k ℓ : ℕ →₀ ℕ), k ≠ ℓ → |beurlingInteger a k - beurlingInteger a ℓ| ≥ 1
 
-/-- If `a` has property `Erdos951_prop` and `1 < a 0`, then `a` is a set of Beurling prime numbers. -/
+/-- If `a` has property `Erdos951Prop` and `1 < a 0`, then `a` is a set of Beurling
+prime numbers. -/
 @[category API, AMS 11]
 theorem erdos_951.variants.isBeurlingPrimes {a : ℕ → ℝ} (ha : 1 < a 0)
     (hm : StrictMono a) (he : Erdos951Prop a) :
@@ -52,7 +54,7 @@ theorem erdos_951.variants.isBeurlingPrimes {a : ℕ → ℝ} (ha : 1 < a 0)
     simpa using he (.single (N + 1) 1) (.single N 1) (by simpa [Finsupp.ext_iff] using ⟨N, by simp⟩)
   linarith [abs_lt.1 (hN N le_rfl), abs_lt.1 (hN (N + 1) (by grind))]
 
-/-- If `1 < a 0 < ...` has property `Erdos951_prop`, is it true that `#{a i ≤ x} ≤ π x`? -/
+/-- If `1 < a 0 < ...` has property `Erdos951Prop`, is it true that `#{a i ≤ x} ≤ π x`? -/
 @[category research open, AMS 11]
 theorem erdos_951 : answer(sorry) ↔
     ∀ a : ℕ → ℝ, 1 < a 0 → StrictMono a → Erdos951Prop a →

--- a/FormalConjecturesForMathlib/NumberTheory/BeurlingPrimes.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/BeurlingPrimes.lean
@@ -36,6 +36,8 @@ it tends to infinity. -/
 noncomputable def IsBeurlingPrimes (a : ℕ → ℝ) : Prop :=
   1 < a 0 ∧ StrictMono a ∧ Tendsto a atTop atTop
 
+/-- A Beurling integer is a number of the form `∏ i, (a i) ^ (k i)` for a given sequence `a` and a
+finitely-supported sequence of naturals `k`. -/
 def beurlingInteger (a : ℕ → ℝ) (k : ℕ →₀ ℕ) : ℝ := k.prod fun x y ↦ (a x) ^ y
 
 @[simp] theorem beurlingInteger_def (a k) : beurlingInteger a k =  k.prod fun x y ↦ (a x) ^ y := rfl


### PR DESCRIPTION
- Missing monotonicity conditions in the main statement
- From the discussion on the webpage small counterexamples can be found, so make this asymptotic in `x`
- `Erdos951Prop` was too weak before. In particular the source text states that the property should hold for distinct exponents, not just for distinct Beurling integers. I.e., the sequence should admit unique factorization of Beurling integers. A counterexample found by AlphaProof is the sequence `a i = i + 2`. For such an `a`, consider `k = (1, 1, 0, 0, ...)` and `l = (0, 0, 0, 0, 1, 0, ...)`. These two distinct exponents both give `6`, and so under the informal version this sequence should be disallowed. However our prior formalisations fails to check the inequality here because the integers are not distinct. 