### PR TITLE
feat(OpenQuantumProblems): Formalization of open quantum problem 41 on rank inequalities for reduced states

### DIFF
--- a/FormalConjectures/OpenQuantumProblems/41.lean
+++ b/FormalConjectures/OpenQuantumProblems/41.lean
@@ -918,7 +918,6 @@ theorem signedParityDiagonal222_not_isDensityMatrix :
 
 /- ## Full conjecture -/
 
-set_option warn.sorry false in
 /-- Open Quantum Problem 41 in the explicit tripartite mixed-state form stated on the OQP page. -/
 @[category research open, AMS 15 47 81 94]
 theorem oqp_41 :


### PR DESCRIPTION
## Summary

This PR adds a formalization of Open Quantum Problem 41 from the IQOQI Vienna Open Quantum Problems list: all rank inequalities for reduced states of quadripartite quantum states.

## Mathematical content

The OQP page states the following concrete tripartite mixed-state formulation.

Given a tripartite density matrix `ρ_ABC`, let
`r_AB = rank(Tr_C(ρ_ABC))`,
`r_AC = rank(Tr_B(ρ_ABC))`, and
`r_BC = rank(Tr_A(ρ_ABC))`
denote the ranks of the corresponding two-body marginals.

The conjecture asks whether
`r_AB ≤ r_AC * r_BC`
holds for all tripartite density matrices.

In the formalization, a state on `H_A ⊗ H_B ⊗ H_C` is represented in computational-basis matrix coordinates as a complex matrix indexed by
`Fin dA × Fin dB × Fin dC`.

## What is introduced

The file defines:

* `TripartiteMatrix dA dB dC` for matrices on `H_A ⊗ H_B ⊗ H_C`,
* `IsDensityMatrix` for tripartite density matrices,
* `partialTraceA`, `partialTraceB`, and `partialTraceC` for the three two-body marginals,
* `marginalRankAB`, `marginalRankAC`, and `marginalRankBC` for the corresponding marginal ranks,
* `SatisfiesOQP41` for the rank inequality
  `marginalRankAB ρ ≤ marginalRankAC ρ * marginalRankBC ρ`.

It also introduces a small reusable sanity-check library around explicit computational-basis projectors and witness matrices.

## Included results

The PR includes:

* the open theorem `oqp_41`, expressing the OQP question for all finite local dimensions,
* explicit density-matrix benchmark families with verified marginal ranks, including:
  * computational-basis projectors with rank triple `(1,1,1)`,
  * a Bell pair on `AB` tensored with a pure ancilla on `C`, with rank triple `(1,2,2)`,
  * a GHZ-type classical mixture with rank triple `(2,2,2)`,
* negative sanity checks showing failure of the density-matrix hypotheses or of the inequality once positivity / normalization assumptions are dropped.

## Background

The OQP title refers to reduced states of quadripartite pure states because the same inequality can be reformulated, via purification, as a rank inequality for four-party pure states.

This formalization follows the explicit tripartite mixed-state formulation stated on the OQP page.

## References

Primary source list entry:

* IQOQI Vienna Open Quantum Problems, problem 41:
  https://oqp.iqoqi.oeaw.ac.at/all-rank-inequalities-for-reduced-states-of-quadripartite-quantum-states
* Master list of open quantum problems:
  https://oqp.iqoqi.oeaw.ac.at/open-quantum-problems

Foundational reference included in the file docstring:

* J. Cadney, M. Huber, N. Linden, and A. Winter,
  *Inequalities for the Ranks of Quantum States*,
  Linear Algebra and its Applications 452, 153–171 (2014), arXiv:1308.0539.

Closes #3458.

Assisted by GPT Pro 5.4 and Codex.