### PR TITLE
Added Dubner's conjecture as a twin-prime variant

### DIFF
--- a/FormalConjectures/Wikipedia/TwinPrimes.lean
+++ b/FormalConjectures/Wikipedia/TwinPrimes.lean
@@ -22,10 +22,16 @@ import FormalConjectures.Util.ProblemImports
 *References:*
 - [Landau Problems Wikipedia Page](https://en.wikipedia.org/wiki/Landau%27s_problems#Twin_prime_conjecture)
 - [Twin Primes Conjecture Wikipedia Page](https://en.wikipedia.org/wiki/Twin_prime#Twin_prime_conjecture)
+- [OEIS A081947](https://oeis.org/A081947)
+- [Prime Puzzles: Conjecture 32](https://www.primepuzzles.net/conjectures/conj_032.htm)
 -/
 
 
 namespace TwinPrimes
+
+/-- A twin prime is a prime number with another prime at distance `2`. -/
+def IsTwinPrime (p : ℕ) : Prop :=
+  p.Prime ∧ ((p + 2).Prime ∨ (p - 2).Prime)
 
 /--
 Are there infinitely many primes p such that p + 2 is prime?
@@ -33,6 +39,14 @@ Are there infinitely many primes p such that p + 2 is prime?
 @[category research open, AMS 11]
 theorem twin_primes :
     answer(sorry) ↔ {p : ℕ | Prime p ∧ Prime (p + 2)}.Infinite := by
+  sorry
+
+/--
+Dubner's conjecture: every even integer greater than `4208` is the sum of two twin primes.
+-/
+@[category research open, AMS 11]
+theorem twin_primes.variants.dubner_conjecture (n : ℕ) (hn : 4208 < n) (hn_even : Even n) :
+    ∃ p q, IsTwinPrime p ∧ IsTwinPrime q ∧ n = p + q := by
   sorry
 
 end TwinPrimes


### PR DESCRIPTION
## Summary
Add Dubner's conjecture as a variant of the existing twin prime conjecture.

## Context
Issue #3628 asks for a formalization of Dubner's conjecture: every even integer greater than `4208` can be written as the sum of two primes that both have twins.

Since this statement is a natural extension of the existing twin prime formalization, it fits best as a variant inside `FormalConjectures/Wikipedia/TwinPrimes.lean` rather than as a standalone file.

## Changed file
- `FormalConjectures/Wikipedia/TwinPrimes.lean`

## What changed
- added two supporting references for Dubner's conjecture
- introduced a local helper predicate `IsTwinPrime`
- added `twin_primes.variants.dubner_conjecture` with the benchmark-style statement

## Review notes
The diff is intentionally small and limited to the existing twin-primes file:
- `IsTwinPrime` captures the intended notion that a prime has another prime at distance `2`
- the new theorem follows the repository's usual style for open conjecture statements
- keeping Dubner's conjecture under `TwinPrimes` makes the relationship to the main conjecture explicit for future variants

Closes #3628
