### PR TITLE
chore: remove dead code

### DIFF
--- a/FormalConjectures/Wikipedia/Schanuel.lean
+++ b/FormalConjectures/Wikipedia/Schanuel.lean
@@ -34,7 +34,6 @@ has transcendence degree at least $n$ over $\mathbb{Q}$.
 -/
 @[category research open, AMS 11 33]
 theorem schanuel_conjecture (n : ℕ) (z : Fin n → ℂ) (h : LinearIndependent ℚ z) :
-    let hinj := algebraMap ℚ (adjoin ℚ (Set.range z ∪ Set.range (cexp ∘ z))) |>.injective
     n ≤ Algebra.trdeg ℚ (adjoin ℚ (Set.range z ∪ Set.range (cexp ∘ z))) := by
   sorry
 


### PR DESCRIPTION
the `let hinj` line is dead code since [this commit](https://github.com/google-deepmind/formal-conjectures/commit/d3d568c9b6ba0b0609b8dd61d0019cd77462e96a).