### PR TITLE
Updated Dickson's conjecture references and wording

### DIFF
--- a/FormalConjectures/Wikipedia/Dickson.lean
+++ b/FormalConjectures/Wikipedia/Dickson.lean
@@ -22,6 +22,10 @@ open Polynomial
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Dickson%27s_conjecture)
+- [PrimePages glossary](https://t5k.org/glossary/xpage/DicksonsConjecture.html)
+- [OEIS Wiki](https://oeis.org/wiki/Dickson%27s_conjecture)
+- [MathWorld](https://mathworld.wolfram.com/DicksonsConjecture.html)
+- [Leonard Eugene Dickson, *History of the Theory of Numbers, Vol. I: Divisibility and Primality*](https://archive.org/details/historyoftheoryo01dickuoft)
 - [Arxiv](https://arxiv.org/pdf/0906.3850)
 -/
 
@@ -29,7 +33,7 @@ namespace Dickson
 
 /--
 **Dickson's conjecture**
-If a finite set of in linear integer forms $f_i(n) = a_i n+b_i$ satisfies Schinzel condition,
+If a finite set of linear integer forms $f_i(n) = a_i n+b_i$ satisfies Schinzel condition,
 there exist infinitely many natural numbers $m$ such that $f_i(m)$ are primes for all $i$.
 -/
 @[category research open, AMS 11]


### PR DESCRIPTION
## Summary
Refresh the references and wording in the existing Dickson's conjecture formalization.

## Context
Issue #3627 asks for a formalization of Dickson's conjecture, but the conjecture is already present in the repository as `Dickson.dickson_conjecture` in `FormalConjectures/Wikipedia/Dickson.lean`.

This PR does not add a new theorem. Instead, it makes a small cleanup to the existing file by:
- adding source links that match the issue references
- fixing a docstring wording typo

## Existing implementation
The conjecture is already formalized here:
- `FormalConjectures/Wikipedia/Dickson.lean`
- theorem: `Dickson.dickson_conjecture`

The existing theorem predates the issue:
- core theorem lines trace back to commit `bf6aef2` from 2025-06-23
- issue #3627 was opened on 2026-03-24

## Changed file
- `FormalConjectures/Wikipedia/Dickson.lean`

## What changed
- added PrimePages, OEIS Wiki, MathWorld, and Dickson book references
- corrected the docstring text from `a finite set of in linear integer forms` to `a finite set of linear integer forms`

## Review notes
This PR is intentionally small. Its main value is to make the existing implementation easier to match against issue #3627, which appears to already be solved by the current repository state.

Closes #3627
