### PR TITLE
style(AMSLinter): Disallow leading zeros in AMS tags

### DIFF
--- a/FormalConjectures/ErdosProblems/1105.lean
+++ b/FormalConjectures/ErdosProblems/1105.lean
@@ -45,7 +45,7 @@ Montellano-Ballesteros and Neumann-Lara [MoNe05] gave an exact formula for $\mat
 which implies in particular that
 $\mathrm{AR}(n,C_k)=\left(\frac{k-2}{2}+\frac{1}{k-1}\right)n+O(1).$
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_1105.parts.i : answer(True) ↔
     ∀ k, 3 ≤ k →
     ((fun n => (antiRamseyNum (cycleGraph k) n : ℝ) - ((k - 2 : ℝ) / 2 + 1 / (k - 1)) * n)
@@ -61,7 +61,7 @@ $\epsilon=2$ otherwise?
 A proof of the formula for $\mathrm{AR}(n,P_k)$ for all $n\geq k\geq 5$ has been announced by
 Yuan [Yu21].
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_1105.parts.ii : answer(True) ↔
     ∀ (k n : ℕ), 5 ≤ k → k ≤ n →
     let ℓ := (k - 1) / 2

--- a/FormalConjectures/ErdosProblems/120.lean
+++ b/FormalConjectures/ErdosProblems/120.lean
@@ -41,14 +41,14 @@ Let $A \subseteq \mathbb{R}$ be an infinite set. Must there be a set $E \subsete
 of positive measure which does not contain any set of the shape $a * A + b$
 for some $a,b \in \mathbb{R}$ and $a \neq 0$?
 -/
-@[category research open, AMS 05 28]
+@[category research open, AMS 5 28]
 theorem erdos_120 : answer(sorry) ↔ ∀ A : Set ℝ, A.Infinite → Erdos120For A := by
   sorry
 
 /--
 Steinhaus [St20] has proved Erdős 120 to be false whenever $A$ is a finite set.
 -/
-@[category research solved, AMS 05 28]
+@[category research solved, AMS 5 28]
 theorem erdos_120.variants.finite_set {A : Set ℝ} (h : A.Finite) : ¬ Erdos120For A := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/170.lean
+++ b/FormalConjectures/ErdosProblems/170.lean
@@ -43,7 +43,7 @@ def PerfectRulersLengthN (N : ℕ) :
 abbrev TrivialRuler (N : ℕ) : Finset ℕ := Finset.range (N+1)
 
 /-- Sanity Check: the trivial ruler is actually a perfect ruler if $K \geq N$ -/
-@[category API, AMS 05]
+@[category API, AMS 5]
 lemma trivial_ruler_is_perfect (N : ℕ) : TrivialRuler N ∈ PerfectRulersLengthN N := by
     simp only [PerfectRulersLengthN, Finset.mem_filter, Finset.mem_powerset, Finset.range_subset]
     exact ⟨by simp, fun k hk => ⟨0, by simp, k, hk, rfl⟩⟩
@@ -54,7 +54,7 @@ def F (N : ℕ) : ℕ :=
                 (Finset.image_nonempty.mpr ⟨TrivialRuler N, trivial_ruler_is_perfect N⟩)
 
 /-- The problem is to determine the limit of the sequence $\frac{F(N)}{\sqrt{N}}$ as $N \to \infty$. -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 lemma erdos170 : Filter.Tendsto (fun N => F N / √N) Filter.atTop (𝓝 answer(sorry)) := by sorry
 
 /-- A known lower bound to the limit by Leech [Le56], which is $1.56\dots$. -/
@@ -65,7 +65,7 @@ noncomputable abbrev upper_bound := √3
 /-- The existence of the limit has been proved by Erdős and Gál [ErGa48].
 The lower bound has been proven by Leech [Le56], who refined an argument of Rédei and Rényi.
 The upper bound is due to Wichmann [Wi63]. -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 lemma erdos170.existing_bounds :
   ∃ x ∈ Set.Icc lower_bound upper_bound,
     Filter.Tendsto (fun N => F N / √N) Filter.atTop (𝓝 x) := by sorry

--- a/FormalConjectures/ErdosProblems/342.lean
+++ b/FormalConjectures/ErdosProblems/342.lean
@@ -66,7 +66,7 @@ theorem erdos_342.test.a2 : ∀ a : ℕ → ℕ, IsUlamSequence a → a 2 = 3 :=
 /-- $a(3) = 4$: among sums $> 3$ with a unique representation from $\{1,2,3\}$,
 the smallest is $4 = 1 + 3$. The candidate $5 = 2 + 3$ is ruled out by minimality since
 $4$ has a unique representation. -/
-@[category test, AMS 05 11 40]
+@[category test, AMS 5 11 40]
 theorem erdos_342.test.a3 : ∀ a : ℕ → ℕ, IsUlamSequence a → a 3 = 4 := by
   intro a ⟨ha0, ha1, ha⟩
   have ha2 := erdos_342.test.a2 a ⟨ha0, ha1, ha⟩
@@ -107,7 +107,7 @@ theorem erdos_342.test.a3 : ∀ a : ℕ → ℕ, IsUlamSequence a → a 3 = 4 :=
 
 /--
 Do infinitely many pairs $(a, a+2)$ occur in Ulam's sequence? -/
-@[category research open, AMS 05 11 40]
+@[category research open, AMS 5 11 40]
 theorem erdos_342.parts.i :
     answer(sorry) ↔
       ∀ a : ℕ → ℕ, IsUlamSequence a →
@@ -117,7 +117,7 @@ theorem erdos_342.parts.i :
 /--
 Does Ulam's sequence eventually have periodic differences? That is, is $a(n+1) - a(n)$ eventually periodic?
 -/
-@[category research open, AMS 05 11 40]
+@[category research open, AMS 5 11 40]
 theorem erdos_342.parts.ii :
     answer(sorry) ↔
       ∀ a : ℕ → ℕ, IsUlamSequence a →
@@ -128,7 +128,7 @@ theorem erdos_342.parts.ii :
 /--
 Part (iii), is the density of the sequence 0?
 -/
-@[category research open, AMS 05 11 40]
+@[category research open, AMS 5 11 40]
 theorem erdos_342.parts.iii :
     answer(sorry) ↔
       ∀ a : ℕ → ℕ, IsUlamSequence a →

--- a/FormalConjectures/ErdosProblems/562.lean
+++ b/FormalConjectures/ErdosProblems/562.lean
@@ -35,7 +35,7 @@ Prove that, for $r \ge 3$,
 $$ \log_{r-1} R_r(n) \asymp_r n, $$
 where $\log_{r-1}$ denotes the $(r-1)$-fold iterated logarithm.
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_562 : answer(sorry) ↔
     ∀ r ≥ 3, (fun n ↦ log^[r - 1] (hypergraphRamsey r n)) ~[atTop] (fun n ↦ (n : ℝ)) := by
   sorry

--- a/FormalConjectures/ErdosProblems/564.lean
+++ b/FormalConjectures/ErdosProblems/564.lean
@@ -33,7 +33,7 @@ hypergraph on $n$ vertices.
 Is there some constant $c>0$ such that
 $$ R_3(n) \geq 2^{2^{cn}}? $$
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_564 : answer(sorry) ↔
     ∃ c > 0, ∀ᶠ n in atTop, (2 : ℝ)^(2 : ℝ)^(c * n) ≤ hypergraphRamsey 3 n := by
   sorry

--- a/FormalConjectures/ErdosProblems/566.lean
+++ b/FormalConjectures/ErdosProblems/566.lean
@@ -36,7 +36,7 @@ Is it true that, if $H$ has $m$ edges and no isolated vertices, then $\hat{r}(G,
 In other words: if $G$ is sparse (every induced subgraph on $k$ vertices has $≤ 2k-3$ edges),
 is $G$ Ramsey size linear?
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_566 : answer(sorry) ↔
     ∀ (p : ℕ) (G : SimpleGraph (Fin p)),
       -- G is sparse: every induced subgraph on k ≥ 2 vertices has ≤ 2k - 3 edges

--- a/FormalConjectures/ErdosProblems/567.lean
+++ b/FormalConjectures/ErdosProblems/567.lean
@@ -56,7 +56,7 @@ def H5 : SimpleGraph (Fin 5) :=
 
 Is $Q_3$ (the 3-dimensional hypercube) Ramsey size linear?
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_567.parts.i : answer(sorry) ↔ IsRamseySizeLinear Q3 := by
   sorry
 
@@ -65,7 +65,7 @@ theorem erdos_567.parts.i : answer(sorry) ↔ IsRamseySizeLinear Q3 := by
 
 Is $K_{3,3}$ Ramsey size linear?
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_567.parts.ii : answer(sorry) ↔ IsRamseySizeLinear K33 := by
   sorry
 
@@ -74,7 +74,7 @@ theorem erdos_567.parts.ii : answer(sorry) ↔ IsRamseySizeLinear K33 := by
 
 Is $H_5$ ($C_5$ with two vertex-disjoint chords) Ramsey size linear?
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_567.parts.iii : answer(sorry) ↔ IsRamseySizeLinear H5 := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/598.lean
+++ b/FormalConjectures/ErdosProblems/598.lean
@@ -39,7 +39,7 @@ Let $m$ be an infinite cardinal and $\kappa$ be the successor cardinal of $2^{\a
 Can one colour the countable subsets of $m$ using $\kappa$ many colours so that every
 $X \subseteq m$ with $|X| = \kappa$ contains subsets of all possible colours?
 -/
-@[category research open, AMS 03 05]
+@[category research open, AMS 3 5]
 theorem erdos_598 : answer(sorry) ↔
     ∃ c : { s : Set m // s.Countable } → κ.out,
     ∀ X : Set m, #X = κ →

--- a/FormalConjectures/ErdosProblems/61.lean
+++ b/FormalConjectures/ErdosProblems/61.lean
@@ -42,7 +42,7 @@ def IsErdosHajnalLowerBound {α : Type*} [Fintype α] [DecidableEq α]
 The Erdős–Hajnal Conjecture states that there is a constant $c(H) > 0$ for each
 $H$ such that we can take $f(n) = n^{c(H)}$ in the above formulation.
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_61 :
     answer(sorry) ↔ ∀ {α : Type*} [Fintype α] [DecidableEq α] (H : SimpleGraph α),
       ∃ c > (0 : ℝ), IsErdosHajnalLowerBound H (fun n : ℕ => (n : ℝ) ^ c) := by
@@ -54,7 +54,7 @@ for some constant $c_H > 0$ dependending on $H$.
 
 [ErHa89] Erdős, P. and Hajnal, A., Ramsey-type theorems. Discrete Appl. Math. (1989), 37-52.
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_61.variants.erha89 :
     ∀ {α : Type*} [Fintype α] [DecidableEq α] (H : SimpleGraph α),
       ∃ c > (0 : ℝ), IsErdosHajnalLowerBound H (fun n : ℕ => exp (c * sqrt (log n))) := by
@@ -66,7 +66,7 @@ $f(n) = \exp(c_H \sqrt{\log n \log \log n})$ for some constant $c_H > 0$ depende
 
 [BNSS23] Bucić, M. and Nguyen, T. and Scott, A. and Seymour, P., A loglog step towards Erdos-Hajnal
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_61.variants.bnss23 :
     ∀ {α : Type*} [Fintype α] [DecidableEq α] (H : SimpleGraph α),
       ∃ c > (0 : ℝ), IsErdosHajnalLowerBound H (fun n : ℕ => exp (c * sqrt (log n * log (log n)))) := by

--- a/FormalConjectures/ErdosProblems/75.lean
+++ b/FormalConjectures/ErdosProblems/75.lean
@@ -32,7 +32,7 @@ Is there a graph of chromatic number `ℵ_ 1` with `ℵ_ 1` vertices such that f
 `ε > 0`, if `n` is sufficiently large and `H` is a subgraph on `n` vertices,
 then `H` contains an independent set of size `> n ^ (1 - ε)`?
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_75 :
     answer(sorry) ↔
     ∃ (V : Type) (G : SimpleGraph V),

--- a/FormalConjectures/ErdosProblems/920.lean
+++ b/FormalConjectures/ErdosProblems/920.lean
@@ -44,7 +44,7 @@ noncomputable def f (k n : ℕ) : ℕ :=
 Is it true that, for $k\geq 4$, $f_k(n) \gg \frac{n^{1-\frac{1}{k-1}}}{(\log n)^{c_k}}$ for some
 constant $c_k>0$?
 -/
-@[category research open, AMS 05]
+@[category research open, AMS 5]
 theorem erdos_920 :
     answer(sorry) ↔ ∀ k : ℕ, k ≥ 4 → ∃ c > 0,
       (fun n ↦ f k n) ≫ (fun n ↦ (n : ℝ) ^ (1 - 1 / ((k : ℝ) - 1)) / (log n) ^ c) := by
@@ -54,7 +54,7 @@ theorem erdos_920 :
 Graver and Yackel [GrYa68] proved that
 $f_k(n) \ll \left(n\frac{\log\log n}{\log n}\right)^{1-\frac{1}{k-1}}.$
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_920.variants.upper_bound (k : ℕ) (hk : k ≥ 3) :
     (fun n ↦ f k n) ≪ (fun n ↦ ((n : ℝ) * log (log n) / log n) ^ (1 - 1 / ((k : ℝ) - 1))) := by
   sorry
@@ -62,7 +62,7 @@ theorem erdos_920.variants.upper_bound (k : ℕ) (hk : k ≥ 3) :
 /--
 It is known that $f_3(n)\asymp (n/\log n)^{1/2}$ (see [erdosproblems.com/1104]).
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_920.variants.k_eq_3 :
     (fun n ↦ (f 3 n : ℝ)) =Θ[atTop] (fun n ↦ ((n : ℝ) / log n) ^ (1 / 2 : ℝ)) := by
   sorry
@@ -71,7 +71,7 @@ theorem erdos_920.variants.k_eq_3 :
 The lower bound $R(4,m) \gg m^3/(\log m)^4$ of Mattheus and Verstraete [MaVe23]
 (see [erdosproblems.com/166]) implies $f_4(n) \gg \frac{n^{2/3}}{(\log n)^{4/3}}$.
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_920.variants.lower_bound_f4 :
     (fun n ↦ f 4 n) ≫ (fun n ↦ (n : ℝ) ^ (2 / 3 : ℝ) / (log n) ^ (4 / 3 : ℝ)) := by
   sorry
@@ -80,7 +80,7 @@ theorem erdos_920.variants.lower_bound_f4 :
 A positive answer to this question would follow from [erdosproblems.com/986]. The known bounds for
 that problem imply $f_k(n) \gg \frac{n^{1-\frac{2}{k+1}}}{(\log n)^{c_k}}.$
 -/
-@[category research solved, AMS 05]
+@[category research solved, AMS 5]
 theorem erdos_920.variants.lower_bound (k : ℕ) (hk : k ≥ 3) :
     ∃ c > 0, (fun n ↦ f k n) ≫ (fun (n : ℕ) ↦
     (n : ℝ) ^ (1 - 2 / ((k : ℝ) + 1)) / (log n) ^ c) := by

--- a/FormalConjectures/ErdosProblems/965.lean
+++ b/FormalConjectures/ErdosProblems/965.lean
@@ -39,7 +39,7 @@ all sums $a + b$ for $a, b ∈ A, a ≠ b$ have the same colour.
 In [Ko16] Péter Komjáth constructed a counterexample.
 The same result was proven independently in [SWCol] by Sokoup and Weiss.
 -/
-@[category research solved, AMS 03 05]
+@[category research solved, AMS 3 5]
 theorem erdos_965 :
     answer(False) ↔ ∀ f : ℝ → Fin 2, ∃ A : Set ℝ, ¬ A.Countable ∧
       ∀ᵉ (a ∈ A) (b ∈ A) (c ∈ A) (d ∈ A), a ≠ b → c ≠ d → f (a + b) = f (c + d) := by
@@ -48,7 +48,7 @@ theorem erdos_965 :
 /--
 In fact, in both [Ko16] and [SWCol] a generalized example for $k$-sums is constructed.
 -/
-@[category research solved, AMS 03 05]
+@[category research solved, AMS 3 5]
 theorem erdos_965.variants.generalization : answer(False) ↔
      ∀ᵉ (k ≥ 2), ∀ f : ℝ → Fin 2, ∃ A : Set ℝ, ¬ A.Countable ∧ ∀ s t : Finset ℝ,
       ↑s ⊆ A → ↑t ⊆ A → s.card = k → t.card = k → f (s.sum id) = f (t.sum id) := by

--- a/FormalConjectures/GreensOpenProblems/37.lean
+++ b/FormalConjectures/GreensOpenProblems/37.lean
@@ -44,7 +44,7 @@ noncomputable def m (N k : ℕ) : ℕ :=
 Given a natural number `N`, what is the smallest size of a subset of `ℕ` that contains, for each `d = 1, …, N`,
 an arithmetic progression of length `k` with common difference `d`.
 -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_37 (N k : ℕ) :
     IsLeast { m | ∃ A : Finset ℕ, A.card = m ∧ IsAPCover (A : Set ℕ) N k } (answer(sorry)) := by
   sorry
@@ -53,25 +53,25 @@ theorem green_37 (N k : ℕ) :
 Asymptotic version: determine the asymptotic behavior of `m(N, k)` as `N` grows.
 The solver should determine what function `f : ℕ → ℝ` eventually equals `(fun N ↦ (m N k : ℝ))`.
 -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_37_asymptotic (k : ℕ) :
     ∀ᶠ N in atTop, (m N k : ℝ) = (answer(sorry) : ℕ → ℝ) N := by
   sorry
 
 /-- Determine the asymptotic equivalence class (theta) of `m(N, k)`. -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_37_theta (k : ℕ) :
     (fun N ↦ (m N k : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 /-- Determine an upper bound (big O) for `m(N, k)`. -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_37_bigO (k : ℕ) :
     (fun N ↦ (m N k : ℝ)) =O[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 /-- Determine a strict upper bound (little o) for `m(N, k)`. -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_37_littleO (k : ℕ) :
     (fun N ↦ (m N k : ℝ)) =o[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry

--- a/FormalConjectures/GreensOpenProblems/38.lean
+++ b/FormalConjectures/GreensOpenProblems/38.lean
@@ -72,7 +72,7 @@ noncomputable def C₁ : ℝ := (367 : ℝ) ^ (5⁻¹ : ℝ)
 noncomputable def C₂ : ℝ := (7 * Real.cos (Real.pi / 7)) / (1 + Real.cos (Real.pi / 7))
 
 /-- Can we improve the lower bound? -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_38.lower :
     let ans := (answer(sorry) : ℕ → ℝ)
     ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
@@ -80,7 +80,7 @@ theorem green_38.lower :
   sorry
 
 /-- Can we improve the best upper bound? -/
-@[category research open, AMS 05 11]
+@[category research open, AMS 5 11]
 theorem green_38.upper :
     let ans := (answer(sorry) : ℕ → ℝ)
     LargestAdmissibleCardinality ≤ᶠ[atTop] ans ∧
@@ -90,27 +90,27 @@ theorem green_38.upper :
 /--
 The current best lower bound is $(C_1 - o(1))^n \leqslant |A|$ where
 $C_1 = 367^{1/5} \approx 3.2578$ [Po20, Section 9.1]. -/
-@[category research solved, AMS 05 11]
+@[category research solved, AMS 5 11]
 theorem green_38.variants.best_lower :
     ∀ ε > 0, ∀ᶠ n in atTop, (C₁ - ε) ^ n ≤ LargestAdmissibleCardinality n := by
   sorry
 
 /-- The current best upper bound is $|A| \leqslant (C_2 + o(1))^n$ where
 $C_2 = \frac{7 \cos(\pi/7)}{1 + \cos(\pi/7)} \approx 3.3177$ [La79, Corollary 5]. -/
-@[category research solved, AMS 05 11]
+@[category research solved, AMS 5 11]
 theorem green_38.variants.best_upper :
     ∀ ε > 0, ∀ᶠ n in atTop, LargestAdmissibleCardinality n ≤ (C₂ + ε) ^ n := by
   sorry
 
 /-- 0 is a valid cardinality, since the empty set vacuously satisfies the condition. -/
-@[category test, AMS 05 11]
+@[category test, AMS 5 11]
 theorem green_38.test_zero_mem_validCardinalities {n : ℕ} :
     0 ∈ ValidCardinalities n := by
   use ∅
   simp [IntersectsOnlyAtZero]
 
 /-- The set of valid cardinalities we take the supremum over is bounded above. -/
-@[category test, AMS 05 11]
+@[category test, AMS 5 11]
 theorem green_38.test_bound_above {n : ℕ} :
     BddAbove (ValidCardinalities n) := by
   use 7 ^ n

--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -45,7 +45,7 @@ noncomputable def AllowedSetSize (k : ℕ) (N : ℕ) : ℕ :=
 
 /-- By the pigeon hole principle, the size of a subset of an $N \times N$ grid such that no $k$
 points lie on a line is bounded by $\leq (k - 1) * N$ for $N \geq k$. -/
-@[category textbook, AMS 05 52]
+@[category textbook, AMS 5 52]
 theorem allowedSetSize_le {k : ℕ} {N : ℕ} (h : k ≤ N) :
     AllowedSetSize k N ≤ (k - 1) * N := by
   sorry
@@ -58,31 +58,31 @@ def NoKInLineFor (k : ℕ) (N : ℕ) : Prop :=
 For $N \geq k$ and $k > 1$, the AllowedSetSize in $(k - 1) * N$, i. e. on an $N \times N$ subset,
 there is a set of $k * N$ points for which no $k$ lie on a line (and not such a set of bigger size).
 -/
-@[category research open, AMS 05 52]
+@[category research open, AMS 5 52]
 theorem NoKInLine {k : ℕ} {N : ℕ} (hk : 1 < k) (h : k ≤ N) : NoKInLineFor k N := by
   sorry
 
 /-- **Green's Open Problem 72 / No-three-in-line problem**:
 The no-k-in-line conjecture holds for $k = 3$. -/
-@[category research open, AMS 05 52]
+@[category research open, AMS 5 52]
 theorem green_72 {N : ℕ} (hN : 3 ≤ N) : NoKInLineFor 3 N := by
   sorry
 
 alias no_three_in_line := green_72
 
 /-- Does the no-three-in-line problem hold when $N$ is big enough? -/
-@[category research open, AMS 05 52]
+@[category research open, AMS 5 52]
 theorem green_72.variants.eventually : answer(sorry) ↔ ∀ᶠ N in Filter.atTop, NoKInLineFor 3 N := by
   sorry
 
 /-- For $N \leq 60$, this has been verfied with computers. -/
-@[category research solved, AMS 05 52]
+@[category research solved, AMS 5 52]
 theorem no_three_in_line_le {N : ℕ} (hN : 3 ≤ N) (hN' : N ≤ 60) :
     NoKInLineFor 3 N := by
   sorry
 
 /-- In [GK2025] Grebennikov and Kwan prove the no-k-in-line conjecture for $k > 10 ^ 37$. -/
-@[category research solved, AMS 05 52]
+@[category research solved, AMS 5 52]
 theorem no_k_in_line_big {k : ℕ} (N : ℕ) (h : 10 ^ 37 < k) :
     NoKInLineFor k N := by
   sorry

--- a/FormalConjectures/OptimizationConstants/1a.lean
+++ b/FormalConjectures/OptimizationConstants/1a.lean
@@ -38,27 +38,27 @@ noncomputable def C1a : ℝ :=
     ≤ sSup {∫ x, f (t - x) * f x | t ∈ Icc (1 / 2 : ℝ) 1}}
 
 /-- The best known lower bound, proven by Matolcsi-Vinuesa in [M2010]-/
-@[category research solved, AMS 05 11 26]
+@[category research solved, AMS 5 11 26]
 theorem c1a_lower_bound : 1.2748 ≤ C1a := by
   sorry
 
 /-- The best known upper bound, proven by Yuksekgonul et al. in [Y2026] -/
-@[category research solved, AMS 05 11 26]
+@[category research solved, AMS 5 11 26]
 theorem c1a_upper_bound : C1a ≤ 1.5029 := by
   sorry
 
 /-- How can the upper bound be improved? -/
-@[category research open, AMS 05 11 26]
+@[category research open, AMS 5 11 26]
 theorem mem_Ico_c1a : answer(sorry) ∈ Set.Ico C1a 1.5029 := by
   sorry
 
 /-- How can the lower bound be improved? -/
-@[category research open, AMS 05 11 26]
+@[category research open, AMS 5 11 26]
 theorem mem_Ioc_c1a : answer(sorry) ∈ Set.Ioc 1.2748 C1a := by
   sorry
 
 /-- What is the exact value of the constant? -/
-@[category research open, AMS 05 11 26]
+@[category research open, AMS 5 11 26]
 theorem c1a_eq : C1a = answer(sorry) := by
   sorry
 

--- a/FormalConjectures/Util/Linters/AMSLinter.lean
+++ b/FormalConjectures/Util/Linters/AMSLinter.lean
@@ -83,6 +83,14 @@ def AMSLinter : Linter where
           -- If we're here then there is at least one AMS tag, but it doesn't have any number.
           logLintIf linter.style.ams_attribute outStx
             "The AMS tag should have at least one subject number."
+          return
+        -- Avoid AMS tags with leading zeros (e.g. AMS 05 -> AMS 5)
+        for n in ams.flatten do
+          if let some str := n.raw.reprint then
+            let trimmed := str.trimAscii.toString
+            if trimmed.length > 1 && trimmed.startsWith "0" then
+              logLintIf linter.style.ams_attribute outStx
+                m!"AMS subject {trimmed} should not have a leading zero."
         -- Check there the AMS tags are sorted and do not contain duplicates
         let ams_sorted := ams.flatten.qsort (fun n m => n.getNat < m.getNat)
         if ams_sorted != ams.flatten then


### PR DESCRIPTION
# Description
Motivated by [this comment](https://github.com/google-deepmind/formal-conjectures/pull/3804#discussion_r3178196707), we would like to harmonize the AMS tags in the repo and disallow leading zeros:
- Raise linting warning if the AMS tag contains leading zeros
- Fix 17 existing files not following the new convention

# Testing
:white_check_mark: Built the whole repo successfully without linting warnings
```shell
$ lake build
Build completed successfully (8669 jobs).
```