### PR TITLE
feat(README.md): Refactored section on contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ There are various ways of contributing to this repository:
    to be worked on in our [list of Milestones](https://github.com/google-deepmind/formal-conjectures/milestones), if you have deeper mathematical expertise in a specific field you can also filter by the AMS 2020 Classification (e.g. [Group Theory Issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ams-20%20Group%20theory%20and%20generalizations%22)) or
    take a look at [good first issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20is%3Aopen%20no%3Aassignee%20label%3A%22good%20first%20issue%22) if you are new to Lean.
 
+   More generally, we encourage adding formalisations of open conjectures from all sorts of sources, including:
+
+      * **Literature:** Textbooks, problem books and research papers (including [arXiv](https://arxiv.org/archive/math)).
+      * **Community Resources:** [Wikipedia](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics), [MathOverflow](https://mathoverflow.net/) and the [OEIS](https://oeis.org/).
+      * **Problem Lists:** Famous collections ([Millennium](https://www.claymath.org/millennium-problems/), [Smale](https://en.wikipedia.org/wiki/Smale%27s_problems), Yau), [Erdős Problems](https://www.erdosproblems.com/), [Ben Green's list](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf), [Kourovka notebook](https://arxiv.org/pdf/1401.0300) or [The Scottish Book](https://en.wikipedia.org/wiki/Scottish_Book)
+    
    Just pick one and comment on the issue (e.g., "I plan to work on this") to
    have it assigned to you.
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ There are various ways of contributing to this repository:
    an issue should contain links to suitable references, and ideally a precise
    informal statement of the conjecture.
 
-   We encourage adding formalisations of open conjectures from all sorts of sources, including:
-   - **Literature:** Textbooks, problem books and research papers (including [arXiv](https://arxiv.org/archive/math)).
-   - **Community Resources:** [Wikipedia](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics), [MathOverflow](https://mathoverflow.net/) and the [OEIS](https://oeis.org/).
-   - **Problem Lists:** Famous collections ([Millennium](https://www.claymath.org/millennium-problems/), [Smale](https://en.wikipedia.org/wiki/Smale%27s_problems), Yau), [Erdős Problems](https://www.erdosproblems.com/), [Ben Green's list](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf), [Kourovka notebook](https://arxiv.org/pdf/1401.0300) or [The Scottish Book](https://en.wikipedia.org/wiki/Scottish_Book)
-
 3. **Improving the referencing and tagging of problems.** For example, adding
    pointers to references in already existing files, or adding additional
    relevant `AMS` subject attributes to statements.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ describing) your favourite conjecture.
 There are various ways of contributing to this repository:
 
 1. **Formalise a Problem**. You can find problem lists ready
-   to be worked on in our [list of Milestones](https://github.com/google-deepmind/formal-conjectures/milestones), if you have deeper mathematical expertise in a specific field you can also filter by the AMS 2020 Classification (e.g. [Group Theory Issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ams-20%20Group%20theory%20and%20generalizations%22)) or
+   to be worked on in our [list of Milestones](https://github.com/google-deepmind/formal-conjectures/milestones), you can also filter by the AMS 2020 Classification (e.g. [Group Theory Issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ams-20%20Group%20theory%20and%20generalizations%22)) or
    take a look at [good first issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20is%3Aopen%20no%3Aassignee%20label%3A%22good%20first%20issue%22) if you are new to Lean.
 
    More generally, we encourage adding formalisations of open conjectures from all sorts of sources, including:

--- a/README.md
+++ b/README.md
@@ -42,40 +42,38 @@ describing) your favourite conjecture.
 
 There are various ways of contributing to this repository:
 
-1.  **Adding new problem formalisations**
+1. **Formalise a Problem**. You can find problem lists ready
+   to be worked on in our [list of Milestones](https://github.com/google-deepmind/formal-conjectures/milestones), if you have deeper mathematical expertise in a specific field you can also filter by the AMS 2020 Classification (e.g. [Group Theory Issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22ams-20%20Group%20theory%20and%20generalizations%22)) or
+   take a look at [good first issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20is%3Aopen%20no%3Aassignee%20label%3A%22good%20first%20issue%22) if you are new to Lean.
 
-    We encourage adding formalisations of open conjectures from all sorts of sources, including:
-
-    * **Literature:** Textbooks, problem books and research papers (including [arXiv](https://arxiv.org/archive/math)).
-    * **Community Resources:** [Wikipedia](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics), [MathOverflow](https://mathoverflow.net/) and the [OEIS](https://oeis.org/).
-    * **Problem Lists:** Famous collections ([Millennium](https://www.claymath.org/millennium-problems/), [Smale](https://en.wikipedia.org/wiki/Smale%27s_problems), Yau), [Erdős Problems](https://www.erdosproblems.com/), [Ben Green's list](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf), [Kourovka notebook](https://arxiv.org/pdf/1401.0300) or [The Scottish Book](https://en.wikipedia.org/wiki/Scottish_Book)
-
-    We are also interested in the formalised statements of solved variants of
-    open conjectures and solved statements from dedicated problem lists.
-    While the main goal is to collect conjecture statements, we appreciate the
-    inclusion of very short proofs for solved items or counterexamples,
-    especially if they are illuminating and testing the definitions.
-    **Longer proofs (i.e. more than 25-50 lines) are not to be included in this repository.** 
-    Instead, we welcome you to host your proof in your own repository and link to it using
-    the `formal_proof` attribute described below. This does not apply to 
-    `FormalConjecturesForMathlib`, where we want all statements to have proofs.
-
-2.  **Opening issues with problems that you would like to see formalised.** Such
-    an issue should contain links to suitable references, and ideally a precise
-    informal statement of the conjecture.
-
-3.  **Formalise a problem already proposed**. You can find a list of problems ready
-   to be worked on in our [list of unassigned new conjectures](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee+label%3A%22new+conjecture%22) or
-   [good first issues](https://github.com/google-deepmind/formal-conjectures/issues?q=is%3Aissue%20is%3Aopen%20no%3Aassignee%20label%3A%22good%20first%20issue%22).
    Just pick one and comment on the issue (e.g., "I plan to work on this") to
    have it assigned to you.
 
-4.  **Improving the referencing and tagging of problems.** For example, adding
-    pointers to references in already existing files, or adding additional
-    relevant `AMS` subject attributes to statements.
+   We are also interested in the formalised statements of solved variants of
+   open conjectures and solved statements from dedicated problem lists.
+   While the main goal is to collect conjecture statements, we appreciate the
+   inclusion of very short proofs for solved items or counterexamples,
+   especially if they are illuminating and testing the definitions.
+   **Longer proofs (i.e. more than 25-50 lines) are not to be included in this repository.**
+   Instead, we welcome you to host your proof in your own repository and link to it using
+   the `formally solved` mechanism described below. This does not apply to
+   `FormalConjecturesForMathlib`, where we want all statements to have proofs.
 
-5.  **Fixing misformalisations.** PRs fixing incorrect formalisations and issues
-    flagging problems are encouraged.
+2. **Opening issues with problems that you would like to see formalised.** Such
+   an issue should contain links to suitable references, and ideally a precise
+   informal statement of the conjecture.
+
+   We encourage adding formalisations of open conjectures from all sorts of sources, including:
+   - **Literature:** Textbooks, problem books and research papers (including [arXiv](https://arxiv.org/archive/math)).
+   - **Community Resources:** [Wikipedia](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics), [MathOverflow](https://mathoverflow.net/) and the [OEIS](https://oeis.org/).
+   - **Problem Lists:** Famous collections ([Millennium](https://www.claymath.org/millennium-problems/), [Smale](https://en.wikipedia.org/wiki/Smale%27s_problems), Yau), [Erdős Problems](https://www.erdosproblems.com/), [Ben Green's list](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf), [Kourovka notebook](https://arxiv.org/pdf/1401.0300) or [The Scottish Book](https://en.wikipedia.org/wiki/Scottish_Book)
+
+3. **Improving the referencing and tagging of problems.** For example, adding
+   pointers to references in already existing files, or adding additional
+   relevant `AMS` subject attributes to statements.
+
+4. **Fixing misformalisations.** PRs fixing incorrect formalisations and issues
+   flagging problems are encouraged.
 
 ### How to Contribute
 


### PR DESCRIPTION
I have created this PR, to suggest a small refactor the contributions section of the README.md in response to the now greater emphasize on the Milestones, which I think are not known by most contributors. Along side with some smaller edits.