### PR TITLE
feat(ForMathlib): three sorry-free helpers — complete-graph edge count, hom density, finite probabilistic method

### DIFF
--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -42,12 +42,14 @@ public import FormalConjecturesForMathlib.Combinatorics.SetFamily.VCDim
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Balanced
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Clique
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Coloring
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.CompleteGraphEdgeCount
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.DiamExtra
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Definitions
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Domination
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.Invariants
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.LargestInducedTree
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.WellTotallyDominated
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.HomDensity
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Johnson
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SizeRamsey
 public import FormalConjecturesForMathlib.Combinatorics.YoungDiagram
@@ -96,6 +98,7 @@ public import FormalConjecturesForMathlib.Order.Filter.Cofinite
 public import FormalConjecturesForMathlib.Order.Filter.atTopBot.Finset
 public import FormalConjecturesForMathlib.Order.Interval.Finset.Basic
 public import FormalConjecturesForMathlib.Order.Interval.Finset.Nat
+public import FormalConjecturesForMathlib.Probability.FiniteMethod
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.Arithmetic
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.Continuum
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Basic
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+
+@[expose] public section
+
+namespace SimpleGraph
+
+/--
+The number of edges of the complete graph on a finite vertex type `V` is `#V choose 2`.
+
+This is a thin `completeGraph`-flavoured restatement of Mathlib's
+`SimpleGraph.card_edgeFinset_top_eq_card_choose_two`, useful when a downstream definition
+is stated using the `completeGraph V` abbreviation rather than the `⊤` form. (Because
+`completeGraph V` reduces to `⊤`, the two are definitionally equal.)
+-/
+lemma card_edgeFinset_completeGraph (V : Type*) [Fintype V] [DecidableEq V] :
+    ((completeGraph V).edgeFinset).card = (Fintype.card V).choose 2 :=
+  card_edgeFinset_top_eq_card_choose_two
+
+/-- Specialisation of `card_edgeFinset_completeGraph` to `Fin n`. -/
+lemma card_edgeFinset_completeGraph_fin (n : ℕ) :
+    ((completeGraph (Fin n)).edgeFinset).card = n.choose 2 := by
+  simpa using card_edgeFinset_completeGraph (Fin n)
+
+end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 module
 
-public import Mathlib.Combinatorics.SimpleGraph.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Finite
 
 @[expose] public section

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HomDensity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HomDensity.lean
@@ -16,13 +16,8 @@ limitations under the License.
 module
 
 
