### PR TITLE
feat: Nivat conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/NivatConjecture.lean
+++ b/FormalConjectures/Wikipedia/NivatConjecture.lean
@@ -42,8 +42,7 @@ def IsPeriodic (x : ℤ × ℤ → A) : Prop :=
 satisfies `P_x(n, m) ≤ n * m`, then the configuration `x` is periodic.
 -/
 @[category research open, AMS 37 68]
-theorem nivat_conjecture answer(sorry) ↔ (x : ℤ × ℤ → A) :
-    (∃ n m : ℕ, 1 ≤ n ∧ 1 ≤ m ∧ blockComplexity x n m ≤ n * m) → IsPeriodic x := by
+theorem nivat_conjecture : answer(sorry) ↔ ∀ (x : ℤ × ℤ → A), (∃ n m : ℕ, 1 ≤ n ∧ 1 ≤ m ∧ blockComplexity x n m ≤ n * m) → IsPeriodic x := by
   sorry
 
 end NivatConjecture

--- a/FormalConjectures/Wikipedia/NivatConjecture.lean
+++ b/FormalConjectures/Wikipedia/NivatConjecture.lean
@@ -40,9 +40,6 @@ def IsPeriodic (x : ℤ × ℤ → A) : Prop :=
 
 /-- The **Nivat conjecture**: if there exist integers `n, m ≥ 1` such that the block complexity
 satisfies `P_x(n, m) ≤ n * m`, then the configuration `x` is periodic.
-
-This is a two-dimensional analogue of the Morse–Hedlund theorem: a bi-infinite word over a
-finite alphabet is periodic if and only if its factor complexity is bounded above by some `n`.
 -/
 @[category research open, AMS 37 68]
 theorem nivat_conjecture answer(sorry) ↔ (x : ℤ × ℤ → A) :

--- a/FormalConjectures/Wikipedia/NivatConjecture.lean
+++ b/FormalConjectures/Wikipedia/NivatConjecture.lean
@@ -27,17 +27,6 @@ namespace NivatConjecture
 
 variable {A : Type*} [Finite A]
 
-/-- The **block complexity** of a configuration `x : ℤ × ℤ → A` at scale `n × m` is the number
-of distinct `n × m` rectangular patterns appearing in `x`. -/
-noncomputable def blockComplexity (x : ℤ × ℤ → A) (n m : ℕ) : ℕ :=
-  (Set.range fun (p : ℤ × ℤ) => fun (q : Fin n × Fin m) =>
-    x (p.1 + (q.1 : ℤ), p.2 + (q.2 : ℤ))).ncard
-
-/-- A configuration `x : ℤ × ℤ → A` is **periodic** if there exists a nonzero vector
-`v : ℤ × ℤ` such that translating by `v` leaves `x` invariant. -/
-def IsPeriodic (x : ℤ × ℤ → A) : Prop :=
-  ∃ v : ℤ × ℤ, v ≠ 0 ∧ Function.Periodic x v
-
 /-- The **Nivat conjecture**: if there exist integers `n, m ≥ 1` such that the block complexity
 satisfies `P_x(n, m) ≤ n * m`, then the configuration `x` is periodic.
 -/

