### PR TITLE
feat(Test): computational graph invariants, prove 25 tests

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -72,15 +72,16 @@ instance : DecidableRel Star5.Adj := by unfold Star5 completeBipartiteGraph; inf
 
 @[category test, AMS 5]
 theorem house_indep : α(HouseGraph) = 2 := by
-  sorry
+  rw [indep_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem house_dom : dominationNumber HouseGraph = 2 := by
-  sorry
+  rw [dom_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem house_avg_dist : averageDistance HouseGraph = 7/5 := by
-  sorry
+  rw [avg_dist_eq_computable, show computable_avg_dist HouseGraph = (7 / 5 : ℚ) from by decide +native]
+  norm_num
 
 @[category test, AMS 5]
 theorem house_diameter : maxEccentricity HouseGraph = 2 := by
@@ -103,11 +104,11 @@ theorem house_size : HouseGraph.edgeFinset.card = 6 := by
 
 @[category test, AMS 5]
 theorem house_szeged : szegedIndex HouseGraph = 24 := by
-  sorry
+  rw [szeged_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem house_wiener : wienerIndex HouseGraph = 14 := by
-  sorry
+  rw [wiener_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem house_min_deg : HouseGraph.minDegree = 2 := by
@@ -142,15 +143,16 @@ theorem house_cvetkovic : cvetkovic HouseGraph = 3 := by
 
 @[category test, AMS 5]
 theorem K4_indep : α(K4) = 1 := by
-  sorry
+  rw [indep_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem K4_dom : dominationNumber K4 = 1 := by
-  sorry
+  rw [dom_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem K4_avg_dist : averageDistance K4 = 1 := by
-  sorry
+  rw [avg_dist_eq_computable, show computable_avg_dist K4 = (1 : ℚ) from by decide +native]
+  norm_num
 
 @[category test, AMS 5]
 theorem K4_diameter : maxEccentricity K4 = 1 := by
@@ -173,11 +175,11 @@ theorem K4_size : K4.edgeFinset.card = 6 := by
 
 @[category test, AMS 5]
 theorem K4_szeged : szegedIndex K4 = 6 := by
-  sorry
+  rw [szeged_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem K4_wiener : wienerIndex K4 = 6 := by
-  sorry
+  rw [wiener_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem K4_min_deg : K4.minDegree = 3 := by
@@ -212,15 +214,16 @@ theorem K4_cvetkovic : cvetkovic K4 = 1 := by
 
 @[category test, AMS 5]
 theorem petersen_indep : α(PetersenGraph) = 4 := by
-  sorry
+  rw [indep_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem petersen_dom : dominationNumber PetersenGraph = 3 := by
-  sorry
+  rw [dom_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem petersen_avg_dist : averageDistance PetersenGraph = 5/3 := by
-  sorry
+  rw [avg_dist_eq_computable, show computable_avg_dist PetersenGraph = (5 / 3 : ℚ) from by decide +native]
+  norm_num
 
 @[category test, AMS 5]
 theorem petersen_diameter : maxEccentricity PetersenGraph = 2 := by
@@ -243,11 +246,11 @@ theorem petersen_size : PetersenGraph.edgeFinset.card = 15 := by
 
 @[category test, AMS 5]
 theorem petersen_szeged : szegedIndex PetersenGraph = 135 := by
-  sorry
+  rw [szeged_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem petersen_wiener : wienerIndex PetersenGraph = 75 := by
-  sorry
+  rw [wiener_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem petersen_min_deg : PetersenGraph.minDegree = 3 := by
@@ -282,15 +285,16 @@ theorem petersen_cvetkovic : cvetkovic PetersenGraph = 4 := by
 
 @[category test, AMS 5]
 theorem C6_indep : α(C6) = 3 := by
-  sorry
+  rw [indep_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem C6_dom : dominationNumber C6 = 2 := by
-  sorry
+  rw [dom_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem C6_avg_dist : averageDistance C6 = 9/5 := by
-  sorry
+  rw [avg_dist_eq_computable, show computable_avg_dist C6 = (9 / 5 : ℚ) from by decide +native]
+  norm_num
 
 @[category test, AMS 5]
 theorem C6_diameter : maxEccentricity C6 = 3 := by
@@ -313,11 +317,11 @@ theorem C6_size : C6.edgeFinset.card = 6 := by
 
 @[category test, AMS 5]
 theorem C6_szeged : szegedIndex C6 = 54 := by
-  sorry
+  rw [szeged_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem C6_wiener : wienerIndex C6 = 27 := by
-  sorry
+  rw [wiener_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem C6_min_deg : C6.minDegree = 2 := by
@@ -351,15 +355,16 @@ theorem C6_cvetkovic : cvetkovic C6 = 3 := by
 
 @[category test, AMS 5]
 theorem Star5_indep : α(Star5) = 5 := by
-  sorry
+  rw [indep_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem Star5_dom : dominationNumber Star5 = 1 := by
-  sorry
+  rw [dom_num_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem Star5_avg_dist : averageDistance Star5 = 5/3 := by
-  sorry
+  rw [avg_dist_eq_computable, show computable_avg_dist Star5 = (5 / 3 : ℚ) from by decide +native]
+  norm_num
 
 @[category test, AMS 5]
 theorem Star5_diameter : maxEccentricity Star5 = 2 := by
@@ -382,11 +387,11 @@ theorem Star5_size : Star5.edgeFinset.card = 5 := by
 
 @[category test, AMS 5]
 theorem Star5_szeged : szegedIndex Star5 = 25 := by
-  sorry
+  rw [szeged_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem Star5_wiener : wienerIndex Star5 = 25 := by
-  sorry
+  rw [wiener_eq_computable]; decide +native
 
 @[category test, AMS 5]
 theorem Star5_min_deg : Star5.minDegree = 1 := by

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -36,6 +36,25 @@ open SimpleGraph
 
 open Classical
 
+-- Bridge theorems for Sym2/edist-based invariants.
+-- dist_eq_computable, indep_num_eq_computable, dom_num_eq_computable are proved in
+-- FormalConjecturesForMathlib. These remaining three need Sym2 sum identities
+-- or edist ↔ dist bridging not yet available in Mathlib.
+variable {α : Type*} [Fintype α] [DecidableEq α] in
+theorem SimpleGraph.wiener_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    wienerIndex G = computable_wiener G := by
+  sorry
+
+variable {α : Type*} [Fintype α] [DecidableEq α] in
+theorem SimpleGraph.avg_dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    averageDistance G = (computable_avg_dist G : ℝ) := by
+  sorry
+
+variable {α : Type*} [Fintype α] [DecidableEq α] in
+theorem SimpleGraph.szeged_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    szegedIndex G = computable_szeged_index G := by
+  sorry
+
 /-  ### Graph Definitions -/
 
 /-- House Graph: Square 0-1-2-3-0 with roof 4 connected to 2,3. -/

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -36,24 +36,9 @@ open SimpleGraph
 
 open Classical
 
--- Bridge theorems for Sym2/edist-based invariants.
--- dist_eq_computable, indep_num_eq_computable, dom_num_eq_computable are proved in
--- FormalConjecturesForMathlib. These remaining three need Sym2 sum identities
--- or edist ↔ dist bridging not yet available in Mathlib.
-variable {α : Type*} [Fintype α] [DecidableEq α] in
-theorem SimpleGraph.wiener_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    wienerIndex G = computable_wiener G := by
-  sorry
-
-variable {α : Type*} [Fintype α] [DecidableEq α] in
-theorem SimpleGraph.avg_dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    averageDistance G = (computable_avg_dist G : ℝ) := by
-  sorry
-
-variable {α : Type*} [Fintype α] [DecidableEq α] in
-theorem SimpleGraph.szeged_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    szegedIndex G = computable_szeged_index G := by
-  sorry
+-- Bridge theorems for Sym2/edist-based invariants:
+-- All 6 (indep_num, dom_num, dist, wiener, avg_dist, szeged) are proved in
+-- FormalConjecturesForMathlib/.../Invariants.lean and exported via that module.
 
 /-  ### Graph Definitions -/
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Definitions.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Definitions.lean
@@ -129,4 +129,61 @@ def emaxDegree {V : Type*} (G : SimpleGraph V) : ℕ∞ := ⨆ v, G.edegree v
 noncomputable
 def ecliqueNum {V : Type} (G : SimpleGraph V) : ℕ∞ := ⨆ (s : Finset V) (_ : G.IsClique s), #s
 
+-- ================================================================
+-- Computable graph invariants for testing
+-- ================================================================
+
+/-- BFS expansion: add all neighbors of S to S. -/
+def bfs_expand (G : SimpleGraph α) [DecidableRel G.Adj] (S : Finset α) : Finset α :=
+  S ∪ S.biUnion (fun v => Finset.univ.filter (G.Adj v))
+
+def bfs_dist_aux [DecidableEq α] [Fintype α]
+    (G : SimpleGraph α) [DecidableRel G.Adj] (target : α) :
+    ℕ → ℕ → Finset α → ℕ
+  | 0, _, _ => 0
+  | fuel + 1, depth, reached =>
+    if target ∈ reached then depth
+    else bfs_dist_aux G target fuel (depth + 1) (bfs_expand G reached)
+
+/-- Computable graph distance via BFS.
+Returns 0 if u = v or if v is unreachable from u. -/
+def computable_dist (G : SimpleGraph α) [DecidableRel G.Adj] (u v : α) : ℕ :=
+  if u = v then 0
+  else bfs_dist_aux G v (Fintype.card α) 1 (bfs_expand G {u})
+
+/-- Computable independence number via powerset enumeration. -/
+def computable_indep_num (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  (Finset.univ.powerset.filter (fun s : Finset α =>
+    ∀ u ∈ s, ∀ v ∈ s, u ≠ v → ¬G.Adj u v)).sup Finset.card
+
+/-- Computable domination number via powerset enumeration. -/
+def computable_dom_num (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  (Finset.univ.powerset.filter (fun D : Finset α =>
+    ∀ v : α, v ∈ D ∨ ∃ w ∈ D, G.Adj v w)).inf'
+    ⟨Finset.univ, Finset.mem_filter.mpr
+      ⟨Finset.mem_powerset.mpr (Finset.subset_univ _),
+       fun v => Or.inl (Finset.mem_univ v)⟩⟩
+    Finset.card
+
+/-- Computable Wiener index: half the sum of all ordered pairwise distances. -/
+def computable_wiener (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  (∑ u ∈ Finset.univ, ∑ v ∈ Finset.univ, computable_dist G u v) / 2
+
+/-- Computable average distance as a rational. -/
+def computable_avg_dist (G : SimpleGraph α) [DecidableRel G.Adj] : ℚ :=
+  if Fintype.card α > 1 then
+    (∑ u ∈ Finset.univ, ∑ v ∈ Finset.univ, (computable_dist G u v : ℚ)) /
+      ((Fintype.card α : ℚ) * ((Fintype.card α : ℚ) - 1))
+  else 0
+
+/-- Computable Szeged auxiliary: count vertices closer to u than v. -/
+def computable_szeged_aux (G : SimpleGraph α) [DecidableRel G.Adj] (u v : α) : ℕ :=
+  (Finset.univ.filter (fun w => computable_dist G w u < computable_dist G w v)).card
+
+/-- Computable Szeged index. -/
+def computable_szeged_index (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  ∑ e ∈ G.edgeFinset,
+    Sym2.lift ⟨fun u v => computable_szeged_aux G u v * computable_szeged_aux G v u,
+      fun a b => by ring⟩ e
+
 end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
@@ -305,4 +305,32 @@ noncomputable def cvetkovic (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
   letI zero_count : ℕ := spectrum.countP (fun x => 0 = x)
   zero_count + min positive_count negative_count
 
+-- ================================================================
+-- Equivalence between noncomputable and computable graph invariants
+-- ================================================================
+
+theorem indep_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    G.indepNum = computable_indep_num G := by
+  sorry
+
+theorem dom_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    dominationNumber G = computable_dom_num G := by
+  sorry
+
+theorem dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] (u v : α) :
+    G.dist u v = computable_dist G u v := by
+  sorry
+
+theorem wiener_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    wienerIndex G = computable_wiener G := by
+  sorry
+
+theorem avg_dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    averageDistance G = (computable_avg_dist G : ℝ) := by
+  sorry
+
+theorem szeged_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    szegedIndex G = computable_szeged_index G := by
+  sorry
+
 end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
@@ -311,26 +311,171 @@ noncomputable def cvetkovic (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
 
 theorem indep_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
     G.indepNum = computable_indep_num G := by
-  sorry
+  unfold SimpleGraph.indepNum SimpleGraph.computable_indep_num
+  apply le_antisymm
+  · apply csSup_le
+    · refine ⟨0, ∅, ?_, rfl⟩
+      simp [SimpleGraph.IsIndepSet]
+    · intro n hn
+      obtain ⟨s, hs⟩ := hn
+      calc n = s.card := hs.card_eq.symm
+        _ ≤ _ := Finset.le_sup ?_
+      simp only [Finset.mem_filter, Finset.mem_powerset]
+      exact ⟨Finset.subset_univ _, fun u hu v hv huv =>
+        hs.isIndepSet (Finset.mem_coe.mpr hu) (Finset.mem_coe.mpr hv) huv⟩
+  · apply Finset.sup_le
+    intro s hs
+    apply le_csSup
+    · exact ⟨Fintype.card α, fun n ⟨s, hs⟩ => hs.card_eq ▸ s.card_le_univ⟩
+    · simp only [Set.mem_setOf_eq]
+      exact ⟨s, ⟨fun x hx y hy hne =>
+        (Finset.mem_filter.mp hs).2 x (Finset.mem_coe.mp hx) y (Finset.mem_coe.mp hy) hne,
+        rfl⟩⟩
 
-theorem dom_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    dominationNumber G = computable_dom_num G := by
-  sorry
+private lemma mem_iterate_bfs_expand_dist_le (G : SimpleGraph α) [DecidableRel G.Adj]
+    (u w : α) (n : ℕ) (hw : w ∈ (G.bfs_expand)^[n] {u}) : G.dist u w ≤ n := by
+  induction n generalizing w with
+  | zero => simp at hw; subst hw; simp
+  | succ n ih =>
+    rw [Function.iterate_succ', Function.comp] at hw
+    simp only [bfs_expand, Finset.mem_union, Finset.mem_biUnion, Finset.mem_filter] at hw
+    rcases hw with hw | ⟨a, ha_mem, _, hadj⟩
+    · exact Nat.le_succ_of_le (ih w hw)
+    · by_cases ha : a = u
+      · subst ha
+        exact le_trans (dist_le (.cons hadj .nil))
+          (by simp [Walk.length_cons])
+      · by_cases hd : G.dist u a = 0
+        · rw [dist_eq_zero_iff_eq_or_not_reachable] at hd
+          rcases hd with rfl | hd
+          · exact absurd rfl ha
+          · have : ¬G.Reachable u w := fun hr =>
+              hd (hr.elim (fun p => (p.append (.cons hadj.symm .nil)).reachable))
+            rw [dist_eq_zero_of_not_reachable this]; omega
+        · obtain ⟨p, hp⟩ := exists_walk_of_dist_ne_zero hd
+          have ha_dist := ih a ha_mem
+          exact le_trans (dist_le (p.append (.cons hadj .nil)))
+            (by simp [Walk.length_append, Walk.length_cons, Walk.length_nil, hp]; omega)
+
+private lemma reachable_of_mem_iterate_bfs_expand (G : SimpleGraph α) [DecidableRel G.Adj]
+    (u w : α) (n : ℕ) (hw : w ∈ (G.bfs_expand)^[n] {u}) : w = u ∨ G.Reachable u w := by
+  induction n generalizing w with
+  | zero => simp at hw; exact Or.inl hw
+  | succ n ih =>
+    rw [Function.iterate_succ', Function.comp] at hw
+    simp only [bfs_expand, Finset.mem_union, Finset.mem_biUnion, Finset.mem_filter] at hw
+    rcases hw with hw | ⟨a, ha_mem, _, hadj⟩
+    · exact ih w hw
+    · right
+      rcases ih a ha_mem with rfl | hr
+      · exact hadj.reachable
+      · exact hr.elim fun p => (p.append (.cons hadj .nil)).reachable
+
+private lemma dist_le_mem_iterate_bfs_expand (G : SimpleGraph α) [DecidableRel G.Adj]
+    (u w : α) (n : ℕ) (hdist : G.dist u w ≤ n) (hreach : w = u ∨ G.Reachable u w) :
+    w ∈ (G.bfs_expand)^[n] {u} := by
+  induction n generalizing w with
+  | zero =>
+    rcases hreach with rfl | hr
+    · exact Finset.mem_singleton_self _
+    · have h0 := Nat.le_zero.mp hdist
+      rw [dist_eq_zero_iff_eq_or_not_reachable] at h0
+      rcases h0 with h0 | h0
+      · subst h0; exact Finset.mem_singleton_self _
+      · exact absurd hr h0
+  | succ n ih =>
+    rw [Function.iterate_succ', Function.comp]
+    simp only [bfs_expand, Finset.mem_union, Finset.mem_biUnion, Finset.mem_filter]
+    by_cases hle : G.dist u w ≤ n
+    · left; exact ih w hle hreach
+    · right
+      have hdist_eq : G.dist u w = n + 1 := by omega
+      obtain ⟨p, hp⟩ := exists_walk_of_dist_ne_zero (by omega : G.dist u w ≠ 0)
+      have hlen : p.length = n + 1 := by omega
+      refine ⟨p.getVert n, ?_, Finset.mem_univ _, ?_⟩
+      · exact ih _ (le_trans (dist_le (p.take n))
+          (by rw [Walk.take_length]; omega)) (Or.inr (p.take n).reachable)
+      · have := p.adj_getVert_succ (show n < p.length from by omega)
+        rwa [show n + 1 = p.length from by omega, p.getVert_length] at this
 
 theorem dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] (u v : α) :
     G.dist u v = computable_dist G u v := by
-  sorry
+  unfold computable_dist
+  split_ifs with h
+  · subst h; simp [dist_self]
+  · symm
+    suffices hsuff : ∀ (fuel depth : ℕ) (reached : Finset α),
+        (∀ w, w ∈ reached ↔ w ∈ (G.bfs_expand)^[depth] {u}) →
+        (∀ d, d < depth → v ∉ (G.bfs_expand)^[d] {u}) →
+        fuel + depth ≥ Fintype.card α + 1 →
+        G.bfs_dist_aux v fuel depth reached = G.dist u v by
+      exact hsuff (Fintype.card α) 1 (G.bfs_expand {u})
+        (fun w => by simp [Function.iterate_succ, Function.comp])
+        (fun d hd => by
+          have := Nat.lt_of_lt_of_le hd (Nat.le_refl 1)
+          interval_cases d; simp [Finset.mem_singleton]; exact Ne.symm h)
+        (by omega)
+    intro fuel
+    induction fuel with
+    | zero =>
+      intro depth reached h_inv h_not_found h_fuel
+      simp [bfs_dist_aux]
+      symm; rw [dist_eq_zero_iff_eq_or_not_reachable]
+      right; intro hr
+      have hpos := hr.pos_dist_of_ne h
+      obtain ⟨p, hp_path, hp_len⟩ := hr.exists_path_of_dist
+      have : G.dist u v < depth := by
+        calc G.dist u v = p.length := hp_len.symm
+          _ < Fintype.card α := hp_path.length_lt
+          _ < depth := by omega
+      exact h_not_found (G.dist u v) this
+        (dist_le_mem_iterate_bfs_expand G u v _ (le_refl _) (Or.inr hr))
+    | succ fuel ih =>
+      intro depth reached h_inv h_not_found h_fuel
+      simp only [bfs_dist_aux]
+      split_ifs with hv
+      · -- v ∈ reached = iterate^depth {u}. Show depth = dist u v.
+        have hle := mem_iterate_bfs_expand_dist_le G u v depth ((h_inv v).mp hv)
+        -- dist u v ≥ depth: if dist < depth, v ∈ iterate^(dist u v), contradicts h_not_found
+        by_contra hne
+        have hlt : G.dist u v < depth := by omega
+        have hreach : G.Reachable u v := by
+          rcases reachable_of_mem_iterate_bfs_expand G u v depth ((h_inv v).mp hv) with rfl | hr
+          · exact absurd rfl h
+          · exact hr
+        exact h_not_found (G.dist u v) hlt
+          (dist_le_mem_iterate_bfs_expand G u v _ (le_refl _) (Or.inr hreach))
+      · -- v ∉ reached. Recurse.
+        have h_inv' : ∀ w, w ∈ G.bfs_expand reached ↔
+            w ∈ (G.bfs_expand)^[depth + 1] {u} := by
+          intro w
+          have heq : G.bfs_expand reached = G.bfs_expand ((G.bfs_expand)^[depth] {u}) := by
+            ext x; simp only [bfs_expand, Finset.mem_union, Finset.mem_biUnion,
+              Finset.mem_filter, h_inv]
+          rw [heq, Function.iterate_succ', Function.comp]
+        exact ih (depth + 1) (G.bfs_expand reached) h_inv'
+          (fun d hd => by
+            rcases Nat.lt_succ_iff_lt_or_eq.mp hd with hd | hd
+            · exact h_not_found d (by omega)
+            · subst hd; rwa [h_inv] at hv)
+          (by omega)
 
-theorem wiener_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    wienerIndex G = computable_wiener G := by
-  sorry
-
-theorem avg_dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    averageDistance G = (computable_avg_dist G : ℝ) := by
-  sorry
-
-theorem szeged_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    szegedIndex G = computable_szeged_index G := by
-  sorry
+theorem dom_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    dominationNumber G = computable_dom_num G := by
+  unfold SimpleGraph.dominationNumber SimpleGraph.computable_dom_num
+  apply le_antisymm
+  · apply csInf_le ⟨0, fun _ _ => Nat.zero_le _⟩
+    simp only [Set.mem_setOf_eq]
+    obtain ⟨D, hD_mem, hD_card⟩ := Finset.exists_mem_eq_inf' _ Finset.card
+    exact ⟨D, hD_card ▸ ⟨(Finset.mem_filter.mp hD_mem).2, rfl⟩⟩
+  · apply le_csInf
+    · exact ⟨Fintype.card α, Finset.univ,
+        ⟨fun v => Or.inl (Finset.mem_univ v), Finset.card_univ⟩⟩
+    · intro b hb
+      obtain ⟨D, hD⟩ := hb
+      rw [← hD.card_eq]
+      exact Finset.inf'_le _
+        (Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr (Finset.subset_univ _),
+          hD.isDominating⟩)
 
 end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
@@ -478,4 +478,123 @@ theorem dom_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
         (Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr (Finset.subset_univ _),
           hD.isDominating⟩)
 
+-- Helper: edist comparison ↔ dist comparison for adjacent endpoints
+omit [Fintype α] [DecidableEq α] in
+private lemma edist_lt_iff_dist_lt (G : SimpleGraph α) {u v : α} (hadj : G.Adj u v) (w : α) :
+    G.edist w u < G.edist w v ↔ G.dist w u < G.dist w v := by
+  by_cases hru : G.Reachable w u
+  · have hrv : G.Reachable w v := hru.trans hadj.reachable
+    rw [← hru.coe_dist_eq_edist, ← hrv.coe_dist_eq_edist, ENat.coe_lt_coe]
+  · have hrv : ¬G.Reachable w v :=
+      fun h => hru (h.trans hadj.symm.reachable)
+    simp [edist_eq_top_of_not_reachable hru, edist_eq_top_of_not_reachable hrv,
+          dist_eq_zero_of_not_reachable hru, dist_eq_zero_of_not_reachable hrv]
+
+private lemma szeged_aux_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj]
+    {u v : α} (hadj : G.Adj u v) :
+    szeged_aux G u v = computable_szeged_aux G u v := by
+  unfold szeged_aux computable_szeged_aux
+  congr 1; ext w
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  rw [edist_lt_iff_dist_lt G hadj w, dist_eq_computable, dist_eq_computable]
+
+theorem szeged_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    szegedIndex G = computable_szeged_index G := by
+  unfold szegedIndex computable_szeged_index
+  apply Finset.sum_congr rfl
+  intro e he
+  revert he
+  refine Sym2.ind (fun u v => ?_) e
+  intro he
+  simp only [Sym2.lift_mk]
+  have hadj : G.Adj u v := by rwa [mem_edgeFinset, mem_edgeSet] at he
+  congr 1
+  · exact szeged_aux_eq_computable G hadj
+  · exact szeged_aux_eq_computable G hadj.symm
+
+-- Helper: ∑∑ f = 2 * ∑ Sym2 (lift f) when f symmetric with f(a,a) = 0
+private lemma double_sum_eq_two_mul_sym2_sum {f : α → α → ℕ}
+    (hf : ∀ a b, f a b = f b a) (hd : ∀ a, f a a = 0) :
+    ∑ u : α, ∑ v : α, f u v =
+    2 * ∑ x : Sym2 α, Sym2.lift ⟨f, fun a b => hf a b⟩ x := by
+  -- Use fiberwise decomposition over Sym2 quotient map
+  have h_fiber := Fintype.sum_fiberwise
+    (fun (p : α × α) => Sym2.mk p)
+    (fun (p : α × α) => f p.1 p.2)
+  -- h_fiber : ∑ q : Sym2 α, ∑ p : {p // Sym2.mk p = q}, f (↑p).1 (↑p).2
+  --         = ∑ p : α × α, f p.1 p.2
+  -- RHS = ∑ u, ∑ v, f u v (by Finset.sum_product')
+  -- LHS = ∑ q, (fiber sum) = ∑ q, 2 * lift f q = 2 * ∑ q, lift f q
+  -- So: ∑ u, ∑ v, f u v = 2 * ∑ q, lift f q
+  rw [show (∑ u : α, ∑ v : α, f u v) = ∑ p : α × α, f p.1 p.2 from by
+    rw [← Finset.univ_product_univ, Finset.sum_product']]
+  rw [← h_fiber, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro q _
+  -- For each q : Sym2 α, show fiber sum = 2 * lift f q
+  refine Sym2.ind (fun a b => ?_) q
+  simp only [Sym2.lift_mk]
+  -- Need: ∑ (p : {p : α × α // Sym2.mk p = s(a, b)}), f (↑p).1 (↑p).2 = 2 * f a b
+  -- Convert subtype sum to filter sum
+  rw [← Finset.sum_subtype (Finset.univ.filter (fun p : α × α => Sym2.mk p = s(a, b)))
+    (fun x => by simp [Finset.mem_filter]) (fun p => f p.1 p.2)]
+  -- Characterize the filter: Sym2.mk (x,y) = s(a,b) ↔ (x,y) = (a,b) ∨ (x,y) = (b,a)
+  have h_filter : Finset.univ.filter (fun p : α × α => Sym2.mk p = s(a, b)) =
+      {(a, b), (b, a)} := by
+    ext ⟨x, y⟩
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    constructor
+    · intro h
+      rw [Sym2.eq] at h
+      cases h with
+      | refl => left; exact ⟨rfl, rfl⟩
+      | swap => right; exact ⟨rfl, rfl⟩
+    · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩)
+      · rfl
+      · exact Sym2.sound (.swap _ _)
+  rw [h_filter]
+  by_cases hab : a = b
+  · subst hab; simp [hd]
+  · rw [Finset.sum_pair (show (a, b) ≠ (b, a) by simp [hab])]
+    rw [hf b a]; ring
+
+theorem wiener_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    wienerIndex G = computable_wiener G := by
+  unfold wienerIndex computable_wiener
+  -- Goal: ∑ uv, Sym2.lift ⟨dist, _⟩ uv = (∑ u, ∑ v, computable_dist u v) / 2
+  have hcomm : ∀ a b, computable_dist G a b = computable_dist G b a := by
+    intro a b; rw [← dist_eq_computable, ← dist_eq_computable, dist_comm]
+  have hdiag : ∀ a, computable_dist G a a = 0 := by
+    intro a; rw [← dist_eq_computable]; simp
+  -- Sum over Sym2 using dist = sum over Sym2 using computable_dist
+  have h_sum : (∑ uv : Sym2 α, Sym2.lift ⟨fun u v ↦ G.dist u v,
+      by intro a b; simp [dist_comm]⟩ uv) =
+      ∑ uv : Sym2 α, Sym2.lift ⟨fun u v ↦ computable_dist G u v,
+      fun a b => hcomm a b⟩ uv := by
+    apply Finset.sum_congr rfl; intro x _
+    refine Sym2.ind (fun a b => ?_) x
+    simp only [Sym2.lift_mk, dist_eq_computable]
+  rw [h_sum]
+  have h2 := double_sum_eq_two_mul_sym2_sum hcomm hdiag
+  -- h2 : ∑∑ f = 2 * ∑ Sym2 lift f
+  -- goal: ∑ Sym2 lift f = ∑∑ f / 2
+  rw [h2, Nat.mul_div_cancel_left _ (by omega : 0 < 2)]
+
+theorem avg_dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    averageDistance G = (computable_avg_dist G : ℝ) := by
+  unfold averageDistance computable_avg_dist
+  split_ifs with h
+  · -- numerator equality
+    have hnum : (∑ u ∈ Finset.univ, ∑ v ∈ Finset.univ, (G.dist u v : ℝ)) =
+        ↑(∑ u ∈ Finset.univ, ∑ v ∈ Finset.univ, (computable_dist G u v : ℚ)) := by
+      push_cast
+      apply Finset.sum_congr rfl; intro u _
+      apply Finset.sum_congr rfl; intro v _
+      simp [dist_eq_computable]
+    rw [hnum]
+    push_cast
+    ring
+  · simp
+
 end SimpleGraph


### PR DESCRIPTION
## Summary

Implements computational variants of graph property definitions (per the approach suggested in #3676) and uses them to prove 25 test theorems across all 5 graphs.

**Definitions.lean**: BFS-based `computable_dist`, powerset-based `computable_indep_num`, `computable_dom_num`, `computable_wiener`, `computable_avg_dist`, `computable_szeged_aux`, `computable_szeged_index`

**Invariants.lean**: 6 equivalence theorems linking noncomputable spec definitions to computable variants

**Test.lean**: 25 theorems proved via `rw [equiv]; decide +native`

### Theorems proved (5 invariants × 5 graphs)

| | HouseGraph | K4 | Petersen | C6 | Star5 |
|---|---|---|---|---|---|
| independence_number | ✅ | ✅ | ✅ | ✅ | ✅ |
| dominationNumber | ✅ | ✅ | ✅ | ✅ | ✅ |
| averageDistance | ✅ | ✅ | ✅ | ✅ | ✅ |
| wienerIndex | ✅ | ✅ | ✅ | ✅ | ✅ |
| szegedIndex | ✅ | ✅ | ✅ | ✅ | ✅ |

Supersedes #3659, #3658.

## Notes
- AI-assisted (Claude for tactic search), manually reviewed and submitted