### PR TITLE
Add Erdős 1151 scalar variant formal proof link

### DIFF
--- a/FormalConjectures/ErdosProblems/1151.lean
+++ b/FormalConjectures/ErdosProblems/1151.lean
@@ -1,0 +1,96 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.RootsExtrema
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+import Mathlib.LinearAlgebra.Lagrange
+import Mathlib.Topology.ClusterPt
+import Mathlib.Topology.ContinuousMap.Basic
+
+/-!
+# Erdős Problem 1151
+
+*References:*
+- [erdosproblems.com/forum/thread/1151](https://www.erdosproblems.com/forum/thread/1151)
+- [Ha26] A. Hart, [Erdős Problem 1151](https://www.ulam.ai/research/erdos1151.pdf) (2026)
+
+Erdős Problem 1151 asks which sets can occur as cluster sets for sequences obtained by
+evaluating interpolation polynomials.  The original formulation is somewhat ambiguous; this
+file records the nonempty fixed-point scalar version treated in [Ha26].
+
+Fix a point `x0 ∈ [-1, 1]`.  For each `n`, interpolate a continuous function `f` at the
+`n` Chebyshev roots and evaluate the resulting Lagrange interpolation polynomial at `x0`.
+The theorem below says that every nonempty closed subset of `[-1, 1]` is exactly the set of
+finite real cluster values of this scalar sequence.
+
+The empty-set case, divergence-to-infinity assertions, and other possible interpretations of
+the original Erdős problem are not formalised by this theorem.
+-/
+
+noncomputable section
+
+namespace Erdos1151
+
+/-- Spatial interval `[-1, 1]`. -/
+abbrev SpaceI : Set ℝ := Set.Icc (-1 : ℝ) 1
+
+/-- Continuous real-valued functions on `[-1, 1]`. -/
+abbrev SpaceFun := C(SpaceI, ℝ)
+
+/-- The finite real cluster set of a real sequence. -/
+def clusterSet (u : ℕ → ℝ) : Set ℝ :=
+  {y | MapClusterPt y Filter.atTop u}
+
+/-- The `k`-th Chebyshev-root angle in row `n`, zero-indexed. -/
+def thetaNode (n k : ℕ) : ℝ :=
+  ((2 * (k : ℝ) + 1) * Real.pi) / (2 * (n : ℝ))
+
+/-- The corresponding Chebyshev root. -/
+def xNode (n k : ℕ) : ℝ :=
+  Real.cos (thetaNode n k)
+
+lemma xNode_mem_spaceI (n k : ℕ) : xNode n k ∈ SpaceI :=
+  Real.cos_mem_Icc _
+
+/-- Chebyshev-root Lagrange interpolation evaluated at a fixed point. -/
+def chebLagEval (x0 : ℝ) (f : SpaceFun) (n : ℕ) : ℝ :=
+  Polynomial.eval x0
+    (Lagrange.interpolate (Finset.range n) (fun k : ℕ => xNode n k)
+      (fun k : ℕ => f ⟨xNode n k, xNode_mem_spaceI n k⟩))
+
+/--
+Nonempty fixed-point scalar version of Erdős Problem 1151.
+
+This is not stated as a full formalisation of every reading of the original problem.  It is the
+closed, nonempty, finite-cluster-value theorem for a fixed evaluation point `x0`.
+-/
+@[category research solved, AMS 41 30, formal_proof using lean4 at
+  "https://github.com/AllenGrahamHart/FormalConjectures-Bench/blob/c5ecf630e05c25e25c9d65d9e2065139b86ece7a/formalizations/erdos1151/Erdos1151Formalization/Main.lean#L251"]
+theorem erdos_1151_nonempty_fixed_point_scalar
+    {x0 : ℝ} (hx0 : x0 ∈ SpaceI)
+    {A : Set ℝ} (hA_closed : IsClosed A)
+    (hA_nonempty : A.Nonempty)
+    (hA_subset : A ⊆ SpaceI) :
+    ∃ f : SpaceFun,
+      clusterSet (fun m : ℕ => chebLagEval x0 f (m.succ)) = A := by
+  sorry
+
+end Erdos1151
+
+end


### PR DESCRIPTION
fixes #1981

This adds a new Erdős Problem 1151 statement for the nonempty fixed-point scalar version treated in the linked note.

The file explicitly records the relation to the original problem: the original formulation admits several interpretations, and this theorem covers the closed nonempty finite-cluster-value statement for a fixed evaluation point x0. It does not claim the empty-set case, divergence-to-infinity assertions, or other possible interpretations.

The long Lean proof is hosted externally in FormalConjectures-Bench and linked through formal_proof using lean4.

Verification run locally:

lake env lean FormalConjectures/ErdosProblems/1151.lean

This completed successfully, with only the expected sorry warning for the linked statement.