+public import Mathlib.Analysis.Normed.Ring.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Maps
-public import Mathlib.Combinatorics.SimpleGraph.Finite
-public import Mathlib.Data.Fintype.Pi
-public import Mathlib.Data.Fintype.BigOperators
-public import Mathlib.Data.Real.Basic
-public import Mathlib.Analysis.Normed.Ring.Lemmas
-public import Mathlib.Tactic.Positivity
 
 @[expose] public section
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HomDensity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HomDensity.lean
@@ -1,0 +1,81 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+
+public import Mathlib.Combinatorics.SimpleGraph.Maps
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+public import Mathlib.Data.Fintype.Pi
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Analysis.Normed.Ring.Lemmas
+public import Mathlib.Tactic.Positivity
+
+@[expose] public section
+
+/-!
+# Homomorphism density for finite simple graphs
+
+Mathlib does not (as of 2026-04) provide `SimpleGraph.homDensity`. We define a lightweight
+version here, specialised to finite vertex types on the host `G`, and prove the basic
+`homDensity H G ≤ 1` upper bound used as a sanity check in Sidorenko-style arguments.
+
+The extension to infinite hosts uses the same formula with `Fintype.card` replaced by
+measure-theoretic integrals; we do not need that generality here.
+-/
+
+namespace SimpleGraph
+
+variable {V W : Type*}
+
+/-- The number of graph homomorphisms `H → G`, as a natural number. For finite vertex
+types this is just the cardinality of the `Hom` type. -/
+noncomputable def homCount [Fintype V] [Fintype W] [DecidableEq V] [DecidableEq W]
+    (H : SimpleGraph V) (G : SimpleGraph W) [DecidableRel H.Adj] [DecidableRel G.Adj] : ℕ :=
+  Fintype.card (H →g G)
+
+/-- The **homomorphism density** `t(H, G)` of a simple graph `H` in a simple graph `G` with
+finite vertex sets is `#Hom(H, G) / |V(G)|^{|V(H)|}`. -/
+noncomputable def homDensity [Fintype V] [Fintype W] [DecidableEq V] [DecidableEq W]
+    (H : SimpleGraph V) (G : SimpleGraph W) [DecidableRel H.Adj] [DecidableRel G.Adj] : ℝ :=
+  (homCount H G : ℝ) / (Fintype.card W : ℝ) ^ (Fintype.card V)
+
+/-- The homomorphism density `t(H, G)` is at most `1`.
+
+Proof outline: the underlying function of a `H →g G`-homomorphism is an element of
+`V → W`, which has `|W|^|V|` elements, so `homCount H G ≤ |W|^|V|`. Divide. -/
+lemma homDensity_le_one {V W : Type*} [Fintype V] [Fintype W] [Nonempty W]
+    [DecidableEq V] [DecidableEq W]
+    (H : SimpleGraph V) (G : SimpleGraph W)
+    [DecidableRel H.Adj] [DecidableRel G.Adj] :
+    homDensity H G ≤ 1 := by
+  -- `homCount H G = #(H →g G) ≤ #(V → W) = |W| ^ |V|`. Divide and simplify.
+  have hWpos : 0 < Fintype.card W := Fintype.card_pos
+  have h₁ : Fintype.card (H →g G) ≤ Fintype.card (V → W) :=
+    Fintype.card_le_of_injective (fun f => (f : V → W)) DFunLike.coe_injective
+  have h₂ : Fintype.card (V → W) = Fintype.card W ^ Fintype.card V := Fintype.card_fun
+  have hnat : homCount H G ≤ Fintype.card W ^ Fintype.card V := by
+    unfold homCount
+    exact h₂ ▸ h₁
+  have hle : (homCount H G : ℝ) ≤ (Fintype.card W : ℝ) ^ (Fintype.card V) := by
+    have := (Nat.cast_le (α := ℝ)).mpr hnat
+    simpa [Nat.cast_pow] using this
+  have hpos : (0 : ℝ) < (Fintype.card W : ℝ) ^ (Fintype.card V) :=
+    pow_pos (by exact_mod_cast hWpos) _
+  rw [homDensity, div_le_one hpos]
+  exact hle
+
+end SimpleGraph

--- a/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
+++ b/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
@@ -15,11 +15,8 @@ limitations under the License.
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 public import Mathlib.Algebra.BigOperators.Ring.Finset
 public import Mathlib.Algebra.Order.BigOperators.Group.Finset
-public import Mathlib.Tactic.Linarith
-public import Mathlib.Tactic.Positivity
 public import Mathlib.Data.Real.Basic
 
 @[expose] public section

