### PR TITLE
chore: enable `CategoryDocstringLinter` and fix findings

### DIFF
--- a/FormalConjectures/Arxiv/2504.17644/Margulis.lean
+++ b/FormalConjectures/Arxiv/2504.17644/Margulis.lean
@@ -42,8 +42,10 @@ end
 
 
 /--
-Let $D$ be the diagonal group of $\mathrm{SL}_n(\mathbb{R})$ where $n \ge 3$. Then any relatively compact $D$-orbit in
-$\mathrm{SL}_n(\mathbb{R})/ \mathrm{SL}_n(\mathbb{Z})$ is closed. -/
+Let $D$ be the diagonal group of $\mathrm{SL}_n(\mathbb{R})$ where $n \ge 3$.
+Then any relatively compact $D$-orbit in
+$\mathrm{SL}_n(\mathbb{R})/ \mathrm{SL}_n(\mathbb{Z})$ is closed.
+-/
 @[category research open, AMS 11 15 22]
 theorem conjecture_1_1 {n : ℕ} (hn : 3 ≤ n)
     (g : SL(n, ℝ) ⧸ Subgroup.map (map (Int.castRingHom ℝ)) ⊤)

--- a/FormalConjectures/Arxiv/2504.17644/Margulis.lean
+++ b/FormalConjectures/Arxiv/2504.17644/Margulis.lean
@@ -41,9 +41,9 @@ instance : TopologicalSpace (SpecialLinearGroup n ℝ) :=
 end
 
 
-/-
-Let `D` be the diagonal group of `SL_n(R)` where `n ≥ 3`. Then any relatively compact `D`-orbit in
-`SL_n(R)/ SLn(Z)` is closed. -/
+/--
+Let $D$ be the diagonal group of $\mathrm{SL}_n(\mathbb{R})$ where $n \ge 3$. Then any relatively compact $D$-orbit in
+$\mathrm{SL}_n(\mathbb{R})/ \mathrm{SL}_n(\mathbb{Z})$ is closed. -/
 @[category research open, AMS 11 15 22]
 theorem conjecture_1_1 {n : ℕ} (hn : 3 ≤ n)
     (g : SL(n, ℝ) ⧸ Subgroup.map (map (Int.castRingHom ℝ)) ⊤)

--- a/FormalConjectures/ErdosProblems/1060.lean
+++ b/FormalConjectures/ErdosProblems/1060.lean
@@ -37,6 +37,7 @@ theorem erdos_1060.parts.i :
     ∃ h : ℕ → ℝ,
       h =o[atTop] (fun n ↦ 1 / log (log n)) ∧ ∀ᶠ n in atTop, #{k ≤ n | k * σ 1 k = n} ≤ (n : ℝ) ^ h n := by sorry
 
+/-- Part (ii) of Erdős Problem 1060: bound on the number of $k \le n$ with $k \sigma_1(k) = n$. -/
 @[category research open, AMS 11]
 theorem erdos_1060.parts.ii :
     ∃ (C : ℝ), (fun n ↦ (#{k ≤ n | k * σ 1 k = n} : ℝ)) =O[atTop]

--- a/FormalConjectures/ErdosProblems/1092.lean
+++ b/FormalConjectures/ErdosProblems/1092.lean
@@ -53,11 +53,13 @@ noncomputable def f (r n : ℕ) : ℕ :=
           chromaticNumber (H.coe.deleteEdges E) ≤ (r + 1 : ℕ∞)) →
       chromaticNumber G ≤ (r + 1 : ℕ∞)}
 
+/-- Asymptotic behavior of $f(2, n)$. -/
 @[category research open, AMS 5]
 theorem f_asymptotic_2 : answer(sorry) ↔
     (fun (n : ℕ) => (n : ℝ)) =o[atTop] (fun (n : ℕ) => (f 2 n : ℝ)) := by
   sorry
 
+/-- Asymptotic behavior of $f(r, n)$ for general $r$. -/
 @[category research open, AMS 5]
 theorem f_asymptotic_general :
     answer(sorry) ↔ ∀ r : ℕ, (fun n : ℕ => ((r : ℝ) * n)) =o[atTop] (fun n : ℕ => (f r n : ℝ)) := by

