### PR TITLE
Link formal proof of Erdos699 Sylvester-Schur

### DIFF
--- a/FormalConjectures/ErdosProblems/699.lean
+++ b/FormalConjectures/ErdosProblems/699.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos699
 
 /-- Sylvester and Schur: for $1 \le i \le n/2$ there is a prime $p > i$ dividing `n.choose i`. -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/AllenGrahamHart/FormalConjectures-Bench/blob/482dacc4d9335240f26218cdc62032da3100392b/formalizations/erdos699/Erdos699Formalization.lean#L7679"]
 theorem sylvester_schur (n i : ℕ) (hi : 1 ≤ i) (hi_half : i ≤ n / 2) :
     ∃ p : ℕ, p.Prime ∧ i < p ∧ p ∣ Nat.choose n i := by
   sorry


### PR DESCRIPTION
This PR adds a `formal_proof` annotation to the solved Sylvester-Schur theorem in `Erdos699`.

The linked Lean proof is in FormalConjectures-Bench at commit `482dacc4d9335240f26218cdc62032da3100392b`:

https://github.com/AllenGrahamHart/FormalConjectures-Bench/blob/482dacc4d9335240f26218cdc62032da3100392b/formalizations/erdos699/Erdos699Formalization.lean#L7679

Scope note: this links a proof of the existing solved theorem `Erdos699.sylvester_schur`. It does not claim a proof of the open gcd statement `Erdos699.erdos_699`.

Verification run locally:

```bash
lake build FormalConjectures.ErdosProblems.«699»
```
