### PR TITLE
fix: `of` definitions in monads take explicit type arguments

### DIFF
--- a/FormalConjecturesForMathlib/Lean/Elab/InfoTree/Util.lean
+++ b/FormalConjecturesForMathlib/Lean/Elab/InfoTree/Util.lean
@@ -27,6 +27,8 @@ public section
 
 variable {α σ m} [Monad m]
 
+variable (σ)
+
 /-- Visit nodes in an infotree, where state is set only within a single branch. -/
 partial def Lean.Elab.InfoTree.visitStateOf [MonadStateOf σ m]
     (visit : ContextInfo → Info → (children : PersistentArray InfoTree) → m Unit) :


### PR DESCRIPTION
This was incorrectly upstreamed without the `variable` command

(as a reminder, `MonadStateOf` is `MonadState` with `σ` explicit)