### PR TITLE
fix(GraphConjecture34): use max-degree vertices per WOWII statement (closes #3808)

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -37,13 +37,14 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 34](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-Let `path(G)` be the floor of the average distance of a connected graph `G`.
-Then
-`path(G) ≥ ceil( distavg(G, center) + distavg(G, maxEccentricityVertices G) )`.
+Let `path(G)` be the size of the longest induced path of a connected graph `G`,
+let `C = graphCenter G` be the set of centers (minimum-eccentricity vertices)
+and `M = maxDegreeVertices G` be the set of vertices of maximum degree. Then
+`path(G) ≥ ceil( distavg(G, C) + distavg(G, M) )`.
 -/
 @[category research open, AMS 5]
 theorem conjecture34 [Nontrivial α] (G : SimpleGraph α) (h_conn : G.Connected) :
-    Int.ceil (distavg G (graphCenter G) + distavg G (maxEccentricityVertices G)) ≤ (path G : ℤ) := by
+    Int.ceil (distavg G (graphCenter G) + distavg G (maxDegreeVertices G)) ≤ (path G : ℤ) := by
   sorry
 
 end WrittenOnTheWallII.GraphConjecture34

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean
@@ -105,6 +105,10 @@ noncomputable def maxEccentricity (G : SimpleGraph α) : ℕ∞ :=
 noncomputable def maxEccentricityVertices (G : SimpleGraph α) : Set α :=
   {v : α | eccentricity G v = maxEccentricity G}
 
+/-- The set of vertices of maximum degree. -/
+noncomputable def maxDegreeVertices (G : SimpleGraph α) [DecidableRel G.Adj] : Set α :=
+  {v : α | G.degree v = G.maxDegree}
+
 /-- The average eccentricity of a graph `G`: the mean of `eccentricity G v` over all vertices,
 converted to a real number. Returns 0 if the graph has no vertices. -/
 noncomputable def averageEccentricity (G : SimpleGraph α) : ℝ :=


### PR DESCRIPTION
Closes #3808.

WOWII Conjecture 34 says
`path(G) ≥ ceil( distavg(C, V) + distavg(M, V) )`
where `C` = centers (min-eccentricity vertices) and **`M` = max-degree
vertices**. The upstream formalization mistakenly used
`maxEccentricityVertices` (the boundary set of max-eccentricity vertices)
instead of max-degree vertices. These are different vertex sets in
general, so the theorem as previously stated was not WOWII Conjecture 34.

## Changes

- `FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Invariants.lean`:
  add `maxDegreeVertices G := {v | G.degree v = G.maxDegree}` next to
  the existing `maxEccentricityVertices`.
- `FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean`:
  - theorem statement now uses `maxDegreeVertices G`.
  - module docstring corrected: `path(G)` is the longest induced path,
    not the floor of the average distance; description references `C`
    and `M` consistently with the WOWII wording.

## Build

Verified locally with `lake build FormalConjectures.WrittenOnTheWallII.GraphConjecture34` (success).

## Notes

Conjecture 34 remains `@[category research open, AMS 5]`; the `sorry`
proof body is unchanged. No other files are affected.