--- a/FormalConjectures/Wikipedia/NivatConjecture.lean
+++ b/FormalConjectures/Wikipedia/NivatConjecture.lean
@@ -1,0 +1,52 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Nivat conjecture
+
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Nivat_conjecture)
+-/
+
+namespace NivatConjecture
+
+variable {A : Type*} [Finite A]
+
+/-- The **block complexity** of a configuration `x : ℤ × ℤ → A` at scale `n × m` is the number
+of distinct `n × m` rectangular patterns appearing in `x`. -/
+noncomputable def blockComplexity (x : ℤ × ℤ → A) (n m : ℕ) : ℕ :=
+  (Set.range fun (p : ℤ × ℤ) => fun (q : Fin n × Fin m) =>
+    x (p.1 + (q.1 : ℤ), p.2 + (q.2 : ℤ))).ncard
+
+/-- A configuration `x : ℤ × ℤ → A` is **periodic** if there exists a nonzero vector
+`v : ℤ × ℤ` such that translating by `v` leaves `x` invariant. -/
+def IsPeriodic (x : ℤ × ℤ → A) : Prop :=
+  ∃ v : ℤ × ℤ, v ≠ 0 ∧ Function.Periodic x v
+
+/-- The **Nivat conjecture**: if there exist integers `n, m ≥ 1` such that the block complexity
+satisfies `P_x(n, m) ≤ n * m`, then the configuration `x` is periodic.
+
+This is a two-dimensional analogue of the Morse–Hedlund theorem: a bi-infinite word over a
+finite alphabet is periodic if and only if its factor complexity is bounded above by some `n`.
+-/
+@[category research open, AMS 37 68]
+theorem nivat_conjecture answer(sorry) ↔ (x : ℤ × ℤ → A) :
+    (∃ n m : ℕ, 1 ≤ n ∧ 1 ≤ m ∧ blockComplexity x n m ≤ n * m) → IsPeriodic x := by
+  sorry
+
+end NivatConjecture

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -50,6 +50,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConject
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.WellTotallyDominated
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Johnson
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SizeRamsey
+public import FormalConjecturesForMathlib.Combinatorics.Words
 public import FormalConjecturesForMathlib.Combinatorics.YoungDiagram
 public import FormalConjecturesForMathlib.Computability.Encoding
 public import FormalConjecturesForMathlib.Computability.TuringMachine.BusyBeavers

--- a/FormalConjecturesForMathlib/Combinatorics/Words.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Words.lean
@@ -1,0 +1,34 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Ring.Periodic
+public import Mathlib.Data.Set.Card
+
+@[expose] public section
+
+variable {A : Type*} [Finite A]
+
+/-- The **block complexity** of a configuration `x : ℤ × ℤ → A` at scale `n × m` is the number
+of distinct `n × m` rectangular patterns appearing in `x`. -/
+noncomputable def blockComplexity (x : ℤ × ℤ → A) (n m : ℕ) : ℕ :=
+  (Set.range fun (p : ℤ × ℤ) => fun (q : Fin n × Fin m) =>
+    x (p.1 + (q.1 : ℤ), p.2 + (q.2 : ℤ))).ncard
+
+/-- A configuration `x : ℤ × ℤ → A` is **periodic** if there exists a nonzero vector
+`v : ℤ × ℤ` such that translating by `v` leaves `x` invariant. -/
+def IsPeriodic (x : ℤ × ℤ → A) : Prop :=
+  ∃ v : ℤ × ℤ, v ≠ 0 ∧ Function.Periodic x v


### PR DESCRIPTION
### Add formalization of Nivat Conjecture

This PR adds a Lean formalization of the **Nivat Conjecture**, a central open problem in symbolic dynamics concerning the relationship between block complexity and periodicity of two-dimensional configurations.

Changes:
- `FormalConjectures/Wikipedia/NivatConjecture.lean`

Closes #3907

---

### Original problem statement

Let A be a finite alphabet and let x : ℤ² → A be a configuration.

For integers n, m ≥ 1, define the block complexity P_x(n,m)
as the number of distinct n × m rectangular patterns appearing in x.

The Nivat conjecture states:

If there exist integers n, m ≥ 1 such that P_x(n,m) ≤ n · m, then the configuration x is periodic, i.e. there exists a nonzero vector v ∈ ℤ² such that x(p + v) = x(p) for all p ∈ ℤ².

---

### Implementation details

- Block complexity is formalized as:

noncomputable def blockComplexity (x : ℤ × ℤ → A) (n m : ℕ) : ℕ :=
  (Set.range fun (p : ℤ × ℤ) => fun (q : Fin n × Fin m) =>
    x (p.1 + (q.1 : ℤ), p.2 + (q.2 : ℤ))).ncard

- Periodicity is defined by:

def IsPeriodic (x : ℤ × ℤ → A) : Prop :=
  ∃ v : ℤ × ℤ, v ≠ 0 ∧ Function.Periodic x v
