### PR TITLE
feat(ErdosProblems): 1109

### DIFF
--- a/FormalConjectures/ErdosProblems/1109.lean
+++ b/FormalConjectures/ErdosProblems/1109.lean
@@ -1,0 +1,100 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 1109
+
+*Reference:* [erdosproblems.com/1109](https://www.erdosproblems.com/1109)
+-/
+
+open Filter Asymptotics
+open scoped Pointwise
+
+namespace Erdos1109
+
+/--
+A finite set `A` has squarefree sumset if every element of `A + A` is squarefree.
+-/
+def IsSquarefreeSumset (A : Finset ℕ) : Prop :=
+  ∀ n ∈ A + A, Squarefree n
+
+/--
+`f N` is the largest size of a subset `A ⊆ {1, ..., N}` such that every element
+of `A + A` is squarefree.
+-/
+noncomputable def f (N : ℕ) : ℕ :=
+  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsSquarefreeSumset A ∧ A.card = k}
+
+/--
+Let $f(N)$ be the size of the largest subset $A\subseteq \{1,\ldots,N\}$ such that
+every $n\in A+A$ is squarefree. Is it true that $f(N)\leq N^{o(1)}$?
+
+This formalizes the subpolynomial reading as `f(N) = O(N^ε)` for every `ε > 0`.
+-/
+@[category research open, AMS 5 11]
+theorem erdos_1109 :
+    answer(sorry) ↔ ∀ ε > (0 : ℝ),
+      (fun N : ℕ => (f N : ℝ)) =O[atTop] fun N : ℕ => (N : ℝ) ^ ε := by
+  sorry
+
+/--
+Is the stronger polylogarithmic bound $f(N) \leq (\log N)^{O(1)}$ true?
+-/
+@[category research open, AMS 5 11]
+theorem erdos_1109.variants.polylog :
+    answer(sorry) ↔ ∃ C > (0 : ℝ),
+      (fun N : ℕ => (f N : ℝ)) =O[atTop] fun N : ℕ => (Real.log N) ^ C := by
+  sorry
+
+/--
+Erdős and Sárközy proved the lower bound $\log N \ll f(N)$.
+-/
+@[category research solved, AMS 5 11]
+theorem erdos_1109.variants.erdos_sarkozy_lower :
+    (fun N : ℕ => Real.log N) =O[atTop] fun N : ℕ => (f N : ℝ) := by
+  sorry
+
+/--
+Erdős and Sárközy proved the upper bound $f(N) \ll N^{3/4}\log N$.
+-/
+@[category research solved, AMS 5 11]
+theorem erdos_1109.variants.erdos_sarkozy_upper :
+    (fun N : ℕ => (f N : ℝ)) =O[atTop]
+      fun N : ℕ => (N : ℝ) ^ ((3 : ℝ) / 4) * Real.log N := by
+  sorry
+
+/--
+Konyagin improved the lower bound to
+$\log\log N(\log N)^2 \ll f(N)$.
+-/
+@[category research solved, AMS 5 11]
+theorem erdos_1109.variants.konyagin_lower :
+    (fun N : ℕ => Real.log (Real.log N) * (Real.log N) ^ 2) =O[atTop]
+      fun N : ℕ => (f N : ℝ) := by
+  sorry
+
+/--
+Konyagin improved the upper bound to $f(N) \ll N^{11/15+o(1)}$.
+-/
+@[category research solved, AMS 5 11]
+theorem erdos_1109.variants.konyagin_upper :
+    ∀ ε > (0 : ℝ), (fun N : ℕ => (f N : ℝ)) =O[atTop]
+      fun N : ℕ => (N : ℝ) ^ ((11 : ℝ) / 15 + ε) := by
+  sorry
+
+end Erdos1109

--- a/FormalConjectures/ErdosProblems/1109.lean
+++ b/FormalConjectures/ErdosProblems/1109.lean
@@ -14,12 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
+import FormalConjecturesUtil
 
 /-!
 # Erdős Problem 1109
 
