### PR TITLE
fix(ErdosProblems): 522 

### DIFF
--- a/FormalConjectures/ErdosProblems/522.lean
+++ b/FormalConjectures/ErdosProblems/522.lean
@@ -22,71 +22,98 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [erdosproblems.com/522](https://www.erdosproblems.com/522)
 -/
 
-open MeasureTheory Classical
+open MeasureTheory Classical Filter
 open scoped ProbabilityTheory Topology Real
 
 namespace Erdos522
 
 /--
-A *Kac Polynomial* in `n` coefficients over some subset `S` of a field `k` is a polynomial whose `n`
-first coefficients are picked uniformely at random in `S` and whose other coefficients are all `0`.
+A sequence of *Kac coefficients* over a subset `S` of a field `k` is a countably infinite sequence
+of independent random variables, each uniformly distributed over `S`.
+
+Such a sequence determines a *Kac polynomial* of degree `n` for each `n`, which is the random
+polynomial given by `KacCoefficients.polynomial`.
 -/
 @[ext]
-structure KacPolynomial
-    {k : Type*} (n : ℕ) [Field k] [MeasurableSpace k] (S : Set k)
+structure KacCoefficients
+    {k : Type*} [Field k] [MeasurableSpace k] (S : Set k)
     (Ω : Type*) [MeasureSpace Ω] (μ : Measure k := by volume_tac) where
-  toFun : Fin n.succ → Ω → k
+  toFun : ℕ → Ω → k
   h_indep : ProbabilityTheory.iIndepFun toFun ℙ
   h_unif : ∀ i, MeasureTheory.pdf.IsUniform (toFun i) S ℙ μ
 
-variable {k : Type*} (n : ℕ) [Field k] [MeasurableSpace k] (S : Set k)
+variable {k : Type*} [Field k] [MeasurableSpace k] (S : Set k)
     (Ω : Type*) [MeasureSpace Ω] (μ : Measure k := by volume_tac)
 
 /--
-We can always view a Kac polynomial as a random vector
+We can always view a Kac polynomial as a random variable on `ℕ`.
 -/
-instance : FunLike (KacPolynomial n S Ω μ) (Fin n.succ) (Ω → k) where
+instance : FunLike (KacCoefficients S Ω μ) ℕ (Ω → k) where
   coe P := P.toFun
   coe_injective' := by intro P Q h ; aesop
 
-namespace KacPolynomial
+namespace KacCoefficients
 
 open scoped Polynomial
 
-variable {n S Ω} {μ : Measure k}
+variable {S Ω} {μ : Measure k}
 
 /--
-The random polynomial associated to a Kac polynomial
+The random polynomial associated to a sequence `c : KacCoefficients S Ω μ` of Kac coefficients
+given by `∑ i ∈ Finset.range (n + 1), c i z^i`.
 -/
-noncomputable def toRandomPolynomial (f : KacPolynomial n S Ω μ) :
-    Ω → k[X] := fun ω => ∑ i, Polynomial.monomial i.val (f i ω)
+noncomputable def polynomial (c : KacCoefficients S Ω μ) (n : ℕ) :
+    Ω → k[X] := fun ω => ∑ i ∈ Finset.range (n + 1), Polynomial.monomial i (c i ω)
 
 /--
 The random multiset of roots associated to a Kac polynomial
 -/
-noncomputable def roots (f : KacPolynomial n S Ω μ) : Ω → Multiset k :=
-    fun ω => (f.toRandomPolynomial ω).roots
+noncomputable def roots (c : KacCoefficients S Ω μ) (n : ℕ) : Ω → Multiset k :=
+    fun ω => (c.polynomial n ω).roots
 
-end KacPolynomial
+/-- Counts the number of roots of a Kac polynomial in the unit disk with multiplicity. -/
+noncomputable def numRootsInUnitDisk [PseudoMetricSpace k] (c : KacCoefficients S Ω μ) (n : ℕ)
+    (ω : Ω) : ℕ := (c.roots n ω).countP (· ∈ Metric.closedBall 0 1)
+
+end KacCoefficients
 
 /--
-Let `f(z)=∑_{0≤k≤n} ϵ_k z^k` be a random polynomial, where `ϵ_k∈{−1,1}` independently uniformly at
-random for `0≤k≤n`.
-Is it true that the number of roots of `f(z)` in `{z∈C:|z|≤1}` is, almost surely, `(1/2+o(1))n`?
+Let $f(z)=\sum_{0\leq k\leq n} \epsilon_k z^k$ be a random polynomial, where
+$\epsilon_k\in \{-1,1\}$ independently uniformly at random for $0\leq k\leq n$.
 
-Formalization note: here the goal seems to mean that
-` ℙ(| #roots of f in unit disk - n/2 | ≥ o(1)) → 0` as `n → ∞`
-This is quite awkward to formalise!
+Is it true that, if $R_n$ is the number of roots of $f(z)$ in
+$\{ z\in \mathbb{C} : \lvert z\rvert \leq 1\}$, then
+$$
+  \frac{R_n}{n/2}\to 1
+$$
+almost surely?
+
+There is some ambiguity as to whether the intended coefficient set is $\{-1, 1\}$ or $\{0, 1\}$,
+see `erdos_522.variants.zero_one` for the alternate version.
 -/
 @[category research open, AMS 12 60]
 theorem erdos_522 :
-    answer(sorry) →
-      ∃ p o : ℕ → ℝ, Filter.Tendsto o Filter.atTop (𝓝 0) ∧
-      Filter.Tendsto p Filter.atTop (𝓝 0) ∧
-      ∀ (Ω : Type*) [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-        (n : ℕ) (hn : 1 ≤ n) (f : KacPolynomial n ({-1, 1} : Set ℂ) Ω),
-        (ℙ {ω | |(f.roots ω).countP
-          (· ∈ Metric.closedBall 0 1) - (n / 2 : ℝ)| ≥ (o n) * n }).toReal ≤ p n := by
+    answer(sorry) ↔ ∀ {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
+      (c : KacCoefficients ({-1, 1} : Set ℂ) Ω),
+      ℙ {ω | atTop.Tendsto (fun n : ℕ ↦ (2 * c.numRootsInUnitDisk n ω : ℝ) / n) (𝓝 1)} = 1 := by
+  sorry
+
+/--
+Let $f(z)=\sum_{0\leq k\leq n} \epsilon_k z^k$ be a random polynomial, where
+$\epsilon_k\in \{0,1\}$ independently uniformly at random for $0\leq k\leq n$.
+
+Is it true that, if $R_n$ is the number of roots of $f(z)$ in
+$\{ z\in \mathbb{C} : \lvert z\rvert \leq 1\}$, then
+$$
+  \frac{R_n}{n/2}\to 1
+$$
+almost surely?
+-/
+@[category research open, AMS 12 60]
+theorem erdos_522.variants.zero_one :
+    answer(sorry) ↔ ∀ {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
+      {n : ℕ} (hn : 1 ≤ n) (f : KacCoefficients ({0, 1} : Set ℂ) Ω),
+      ℙ {ω | atTop.Tendsto (fun n : ℕ ↦ (2 * f.numRootsInUnitDisk n ω : ℝ) / n) (𝓝 1)} = 1 := by
   sorry
 
 /--
@@ -95,10 +122,10 @@ coefficients is `(2/π+o(1))log n`.
 -/
 @[category research solved, AMS 12 60]
 theorem erdos_522.variants.number_real_roots : ∃ p o : ℕ → ℝ,
-    Filter.Tendsto o Filter.atTop (𝓝 0) ∧ Filter.Tendsto p Filter.atTop (𝓝 0) ∧
+    atTop.Tendsto o (𝓝 0) ∧ atTop.Tendsto p (𝓝 0) ∧
     ∀ (Ω : Type*) [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-      (n : ℕ) (hn : 2 ≤ n) (f : KacPolynomial n ({-1, 1} : Set ℝ) Ω),
-      (ℙ {ω | |(f.roots ω).card / (n : ℝ).log - 2 / π| ≥ o n}).toReal ≤ p n := by
+      (n : ℕ) (hn : 2 ≤ n) (f : KacCoefficients ({-1, 1} : Set ℝ) Ω),
+      (ℙ {ω | |(f.roots n ω).card / (n : ℝ).log - 2 / π| ≥ o n}).toReal ≤ p n := by
   sorry
 
 /--
@@ -106,10 +133,10 @@ Yakir proved that almost all Kac polynomials have `n/2+O(n^(9/10))` many roots i
 -/
 @[category research solved, AMS 12 60]
 theorem erdos_522.variants.yakir_solution :
-    ∃ p : ℕ → ℝ, Filter.Tendsto p Filter.atTop (𝓝 0) ∧
+    ∃ p : ℕ → ℝ, atTop.Tendsto p (𝓝 0) ∧
     ∀ (Ω : Type*) [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-      (n : ℕ) (hn : 2 ≤ n) (f : KacPolynomial n ({-1, 1} : Set ℂ) Ω),
-       (ℙ {ω | |(f.roots ω).countP
+      (n : ℕ) (hn : 2 ≤ n) (f : KacCoefficients ({-1, 1} : Set ℂ) Ω),
+       (ℙ {ω | |(f.roots n ω).countP
          (· ∈ Metric.closedBall 0 1) - (n / 2 : ℝ)| ≥ n^(9/10 : ℝ) }).toReal ≤ p n := by
   sorry
 


### PR DESCRIPTION
- Redefine `KacPolynomial` structure to `KacCoefficients` which is a countably infinite sequence of uniform variables.
- These determine Kac polynomials of any degree, defined in `KacCoefficients.polynomial`.
- This enables an almost surely formalisation of the main problem, as discussed in #3473 
- Add variant with `{0, 1}` coefficients following website update.