### PR TITLE
Update totalCount calculation in build.js

### DIFF
--- a/site/build.js
+++ b/site/build.js
@@ -351,7 +351,7 @@ function main() {
   const solvedCount = stats.byCategory['research solved'] || 0;
   const formalCount = conjectures.filter(c => c.hasFormalProof).length;
   writePage('site/index.html', applyBasePath(fill(indexHtml, {
-    totalCount:      openCount + solvedCount + formalCount,
+    totalCount:      openCount + solvedCount,
     openCount,
     solvedCount,
     formalCount,


### PR DESCRIPTION
Removed _formalCount_ from _totalCount_ calculation, since it is already taken into account by _solvedCount_.