### PR TITLE
chore(Wikipedia): harmonize module docstrings

### DIFF
--- a/FormalConjectures/Wikipedia/Brennanconjecture.lean
+++ b/FormalConjectures/Wikipedia/Brennanconjecture.lean
@@ -19,7 +19,7 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Brennan's Conjecture
 
-*Reference:*
+*References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Brennan_conjecture)
 - [arXiv:2409.15074](https://arxiv.org/abs/2409.15074)
 - [arXiv:2512.09330](https://arxiv.org/abs/2512.09330)

--- a/FormalConjectures/Wikipedia/CollatzConjecture.lean
+++ b/FormalConjectures/Wikipedia/CollatzConjecture.lean
@@ -20,13 +20,13 @@ import FormalConjectures.Util.ProblemImports
 # Collatz conjecture
 
 *References:*
-* [Wikipedia](https://en.wikipedia.org/wiki/Collatz_conjecture)
-* [erdosproblems.com/1135](https://www.erdosproblems.com/1135)
-* [Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.
-* [La10] Lagarias, Jeffrey C., The {$3x+1$} problem: an overview. (2010), 3--29.
-* [La16] Lagarias, Jeffrey C., Erdős, Klarner, and the {$3x+1$} problem. Amer. Math. Monthly
+- [Wikipedia](https://en.wikipedia.org/wiki/Collatz_conjecture)
+- [erdosproblems.com/1135](https://www.erdosproblems.com/1135)
+- [Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.
+- [La10] Lagarias, Jeffrey C., The {$3x+1$} problem: an overview. (2010), 3--29.
+- [La16] Lagarias, Jeffrey C., Erdős, Klarner, and the {$3x+1$} problem. Amer. Math. Monthly
   (2016), 753--776.
-* [La85] Lagarias, Jeffrey C., The {$3x+1$} problem and its generalizations. Amer. Math. Monthly
+- [La85] Lagarias, Jeffrey C., The {$3x+1$} problem and its generalizations. Amer. Math. Monthly
   (1985), 3--23.
 -/
 

--- a/FormalConjectures/Wikipedia/GromovPolynomialGrowth.lean
+++ b/FormalConjectures/Wikipedia/GromovPolynomialGrowth.lean
@@ -19,8 +19,7 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Gromov's theorem on groups of polynomial growth
 
-*Reference:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Gromov%27s_theorem_on_groups_of_polynomial_growth)
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Gromov%27s_theorem_on_groups_of_polynomial_growth)
 -/
 
 /-

--- a/FormalConjectures/Wikipedia/Hadamard.lean
+++ b/FormalConjectures/Wikipedia/Hadamard.lean
@@ -20,8 +20,8 @@ import FormalConjectures.Util.ProblemImports
 # Hadamard's conjecture
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Hadamard_matrix#Hadamard_conjecture)
- - [Résolution d'une question relative aux déterminants](https://gallica.bnf.fr/ark:/12148/bpt6k486252g/f400.image.r) by *Jacques Hadamard*,  Bull. des sciences math., p.245, 1893
+- [Wikipedia](https://en.wikipedia.org/wiki/Hadamard_matrix#Hadamard_conjecture)
+- [Résolution d'une question relative aux déterminants](https://gallica.bnf.fr/ark:/12148/bpt6k486252g/f400.image.r) by *Jacques Hadamard*,  Bull. des sciences math., p.245, 1893
 -/
 
 namespace Hadamard

--- a/FormalConjectures/Wikipedia/InscribedSquare.lean
+++ b/FormalConjectures/Wikipedia/InscribedSquare.lean
@@ -24,10 +24,10 @@ close curve in ℝ²) admits an inscribed square, i.e. a square whose vertices a
 There are several open and solved variants of this conjecture.
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Inscribed_square_problem)
- - [A Survey on the Square Peg Problem](https://www.researchgate.net/publication/274622766_A_Survey_on_the_Square_Peg_Problem)
+- [Wikipedia](https://en.wikipedia.org/wiki/Inscribed_square_problem)
+- [A Survey on the Square Peg Problem](https://www.researchgate.net/publication/274622766_A_Survey_on_the_Square_Peg_Problem)
    by *Benjamin Matschke*
- - [arxiv/2005.09193](https://arxiv.org/abs/2005.09193)
+- [arxiv/2005.09193](https://arxiv.org/abs/2005.09193)
 -/
 
 open Topology ContDiff Manifold

--- a/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
+++ b/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
@@ -19,8 +19,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Invariant Subspace Problem
 
-*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Invariant_subspace_problem),
-[Chalendar-Partington](https://arxiv.org/abs/2507.21834)
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Invariant_subspace_problem)
+- [Chalendar-Partington](https://arxiv.org/abs/2507.21834)
 -/
 
 namespace InvariantSubspaceProblem

--- a/FormalConjectures/Wikipedia/LanderParkinAndSelfridgeConjecture.lean
+++ b/FormalConjectures/Wikipedia/LanderParkinAndSelfridgeConjecture.lean
@@ -19,7 +19,7 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Lander, Parkin, and Selfridge Conjecture
 
-**Reference:** https://en.wikipedia.org/wiki/Lander,_Parkin,_and_Selfridge_conjecture
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Lander,_Parkin,_and_Selfridge_conjecture)
 -/
 
 namespace LanderParkinSelfridge

--- a/FormalConjectures/Wikipedia/LeinsterGroup.lean
+++ b/FormalConjectures/Wikipedia/LeinsterGroup.lean
@@ -23,11 +23,11 @@ A finite group is a Leinster group if the sum of the orders of all its normal su
 equals twice the group's order.
 
 *References:*
-* [Wikipedia](https://en.wikipedia.org/wiki/Leinster_group)
-* Leinster, Tom (2001). "Perfect numbers and groups".
+- [Wikipedia](https://en.wikipedia.org/wiki/Leinster_group)
+- Leinster, Tom (2001). "Perfect numbers and groups".
   [arXiv:math/0104012](https://arxiv.org/abs/math/0104012)
 
-TODO: The following properties from the Wikipedia article can also be formalized:
+Further properties from the Wikipedia article that could also be formalized:
 - There are no Leinster groups that are symmetric or alternating.
 - There is no Leinster group of order p²q² where p, q are primes.
 - No finite semi-simple group is Leinster.

--- a/FormalConjectures/Wikipedia/LittlewoodConjecture.lean
+++ b/FormalConjectures/Wikipedia/LittlewoodConjecture.lean
@@ -21,7 +21,7 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Littlewood_conjecture)
-- [Bernard Mathan and Olivier Touli´e, *Problem`emes diophantiens simultan´es*][mathantoilie2004]
+- [Bernard de Mathan and Olivier Teulié, *Problèmes diophantiens simultanés*](https://doi.org/10.1007/s00605-003-0199-y)
 -/
 
 open Filter

--- a/FormalConjectures/Wikipedia/LychrelNumbers.lean
+++ b/FormalConjectures/Wikipedia/LychrelNumbers.lean
@@ -28,10 +28,10 @@ One commonly stated conjectural direction is that there are no Lychrel numbers i
 The smallest widely studied open case is `196`.
 
 *References:*
-* [Wikipedia: Lychrel number](https://en.wikipedia.org/wiki/Lychrel_number)
-* [MathWorld: Lychrel Number](https://mathworld.wolfram.com/LychrelNumber.html)
-* [OEIS A023108](https://oeis.org/A023108)
-* [OEIS A023109](https://oeis.org/A023109)
+- [Wikipedia: Lychrel number](https://en.wikipedia.org/wiki/Lychrel_number)
+- [MathWorld: Lychrel Number](https://mathworld.wolfram.com/LychrelNumber.html)
+- [OEIS A023108](https://oeis.org/A023108)
+- [OEIS A023109](https://oeis.org/A023109)
 -/
 
 namespace LychrelNumbers

--- a/FormalConjectures/Wikipedia/MagicSquares.lean
+++ b/FormalConjectures/Wikipedia/MagicSquares.lean
@@ -21,10 +21,10 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 
-* [Magic Square of Squares - Wikipedia](https://en.wikipedia.org/wiki/Magic_square_of_squares)
-* [multimagie.com](http://www.multimagie.com/English/SquaresOfSquaresSearch.htm)
-* [Semi-Magic Square of Cubes](https://unsolvedproblems.org/index_files/SquareofCubes.htm)
-* [Magic Square of Squares](https://static.nsta.org/pdfs/QuantumV6N3.pdf)
+- [Magic Square of Squares - Wikipedia](https://en.wikipedia.org/wiki/Magic_square_of_squares)
+- [multimagie.com](http://www.multimagie.com/English/SquaresOfSquaresSearch.htm)
+- [Semi-Magic Square of Cubes](https://unsolvedproblems.org/index_files/SquareofCubes.htm)
+- [Magic Square of Squares](https://static.nsta.org/pdfs/QuantumV6N3.pdf)
 -/
 
 namespace MagicSquares

--- a/FormalConjectures/Wikipedia/Mandelbrot.lean
+++ b/FormalConjectures/Wikipedia/Mandelbrot.lean
@@ -26,9 +26,9 @@ This file adds three conjectures about the Mandelbrot and Multibrot sets:
 The first two conjectures are related in that the former implies the latter.
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Mandelbrot_set#Local_connectivity)
- - [arxiv/math/9902155](https://arxiv.org/abs/math/9902155)
- - [mathoverflow/37229](https://mathoverflow.net/questions/37229/)
+- [Wikipedia](https://en.wikipedia.org/wiki/Mandelbrot_set#Local_connectivity)
+- [arxiv/math/9902155](https://arxiv.org/abs/math/9902155)
+- [mathoverflow/37229](https://mathoverflow.net/questions/37229/)
 -/
 
 open Topology Set Function Filter Bornology Metric MeasureTheory

--- a/FormalConjectures/Wikipedia/MeanValueProblem.lean
+++ b/FormalConjectures/Wikipedia/MeanValueProblem.lean
@@ -19,10 +19,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Mean value problem
 
-*Reference:*
+*References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Mean_value_problem)
-- [The fundamental theorem of algebra and complexity theory](https://www.ams.org/journals/bull/1981-04-01/S0273-0979-1981-14858-8/)
-by Steve Smale
+- [The fundamental theorem of algebra and complexity theory](https://www.ams.org/journals/bull/1981-04-01/S0273-0979-1981-14858-8/) by *Steve Smale*
 
 Given a complex polynomial $p$ of degree $d ≥ 2$ and a complex number $z$
 there is a critical point $c$ of $p$, such that $|p(z)-p(c)|/|z-c| ≤ K* |p'(z)|$ for $K=1$.

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -30,7 +30,7 @@ assumption that `p ∤ N`, in order to give an equivalent statement.
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Modularity_theorem)
-- [F. Diamond and J. Shurman, *A First Course in Modular Forms*][diamondshurman2005]
+- [F. Diamond and J. Shurman, *A First Course in Modular Forms*](https://link.springer.com/book/10.1007/978-0-387-27226-9)
 
 -/
 

--- a/FormalConjectures/Wikipedia/NormalityOfPi.lean
+++ b/FormalConjectures/Wikipedia/NormalityOfPi.lean
@@ -25,8 +25,8 @@ whether any of the classical constants $\pi$, $e$, $\sqrt{2}$, $\ln 2$, or $\var
 normal in any base.
 
 *References:*
-* [Wikipedia (Normal number)](https://en.wikipedia.org/wiki/Normal_number)
-* [Wikipedia (Pi)](https://en.wikipedia.org/wiki/Pi)
+- [Wikipedia (Normal number)](https://en.wikipedia.org/wiki/Normal_number)
+- [Wikipedia (Pi)](https://en.wikipedia.org/wiki/Pi)
 -/
 
 open Real

--- a/FormalConjectures/Wikipedia/OddWeirdNumber.lean
+++ b/FormalConjectures/Wikipedia/OddWeirdNumber.lean
@@ -17,11 +17,10 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 import FormalConjectures.ErdosProblems.«470»
 
-/-
+/-!
 # Existence of Odd Weird Numbers
 
 *References:*
-- [Wikipedia] (https://en.wikipedia.org/wiki/Weird_number)
-- [A006037] (https://oeis.org/A006037)
+- [Wikipedia](https://en.wikipedia.org/wiki/Weird_number)
+- [OEIS A006037](https://oeis.org/A006037)
 -/
-

--- a/FormalConjectures/Wikipedia/Pell.lean
+++ b/FormalConjectures/Wikipedia/Pell.lean
@@ -20,8 +20,8 @@ import FormalConjectures.Util.ProblemImports
 # Infinitude of Pell number primes
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Pell_number#Primes_and_squares)
- - [A86383](https://oeis.org/A86383)
+- [Wikipedia](https://en.wikipedia.org/wiki/Pell_number#Primes_and_squares)
+- [A86383](https://oeis.org/A86383)
 
 The Pell numbers $P_n$ are defined by $P_0 = 0$,
 $P_1 = 1$, $P_{n+2} = 2*P_{n+1} + P_n$. [OEIS A129](https://oeis.org/A129)

--- a/FormalConjectures/Wikipedia/QuasiperfectNumbers.lean
+++ b/FormalConjectures/Wikipedia/QuasiperfectNumbers.lean
@@ -19,8 +19,7 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Quasiperfect Numbers
 
-*Reference:* 
-- [Wikipedia](https://en.wikipedia.org/wiki/Quasiperfect_number)
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Quasiperfect_number)
 -/
 
 namespace QuasiperfectNumbers

--- a/FormalConjectures/Wikipedia/RationalDistanceProblem.lean
+++ b/FormalConjectures/Wikipedia/RationalDistanceProblem.lean
@@ -21,10 +21,10 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Unit_square#Rational_distance_problem)
-- [mathoverflow/418260](https://mathoverflow.net/questions/418260/)
-asked by user [Yuan Yang](https://mathoverflow.net/users/177957/yuan-yang)
+- [mathoverflow/418260](https://mathoverflow.net/questions/418260/) asked by user
+  [Yuan Yang](https://mathoverflow.net/users/177957/yuan-yang)
 - D19 in [Unsolved Problems in Number Theory](https://doi.org/10.1007/978-0-387-26677-0)
-by *Richard K. Guy*
+  by *Richard K. Guy*
 -/
 
 namespace RationalDistanceProblem

--- a/FormalConjectures/Wikipedia/SumOfThreeCubes.lean
+++ b/FormalConjectures/Wikipedia/SumOfThreeCubes.lean
@@ -23,9 +23,9 @@ An integer `n : ℤ` can be written as a sum of three cubes (of integers) if and
 `n` is not `4` or `5` mod `9`.
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Sums_of_three_cubes)
- - [mathoverflow/100324](https://mathoverflow.net/a/100324)
-asked by user [*David Feldman*](https://mathoverflow.net/users/10909/david-feldman)
+- [Wikipedia](https://en.wikipedia.org/wiki/Sums_of_three_cubes)
+- [mathoverflow/100324](https://mathoverflow.net/a/100324) asked by user
+  [*David Feldman*](https://mathoverflow.net/users/10909/david-feldman)
 -/
 
 namespace SumOfThreeCubes

--- a/FormalConjectures/Wikipedia/Superperfectnumbers.lean
+++ b/FormalConjectures/Wikipedia/Superperfectnumbers.lean
@@ -23,8 +23,8 @@ An integer `n : ℤ` is `(m,k)-perfect` if `σᵐ(n) = kn` where `σᵐ` is the 
 sum of divisors function.
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Superperfect_number#Generalizations)
- - [Wikipedia](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics#General)
+- [Wikipedia](https://en.wikipedia.org/wiki/Superperfect_number#Generalizations)
+- [Wikipedia](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics#General)
 -/
 
 open ArithmeticFunction.sigma

--- a/FormalConjectures/Wikipedia/Taxicab.lean
+++ b/FormalConjectures/Wikipedia/Taxicab.lean
@@ -35,11 +35,11 @@ In particular, it is not known whether there exists a
 taxicab number for $k=5$, $m=2$, and $n=2$.
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Taxicab_number)
- - [Generalized taxicab number](https://en.wikipedia.org/wiki/Generalized_taxicab_number)
- - [OEIS taxicab cubes](https://oeis.org/A001235)
- - [OEIS taxicab 4th powers](https://oeis.org/A018786)
- - [OEIS taxicab conjecture](https://oeis.org/A088703)
+- [Wikipedia](https://en.wikipedia.org/wiki/Taxicab_number)
+- [Generalized taxicab number](https://en.wikipedia.org/wiki/Generalized_taxicab_number)
+- [OEIS taxicab cubes](https://oeis.org/A001235)
+- [OEIS taxicab 4th powers](https://oeis.org/A018786)
+- [OEIS taxicab conjecture](https://oeis.org/A088703)
 -/
 
 namespace Taxicab

--- a/FormalConjectures/Wikipedia/Toronto.lean
+++ b/FormalConjectures/Wikipedia/Toronto.lean
@@ -26,8 +26,8 @@ It is conjectured that every T2, Toronto space is discrete.
 W.R. Brian proved that this holds under GCH.
 
 *References:*
- - [Wikipedia](https://en.wikipedia.org/wiki/Toronto_space)
- - [The Toronto problem](https://wrbrian.wordpress.com/wp-content/uploads/2012/01/thetorontoproblem.pdf) by *W.R. Brian*
+- [Wikipedia](https://en.wikipedia.org/wiki/Toronto_space)
+- [The Toronto problem](https://wrbrian.wordpress.com/wp-content/uploads/2012/01/thetorontoproblem.pdf) by *W.R. Brian*
 -/
 
 namespace Toronto

--- a/FormalConjectures/Wikipedia/WoodalPrimes.lean
+++ b/FormalConjectures/Wikipedia/WoodalPrimes.lean
@@ -16,11 +16,12 @@ limitations under the License.
 
 import FormalConjectures.Util.ProblemImports
 
-/-! # Woodall Primes
+/-!
+# Woodall Primes
 
-References:
-* [Wikipedia/Woodall Number](https://en.wikipedia.org/wiki/Woodall_number#Woodall_primes)
-* [A2234](https://oeis.org/A2234)
+*References:*
+- [Wikipedia: Woodall number](https://en.wikipedia.org/wiki/Woodall_number#Woodall_primes)
+- [OEIS A002234](https://oeis.org/A002234)
 
 -/
 


### PR DESCRIPTION
Various fixes:
- fixing `OddWeirdNumber.lean` to use a module docstring (`/-!`) so it appears in generated docs
- converting broken or literal-rendering references to normal Markdown links
- making reference headings and bullet styles more uniform across the Wikipedia files
- attaching continuation text such as authors and MathOverflow askers to the relevant reference bullets