### PR TITLE
fix(HasMonotoneAP): values should form AP, not positions

### DIFF
--- a/FormalConjectures/ErdosProblems/197.lean
+++ b/FormalConjectures/ErdosProblems/197.lean
@@ -33,8 +33,8 @@ Can $\mathbb{N}$ be partitioned into two sets, each of which can be permuted to 
 @[category research open, AMS 5]
 theorem erdos_197 :
     answer(sorry) ↔ ∃ A B : Set ℕ, IsCompl A B ∧
-      (∃ f : ℕ ≃ A, ¬ HasMonotoneAP f 3) ∧
-      (∃ g : ℕ ≃ B, ¬ HasMonotoneAP g 3) := by
+      (∃ f : A ≃ ℕ, ¬ HasMonotoneAP f 3) ∧
+      (∃ g : B ≃ ℕ , ¬ HasMonotoneAP g 3) := by
   sorry
 
 end Erdos197

--- a/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
@@ -241,11 +241,12 @@ def ContainsMonoAPofLength {κ : Type} [Finite κ] {M : Set α}
     ∀ m ∈ ap, coloring m = c
 
 /--
-A function `f : α → β` has a monotone `k`-term arithmetic progression if there exists an
-arithmetic progression `l` of length `k` in `α` such that its image under `f` is sorted.
+A function `f : α → β` has a monotone `k`-term arithmetic progression if there exist
+`k` elements of `α` in increasing order whose images under `f` form an arithmetic progression
+of length `k`.
 -/
-def HasMonotoneAP {β : Type*} [Preorder β] (f : α → β) (k : ℕ) : Prop :=
-  ∃ l : List α, l.IsAPOfLength k ∧ (l.map f).Pairwise (· < ·)
+def HasMonotoneAP {β : Type*} [Preorder α] [AddCommMonoid β] (f : α → β) (k : ℕ) : Prop :=
+  ∃ l : List α, l.Pairwise (· < ·) ∧ (l.map f).IsAPOfLength k
 
 /--
 Define the largest possible size of a subset of a finset `s` that does not contain


### PR DESCRIPTION
The original definition required positions to form an AP with monotone values. The correct mathematical concept (Erdős-Graham 1980) requires ordered positions with values forming an AP. This fixes Erdős 197. The other problems using the definition were not affected because source and target were identical.