### PR TITLE
feat(GreensOpenProblems): 41

### DIFF
--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -1,0 +1,47 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Ben Green's Open Problem 41
+
+*Reference:* [Ben Green's Open Problem 41](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.41)
+-/
+
+namespace Green41
+
+open Set
+
+/-- The pyjama set is the set of points in the plane whose x-coordinate is within ε of an integer. -/
+def pyjamaSet (ε : ℝ) : Set (ℝ × ℝ) :=
+  { p | ∃ z : ℤ, |p.1 - (z : ℝ)| ≤ ε }
+
+/-- A rotation about the origin by angle θ. -/
+noncomputable def rotate (θ : ℝ) (p : ℝ × ℝ) : ℝ × ℝ :=
+  (p.1 * Real.cos θ - p.2 * Real.sin θ, p.1 * Real.sin θ + p.2 * Real.cos θ)
+
+/--
+How many rotated (about the origin) copies of the 'pyjama set' $\\{(x, y) \in \mathbb{R}^2 : \text{dist}(x, \mathbb{Z}) \leq \varepsilon\\}$ are needed to cover $\mathbb{R}^2$?
+-/
+@[category research open, AMS 51 52]
+theorem green_41 :
+    ∀ ε > 0,
+      let ans := (answer(sorry) : ℕ)
+      IsLeast { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧ ∀ p : ℝ × ℝ, ∃ θ ∈ Θ, p ∈ rotate θ '' pyjamaSet ε } ans := by
+  sorry
+
+end Green41

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -42,12 +42,16 @@ noncomputable def minCopies (ε : ℝ) : ℕ :=
   sInf { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
     (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }
 
-/-- How many rotated (about the origin) copies of the 'pyjama set' are needed to cover the plane? -/
+/--
+How many rotated (about the origin) copies of the 'pyjama set'
+$\\{(x, y) \in \mathbb{R}^2 : \text{dist}(x, \mathbb{Z}) \leq \varepsilon\\}$ are needed to cover
+$\mathbb{R}^2$?
+-/
 @[category research open, AMS 51 52]
 theorem green_41 :
-    ∀ ε > 0,
-      let ans := (answer(sorry) : ℕ)
-      minCopies ε = ans := by
+    ∃ C : ℝ, C > 0 ∧ ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀,
+      let ans := (answer(sorry) : ℝ)
+      (minCopies ε : ℝ) ≤ ans ∧ ans < Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
   sorry
 
 /-- Is $\varepsilon^{-C}$ rotations enough? -/

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -37,13 +37,32 @@ an integer.
 def pyjamaSet (ε : ℝ) : Set ℂ :=
   { z | ∃ k : ℤ, |z.re - (k : ℝ)| ≤ ε }
 
+/-- The minimal number of rotated copies of the pyjama set of width ε needed to cover the plane. -/
+noncomputable def minCopies (ε : ℝ) : ℕ :=
+  sInf { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
+    (⋃ θ ∈ Θ, (fun z => exp (θ * I) * z) '' pyjamaSet ε) = univ }
+
 /-- How many rotated (about the origin) copies of the 'pyjama set' are needed to cover the plane? -/
 @[category research open, AMS 51 52]
 theorem green_41 :
     ∀ ε > 0,
       let ans := (answer(sorry) : ℕ)
-      IsLeast { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
-        (⋃ θ ∈ Θ, (fun z => exp (θ * I) * z) '' pyjamaSet ε) = univ } ans := by
+      minCopies ε = ans := by
+  sorry
+
+/-- Is $\varepsilon^{-C}$ rotations enough? -/
+@[category research open, AMS 51 52]
+theorem green_41.variants.polynomial_bound : answer(sorry) ↔
+    ∃ C : ℝ, ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀, (minCopies ε : ℝ) ≤ ε ^ (-C) := by
+  sorry
+
+/--
+[KrLe25] have established the first quantitative bound, showing via an analysis of [Ma15]'s method
+that $\exp\exp\exp(\varepsilon^{-C})$ rotations suffice.
+-/
+@[category research solved, AMS 51 52]
+theorem green_41.variants.kravitz_leng :
+    ∃ C : ℝ, ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀, (minCopies ε : ℝ) ≤ Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
   sorry
 
 end Green41

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -46,12 +46,24 @@ noncomputable def minCopies (ε : ℝ) : ℕ :=
 How many rotated (about the origin) copies of the 'pyjama set'
 $\\{(x, y) \in \mathbb{R}^2 : \text{dist}(x, \mathbb{Z}) \leq \varepsilon\\}$ are needed to cover
 $\mathbb{R}^2$?
+
+In particular, can one find a better bound than the best-known bound from [KrLe25]?
 -/
 @[category research open, AMS 51 52]
 theorem green_41 :
     ∃ C : ℝ, C > 0 ∧ ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀,
       let ans := (answer(sorry) : ℝ)
       (minCopies ε : ℝ) ≤ ans ∧ ans < Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
+  sorry
+
+/--
+Is there a better bound than the best-known bound from [KrLe25]?
+This is an existential version of the main problem that does not require providing the bound explicitly.
+-/
+@[category research open, AMS 51 52]
+theorem green_41.variants.exists_better_bound : answer(sorry) ↔
+    ∃ C : ℝ, C > 0 ∧ ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀,
+      ∃ ans : ℝ, (minCopies ε : ℝ) ≤ ans ∧ ans < Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
   sorry
 
 /-- Is $\varepsilon^{-C}$ rotations enough? -/

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -19,7 +19,11 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Ben Green's Open Problem 41
 
-*Reference:* [Ben Green's Open Problem 41](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.41)
+*References*
+- [Gr24] [Ben Green's Open Problem 41](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.41)
+- [Ma15] Manners, Freddie. "A solution to the pyjama problem." Inventiones mathematicae 202.1 (2015): 239-270.
+- [KrLe25] Kravitz, Noah, and James Leng. "Quantitative pyjama." arXiv preprint arXiv:2510.17744 (2025).
+
 -/
 
 namespace Green41

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -37,10 +37,14 @@ an integer.
 def pyjamaSet (ε : ℝ) : Set ℂ :=
   { z | ∃ k : ℤ, |z.re - (k : ℝ)| ≤ ε }
 
+/-- The set of valid numbers of rotated copies of the pyjama set of width ε that cover the plane. -/
+def coveringCopies (ε : ℝ) : Set ℕ :=
+  { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
+    (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }
+
 /-- The minimal number of rotated copies of the pyjama set of width ε needed to cover the plane. -/
 noncomputable def minCopies (ε : ℝ) : ℕ :=
-  sInf { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
-    (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }
+  sInf (coveringCopies ε)
 
 /--
 [Ma15] proved that for any $\varepsilon > 0$, finitely many rotations of the pyjama set of width
@@ -49,8 +53,7 @@ is non-empty.
 -/
 @[category test, AMS 51 52]
 theorem minCopies_set_nonempty (ε : ℝ) (hε : 0 < ε) :
-    { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
-      (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }.Nonempty := by
+    (coveringCopies ε).Nonempty := by
   sorry
 
 /--

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -28,7 +28,7 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Green41
 
-open Complex Set
+open Complex Set Pointwise
 
 /--
 The pyjama set is the set of points in the complex plane whose real part is within $\varepsilon$ of
@@ -40,7 +40,7 @@ def pyjamaSet (ε : ℝ) : Set ℂ :=
 /-- The minimal number of rotated copies of the pyjama set of width ε needed to cover the plane. -/
 noncomputable def minCopies (ε : ℝ) : ℕ :=
   sInf { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
-    (⋃ θ ∈ Θ, (fun z => exp (θ * I) * z) '' pyjamaSet ε) = univ }
+    (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }
 
 /-- How many rotated (about the origin) copies of the 'pyjama set' are needed to cover the plane? -/
 @[category research open, AMS 51 52]

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -51,7 +51,7 @@ noncomputable def minCopies (ε : ℝ) : ℕ :=
 $\varepsilon$ cover the plane. This implies that the set we are taking the infimum over in `minCopies`
 is non-empty.
 -/
-@[category test, AMS 51 52]
+@[category research solved, AMS 51 52]
 theorem minCopies_set_nonempty (ε : ℝ) (hε : 0 < ε) :
     (coveringCopies ε).Nonempty := by
   sorry

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -28,24 +28,22 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Green41
 
-open Set
-
-/-- The pyjama set is the set of points in the plane whose x-coordinate is within ε of an integer. -/
-def pyjamaSet (ε : ℝ) : Set (ℝ × ℝ) :=
-  { p | ∃ z : ℤ, |p.1 - (z : ℝ)| ≤ ε }
-
-/-- A rotation about the origin by angle θ. -/
-noncomputable def rotate (θ : ℝ) (p : ℝ × ℝ) : ℝ × ℝ :=
-  (p.1 * Real.cos θ - p.2 * Real.sin θ, p.1 * Real.sin θ + p.2 * Real.cos θ)
+open Complex Set
 
 /--
-How many rotated (about the origin) copies of the 'pyjama set' $\\{(x, y) \in \mathbb{R}^2 : \text{dist}(x, \mathbb{Z}) \leq \varepsilon\\}$ are needed to cover $\mathbb{R}^2$?
+The pyjama set is the set of points in the complex plane whose real part is within $\varepsilon$ of
+an integer.
 -/
+def pyjamaSet (ε : ℝ) : Set ℂ :=
+  { z | ∃ k : ℤ, |z.re - (k : ℝ)| ≤ ε }
+
+/-- How many rotated (about the origin) copies of the 'pyjama set' are needed to cover the plane? -/
 @[category research open, AMS 51 52]
 theorem green_41 :
     ∀ ε > 0,
       let ans := (answer(sorry) : ℕ)
-      IsLeast { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧ ∀ p : ℝ × ℝ, ∃ θ ∈ Θ, p ∈ rotate θ '' pyjamaSet ε } ans := by
+      IsLeast { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
+        (⋃ θ ∈ Θ, (fun z => exp (θ * I) * z) '' pyjamaSet ε) = univ } ans := by
   sorry
 
 end Green41

--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -43,6 +43,17 @@ noncomputable def minCopies (ε : ℝ) : ℕ :=
     (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }
 
 /--
+[Ma15] proved that for any $\varepsilon > 0$, finitely many rotations of the pyjama set of width
+$\varepsilon$ cover the plane. This implies that the set we are taking the infimum over in `minCopies`
+is non-empty.
+-/
+@[category test, AMS 51 52]
+theorem minCopies_set_nonempty (ε : ℝ) (hε : 0 < ε) :
+    { n : ℕ | ∃ (Θ : Finset ℝ), Θ.card = n ∧
+      (⋃ θ ∈ Θ, exp (θ * I) • pyjamaSet ε) = univ }.Nonempty := by
+  sorry
+
+/--
 How many rotated (about the origin) copies of the 'pyjama set'
 $\\{(x, y) \in \mathbb{R}^2 : \text{dist}(x, \mathbb{Z}) \leq \varepsilon\\}$ are needed to cover
 $\mathbb{R}^2$?


### PR DESCRIPTION
# Description
> How many rotated (about the origin) copies of the "pyjama set" $\\{(x, y) \in ℝ^2 : \text{dist}(x, \mathbb{Z}) \leq \varepsilon\\}$ are needed to cover $ℝ^2$?
- Closes #1597.
- Proposed as an improvement over currently best-known bound.
- Added variants.
- :robot: Drafted with **Gemini 3.1 Pro** and patched up manually for style and modularity.

# Testing
:white_check_mark: Builds successfully.
```shell
$ lake build FormalConjectures/GreensOpenProblems/41.lean 
Build completed successfully (7993 jobs).
```