### PR TITLE
chore: enable Namespace Linter and fix findings

### DIFF
--- a/FormalConjectures/Arxiv/2504.17644/Margulis.lean
+++ b/FormalConjectures/Arxiv/2504.17644/Margulis.lean
@@ -24,7 +24,7 @@ import FormalConjectures.Util.ProblemImports
 by *Qianlin Huang, Ronggang Shi*
 -/
 
-section MatrixGroupConjecture
+namespace Margulis
 
 open Matrix SpecialLinearGroup
 open scoped MatrixGroups Polynomial
@@ -53,4 +53,4 @@ theorem conjecture_1_1 {n : ℕ} (hn : 3 ≤ n)
 
 -- TODO(Paul-Lez): add main theorem from the paper.
 
-end MatrixGroupConjecture
+end Margulis

--- a/FormalConjectures/ErdosProblems/276.lean
+++ b/FormalConjectures/ErdosProblems/276.lean
@@ -23,6 +23,8 @@ import FormalConjectures.Util.ProblemImports
 [erdosproblems.com/276](https://www.erdosproblems.com/276)
 -/
 
+namespace Erdos276
+
 /--
 We define a Lucas sequence to be a Fibonacci sequence with arbitrary starting points
 `L 0` and `L 1`.
@@ -34,8 +36,6 @@ However before moving this into `ForMathlib` one should make a concious decision
 which definition to choose.
 -/
 def IsLucasSequence (L : ℕ → ℕ) : Prop := ∀ n, L (n + 2) = L (n + 1) + L n
-
-namespace Erdos276
 
 /--
 Is there an infinite Lucas sequence $a_0, a_1, \ldots$ where $a_{n+2} = a_{n+1} + a_n$ for

--- a/FormalConjectures/ErdosProblems/516.lean
+++ b/FormalConjectures/ErdosProblems/516.lean
@@ -29,13 +29,13 @@ import FormalConjectures.Util.ProblemImports
 open scoped Nat
 open Filter Real Set
 
+namespace Erdos516
+
 /-- An entire function `f` is said to be of finite order if there exist numbers c, a ≥ 0
 such that for all `z`, `‖f z‖ ≤ c * rexp (‖z‖ ^ a)`. -/
 def OfFiniteOrder {E F: Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
     [NormedAddCommGroup F] [NormedSpace ℂ F] (f : E → F) : Prop :=
   Differentiable ℂ f ∧ ∃ c ≥ 0, ∃ a ≥ 0, ∀ z, ‖f z‖ ≤ c * rexp (‖z‖ ^ a)
-
-namespace Erdos516
 
 noncomputable def ratio (r : ℝ) (f : ℂ → ℂ) : ℝ :=
   (⨅ z : {z : ℂ // ‖z‖ = r}, ‖f z‖).log / (⨆ z : {z : ℂ // ‖z‖ = r}, ‖f z‖).log

--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -23,11 +23,11 @@ import FormalConjectures.Util.ProblemImports
   - [erdosproblems.com/730](https://www.erdosproblems.com/730)
   - [A129515](https://oeis.org/A129515)
 -/
+namespace Erdos730
+
 abbrev S :=
   {(n, m) : ℕ × ℕ | n < m ∧ n.centralBinom.primeFactors = m.centralBinom.primeFactors}
 
-
-namespace Erdos730
 
 /--
 Are there infinitely many pairs of integers $n < m$ such that $\binom{2n}{n}$

--- a/FormalConjectures/ErdosProblems/996.lean
+++ b/FormalConjectures/ErdosProblems/996.lean
@@ -29,11 +29,11 @@ import FormalConjectures.Util.ProblemImports
 
 open MeasureTheory AddCircle Filter Topology Asymptotics Finset Real
 
+namespace Erdos996
+
 noncomputable def fourierPartial {T : ℝ} [hT : Fact (0 < T)] (f : Lp ℂ 2 (@haarAddCircle T hT))
     (k : ℕ) : AddCircle T → ℂ :=
   fun x => ∑ i ∈ Icc (-k : ℤ) k, fourierCoeff f k • fourier i x
-
-namespace Erdos996
 
 /-- Does there exists a positive constant `C` such that for all `f ∈ L²[0,1]` and all lacunary
 sequences `n`, if `‖f - fₖ‖₂ = O(1 / log log log k ^ C)`, then for almost every `x`,

--- a/FormalConjectures/Millenium/RiemannHypothesis.lean
+++ b/FormalConjectures/Millenium/RiemannHypothesis.lean
@@ -43,7 +43,7 @@ Note: in Mathlib, `NumberField.dedekindZeta` is currently defined as the naive D
 - D. A. Marcus, *Number Fields*, Springer (GTM 81), 1977, Chapter VII.
 -/
 
-section RiemannHypothesis
+namespace RiemannHypothesis
 
 /-- The **Riemann Hypothesis**: all non-trivial zeros of the Riemann zeta function have real
 part $\frac{1}{2}$. That is, if $\zeta(s) = 0$, $s \neq 1$, and $s$ is not a trivial zero

--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -29,6 +29,8 @@ and conjectures that every convex set in ℝⁿ⁺¹ has finite VCₙ dimension.
 
 open scoped EuclideanGeometry Pointwise
 
+namespace VCDimConvex
+
 /-  ### What's known in the literature -/
 
 /-- Every convex set in $\mathbb R^2$ has VC dimension at most 3. -/
@@ -66,3 +68,5 @@ lemma exists_hasAddVCNDimAtMost_n_of_convex_rn_add_one (n : ℕ) :
 @[category research open, AMS 5 52]
 lemma hasAddVCNDimAtMost_n_one_of_convex_rn_add_one {n : ℕ} (hn : 2 ≤ n) {C : Set (Fin (n + 1) → ℝ)}
     (hC : Convex ℝ C) : HasAddVCNDimAtMost C n 1 := sorry
+
+end VCDimConvex

--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -26,10 +26,14 @@ open BigOperators
 open Classical
 open scoped Finset
 
+namespace DegreeSequencesTriangleFree
+
 /-- A sequence of natural numbers is **compact** on a set `S` if consecutive terms at distance
 `2` differ by `1` for all `k ∈ S`. -/
 def IsCompactSequenceOn (d : ℕ → ℕ) (S : Set ℕ) : Prop :=
   ∀ k ∈ S, d (k + 2) = d k + 1
+
+end DegreeSequencesTriangleFree
 
 namespace SimpleGraph
 
@@ -41,7 +45,7 @@ noncomputable def degreeFreq (G : SimpleGraph α) (d : ℕ) : ℕ :=
 
 end SimpleGraph
 
-section lemmas
+namespace DegreeSequencesTriangleFree
 
 variable (d : ℕ → ℕ) (n k r : ℕ)
 
@@ -114,7 +118,7 @@ lemma lemma2_d
         ∑ i ∈ .Icc 1 (2 * n + 1), d i := by
   sorry
 
-end lemmas
+end DegreeSequencesTriangleFree
 
 namespace SimpleGraph
 
@@ -124,7 +128,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /-- The degree sequence of `G` is **compact** if it satisfies
 `IsCompactSequenceOn` for all valid indices `k` such that `k + 2 < Fintype.card α`. -/
 def HasCompactdegreeSequence (G : SimpleGraph α) [DecidableRel G.Adj] : Prop :=
-  IsCompactSequenceOn (fun k => (degreeSequence G).getD k 0) {k | k + 2 < Fintype.card α}
+  DegreeSequencesTriangleFree.IsCompactSequenceOn (fun k => (degreeSequence G).getD k 0) {k | k + 2 < Fintype.card α}
 
 /-- **Theorem 1.** If a triangle-free graph has `f = 2`,
 then it is bipartite, has minimum degree `1`, and

--- a/FormalConjectures/Paper/LatinSquare.lean
+++ b/FormalConjectures/Paper/LatinSquare.lean
@@ -28,6 +28,8 @@ This file formalizes some conjectures and theorems around latin squares.
 * https://en.wikipedia.org/wiki/Problems_in_Latin_squares
 -/
 
+namespace LatinSquare
+
 variable {n : ℕ}
 
 /--
@@ -162,3 +164,5 @@ If $n$ is even, then $f(n, 2) = n$; if $n$ is odd, then $f(n, 2) > n$.
 TODO(rao107): Conjecture 10.10 in [Wa2011]:
 Every latin hypercube of odd dimension or of odd oder has a transversal.
 -/
+
+end LatinSquare

--- a/FormalConjectures/Util/ProblemImports.lean
+++ b/FormalConjectures/Util/ProblemImports.lean
@@ -23,6 +23,7 @@ public import FormalConjectures.Util.Linters.AnswerLinter
 public import FormalConjectures.Util.Linters.CategoryLinter
 public import FormalConjectures.Util.Linters.CopyrightLinter
 public import FormalConjectures.Util.Linters.ModuleDocstringLinter
+public import FormalConjectures.Util.Linters.NamespaceLinter
 
 
 /-!

--- a/FormalConjectures/Wikipedia/FeitThompsonPrimeConjecture.lean
+++ b/FormalConjectures/Wikipedia/FeitThompsonPrimeConjecture.lean
@@ -22,6 +22,8 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Feit%E2%80%93Thompson_conjecture)
 -/
 
+namespace FeitThompsonPrimeConjecture
+
 /--
 There are no distinct primes $p$ and $q$ such that $\frac{q^p - 1}{q - 1}$ divides $\frac{p^q - 1}{p - 1}$
 -/
@@ -29,3 +31,5 @@ There are no distinct primes $p$ and $q$ such that $\frac{q^p - 1}{q - 1}$ divid
 theorem feit_thompson_primes (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (h : p < q) :
     ¬ (q ^ p - 1) / (q - 1) ∣ (p ^ q - 1) / (p - 1) := by
   sorry
+
+end FeitThompsonPrimeConjecture

--- a/FormalConjectures/Wikipedia/InscribedSquare.lean
+++ b/FormalConjectures/Wikipedia/InscribedSquare.lean
@@ -33,6 +33,8 @@ There are several open and solved variants of this conjecture.
 open Topology ContDiff Manifold
 open scoped EuclideanGeometry
 
+namespace InscribedSquare
+
 /-- Four points `a b c d` in the plane form a rectangle with `a` opposite to `c` iff the line
 segments from `a` to `c` and from `b` to `d` have both the same length and the same midpoint, acting
 as the diagonals of the rectangle. We also require the rectangle to be nondegenerate and have a
@@ -89,3 +91,5 @@ theorem exists_inscribed_square_of_C2 (γ : Circle → ℝ²)
     (hγ : IsEmbedding γ) (hγ' : ContMDiff (𝓡 1) (𝓡 2) 2 γ) :
     ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) 1 := by
   sorry
+
+end InscribedSquare

--- a/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
+++ b/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
@@ -23,6 +23,8 @@ import FormalConjectures.Util.ProblemImports
 [Chalendar-Partington](https://arxiv.org/abs/2507.21834)
 -/
 
+namespace InvariantSubspaceProblem
+
 variable {H : Type*} [NormedAddCommGroup H]
 
 /-- `ClosedInvariantSubspace T` is the type of non-trivial (different from `H` and `{0}`) closed
@@ -115,3 +117,5 @@ theorem Invariant_subspace_problem_l1 :
     ∃ (T : (lp (fun (_ : ℕ) => ℂ) 1) →L[ℂ] (lp (fun (_ : ℕ) => ℂ) 1)),
     IsEmpty (ClosedInvariantSubspace T) := by
   sorry
+
+end InvariantSubspaceProblem

--- a/FormalConjectures/Wikipedia/KummerVandiver.lean
+++ b/FormalConjectures/Wikipedia/KummerVandiver.lean
@@ -24,6 +24,8 @@ import FormalConjectures.Util.ProblemImports
 
 open NumberField CyclotomicField IsCyclotomicExtension
 
+namespace KummerVandiver
+
 -- TODO(Paul-Lez): change `PNat` to `Nat` once the version of Mathlib we're on allows it.
 
 /--
@@ -34,3 +36,5 @@ real subfield of $\mathbb{Q}(\zeta_p)$ is not divisible by $p$.
 theorem kummer_vandiver (p : ℕ+) (hp : p.Prime) :
     ¬ ↑p ∣ (classNumber (maximalRealSubfield (CyclotomicField p ℚ))) := by
   sorry
+
+end KummerVandiver

--- a/FormalConjectures/Wikipedia/MeanValueProblem.lean
+++ b/FormalConjectures/Wikipedia/MeanValueProblem.lean
@@ -37,6 +37,8 @@ The conjecture has been proven for:
   by *David Tischler*
 -/
 
+namespace MeanValueProblem
+
 /--
 Given a complex polynomial $p$ of degree $d ≥ 2$ and a complex number $z$
 there is a critical point $c$ of $p$, such that $|p(z)-p(c)|/|z-c| ≤ |p'(z)|$.
@@ -83,3 +85,5 @@ lemma mean_value_problem_of_roots_same_norm (p : Polynomial ℂ) (hp : 2 ≤ p.n
     ∃ c : ℂ, p.derivative.eval c = 0 ∧
       ‖p.eval z - p.eval c‖ / ‖z - c‖ ≤ (p.natDegree - 1)/ p.natDegree * ‖p.derivative.eval z‖ := by
   sorry
+
+end MeanValueProblem

--- a/FormalConjectures/Wikipedia/MoserWorm.lean
+++ b/FormalConjectures/Wikipedia/MoserWorm.lean
@@ -24,6 +24,8 @@ import FormalConjectures.Util.ProblemImports
 
 open EuclideanGeometry MeasureTheory
 
+namespace MoserWorm
+
 /--
 The set of worms is the set of curves of length (at most) 1.
 We formalize this as the set of ranges of 1-Lipschitz functions from `[0,1]` to `ℝ²`.
@@ -115,3 +117,5 @@ International Journal of Computational Geometry & Applications,
 theorem convex_mosers_worm_problem_lower_bound :
     0.232239 ∈ lowerBounds {v | ∃ X ∈ WormCovers, Convex ℝ X ∧ volume X = v} := by
   sorry
+
+end MoserWorm

--- a/FormalConjectures/Wikipedia/PierceBirkhoff.lean
+++ b/FormalConjectures/Wikipedia/PierceBirkhoff.lean
@@ -29,6 +29,8 @@ Melvin Henriksen and John R. Isbell.
 The conjecture has been proved for `n = 1` and `n = 2` by Louis Mahé.
 -/
 
+namespace PierceBirkhoff
+
 /--
 A set is semi-algebraic in `ℝⁿ` if it can be described by a finite union of sets defined by
 multivariate polynomial equations and inequalities.
@@ -109,3 +111,5 @@ theorem pierce_birkhoff_conjecture_dim_two
     ∃ (ι κ : Type) (g : ι → κ → MvPolynomial (Fin 2) ℝ), Finite ι ∧ Finite κ ∧
       ∀ x, f x = ⨆ i, ⨅ j, MvPolynomial.eval x (g i j) := by
   sorry
+
+end PierceBirkhoff

--- a/FormalConjectures/Wikipedia/WallSunSun.lean
+++ b/FormalConjectures/Wikipedia/WallSunSun.lean
@@ -24,6 +24,8 @@ import FormalConjectures.Util.ProblemImports
 
 -- TODO: add more statements about Wall-Sun-Sun primes from the wiki page.
 
+namespace WallSunSun
+
 /--
 A prime $p$ is a Wall–Sun–Sun prime if and only if $L_p \equiv 1 \pmod{p^2}$, where $L_p$ is the
 $p$-th Lucas number. It is conjectured that there is at least one Wall–Sun–Sun prime.
@@ -52,3 +54,5 @@ theorem infinite_isWallSunSunPrime_of_disc_eq {D : ℕ} (hD₀ : 0 < D)
     (hD : D ≡ 0 [MOD 4] ∨ D ≡ 1 [MOD 4]) :
     {p : ℕ | ∃ a b : ℕ, a ^ 2 - 4 * b = D ∧ IsLucasWieferichPrime a b p}.Infinite := by
   sorry
+
+end WallSunSun

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -34,6 +34,8 @@ average_degree, matching_number, residue, annihilation_number, cvetkovic.
 
 open SimpleGraph
 
+namespace WrittenOnTheWallII.Test
+
 open Classical
 
 -- Bridge theorems for Sym2/edist-based invariants:
@@ -424,3 +426,5 @@ theorem Star5_annihilation : annihilationNumber Star5 = 5 := by
 @[category test, AMS 5]
 theorem Star5_cvetkovic : cvetkovic Star5 = 5 := by
   sorry
+
+end WrittenOnTheWallII.Test


### PR DESCRIPTION
fixes #2179

Not sure why it wasn't turned on in #2229 