### PR TITLE
fix(WOWII): Fix conjecture 22

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
@@ -17,30 +17,34 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Written on the Wall II - Conjecture 22
+# Written on the Wall II - Conjecture 23
 
 *Reference:*
 [E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 -/
 
-namespace WrittenOnTheWallII.GraphConjecture22
+namespace WrittenOnTheWallII.GraphConjecture23
 
 open Classical SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
 /--
-WOWII [Conjecture 22](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+WOWII [Conjecture 23](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `b(G) ≥ ⌊α(G) + dist_avg(M, V)⌋`, where `b(G)` is
+For a simple connected graph `G`, `b(G) ≥ ⌊α(G) + dist_avg(M, V) / 2⌋`, where `b(G)` is
 the size of a largest induced bipartite subgraph, `α(G)` is the independence number,
 and `M` is the set of maximum-degree vertices, and `dist_avg(M, V)` is the average
 distance from all vertices to `M`.
+
+This conjecture is false; there is a counterexample with `b(G) = 19`, `α(G) = 15`,
+and `dist_avg(M, V) = 10`.
 -/
 @[category research solved, AMS 5]
-theorem conjecture22 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
+theorem conjecture23 : answer(False) ↔
+  ∀ (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected),
     let M : Set α := {v | G.degree v = G.maxDegree}
-    ⌊(G.indepNum : ℝ) + distavg G M⌋ ≤ (b G : ℝ) := by
+    ⌊(G.indepNum : ℝ) + distavg G M / 2⌋ ≤ (b G : ℝ) := by
   sorry
 
 -- Sanity checks
@@ -53,4 +57,4 @@ example (G : SimpleGraph (Fin 3)) : 0 ≤ b G := Nat.cast_nonneg _
 @[category test, AMS 5]
 example : (⊤ : SimpleGraph (Fin 3)).maxDegree = 2 := by decide +native
 
-end WrittenOnTheWallII.GraphConjecture22
+end WrittenOnTheWallII.GraphConjecture23


### PR DESCRIPTION
# Description
I might have caught a couple quick fixes in `WrittenOnTheWallII`:
1. The implementation in `GraphConjecture22.lean` stated `b(G) ≥ ⌊α(G) + dist_avg(M, V)⌋`, which does not match 
Conjecture 22 described as `CEIL(2dist(B,V)))≥ CEIL(2distavg(V))` at http://cms.dt.uh.edu/faculty/delavinae/research/wowII/. The statement in the file looks closer (but not exactly) to conjecture 23 `b(G) ≥ ⌊α(G) + dist_avg(M, V) / 2⌋`. @henrykmichalewski this might have been the original intent?
2. The conjecture was actually disproved, so we need to either negate the statement as it is, or add `answer(False)`.
 
**Proposed changes:**
- Rename file, namespace, theorem to conjecture 23
- Added `answer(False)` to show conjecture was actually disproved

# Testing
:white_check_mark: Builds fine
```shell
$ lake build FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean 
Build completed successfully (7985 jobs).
```