--- a/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
+++ b/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
@@ -1,0 +1,95 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Algebra.BigOperators.Ring.Finset
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Tactic.Linarith
+public import Mathlib.Tactic.Positivity
+public import Mathlib.Data.Real.Basic
+
+@[expose] public section
+
+/-!
+# The finite probabilistic method (averaging / pigeonhole primitive)
+
+This file provides the core averaging lemma underlying the elementary form of Erdős's
+**probabilistic method**:
+
+> If the sum of a `ℕ`-valued function `f` over a finite set `s` is strictly less than the
+> cardinality of `s`, then `f` vanishes somewhere on `s`.
+
+Interpreting `f a` as "the number of bad configurations caused by choice `a`", and sampling
+`a` uniformly from `s`, the expected number of bad configurations is `(∑ f) / |s| < 1`,
+so there must exist at least one `a ∈ s` with `f a = 0`.
+
+This is used by:
+- `FormalConjectures/Probabilistic/RamseyDiagonalLowerBound.lean`
+  to close the `R(k,k) > 2^{k/2}` lower bound (Erdős 1947).
+- downstream deletion-method / alteration-method arguments.
+
+Both the `ℕ`-form and a convenience `ℝ`-form are provided; the latter is useful when the
+expectation bound is derived via `rpow`/`log` manipulations on the reals and only later
+cast back to counting.
+
+## References
+
+- [Er47] Erdős, P. (1947). "Some remarks on the theory of graphs." *Bull. Amer. Math. Soc.*
+  53, pp. 292--294.
+- [AlSp16] Alon, N. and Spencer, J. (2016). *The Probabilistic Method* (4th ed.), §1.1.
+-/
+
+namespace FormalConjecturesForMathlib.Probability
+
+open Finset
+
+/-- **Finite probabilistic method (integer form).**
+
+If `∑ x ∈ s, f x < s.card`, then there exists `a ∈ s` with `f a = 0`.
+
+**Proof idea.** Contrapositive: if every value is at least `1`, the sum is at least
+`s.card · 1 = s.card`, contradicting the hypothesis. -/
+theorem Finset.exists_eq_zero_of_sum_lt_card
+    {α : Type*} {s : Finset α} {f : α → ℕ} (h : ∑ x ∈ s, f x < s.card) :
+    ∃ a ∈ s, f a = 0 := by
+  by_contra hne
+  push_neg at hne
+  have hge : ∀ a ∈ s, 1 ≤ f a :=
+    fun a ha => Nat.one_le_iff_ne_zero.mpr (hne a ha)
+  have hbound : s.card ≤ ∑ x ∈ s, f x := by
+    calc s.card
+        = ∑ _x ∈ s, 1 := by rw [sum_const, smul_eq_mul, mul_one]
+      _ ≤ ∑ x ∈ s, f x := sum_le_sum hge
+  omega
+
+/-- **Finite probabilistic method (real form).**
+
+If `(∑ x ∈ s, (f x : ℝ)) < s.card`, then there exists `a ∈ s` with `f a = 0`.
+
+This is the same statement as `Finset.exists_eq_zero_of_sum_lt_card` after casting the
+counting inequality to `ℝ`; it is the convenient entry point when `f` arises as an expectation
+whose bound was computed in the reals (e.g. via `Real.rpow` / `Real.log`). -/
+theorem Finset.exists_eq_zero_of_real_sum_lt_card
+    {α : Type*} {s : Finset α} {f : α → ℕ}
+    (h : (∑ x ∈ s, (f x : ℝ)) < s.card) : ∃ a ∈ s, f a = 0 := by
+  apply Finset.exists_eq_zero_of_sum_lt_card
+  have hcast : ((∑ x ∈ s, f x : ℕ) : ℝ) = ∑ x ∈ s, (f x : ℝ) :=
+    Nat.cast_sum s f
+  have : ((∑ x ∈ s, f x : ℕ) : ℝ) < (s.card : ℝ) := hcast ▸ h
+  exact_mod_cast this
+
+end FormalConjecturesForMathlib.Probability


### PR DESCRIPTION
Adds three small, sorry-free infrastructure modules under
`FormalConjecturesForMathlib/` that we have found useful while
formalizing probabilistic graph theory results on our private track
(Sidorenko K_{2,2}, Erdős 1947 R(k,k) ≥ 2^(k/2), etc.). Each is
short and self-contained; Mathlib does not currently expose any of
them in a directly reusable form.

## What the three helpers provide

**`Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean`** (~15 LoC).
A `Fin n` specialisation on top of Mathlib's
`SimpleGraph.card_edgeFinset_top_eq_card_choose_two`, giving
```
(completeGraph (Fin n)).edgeFinset.card = n.choose 2
```
without instance plumbing at the call site.

**`Combinatorics/SimpleGraph/HomDensity.lean`** (~80 LoC).
Defines `homCount H G = Fintype.card (H →g G)` and
`homDensity H G = homCount H G / (Fintype.card W)^(Fintype.card V)`,
plus the bound `homDensity_le_one`. Foundational for formalizing
Sidorenko-style extremal inequalities, Lovász's quasi-random
inequalities, and other homomorphism-density statements.

**`Probability/FiniteMethod.lean`** (~95 LoC).
Two variants of the Erdős averaging primitive:
`Finset.exists_eq_zero_of_sum_lt_card` (ℕ-valued) and
`Finset.exists_eq_zero_of_real_sum_lt_card` (ℝ-valued). Both are
strict corollaries of Mathlib's `Finset.exists_lt_of_sum_lt`, named
for downstream caller ergonomics ("zero witness" reads more clearly
than "pointwise-smaller than `1`").

## Why here rather than Mathlib

Each of these is a candidate for Mathlib proper; raising them inside
`FormalConjecturesForMathlib` lets this project use them now while
the more involved Mathlib review of `homDensity` / `homCount` (where
API surface decisions — e.g., is `homDensity` the right definition
vs. `GraphHomCount.density` — would need discussion) happens on its
own schedule. If the project prefers them in a different subdirectory,
or split across separate PRs, happy to adjust.

## Build

Verified with `lake build FormalConjecturesForMathlib` (success).
All three modules are sorry-free.

## Notes

The umbrella `FormalConjecturesForMathlib.lean` gains three import
lines in alphabetical position. No other files are modified.