### PR TITLE
feat: Cerny conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -33,18 +33,11 @@ automata `Cₙ` witnesses it, requiring exactly `(n - 1)²` steps.
 (Shitov, 2019). The bound `(n − 1)²` has been verified for small `n` and for special classes of
 automata (e.g., Eulerian, aperiodic, cyclic automata).
 
-We use Mathlib's `DFA α σ` (from `Mathlib.Computability.DFA`), which consists of:
-- a state type `σ`,
-- an alphabet type `α`,
-- a transition function `step : σ → α → σ`,
-- a starting state `start : σ`,
-- a set of accepting states `accept : Set σ`.
-
-The key function is `M.evalFrom s w : σ`, which evaluates the word `w : List α` starting from
-state `s`, using `List.foldl`.
+We use Mathlib's `DFA α σ` (from `Mathlib.Computability.DFA`), together with the auxiliary
+`DFA.IsSynchronizingWord` and `DFA.IsSynchronizing` predicates defined in
+`FormalConjecturesForMathlib.Computability.DFA`.
 
 *References:*
-- [Wikipedia: Černý conjecture](https://en.wikipedia.org/wiki/Černý_conjecture)
 - [Wikipedia: Synchronizing word](https://en.wikipedia.org/wiki/Synchronizing_word)
 - J. Černý, *Poznámka k homogénnym experimentom s konečnými automatmi*, 1964.
 -/
@@ -53,25 +46,13 @@ namespace CernyConjecture
 
 variable {α : Type*} {σ : Type*}
 
-/-! ## Core definitions -/
-
-/-- A word `w` is a **synchronizing word** (or reset word) for a DFA `M` if reading `w` from
-any state leads to the same single state. -/
-def IsSynchronizingWord (M : DFA α σ) (w : List α) : Prop :=
-  ∃ p : σ, ∀ q : σ, M.evalFrom q w = p
-
-/-- A DFA `M` is **synchronizing** if it has at least one synchronizing word. -/
-def IsSynchronizing (M : DFA α σ) : Prop :=
-  ∃ w : List α, IsSynchronizingWord M w
-
-/-! ## The conjecture -/
-
-/-- **Černý Conjecture**: Every synchronizing DFA with `n` states admits a synchronizing word of
-length at most `(n - 1)²`.
+/-- **Černý Conjecture**: Every synchronizing DFA with `n` states admits a
+synchronizing word of length at most `(n - 1)²`.
 -/
 @[category research open, AMS 68]
-theorem cerny_conjecture [Fintype σ] (M : DFA α σ) (hM : IsSynchronizing M) :
-    answer(sorry) ↔ ∃ w : List α, IsSynchronizingWord M w ∧ w.length ≤ (Fintype.card σ - 1)^2 := by
+theorem cerny_conjecture :
+    answer(sorry) ↔ ∀ [Fintype σ] (M : DFA α σ) (hM : M.IsSynchronizing) ,
+    ∃ w : List α, M.IsSynchronizingWord w ∧ w.length ≤ (Fintype.card σ - 1)^2 := by
   sorry
 
 end CernyConjecture

--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -1,0 +1,77 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Černý Conjecture
+
+A **synchronizing word** (also called a reset word) for a deterministic finite automaton (DFA)
+`M = (Q, Σ, δ)` is a word `w ∈ Σ*` such that reading `w` from any state always leads to the
+same single state — formally, `∃ p ∈ Q, ∀ q ∈ Q, δ*(q, w) = p`.
+
+A DFA is called **synchronizing** if it admits at least one synchronizing word.
+
+The **Černý conjecture** asserts that every synchronizing DFA with `n` states has a
+synchronizing word of length at most `(n - 1)²`. This bound is sharp: the family of Černý
+automata `Cₙ` witnesses it, requiring exactly `(n - 1)²` steps.
+
+**Status:** Open. The best known upper bound is approximately `n(7n² + 6n − 16)/48`
+(Shitov, 2019). The bound `(n − 1)²` has been verified for small `n` and for special classes of
+automata (e.g., Eulerian, aperiodic, cyclic automata).
+
+We use Mathlib's `DFA α σ` (from `Mathlib.Computability.DFA`), which consists of:
+- a state type `σ`,
+- an alphabet type `α`,
+- a transition function `step : σ → α → σ`,
+- a starting state `start : σ`,
+- a set of accepting states `accept : Set σ`.
+
+The key function is `M.evalFrom s w : σ`, which evaluates the word `w : List α` starting from
+state `s`, using `List.foldl`.
+
+*References:*
+- [Wikipedia: Černý conjecture](https://en.wikipedia.org/wiki/Černý_conjecture)
+- [Wikipedia: Synchronizing word](https://en.wikipedia.org/wiki/Synchronizing_word)
+- J. Černý, *Poznámka k homogénnym experimentom s konečnými automatmi*, 1964.
+-/
+
+namespace CernyConjecture
+
+variable {α : Type*} {σ : Type*}
+
+/-! ## Core definitions -/
+
+/-- A word `w` is a **synchronizing word** (or reset word) for a DFA `M` if reading `w` from
+any state leads to the same single state. -/
+def IsSynchronizingWord (M : DFA α σ) (w : List α) : Prop :=
+  ∃ p : σ, ∀ q : σ, M.evalFrom q w = p
+
+/-- A DFA `M` is **synchronizing** if it has at least one synchronizing word. -/
+def IsSynchronizing (M : DFA α σ) : Prop :=
+  ∃ w : List α, IsSynchronizingWord M w
+
+/-! ## The conjecture -/
+
+/-- **Černý Conjecture**: Every synchronizing DFA with `n` states admits a synchronizing word of
+length at most `(n - 1)²`.
+-/
+@[category research open, AMS 68]
+theorem cerny_conjecture [Fintype σ] (M : DFA α σ) (hM : IsSynchronizing M) :
+    answer(sorry) ↔ ∃ w : List α, IsSynchronizingWord M w ∧ w.length ≤ (Fintype.card σ - 1)^2 := by
+  sorry
+
+end CernyConjecture

--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -20,17 +20,18 @@ import FormalConjectures.Util.ProblemImports
 # Černý Conjecture
 
 A **synchronizing word** (also called a reset word) for a deterministic finite automaton (DFA)
-`M = (Q, Σ, δ)` is a word `w ∈ Σ*` such that reading `w` from any state always leads to the
-same single state — formally, `∃ p ∈ Q, ∀ q ∈ Q, δ*(q, w) = p`.
+$M = (Q, \Sigma, \delta)$ is a word $w \in \Sigma^*$ such that reading $w$ from any state always
+leads to the same single state — formally, $\exists p \in Q, \forall q \in Q, \delta^*(q, w) = p$.
 
 A DFA is called **synchronizing** if it admits at least one synchronizing word.
 
-The **Černý conjecture** asserts that every synchronizing DFA with `n` states has a
-synchronizing word of length at most `(n - 1)²`. This bound is sharp: the family of Černý
-automata `Cₙ` witnesses it, requiring exactly `(n - 1)²` steps.
+The **Černý conjecture** asserts that every synchronizing DFA with $n$ states has a
+synchronizing word of length at most $(n - 1)^2$. This bound is sharp: the family of Černý
+automata $C_n$ witnesses it, requiring exactly $(n - 1)^2$ steps.
 
-**Status:** Open. The best known upper bound is approximately `n(7n² + 6n − 16)/48`
-(Shitov, 2019). The bound `(n − 1)²` has been verified for small `n` and for special classes of
+**Status:** Open. The best known upper bound is
+$\left(\frac{7}{48} + \frac{2 \cdot 15625}{1597536}\right) n^3 + o(n^3) \approx 0.1654\,n^3$
+(Shitov, 2019). The bound $(n - 1)^2$ has been verified for small $n$ and for special classes of
 automata (e.g., Eulerian, aperiodic, cyclic automata).
 
 We use Mathlib's `DFA α σ` (from `Mathlib.Computability.DFA`), together with the auxiliary
@@ -39,20 +40,39 @@ We use Mathlib's `DFA α σ` (from `Mathlib.Computability.DFA`), together with t
 
 *References:*
 - [Wikipedia: Synchronizing word](https://en.wikipedia.org/wiki/Synchronizing_word)
-- J. Černý, *Poznámka k homogénnym experimentom s konečnými automatmi*, 1964.
+- J. Černý, [*Poznámka k homogénnym experimentom s konečnými automatmi*](https://dml.cz/bitstream/handle/10338.dmlcz/126647/MathSlov_14-1964-3_2.pdf),
+  Matematicko-fyzikálny časopis, Vol. 14 (1964), No. 3, 208--216.
+- Y. Shitov, *An improvement to a recent upper bound for synchronizing words of finite automata*,
+  J. Autom. Lang. Comb. Vol. 24 (2019), 367--373}.
 -/
+
+open Filter
 
 namespace CernyConjecture
 
 variable {α : Type*} {σ : Type*}
 
-/-- **Černý Conjecture**: Every synchronizing DFA with `n` states admits a
-synchronizing word of length at most `(n - 1)²`.
+/-- **Černý Conjecture**: Every synchronizing DFA with $n$ states admits a
+synchronizing word of length at most $(n - 1)^2$.
 -/
 @[category research open, AMS 68]
 theorem cerny_conjecture :
     answer(sorry) ↔ ∀ {α : Type*} {σ : Type*} [Fintype σ] (M : DFA α σ) (hM : M.IsSynchronizing) ,
     ∃ w : List α, M.IsSynchronizingWord w ∧ w.length ≤ (Fintype.card σ - 1)^2 := by
+  sorry
+
+/-- **Shitov's bound (2019)**: Every synchronizing DFA with $n$ states admits a synchronizing
+word of length at most $\left(\frac{7}{48} + \frac{2 \cdot 15625}{1597536}\right) n^3 + o(n^3)$,
+where the $o(n^3)$ term is uniform over all alphabets. This is the best known upper bound
+towards the Černý conjecture.
+-/
+@[category research solved, AMS 68]
+theorem shitov_upper_bound :
+    ∃ f : ℝ → ℝ, f =o[atTop] (fun n : ℝ => n ^ 3) ∧
+    ∀ {α : Type*} {σ : Type*} [Fintype σ] (M : DFA α σ) (hM : M.IsSynchronizing) ,
+    ∃ w : List α, M.IsSynchronizingWord w ∧
+    (w.length : ℝ) ≤ (7 / 48 + 2 * 15625 / 1597536) * (Fintype.card σ : ℝ) ^ 3
+      + f (Fintype.card σ : ℝ) := by
   sorry
 
 end CernyConjecture

--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -43,7 +43,7 @@ We use Mathlib's `DFA α σ` (from `Mathlib.Computability.DFA`), together with t
 - J. Černý, [*Poznámka k homogénnym experimentom s konečnými automatmi*](https://dml.cz/bitstream/handle/10338.dmlcz/126647/MathSlov_14-1964-3_2.pdf),
   Matematicko-fyzikálny časopis, Vol. 14 (1964), No. 3, 208--216.
 - Y. Shitov, *An improvement to a recent upper bound for synchronizing words of finite automata*,
-  J. Autom. Lang. Comb. Vol. 24 (2019), 367--373}.
+  J. Autom. Lang. Comb. Vol. 24 (2019), 367--373.
 -/
 
 open Filter

--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -51,7 +51,7 @@ synchronizing word of length at most `(n - 1)²`.
 -/
 @[category research open, AMS 68]
 theorem cerny_conjecture :
-    answer(sorry) ↔ ∀ [Fintype σ] (M : DFA α σ) (hM : M.IsSynchronizing) ,
+    answer(sorry) ↔ ∀ {α : Type*} {σ : Type*} [Fintype σ] (M : DFA α σ) (hM : M.IsSynchronizing) ,
     ∃ w : List α, M.IsSynchronizingWord w ∧ w.length ≤ (Fintype.card σ - 1)^2 := by
   sorry
 

--- a/FormalConjectures/Wikipedia/CernyConjecture.lean
+++ b/FormalConjectures/Wikipedia/CernyConjecture.lean
@@ -50,8 +50,6 @@ open Filter
 
 namespace CernyConjecture
 
-variable {α : Type*} {σ : Type*}
-
 /-- **Černý Conjecture**: Every synchronizing DFA with $n$ states admits a
 synchronizing word of length at most $(n - 1)^2$.
 -/

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -51,6 +51,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConject
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Johnson
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SizeRamsey
 public import FormalConjecturesForMathlib.Combinatorics.YoungDiagram
+public import FormalConjecturesForMathlib.Computability.DFA
 public import FormalConjecturesForMathlib.Computability.Encoding
 public import FormalConjecturesForMathlib.Computability.TuringMachine.BusyBeavers
 public import FormalConjecturesForMathlib.Computability.TuringMachine.Notation

--- a/FormalConjecturesForMathlib/Computability/DFA.lean
+++ b/FormalConjecturesForMathlib/Computability/DFA.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjecturesForMathlib/Computability/DFA.lean
+++ b/FormalConjecturesForMathlib/Computability/DFA.lean
@@ -1,0 +1,45 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Computability.DFA
+
+@[expose] public section
+
+/-!
+# Synchronizing words for DFAs
+
+A **synchronizing word** (or reset word) for a DFA `M = (Q, Σ, δ)` is a word `w ∈ Σ*` such that
+reading `w` from any state always leads to the same single state. A DFA is **synchronizing** if it
+admits at least one synchronizing word.
+
+These notions support the Černý conjecture (see `FormalConjectures.Wikipedia.CernyConjecture`).
+-/
+
+namespace DFA
+
+variable {α : Type*} {σ : Type*}
+
+/-- A word `w` is a **synchronizing word** (or reset word) for a DFA `M` if reading `w` from
+any state leads to the same single state. -/
+def IsSynchronizingWord (M : DFA α σ) (w : List α) : Prop :=
+  ∃ p : σ, ∀ q : σ, M.evalFrom q w = p
+
+/-- A DFA `M` is **synchronizing** if it has at least one synchronizing word. -/
+def IsSynchronizing (M : DFA α σ) : Prop :=
+  ∃ w : List α, M.IsSynchronizingWord w
+
+end DFA

--- a/FormalConjecturesForMathlib/Computability/DFA.lean
+++ b/FormalConjecturesForMathlib/Computability/DFA.lean
@@ -42,4 +42,27 @@ def IsSynchronizingWord (M : DFA α σ) (w : List α) : Prop :=
 def IsSynchronizing (M : DFA α σ) : Prop :=
   ∃ w : List α, M.IsSynchronizingWord w
 
+/-- The empty word is a synchronizing word for `M` exactly when all states of `M` collapse to a
+single one (equivalently, `σ` is a nonempty subsingleton). -/
+@[simp]
+theorem isSynchronizingWord_nil (M : DFA α σ) :
+    M.IsSynchronizingWord [] ↔ ∃ p : σ, ∀ q : σ, q = p := by
+  simp only [IsSynchronizingWord, evalFrom_nil]
+
+/-- Appending any word `v` to a synchronizing word `w` yields a synchronizing word: reading `w`
+already drives every state to a single state `p`, and reading `v` afterwards sends `p` to
+`M.evalFrom p v` regardless of the starting state. -/
+theorem IsSynchronizingWord.append {M : DFA α σ} {w : List α}
+    (hw : M.IsSynchronizingWord w) (v : List α) : M.IsSynchronizingWord (w ++ v) := by
+  obtain ⟨p, hp⟩ := hw
+  refine ⟨M.evalFrom p v, fun q => ?_⟩
+  rw [M.evalFrom_of_append, hp q]
+
+/-- A DFA whose state type is a nonempty subsingleton (i.e. a single-state DFA) is trivially
+synchronizing: the empty word already synchronizes it. -/
+theorem isSynchronizing_of_subsingleton [Nonempty σ] [Subsingleton σ] (M : DFA α σ) :
+    M.IsSynchronizing := by
+  obtain ⟨p⟩ := ‹Nonempty σ›
+  exact ⟨[], (isSynchronizingWord_nil M).2 ⟨p, fun q => Subsingleton.elim q p⟩⟩
+
 end DFA


### PR DESCRIPTION
### Add formalization of Černý Conjecture

This PR adds a Lean formalization of the **Černý Conjecture**, a central open problem in automata theory concerning the length of reset words in synchronizing deterministic finite automata.

Changes:
- FormalConjectures/Wikipedia/CernyConjecture.lean

Closes #3905


---

### Original problem statement

Let M = (Q, Σ, δ) be a deterministic finite automaton with |Q| = n.

A word w ∈ Σ* is called a **synchronizing word** if there exists a state q₀ ∈ Q such that
∀ q ∈ Q, δ*(q, w) = q₀.

The automaton is called synchronizing if it admits at least one such word.

The Černý conjecture states:

Every synchronizing DFA with n states has a synchronizing word of length at most (n − 1)².

This bound is known to be tight due to the Černý family of automata.

---

### Implementation details

- Synchronizing words are formalized as:

def IsSynchronizingWord (M : DFA α σ) (w : List α) : Prop :=
  ∃ p : σ, ∀ q : σ, M.evalFrom q w = p

- Synchronizing automata are defined by:

def IsSynchronizing (M : DFA α σ) : Prop :=
  ∃ w : List α, IsSynchronizingWord M w