--- a/FormalConjectures/ErdosProblems/252.lean
+++ b/FormalConjectures/ErdosProblems/252.lean
@@ -43,6 +43,7 @@ namespace Erdos252
 /-- The series `∑ σ k n / n!`. -/
 noncomputable def erdos_252_sum (k : ℕ) : ℝ := ∑' n, σ k n / (n ! : ℝ)
 
+/-- Erdős Problem 252: irrationality of the sum for a given $k$. -/
 @[category research open, AMS 11]
 theorem erdos_252 :
     answer(sorry) ↔ ∀ k ≥ 1, Irrational (erdos_252_sum k) := by

--- a/FormalConjectures/ErdosProblems/260.lean
+++ b/FormalConjectures/ErdosProblems/260.lean
@@ -26,8 +26,8 @@ namespace Erdos260
 
 open Filter
 
-/-
-Let $a_1 < a_2 < \cdots$ be an increasing sequence such that $\frac{a_n}{n} → \infty$.
+/--
+Let $a_1 < a_2 < \cdots$ be an increasing sequence such that $\frac{a_n}{n} \to \infty$.
 Is the sum $\sum_{n}^{\infty} \frac{a_n}{2^{a_n}}$ irrational?
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/ErdosProblems/4.lean
+++ b/FormalConjectures/ErdosProblems/4.lean
@@ -40,6 +40,7 @@ $$
 theorem erdos_4 : answer(True) ↔ (∀ C > 0, Erdos4For C) := by
   sorry
 
+/-- Rankin's theorem: there exists a positive constant $C$ such that `Erdos4For C` holds. -/
 @[category research solved, AMS 11]
 theorem erdos_4.variants.rankin :
     ∃ C > 0, Erdos4For C := by

--- a/FormalConjectures/ErdosProblems/494.lean
+++ b/FormalConjectures/ErdosProblems/494.lean
@@ -53,6 +53,7 @@ theorem erdos_494.variants.k_eq_2_card_not_pow_two :
     ∀ card : ℕ, (∀ l : ℕ, card ≠ 2 ^ l) → Erdos494Unique 2 card := by
   sorry
 
+/-- Selfridge and Straus [SeSt58] gave counterexamples to the conjecture when $k = 2$ and $|A| = 2^l$. -/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.k_eq_2_card_pow_two :
     ∀ card : ℕ, (∃ l : ℕ, card = 2 ^ l) → ¬Erdos494Unique 2 card := by
@@ -70,11 +71,13 @@ theorem erdos_494.variants.k_eq_3_card_gt_6 :
     ∀ card > 6, Erdos494Unique 3 card := by
   sorry
 
+/-- Selfridge and Straus [SeSt58] showed that the conjecture is true when $k = 4$ and $|A| > 12$. -/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.k_eq_4_card_gt_12 :
     ∀ card > 12, Erdos494Unique 4 card := by
   sorry
 
+/-- Selfridge and Straus [SeSt58] proved that $A$ is determined by $A_k$ if $|A|$ is divisible by a prime greater than $k$. -/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.card_divisible_by_prime_gt_k :
     ∀ (k card p : ℕ), p.Prime → k ∈ Set.Ioo 0 p → p ∣ card → Erdos494Unique k card := by