-*Reference:* [erdosproblems.com/1109](https://www.erdosproblems.com/1109)
+*References:*
+- [erdosproblems.com/1109](https://www.erdosproblems.com/1109)
+- [ErSa87] P. Erdős and A. Sárközy, *On divisibility properties of integers of the form
+  $a+a'$*, Acta Math. Hungar. (1987), 117--122.
+- [Gy01] Katalin Gyarmati, *On divisibility properties of integers of the form $ab+1$*,
+  Period. Math. Hungar. (2001), 71--79.
+- [Ko04] S. V. Konyagin, *Problems of the set of square-free numbers*,
+  Izv. Ross. Akad. Nauk Ser. Mat. (2004), 63--90.
+- [Sa92c] G. N. Sárközy, *On a problem of P. Erdős*, Acta Math. Hungar.
+  (1992), 271--282.
 -/
 
 open Filter Asymptotics
@@ -42,9 +51,10 @@ noncomputable def f (N : ℕ) : ℕ :=
 
 /--
 Let $f(N)$ be the size of the largest subset $A\subseteq \{1,\ldots,N\}$ such that
-every $n\in A+A$ is squarefree. Is it true that $f(N)\leq N^{o(1)}$?
+every $n\in A+A$ is squarefree. Estimate $f(N)$. In particular, is it true that
+$f(N)\leq N^{o(1)}$, or even $f(N) \leq (\log N)^{O(1)}$?
 
-This formalizes the subpolynomial reading as `f(N) = O(N^ε)` for every `ε > 0`.
+This theorem formalizes the subpolynomial bound as `f(N) = O(N^ε)` for every `ε > 0`.
 -/
 @[category research open, AMS 5 11]
 theorem erdos_1109 :
@@ -62,7 +72,7 @@ theorem erdos_1109.variants.polylog :
   sorry
 
 /--
-Erdős and Sárközy proved the lower bound $\log N \ll f(N)$.
+Erdős and Sárközy [ErSa87] proved the lower bound $\log N \ll f(N)$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.erdos_sarkozy_lower :
@@ -70,7 +80,7 @@ theorem erdos_1109.variants.erdos_sarkozy_lower :
   sorry
 
 /--
-Erdős and Sárközy proved the upper bound $f(N) \ll N^{3/4}\log N$.
+Erdős and Sárközy [ErSa87] proved the upper bound $f(N) \ll N^{3/4}\log N$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.erdos_sarkozy_upper :
@@ -79,7 +89,7 @@ theorem erdos_1109.variants.erdos_sarkozy_upper :
   sorry
 
 /--
-Konyagin improved the lower bound to
+Konyagin [Ko04] improved the lower bound to
 $\log\log N(\log N)^2 \ll f(N)$.
 -/
 @[category research solved, AMS 5 11]
@@ -89,7 +99,7 @@ theorem erdos_1109.variants.konyagin_lower :
   sorry
 
 /--
-Konyagin improved the upper bound to $f(N) \ll N^{11/15+o(1)}$.
+Konyagin [Ko04] improved the upper bound to $f(N) \ll N^{11/15+o(1)}$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.konyagin_upper :

--- a/FormalConjectures/ErdosProblems/1109.lean
+++ b/FormalConjectures/ErdosProblems/1109.lean
@@ -37,17 +37,12 @@ open scoped Pointwise
 namespace Erdos1109
 
 /--
-A finite set `A` has squarefree sumset if every element of `A + A` is squarefree.
--/
-def IsSquarefreeSumset (A : Finset ℕ) : Prop :=
-  ∀ n ∈ A + A, Squarefree n
-
-/--
 `f N` is the largest size of a subset `A ⊆ {1, ..., N}` such that every element
 of `A + A` is squarefree.
 -/
 noncomputable def f (N : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsSquarefreeSumset A ∧ A.card = k}
+  sSup {k : ℕ | ∃ A : Finset ℕ,
+    A ⊆ Finset.Icc 1 N ∧ (∀ n ∈ A + A, Squarefree n) ∧ A.card = k}
 
 /--
 Let $f(N)$ be the size of the largest subset $A\subseteq \{1,\ldots,N\}$ such that
@@ -59,7 +54,7 @@ This theorem formalizes the subpolynomial bound as `f(N) = O(N^ε)` for every `�
 @[category research open, AMS 5 11]
 theorem erdos_1109 :
     answer(sorry) ↔ ∀ ε > (0 : ℝ),
-      (fun N : ℕ => (f N : ℝ)) =O[atTop] fun N : ℕ => (N : ℝ) ^ ε := by
+      (fun N : ℕ => (f N : ℝ)) ≪ fun N : ℕ => (N : ℝ) ^ ε := by
   sorry
 
 /--
@@ -68,7 +63,7 @@ Is the stronger polylogarithmic bound $f(N) \leq (\log N)^{O(1)}$ true?
 @[category research open, AMS 5 11]
 theorem erdos_1109.variants.polylog :
     answer(sorry) ↔ ∃ C > (0 : ℝ),
-      (fun N : ℕ => (f N : ℝ)) =O[atTop] fun N : ℕ => (Real.log N) ^ C := by
+      (fun N : ℕ => (f N : ℝ)) ≪ fun N : ℕ => (Real.log N) ^ C := by
   sorry
 
 /--
@@ -76,7 +71,7 @@ Erdős and Sárközy [ErSa87] proved the lower bound $\log N \ll f(N)$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.erdos_sarkozy_lower :
-    (fun N : ℕ => Real.log N) =O[atTop] fun N : ℕ => (f N : ℝ) := by
+    (fun N : ℕ => Real.log N) ≪ fun N : ℕ => (f N : ℝ) := by
   sorry
 
 /--
@@ -84,7 +79,7 @@ Erdős and Sárközy [ErSa87] proved the upper bound $f(N) \ll N^{3/4}\log N$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.erdos_sarkozy_upper :
-    (fun N : ℕ => (f N : ℝ)) =O[atTop]
+    (fun N : ℕ => (f N : ℝ)) ≪
       fun N : ℕ => (N : ℝ) ^ ((3 : ℝ) / 4) * Real.log N := by
   sorry
 
@@ -94,7 +89,7 @@ $\log\log N(\log N)^2 \ll f(N)$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.konyagin_lower :
-    (fun N : ℕ => Real.log (Real.log N) * (Real.log N) ^ 2) =O[atTop]
+    (fun N : ℕ => Real.log (Real.log N) * (Real.log N) ^ 2) ≪
       fun N : ℕ => (f N : ℝ) := by
   sorry
 
@@ -103,7 +98,7 @@ Konyagin [Ko04] improved the upper bound to $f(N) \ll N^{11/15+o(1)}$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_1109.variants.konyagin_upper :
-    ∀ ε > (0 : ℝ), (fun N : ℕ => (f N : ℝ)) =O[atTop]
+    ∀ ε > (0 : ℝ), (fun N : ℕ => (f N : ℝ)) ≪
       fun N : ℕ => (N : ℝ) ^ ((11 : ℝ) / 15 + ε) := by
   sorry
 


### PR DESCRIPTION
## Summary
- add Erdős Problem 1109 for squarefree sumsets
- define `IsSquarefreeSumset` and the extremal function `f(N)`
- state the subpolynomial and polylogarithmic questions, plus the Erdős-Sárközy and Konyagin bound variants

## Verification
- `COPYFILE_DISABLE=1 ~/.elan/bin/lake build FormalConjectures.ErdosProblems.«1109»`

Closes #1962