### PR TITLE
fix(website): Avoid navbar blowout

### DIFF
--- a/site/src/css/style.css
+++ b/site/src/css/style.css
@@ -458,6 +458,9 @@ a.cat-stat:hover { text-decoration: none; opacity: 0.8; }
   align-items: start;
   padding: 2rem 0;
 }
+.browse-layout > * {
+  min-width: 0;
+}
 @media (max-width: 800px) {
   .browse-layout { grid-template-columns: 1fr; }
 }
@@ -579,9 +582,9 @@ a.cat-stat:hover { text-decoration: none; opacity: 0.8; }
   font-weight: 600;
   font-size: 0.95rem;
   margin-bottom: 0.25rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .theorem-card__name a { color: var(--color-text); }
 .theorem-card__name a:hover { color: var(--color-link); text-decoration: none; }
@@ -590,6 +593,8 @@ a.cat-stat:hover { text-decoration: none; opacity: 0.8; }
   font-size: 0.8rem;
   color: var(--color-text-muted);
   margin-bottom: 0.5rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .theorem-card__tags { display: flex; flex-wrap: wrap; gap: 0.35rem; }


### PR DESCRIPTION
# Description
Addresses #3754: theorems with extremely long names or module paths were causing a CSS Grid blowout on the browse page. The white-space: nowrap property on the theorem titles calculated the minimum required width as the full unbroken length of the title. This forced the grid layout to expand beyond the viewport's bounds, creating a horizontal scrollbar and prematurely cutting off the top navbar background.

**Fixes:**
- Added `min-width: 0` to `.browse-layout` children to strictly constrain the grid columns.
- Replaced `white-space: nowrap` with `white-space: normal` and `word-break: break-word` on `.theorem-card__name` so long titles wrap cleanly across multiple lines instead of expanding the card.
- Added `word-break: break-word` to `.theorem-card__meta` to ensure long module paths also wrap securely.

# Testing
:white_check_mark: I built the website locally and confirmed the expected fixed behavior: long theorem/module names now wrap around, and it is not possible to scroll right anymore. No issues with the navbar.

| Before | After |
| ---------- | -------- |
| <img width="400" height="187" alt="Screencast From 2026-05-06 00-12-48" src="https://github.com/user-attachments/assets/c4058ea0-978d-4a88-bd4e-da103c1fa25e" /> | <img width="400" height="187" alt="Screencast From 2026-05-06 00-12-05" src="https://github.com/user-attachments/assets/55ba0b10-756f-441b-bff2-828eccda150d" /> |
| We can scroll right, navbar blows out | Card titles wrap around, no right-scrolling possible |



**Commands:**
```shell
# Generate site data
mkdir -p site/data
lake exe extract_names > site/data/conjectures.json

# Build website
cd site
node build.js

# Serve locally
python3 -m http.server 8080 --directory site
```