@@ -114,6 +117,7 @@ $A = \{1, \zeta_6, \zeta_6^2, \zeta_6^4\}$ and $B = \{1, \zeta_6^2, \zeta_6^3, \
 noncomputable def prodMultiset (A : Finset ℂ) (k : ℕ) : Multiset ℂ :=
   ((A.powersetCard k).val.map (fun s => s.prod id))
 
+/-- A counterexample to the product version of the conjecture (by Steinerberger). -/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.product :
     ∃ (A B : Finset ℂ), A.card = B.card ∧ prodMultiset A 3 = prodMultiset B 3 ∧

--- a/FormalConjectures/ErdosProblems/494.lean
+++ b/FormalConjectures/ErdosProblems/494.lean
@@ -53,7 +53,10 @@ theorem erdos_494.variants.k_eq_2_card_not_pow_two :
     ∀ card : ℕ, (∀ l : ℕ, card ≠ 2 ^ l) → Erdos494Unique 2 card := by
   sorry
 
-/-- Selfridge and Straus [SeSt58] gave counterexamples to the conjecture when $k = 2$ and $|A| = 2^l$. -/
+/--
+Selfridge and Straus [SeSt58] gave counterexamples to the conjecture
+when $k = 2$ and $|A| = 2^l$.
+-/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.k_eq_2_card_pow_two :
     ∀ card : ℕ, (∃ l : ℕ, card = 2 ^ l) → ¬Erdos494Unique 2 card := by
@@ -71,13 +74,19 @@ theorem erdos_494.variants.k_eq_3_card_gt_6 :
     ∀ card > 6, Erdos494Unique 3 card := by
   sorry
 
-/-- Selfridge and Straus [SeSt58] showed that the conjecture is true when $k = 4$ and $|A| > 12$. -/
+/--
+Selfridge and Straus [SeSt58] showed that the conjecture is true
+when $k = 4$ and $|A| > 12$.
+-/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.k_eq_4_card_gt_12 :
     ∀ card > 12, Erdos494Unique 4 card := by
   sorry
 
-/-- Selfridge and Straus [SeSt58] proved that $A$ is determined by $A_k$ if $|A|$ is divisible by a prime greater than $k$. -/
+/--
+Selfridge and Straus [SeSt58] proved that $A$ is determined by $A_k$
+if $|A|$ is divisible by a prime greater than $k$.
+-/
 @[category research solved, AMS 5]
 theorem erdos_494.variants.card_divisible_by_prime_gt_k :
     ∀ (k card p : ℕ), p.Prime → k ∈ Set.Ioo 0 p → p ∣ card → Erdos494Unique k card := by

--- a/FormalConjectures/ErdosProblems/855.lean
+++ b/FormalConjectures/ErdosProblems/855.lean
@@ -28,6 +28,7 @@ open scoped Nat.Prime
 
 namespace Erdos855
 
+/-- Erdős Problem 855 (Segal's conjecture): $\pi(x + y) \le \pi(x) + \pi(y)$ for sufficiently large $x, y$. -/
 @[category research open, AMS 11]
 theorem erdos_855 : answer(sorry) ↔
     ∀ᶠ x in atTop, ∀ᶠ y in atTop, π (x + y) ≤ π x + π y := by

--- a/FormalConjectures/ErdosProblems/855.lean
+++ b/FormalConjectures/ErdosProblems/855.lean
@@ -28,7 +28,10 @@ open scoped Nat.Prime
 
 namespace Erdos855
 
-/-- Erdős Problem 855 (Segal's conjecture): $\pi(x + y) \le \pi(x) + \pi(y)$ for sufficiently large $x, y$. -/
+/--
+Erdős Problem 855 (Segal's conjecture): $\pi(x + y) \le \pi(x) + \pi(y)$
+for sufficiently large $x, y$.
+-/
 @[category research open, AMS 11]
 theorem erdos_855 : answer(sorry) ↔
     ∀ᶠ x in atTop, ∀ᶠ y in atTop, π (x + y) ≤ π x + π y := by

--- a/FormalConjectures/ErdosProblems/859.lean
+++ b/FormalConjectures/ErdosProblems/859.lean
@@ -48,6 +48,7 @@ theorem erdos_859.variants.erdos_upper_lower_bounds : ∃ᵉ (c₃ > (0 : ℝ)) 
 The density `dₜ` of `DivisorSumSet (t : ℕ)` is assymptotically equivalent to ` c₁ / log (t) ^ c₂`
 for some positive constants `c₁` and `c₂`.
 -/
+/-- The density of the divisor sum set is asymptotically equivalent to $c_1 / \log(t)^{c_2}$. -/
 @[category research open, AMS 11]
 theorem erdos_859 :
     ∃ c₁ > 0, ∃ c₂ > (0 : ℝ), ∃ d : ℕ → ℝ, (∀ t > 0, (DivisorSumSet t).HasDensity (d t)) ∧

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -51,6 +51,7 @@ theorem erdos_961.variants.sylvester_schur_1_1 : Erdos961Prop 1 1 := by
     obtain ⟨p, hp, hpm⟩ := Nat.exists_prime_and_dvd (by omega : m ≠ 1)
     exact ⟨p, (Nat.mem_primeFactorsList hm0).mpr ⟨hp, hpm⟩, hp.two_le⟩
 
+/-- There exists $n$ such that `Erdos961Prop k n` holds. -/
 @[category research solved, AMS 11]
 theorem erdos_961.variants.well_defined (k : ℕ) (hk : 0 < k): ∃ n, Erdos961Prop k n := by
   use k

--- a/FormalConjectures/ErdosProblems/975.lean
+++ b/FormalConjectures/ErdosProblems/975.lean
@@ -65,6 +65,7 @@ theorem erdos_975.variants.upper_bound (f : ℤ[X]) (hf : Irreducible f)
     (hf_pos : ∀ᶠ n in atTop, 1 ≤ f.eval n) : Erdos975Sum f =O[atTop] (fun x ↦ x * log x) := by
   sorry
 
+/-- Lower bound for the growth rate of `Erdos975Sum`, shown in [Va39]. -/
 @[category research solved, AMS 11]
 theorem erdos_975.variants.lower_bound (f : ℤ[X]) (hf : Irreducible f) (hfdeg : f.natDegree ≠ 0)
     (hf_pos : ∀ᶠ n in atTop, 1 ≤ f.eval n) :
@@ -93,6 +94,7 @@ theorem erdos_975.variants.n2_plus_1_strong :
     (fun x ↦ Erdos975Sum (X ^ 2 + 1) x - (3 / π) * x * log x) =O[atTop] id := by
   sorry
 
+/-- Asymptotics for `Erdos975Sum` with $f(X) = X^2 + 1$. -/
 @[category research solved, AMS 11]
 theorem erdos_975.variants.n2_plus_1 :
     ∃ c > (0 : ℝ), Tendsto (fun x ↦ Erdos975Sum (X ^ 2 + 1) x / (x * log x)) atTop (𝓝 c) := by

--- a/FormalConjectures/HilbertProblems/17.lean
+++ b/FormalConjectures/HilbertProblems/17.lean
@@ -34,6 +34,7 @@ namespace Hilbert17
 
 abbrev MvRatFunc (σ K : Type*) [CommRing K] := FractionRing (MvPolynomial σ K)
 
+/-- Hilbert's 17th problem: every non-negative multivariate polynomial is a sum of squares of rational functions. -/
 @[category research solved, AMS 12]
 theorem hilbert_17th_problem {n : ℕ} (hn : 0 < n) (f : MvPolynomial (Fin n) ℝ)
     (h : ∀ x : Fin n → ℝ, 0 ≤ f.eval x) :
@@ -99,6 +100,7 @@ theorem Hilbert17thProblemHomogenousPoly_zero_right (n : ℕ) :
   rw [Finset.sum_congr rfl fun _ _ ↦ (map_pow _ _ _).symm, Real.sq_sqrt <| by simpa using hf₀ 0]
   simpa using hfd
 
+/-- Hilbert's 17th problem for homogeneous polynomials: characterization of dimensions and degrees where non-negative polynomials are sums of squares of polynomials. -/
 @[category research solved, AMS 12]
 theorem hilbert_17th_problem_poly {n d : ℕ} (hn : 0 < n) (hd : 0 < d) :
     Hilbert17thProblemHomogenousPoly n d ↔ n = 1 ∨ n = 2 ∨ d = 1 ∨ n = 3 ∧ d = 2 := by

--- a/FormalConjectures/HilbertProblems/17.lean
+++ b/FormalConjectures/HilbertProblems/17.lean
@@ -34,7 +34,10 @@ namespace Hilbert17
 
 abbrev MvRatFunc (σ K : Type*) [CommRing K] := FractionRing (MvPolynomial σ K)
 
-/-- Hilbert's 17th problem: every non-negative multivariate polynomial is a sum of squares of rational functions. -/
+/--
+Hilbert's 17th problem: every non-negative multivariate polynomial is a sum of
+squares of rational functions.
+-/
 @[category research solved, AMS 12]
 theorem hilbert_17th_problem {n : ℕ} (hn : 0 < n) (f : MvPolynomial (Fin n) ℝ)
     (h : ∀ x : Fin n → ℝ, 0 ≤ f.eval x) :
@@ -100,7 +103,10 @@ theorem Hilbert17thProblemHomogenousPoly_zero_right (n : ℕ) :
   rw [Finset.sum_congr rfl fun _ _ ↦ (map_pow _ _ _).symm, Real.sq_sqrt <| by simpa using hf₀ 0]
   simpa using hfd
 
-/-- Hilbert's 17th problem for homogeneous polynomials: characterization of dimensions and degrees where non-negative polynomials are sums of squares of polynomials. -/
+/--
+Hilbert's 17th problem for homogeneous polynomials: characterization of dimensions and degrees
+where non-negative polynomials are sums of squares of polynomials.
+-/
 @[category research solved, AMS 12]
 theorem hilbert_17th_problem_poly {n d : ℕ} (hn : 0 < n) (hd : 0 < d) :
     Hilbert17thProblemHomogenousPoly n d ↔ n = 1 ∨ n = 2 ∨ d = 1 ∨ n = 3 ∧ d = 2 := by

--- a/FormalConjectures/OEIS/231201.lean
+++ b/FormalConjectures/OEIS/231201.lean
@@ -46,6 +46,7 @@ theorem primeCondition_8 : PrimeCondition 8 :=
 theorem primeCondition_53 : PrimeCondition 53 :=
   ⟨20, 33, by norm_num, by norm_num, by norm_num, by norm_num⟩
 
+/-- The conjecture for sequence A231201: for any $n > 1$, there exist $x, y > 0$ such that $n = x + y$ and $2^x + y$ is prime. -/
 @[category research open, AMS 11]
 theorem conjecture (n : ℕ) (hn : 1 < n) : PrimeCondition n := by
   sorry

--- a/FormalConjectures/Other/EquationalTheories_677_255.lean
+++ b/FormalConjectures/Other/EquationalTheories_677_255.lean
@@ -33,12 +33,14 @@ abbrev Equation255 (G: Type) [Magma G] := ∀ x : G, x = ((x ◇ x) ◇ x) ◇ x
 
 abbrev Equation677 (G: Type) [Magma G] := ∀ x y : G, x = y ◇ (x ◇ ((y ◇ x) ◇ y))
 
+/-- Equation 255 does not imply Equation 677. -/
 @[category research solved, AMS 8]
 theorem Equation255_not_implies_Equation677 :
     ∃ (G : Type) (_ : Magma G), Equation255 G ∧ ¬ Equation677 G :=
   ⟨Fin 3, ⟨![![1, 2, 0], ![2, 0, 1], ![0, 1, 2]]⟩,
     fun x ↦ by fin_cases x <;> rfl, of_decide_eq_false rfl⟩
 
+/-- Equation 677 does not imply Equation 255. -/
 @[category research solved, AMS 8]
 theorem Equation677_not_implies_Equation255 :
     ∃ (G : Type) (_ : Magma G), Equation677 G ∧ ¬ Equation255 G := by

--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -175,10 +175,12 @@ noncomputable def F (n : ℕ) : ℕ :=
   sInf { p | ∃ (G : SimpleGraph (Fin p)) (_ : DecidableRel G.Adj),
     G.CliqueFree 3 ∧ G.chromaticNumber = n ∧ degreeSequenceMultiplicity G = 3 }
 
+/-- The smallest number of vertices of a triangle-free graph with chromatic number 3 and f=3 is 7. -/
 @[category research solved, AMS 5]
 theorem F_three : F 3 = 7 := by
   sorry
 
+/-- The smallest number of vertices of a triangle-free graph with chromatic number 4 and f=3 is at most 19. -/
 @[category research solved, AMS 5]
 theorem F_four_le : F 4 ≤ 19 := by
   sorry

--- a/FormalConjectures/Util/ProblemImports.lean
+++ b/FormalConjectures/Util/ProblemImports.lean
@@ -20,6 +20,7 @@ public import FormalConjecturesForMathlib
 public import FormalConjectures.Util.Answer
 public import FormalConjectures.Util.Linters.AMSLinter
 public import FormalConjectures.Util.Linters.AnswerLinter
+public import FormalConjectures.Util.Linters.CategoryDocstringLinter
 public import FormalConjectures.Util.Linters.CategoryLinter
 public import FormalConjectures.Util.Linters.CopyrightLinter
 public import FormalConjectures.Util.Linters.ModuleDocstringLinter

--- a/FormalConjectures/Wikipedia/BusyBeaver.lean
+++ b/FormalConjectures/Wikipedia/BusyBeaver.lean
@@ -82,6 +82,7 @@ theorem BB_3 : BB 3 = 21 := by
 theorem BB_4 : BB 4 = 107 := by
   sorry
 
+/-- The value of the Busy Beaver function for 5 states is 47176870. -/
 @[category research solved, AMS 3]
 theorem BB_5 : BB 5 = 47176870 := by
   sorry

--- a/FormalConjectures/Wikipedia/CongruentNumber.lean
+++ b/FormalConjectures/Wikipedia/CongruentNumber.lean
@@ -84,11 +84,13 @@ def D (n : ℕ) : Set (ℤ × ℤ × ℤ) := {(x, y, z) | n = 8 * x ^ 2 + 2 * y 
 
 /-  Tunnell's theorem. -/
 
+/-- Tunnell's theorem (necessary condition) for odd squarefree congruent numbers. -/
 @[category research solved, AMS 11]
 theorem Tunnell_odd (n : ℕ) (hsqf : Squarefree n) (hodd : Odd n) :
     congruentNumber n → 2 * (A n).ncard = (B n).ncard := by
   sorry
 
+/-- Tunnell's theorem (necessary condition) for even squarefree congruent numbers. -/
 @[category research solved, AMS 11]
 theorem Tunnell_even (n : ℕ) (hsqf : Squarefree n) (heven : Even n) :
     congruentNumber n → 2 * (C n).ncard = (D n).ncard := by
@@ -96,11 +98,13 @@ theorem Tunnell_even (n : ℕ) (hsqf : Squarefree n) (heven : Even n) :
 
 /-  Converse of Tunnell's theorem. -/
 
+/-- Tunnell's theorem (sufficient condition assuming BSD) for odd squarefree congruent numbers. -/
 @[category research open, AMS 11]
 theorem Tunnell_odd_converse (n : ℕ) (hsqf : Squarefree n) (hodd : Odd n) :
     2 * (A n).ncard = (B n).ncard → congruentNumber n := by
   sorry
 
+/-- Tunnell's theorem (sufficient condition assuming BSD) for even squarefree congruent numbers. -/
 @[category research open, AMS 11]
 theorem Tunnell_even_converse (n : ℕ) (hsqf : Squarefree n) (heven : Even n) :
     2 * (C n).ncard = (D n).ncard → congruentNumber n := by

--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -183,10 +183,12 @@ theorem Δ_elkiesKlagsbrun29 : elkiesKlagsbrun29.Δ =
 instance : elkiesKlagsbrun29.IsElliptic where
   isUnit := by rw [Δ_elkiesKlagsbrun29]; norm_num
 
+/-- The rank of the Elkies-Klagsbrun curve is at least 29. -/
 @[category research solved, AMS 11 14]
 theorem twentynine_le_rank_elkiesKlagsbrun29 : 29 ≤ finrank ℤ elkiesKlagsbrun29⟮ℚ⟯ := by
   sorry
 
+/-- The rank of the Elkies-Klagsbrun curve is exactly 29. -/
 @[category research open, AMS 11 14]
 theorem rank_elkiesKlagsbrun29 : finrank ℤ elkiesKlagsbrun29⟮ℚ⟯ = 29 := by
   sorry
@@ -212,10 +214,12 @@ theorem Δ_elkies28 : elkies28.Δ =
 instance : elkies28.IsElliptic where
   isUnit := by rw [Δ_elkies28]; norm_num
 
+/-- The rank of the Elkies curve is at least 28. -/
 @[category research solved, AMS 11 14]
 theorem twentyeight_le_rank_elkies28 : 28 ≤ finrank ℤ elkies28⟮ℚ⟯ := by
   sorry
 
+/-- The rank of the Elkies curve is exactly 28. -/
 @[category research open, AMS 11 14]
 theorem rank_elkies28 : finrank ℤ elkies28⟮ℚ⟯ = 28 := by
   sorry

--- a/FormalConjectures/Wikipedia/EulerSumOfPowers.lean
+++ b/FormalConjectures/Wikipedia/EulerSumOfPowers.lean
@@ -37,6 +37,7 @@ theorem eulers_sum_of_powers_conjecture (n k b : ℕ) (hn : 1 < n) (hk : 5 < k) 
     (ha : ∀ i, a i > 0) (hsum : ∑ i, (a i) ^ k = b ^ k) : k ≤ n := by
   sorry
 
+/-- Euler's sum of powers conjecture is false for $k=4$ (counterexample exists). -/
 @[category research solved, AMS 11]
 theorem eulers_sum_of_powers_conjecture.false_for_k4 : ¬ (∀ (n b : ℕ) (_ : 1 < n)
     (a: Fin n → ℕ) (_ : ∀ i, a i > 0) (_ : ∑ i, (a i) ^ 4 = b ^ 4), 4 ≤ n) := by
@@ -46,6 +47,7 @@ theorem eulers_sum_of_powers_conjecture.false_for_k4 : ¬ (∀ (n b : ℕ) (_ : 
   use ![95800, 217519, 414560]
   decide
 
+/-- Euler's sum of powers conjecture is false for $k=5$ (counterexample exists). -/
 @[category research solved, AMS 11]
 theorem eulers_sum_of_powers_conjecture.false_for_k5 : ¬ (∀ (n b : ℕ) (_ : 1 < n)
     (a: Fin n → ℕ) (_ : ∀ i, a i > 0) (_ : ∑ i, (a i) ^ 5 = b ^ 5), 5 ≤ n) := by

--- a/FormalConjectures/Wikipedia/Kakeya.lean
+++ b/FormalConjectures/Wikipedia/Kakeya.lean
@@ -54,6 +54,7 @@ Hausdorff dimension `n`.
 def KakeyaSetConjectureDim (n : ℕ) : Prop :=
   ∀ S : Set (ℝ^n), IsKakeya S → dimH S = n
 
+/-- The Kakeya set conjecture: Kakeya sets in $\mathbb{R}^n$ have Hausdorff dimension $n$. -/
 @[category research open, AMS 42]
 theorem kakeya_set_conjecture (n : ℕ) (hn : n > 0) :
     KakeyaSetConjectureDim n := by

--- a/FormalConjectures/Wikipedia/Mersenne.lean
+++ b/FormalConjectures/Wikipedia/Mersenne.lean
@@ -80,6 +80,7 @@ theorem new_mersenne_conjecture_of_prime :
     ∀ p, Odd p → NewMersenneConjectureStatement p := by
   sorry
 
+/-- The New Mersenne Conjecture statement holds for odd primes. -/
 @[category research open, AMS 11]
 theorem new_mersenne_conjecture.variants.prime (p : ℕ) (hp : p.Prime) (h : Odd p) :
     NewMersenneConjectureStatement p := by

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -82,6 +82,7 @@ def modularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
   ∃ (N : ℕ+) (f : CuspForm (Gamma0 N) 2), IsNormalisedEigenform f ∧
     ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p
 
+/-- The Modularity Theorem (formerly Shimura-Taniyama-Weil conjecture): every elliptic curve over $\mathbb{Q}$ is modular. -/
 @[category research solved, AMS 11]
 theorem modularity_conjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : modularityConjecture E := by
   sorry

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -82,7 +82,10 @@ def modularityConjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : Prop :=
   ∃ (N : ℕ+) (f : CuspForm (Gamma0 N) 2), IsNormalisedEigenform f ∧
     ∀ (p : ℕ), p.Prime → (N : ZMod p) ≠ 0 → a_[p]f = E.ap p
 
-/-- The Modularity Theorem (formerly Shimura-Taniyama-Weil conjecture): every elliptic curve over $\mathbb{Q}$ is modular. -/
+/--
+The Modularity Theorem (formerly Shimura-Taniyama-Weil conjecture): every elliptic curve
+over $\mathbb{Q}$ is modular.
+-/
 @[category research solved, AMS 11]
 theorem modularity_conjecture (E : WeierstrassCurve ℚ) [E.IsElliptic] : modularityConjecture E := by
   sorry

--- a/FormalConjectures/Wikipedia/RamanujanTau.lean
+++ b/FormalConjectures/Wikipedia/RamanujanTau.lean
@@ -56,10 +56,12 @@ lemma τ_two : τ 2 = -24 := by
   sorry
 
 
+/-- The Ramanujan-Petersson conjecture: $|\tau(p)| \le 2 p^{11/2}$ for primes $p$. -/
 @[category research solved, AMS 11]
 theorem ramanujan_petersson : ∀ p : ℕ, Prime p → abs (τ p) ≤ 2 * (p : ℝ) ^ ((11 : ℝ) / 2) := by
   sorry
 
+/-- Lehmer's conjecture: $\tau(n) \ne 0$ for all $n > 0$. -/
 @[category research open, AMS 11]
 theorem lehmer_ramanujan_tau : ∀ n > 0, τ n ≠ 0 := by
   sorry

--- a/FormalConjectures/Wikipedia/Singmaster.lean
+++ b/FormalConjectures/Wikipedia/Singmaster.lean
@@ -38,7 +38,10 @@ The set of pairs (n, k) representing the solutions to the equation
 def solutions (t : ℕ) : Set (ℕ × ℕ) :=
   {(n, k) | 1 ≤ k ∧ k < n ∧ Nat.choose n k = t}
 
-/-- Singmaster's conjecture: the number of times any number $t > 1$ appears in Pascal's triangle is bounded. -/
+/--
+Singmaster's conjecture: the number of times any number $t > 1$ appears in
+Pascal's triangle is bounded.
+-/
 @[category research open, AMS 11]
 theorem singmaster: ∃ (C : ℕ), ∀ (t : ℕ), t > 1 →
     (Singmaster.solutions t).Finite ∧ (Singmaster.solutions t).ncard ≤ C := by

--- a/FormalConjectures/Wikipedia/Singmaster.lean
+++ b/FormalConjectures/Wikipedia/Singmaster.lean
@@ -38,6 +38,7 @@ The set of pairs (n, k) representing the solutions to the equation
 def solutions (t : ℕ) : Set (ℕ × ℕ) :=
   {(n, k) | 1 ≤ k ∧ k < n ∧ Nat.choose n k = t}
 
+/-- Singmaster's conjecture: the number of times any number $t > 1$ appears in Pascal's triangle is bounded. -/
 @[category research open, AMS 11]
 theorem singmaster: ∃ (C : ℕ), ∀ (t : ℕ), t > 1 →
     (Singmaster.solutions t).Finite ∧ (Singmaster.solutions t).ncard ≤ C := by

--- a/FormalConjectures/Wikipedia/SnakeInTheBox.lean
+++ b/FormalConjectures/Wikipedia/SnakeInTheBox.lean
@@ -75,29 +75,26 @@ theorem snake_zero_zero : LongestSnakeInTheBox 0 = 0 := by
 
 open List
 
-/-
+/--
 The maximum length for the snake-in-the-box problem is known for dimensions zero through eight;
 it is $0, 1, 2, 4, 7, 13, 26, 50, 98$.
---/
-/-- Values of the longest snake-in-the-box for dimensions up to 8. -/
+-/
 @[category research solved, AMS 5]
 theorem snake_small_dimensions :
     map LongestSnakeInTheBox (range 9) = [0, 1, 2, 4, 7, 13, 26, 50, 98] := by
   sorry
 
-/-
+/--
 For dimension $9$, the length of the longest snake in the box is not known.
 This is currently the smallest dimension where this question is open.
---/
-/-- The value of the longest snake-in-the-box for dimension 9. -/
+-/
 @[category research open, AMS 5]
 theorem snake_dim_nine : LongestSnakeInTheBox 9 = answer(sorry) := by
   sorry
 
-/-
+/--
 The best length found so far for dimension nine is 190.
---/
-/-- A lower bound of 190 for the longest snake-in-the-box in dimension 9. -/
+-/
 @[category research solved, AMS 5]
 theorem snake_dim_nine_lower_bound : 190 ≤ LongestSnakeInTheBox 9 := by
   sorry

--- a/FormalConjectures/Wikipedia/SnakeInTheBox.lean
+++ b/FormalConjectures/Wikipedia/SnakeInTheBox.lean
@@ -79,6 +79,7 @@ open List
 The maximum length for the snake-in-the-box problem is known for dimensions zero through eight;
 it is $0, 1, 2, 4, 7, 13, 26, 50, 98$.
 --/
+/-- Values of the longest snake-in-the-box for dimensions up to 8. -/
 @[category research solved, AMS 5]
 theorem snake_small_dimensions :
     map LongestSnakeInTheBox (range 9) = [0, 1, 2, 4, 7, 13, 26, 50, 98] := by
@@ -88,6 +89,7 @@ theorem snake_small_dimensions :
 For dimension $9$, the length of the longest snake in the box is not known.
 This is currently the smallest dimension where this question is open.
 --/
+/-- The value of the longest snake-in-the-box for dimension 9. -/
 @[category research open, AMS 5]
 theorem snake_dim_nine : LongestSnakeInTheBox 9 = answer(sorry) := by
   sorry
@@ -95,6 +97,7 @@ theorem snake_dim_nine : LongestSnakeInTheBox 9 = answer(sorry) := by
 /-
 The best length found so far for dimension nine is 190.
 --/
+/-- A lower bound of 190 for the longest snake-in-the-box in dimension 9. -/
 @[category research solved, AMS 5]
 theorem snake_dim_nine_lower_bound : 190 ≤ LongestSnakeInTheBox 9 := by
   sorry


### PR DESCRIPTION
turning it on after #3753