### PR TITLE
fix(linting): Remove unused simp arguments

### DIFF
--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
@@ -415,7 +415,7 @@ theorem dist_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] (u v : α) 
         fuel + depth ≥ Fintype.card α + 1 →
         G.bfs_dist_aux v fuel depth reached = G.dist u v by
       exact hsuff (Fintype.card α) 1 (G.bfs_expand {u})
-        (fun w => by simp [Function.iterate_succ, Function.comp])
+        (fun w => by simp)
         (fun d hd => by
           have := Nat.lt_of_lt_of_le hd (Nat.le_refl 1)
           interval_cases d; simp [Finset.mem_singleton]; exact Ne.symm h)


### PR DESCRIPTION
# Description
Fixes a couple unused `simp` arguments in `FormalConjecturesForMathlib` for a warning-free full build.

# Testing
**After**
```shell
$ lake build
Build completed successfully (8658 jobs).
```

**Before**
```shell
$ lake build
⚠ [7989/8658] Built FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
warning: FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean:418:27: This simp argument is unused:
  Function.iterate_succ

Hint: Omit it from the simp argument list.
  simp [̵F̵u̵n̵c̵t̵i̵o̵n̵.̵i̵t̵e̵r̵a̵t̵e̵_̵s̵u̵c̵c̵,̵ ̵F̵u̵n̵c̵t̵i̵o̵n̵.̵c̵o̵m̵p̵]̵[̲F̲u̲n̲c̲t̲i̲o̲n̲.̲c̲o̲m̲p̲]̲

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean:418:50: This simp argument is unused:
  Function.comp

Hint: Omit it from the simp argument list.
  simp [Function.iterate_succ,̵ ̵F̵u̵n̵c̵t̵i̵o̵n̵.̵c̵o̵m̵p̵]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
Build completed successfully (8658 jobs).
```