### PR TITLE
feat: Normality of pi

### DIFF
--- a/FormalConjectures/Wikipedia/NormalityOfPi.lean
+++ b/FormalConjectures/Wikipedia/NormalityOfPi.lean
@@ -29,6 +29,8 @@ normal in any base.
 * [Wikipedia (Pi)](https://en.wikipedia.org/wiki/Pi)
 -/
 
+open Real
+
 namespace NormalNumber
 
 /--

--- a/FormalConjectures/Wikipedia/NormalityOfPi.lean
+++ b/FormalConjectures/Wikipedia/NormalityOfPi.lean
@@ -37,8 +37,6 @@ normal in any base.
 
 open Real Filter
 
-open scoped goldenRatio
-
 namespace NormalNumber
 
 /-- The `n`-th digit (0-indexed) after the radix point in the base-`b` expansion of `x`.

--- a/FormalConjectures/Wikipedia/NormalityOfPi.lean
+++ b/FormalConjectures/Wikipedia/NormalityOfPi.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjecturesForMathlib.NumberTheory.NormalNumber
 
 /-!
 # Normality of mathematical constants

--- a/FormalConjectures/Wikipedia/NormalityOfPi.lean
+++ b/FormalConjectures/Wikipedia/NormalityOfPi.lean
@@ -1,0 +1,66 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Normality of mathematical constants
+
+A real number $x$ is **normal in base $b$** if every digit $d \in \{0, 1, \ldots, b-1\}$
+appears with asymptotic frequency $1/b$ in the base-$b$ expansion of $x$: formally,
+$$\lim_{n \to \infty} \frac{N_d(n)}{n} = \frac{1}{b}$$
+where $N_d(n)$ counts occurrences of digit $d$ among the first $n$ digits.
+A number that is normal in every integer base $b \ge 2$ is called **absolutely normal**.
+
+Despite extensive empirical evidence—billions of digits have been computed for $\pi$,
+$e$, and $\sqrt{2}$, all showing near-uniform digit distribution—it is an open problem
+whether any of the classical constants $\pi$, $e$, $\sqrt{2}$, $\ln 2$, or $\varphi$ is
+normal in any base.
+
+*References:*
+* [Wikipedia (Normal number)](https://en.wikipedia.org/wiki/Normal_number)
+* [Wikipedia (Pi)](https://en.wikipedia.org/wiki/Pi)
+-/
+
+open Real Filter
+
+open scoped goldenRatio
+
+namespace NormalNumber
+
+/-- The `n`-th digit (0-indexed) after the radix point in the base-`b` expansion of `x`.
+Concretely, `digitSeq b x n = ⌊b^(n+1) · {x}⌋ mod b` where `{x}` is the fractional part. -/
+noncomputable def digitSeq (b : ℕ) (x : ℝ) (n : ℕ) : ℕ :=
+  ⌊(b : ℝ) ^ (n + 1) * Int.fract x⌋₊ % b
+
+/-- `x` is **normal in base `b`** if every digit `d < b` appears with asymptotic
+frequency `1/b` in the base-`b` fractional expansion of `x`. -/
+noncomputable def IsNormalInBase (b : ℕ) (x : ℝ) : Prop :=
+  ∀ d : ℕ, d < b → Tendsto (fun n : ℕ => (((Finset.range n).filter (fun k => digitSeq b x k = d)).card : ℝ) / (n : ℝ))
+      atTop (nhds (1 / (b : ℝ)))
+
+/-- `x` is **absolutely normal** if it is normal in every integer base `b ≥ 2`. -/
+noncomputable def IsAbsolutelyNormal (x : ℝ) : Prop :=
+  ∀ b : ℕ, 2 ≤ b → IsNormalInBase b x
+
+/--
+$\pi$ is normal in base 10.
+-/
+@[category research open, AMS 11]
+theorem pi_normal_base_ten : IsNormalInBase 10 π := by
+  sorry
+
+end NormalNumber

--- a/FormalConjectures/Wikipedia/NormalityOfPi.lean
+++ b/FormalConjectures/Wikipedia/NormalityOfPi.lean
@@ -15,15 +15,10 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
+import FormalConjecturesForMathlib.NumberTheory.NormalNumber
 
 /-!
 # Normality of mathematical constants
-
-A real number $x$ is **normal in base $b$** if every digit $d \in \{0, 1, \ldots, b-1\}$
-appears with asymptotic frequency $1/b$ in the base-$b$ expansion of $x$: formally,
-$$\lim_{n \to \infty} \frac{N_d(n)}{n} = \frac{1}{b}$$
-where $N_d(n)$ counts occurrences of digit $d$ among the first $n$ digits.
-A number that is normal in every integer base $b \ge 2$ is called **absolutely normal**.
 
 Despite extensive empirical evidence—billions of digits have been computed for $\pi$,
 $e$, and $\sqrt{2}$, all showing near-uniform digit distribution—it is an open problem
@@ -35,24 +30,7 @@ normal in any base.
 * [Wikipedia (Pi)](https://en.wikipedia.org/wiki/Pi)
 -/
 
-open Real Filter
-
 namespace NormalNumber
-
-/-- The `n`-th digit (0-indexed) after the radix point in the base-`b` expansion of `x`.
-Concretely, `digitSeq b x n = ⌊b^(n+1) · {x}⌋ mod b` where `{x}` is the fractional part. -/
-noncomputable def digitSeq (b : ℕ) (x : ℝ) (n : ℕ) : ℕ :=
-  ⌊(b : ℝ) ^ (n + 1) * Int.fract x⌋₊ % b
-
-/-- `x` is **normal in base `b`** if every digit `d < b` appears with asymptotic
-frequency `1/b` in the base-`b` fractional expansion of `x`. -/
-noncomputable def IsNormalInBase (b : ℕ) (x : ℝ) : Prop :=
-  ∀ d : ℕ, d < b → Tendsto (fun n : ℕ => (((Finset.range n).filter (fun k => digitSeq b x k = d)).card : ℝ) / (n : ℝ))
-      atTop (nhds (1 / (b : ℝ)))
-
-/-- `x` is **absolutely normal** if it is normal in every integer base `b ≥ 2`. -/
-noncomputable def IsAbsolutelyNormal (x : ℝ) : Prop :=
-  ∀ b : ℕ, 2 ≤ b → IsNormalInBase b x
 
 /--
 $\pi$ is normal in base 10.

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -1,4 +1,19 @@
-module  -- shake: keep-all
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
 
 public import FormalConjecturesForMathlib.Algebra.GCDMonoid.Finset
 public import FormalConjecturesForMathlib.Algebra.Group.Action.Pointwise.Set.Basic
@@ -61,7 +76,6 @@ public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
-public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util
 public import FormalConjecturesForMathlib.LinearAlgebra.AffineSpace.Simplex.Basic
 public import FormalConjecturesForMathlib.LinearAlgebra.GeneralLinearGroup
 public import FormalConjecturesForMathlib.LinearAlgebra.SpecialLinearGroup
@@ -86,7 +100,6 @@ public import FormalConjecturesForMathlib.Order.Interval.Finset.Nat
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.Arithmetic
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.Continuum
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.SimpleGraph
-public import FormalConjecturesForMathlib.Tactic.Linter.Term
 public import FormalConjecturesForMathlib.Topology.Algebra.InfiniteSum.Group
 public import FormalConjecturesForMathlib.Topology.Algebra.InfiniteSum.Order
 public import FormalConjecturesForMathlib.Topology.Discrete

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -1,19 +1,4 @@
-/-
-Copyright 2026 The Formal Conjectures Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--/
-module
+module  -- shake: keep-all
 
 public import FormalConjecturesForMathlib.Algebra.GCDMonoid.Finset
 public import FormalConjecturesForMathlib.Algebra.Group.Action.Pointwise.Set.Basic
@@ -76,6 +61,7 @@ public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
+public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util
 public import FormalConjecturesForMathlib.LinearAlgebra.AffineSpace.Simplex.Basic
 public import FormalConjecturesForMathlib.LinearAlgebra.GeneralLinearGroup
 public import FormalConjecturesForMathlib.LinearAlgebra.SpecialLinearGroup
@@ -87,6 +73,7 @@ public import FormalConjecturesForMathlib.NumberTheory.CoveringSystem
 public import FormalConjecturesForMathlib.NumberTheory.DirichletCharacter.Basic
 public import FormalConjecturesForMathlib.NumberTheory.Lacunary
 public import FormalConjecturesForMathlib.NumberTheory.LegendreSymbol.Basic
+public import FormalConjecturesForMathlib.NumberTheory.NormalNumber
 public import FormalConjecturesForMathlib.NumberTheory.PracticalNumbers
 public import FormalConjecturesForMathlib.NumberTheory.PrimeGap
 public import FormalConjecturesForMathlib.NumberTheory.Primitive
@@ -99,6 +86,7 @@ public import FormalConjecturesForMathlib.Order.Interval.Finset.Nat
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.Arithmetic
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.Continuum
 public import FormalConjecturesForMathlib.SetTheory.Cardinal.SimpleGraph
+public import FormalConjecturesForMathlib.Tactic.Linter.Term
 public import FormalConjecturesForMathlib.Topology.Algebra.InfiniteSum.Group
 public import FormalConjecturesForMathlib.Topology.Algebra.InfiniteSum.Order
 public import FormalConjecturesForMathlib.Topology.Discrete

--- a/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
@@ -16,7 +16,8 @@ limitations under the License.
 module
 
 public import Mathlib.Data.Real.Basic
-public import Mathlib.Topology.Algebra.InfiniteSum.Basic
+public import Mathlib.Topology.Algebra.Order.Floor
+public import Mathlib.Topology.Algebra.Ring.Real
 public import Mathlib.Order.Filter.Basic
 public import Mathlib.Data.Finset.Card
 

--- a/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
@@ -15,10 +15,8 @@ limitations under the License.
 -/
 module
 
-public import Mathlib.Data.Real.Basic
-public import Mathlib.Topology.Algebra.InfiniteSum.Basic
-public import Mathlib.Order.Filter.Basic
-public import Mathlib.Data.Finset.Card
+public import Mathlib.Data.Real.Archimedean
+public import Mathlib.Topology.MetricSpace.Pseudo.Defs
 
 @[expose] public section
 /-!

--- a/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
@@ -1,0 +1,77 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Topology.Algebra.InfiniteSum.Basic
+public import Mathlib.Order.Filter.Basic
+public import Mathlib.Data.Finset.Card
+
+@[expose] public section
+/-!
+# Normal numbers
+
+A real number $x$ is *normal in base* $b$ if every digit
+$d \in \{0,1,\dots,b-1\}$ appears with asymptotic frequency $1/b$
+in the base-$b$ expansion of $x$.
+
+A number that is normal in every integer base $b \ge 2$
+is called *absolutely normal*.
+
+Despite extensive empirical evidence, it remains unknown whether
+classical constants such as $\pi$, $e$, or $\sqrt{2}$ are normal in any base.
+
+*References*:
+- [Wikipedia, Normal number](https://en.wikipedia.org/wiki/Normal_number)
+- [Wikipedia, Borel normal number](https://en.wikipedia.org/wiki/Borel_normal_number)
+
+## Main definitions
+
+* `digitSeq`: the sequence of digits in the base-`b` fractional expansion of a real number.
+* `IsNormalInBase`: a real number is normal in base `b`.
+* `IsAbsolutelyNormal`: a real number is normal in every base `b ≥ 2`.
+-/
+
+open Real Filter
+
+namespace NormalNumber
+
+/-- The `n`-th digit (0-indexed) after the radix point in the base-`b`
+expansion of `x`.
+
+Concretely,
+`digitSeq b x n = ⌊b^(n+1) * {x}⌋ mod b`,
+where `{x}` denotes the fractional part of `x`. -/
+noncomputable def digitSeq (b : ℕ) (x : ℝ) (n : ℕ) : ℕ :=
+  ⌊(b : ℝ) ^ (n + 1) * Int.fract x⌋₊ % b
+
+/-- A real number `x` is *normal in base* `b`
+if every digit `d < b` appears with asymptotic frequency `1 / b`
+in the base-`b` fractional expansion of `x`. -/
+noncomputable def IsNormalInBase (b : ℕ) (x : ℝ) : Prop :=
+  ∀ d : ℕ, d < b →
+    Tendsto
+      (fun n : ℕ =>
+        (((Finset.range n).filter (fun k => digitSeq b x k = d)).card : ℝ) / n)
+      atTop
+      (nhds (1 / (b : ℝ)))
+
+/-- A real number `x` is *absolutely normal*
+if it is normal in every integer base `b ≥ 2`. -/
+noncomputable def IsAbsolutelyNormal (x : ℝ) : Prop :=
+  ∀ b : ℕ, 2 ≤ b → IsNormalInBase b x
+
+end NormalNumber

--- a/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
@@ -16,8 +16,7 @@ limitations under the License.
 module
 
 public import Mathlib.Data.Real.Basic
-public import Mathlib.Topology.Algebra.Order.Floor
-public import Mathlib.Topology.Algebra.Ring.Real
+public import Mathlib.Topology.Algebra.InfiniteSum.Basic
 public import Mathlib.Order.Filter.Basic
 public import Mathlib.Data.Finset.Card
 


### PR DESCRIPTION
###Description

This PR adds a Lean formalization of the conjecture about normality of pi.

Changes:

FormalConjectures/Wikipedia/NormalityOfPi.lean

Closes #2255

###Formulation of original problem: 

A number is normal in base 10 if each digit 0 through 9 appears with equal limiting frequency in its decimal expansion. The conjecture asks whether π, the ratio of a circle's circumference to its diameter, is normal in base 10.