### PR TITLE
chore(FormalConjectures): use LaTeX rather than markdown in docstrings

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -167,6 +167,7 @@ jobs:
           node build.js
         env:
           BASE_PATH: /formal-conjectures
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Assemble deploy artifact
         run: |

--- a/FormalConjectures/Arxiv/1308.0994/BoxdotConjecture.lean
+++ b/FormalConjectures/Arxiv/1308.0994/BoxdotConjecture.lean
@@ -23,7 +23,7 @@ This file defines the syntax and proof systems for modal logic, along with the
 Boxdot translation and the Boxdot Conjecture. We introduce:
 
   * `Formula`: the inductive type for propositional modal formulas.
-  * `t`: the recursive Boxdot translation function.
+  * $t$: the recursive Boxdot translation function.
   * `KProof` and `KTProof`: axiomatizations of the basic K system and K plus T.
   * `NormalModalLogic`: a structure capturing any normal modal logic.
   * `KT`: the specific normal modal logic corresponding to K plus T.

--- a/FormalConjectures/Arxiv/2208.14736/ZariskiCancellation.lean
+++ b/FormalConjectures/Arxiv/2208.14736/ZariskiCancellation.lean
@@ -38,8 +38,8 @@ def IsCancellative (k A : Type*) [Field k]
     Nonempty (A ≃ₐ[k] B)
 
 /--
-The **Zariski Cancellation Problem**: every polynomial ring over a field `k` of characteristic
-`0` is cancellative.
+The **Zariski Cancellation Problem**: every polynomial ring over a field $k$ of characteristic
+$0$ is cancellative.
 -/
 @[category research open, AMS 13 14]
 theorem zariski_cancellation_problem {k : Type*} [Field k]
@@ -47,7 +47,7 @@ theorem zariski_cancellation_problem {k : Type*} [Field k]
   sorry
 
 /--
-The single variable polynomial ring `k[X]` is cancellative in any characteristic
+The single variable polynomial ring $k[X]$ is cancellative in any characteristic
 -/
 @[category research solved, AMS 13 14]
 theorem zariski_cancellation_problem.variants.dim_one
@@ -55,7 +55,7 @@ theorem zariski_cancellation_problem.variants.dim_one
   sorry
 
 /--
-The two variable polynomial ring `k[X]` is cancellative in any characteristic
+The two variable polynomial ring $k[X]$ is cancellative in any characteristic
 -/
 @[category research solved, AMS 13 14]
 theorem zariski_cancellation_problem.variants.dim_two {k : Type*} [Field k] :
@@ -63,7 +63,7 @@ theorem zariski_cancellation_problem.variants.dim_two {k : Type*} [Field k] :
   sorry
 
 /--
-The positive characteristic case of the Zariski Cancellation Problem is false in dimension `3`
+The positive characteristic case of the Zariski Cancellation Problem is false in dimension $3$
 -/
 @[category research solved, AMS 13 14]
 theorem zariski_cancellation_problem.variants.false_pos_card

--- a/FormalConjectures/Arxiv/2303.01089/FurstenbergTimesPTimesQ.lean
+++ b/FormalConjectures/Arxiv/2303.01089/FurstenbergTimesPTimesQ.lean
@@ -17,7 +17,7 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Furstenberg's `times p, times q` conjectures
+# Furstenberg's $times p, times q$ conjectures
 
 *Reference:* [arxiv/2303.01089](https://arxiv.org/abs/2303.01089)
 

--- a/FormalConjectures/Books/UniformDistributionOfSequences/Equidistribution.lean
+++ b/FormalConjectures/Books/UniformDistributionOfSequences/Equidistribution.lean
@@ -51,14 +51,14 @@ def isAccumulationPoint_iff_exists_subsequence_tendsto
   sorry
 
 /--
-The sequence `(3/2)^n` is equidistributed modulo `1`.
+The sequence $(3/2)^n$ is equidistributed modulo $1$.
 -/
 @[category research open, AMS 11]
 theorem isEquidistributedModuloOne_three_halves_pow :
     IsEquidistributedModuloOne (fun n => (3 / 2 : ℝ)^n) := by
   sorry
 
-/-- For any transcendental number `x`, the sequence `x * (3 / 2) ^ n` is
+/-- For any transcendental number $x$, the sequence $x * (3 / 2) ^ n$ is
 equidistributed modulo 1. -/
 @[category research open, AMS 11]
 theorem isEquidistributedModuloOne_transcendental_three_halves_pow (x : ℝ)
@@ -67,7 +67,7 @@ theorem isEquidistributedModuloOne_transcendental_three_halves_pow (x : ℝ)
   sorry
 
 /--
-The sequence `(3/2)^n` has infinitely many accumulation points modulo `1`.
+The sequence $(3/2)^n$ has infinitely many accumulation points modulo $1$.
 -/
 @[category research solved, AMS 11]
 theorem isAccumulationPoint_three_halves_pow_infinite :
@@ -75,7 +75,7 @@ theorem isAccumulationPoint_three_halves_pow_infinite :
   sorry
 
 /--
-Find an accumulation point of the sequence `(3/2)^n` modulo `1`.
+Find an accumulation point of the sequence $(3/2)^n$ modulo $1$.
 -/
 @[category research open, AMS 11]
 theorem isAccumulationPoint_three_halves_pow :
@@ -83,7 +83,7 @@ theorem isAccumulationPoint_three_halves_pow :
   sorry
 
 /--
-There is an accumulation point of the sequence `(3/2)^n` modulo `1`.
+There is an accumulation point of the sequence $(3/2)^n$ modulo $1$.
 -/
 @[category test, AMS 11]
 theorem isAccumulationPoint_three_halves_pow_exists :

--- a/FormalConjectures/ErdosProblems/10.lean
+++ b/FormalConjectures/ErdosProblems/10.lean
@@ -66,7 +66,7 @@ theorem erdos_10.variants.granville_soundararajan_odd :
   sorry
 
 /--
-Bogdan Grechuk has observed that `1117175146` is not the sum of a prime
+Bogdan Grechuk has observed that $1117175146$ is not the sum of a prime
 and at most $3$ powers of $2$.
 -/
 @[category research solved, AMS 5 11]

--- a/FormalConjectures/ErdosProblems/1038.lean
+++ b/FormalConjectures/ErdosProblems/1038.lean
@@ -31,8 +31,8 @@ open MeasureTheory
 
 namespace Erdos1038
 
-/-- What is the infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such
-that all of its roots are real and contained in `[-1,1]`? -/
+/-- What is the infimum of $|{x ∈ ℝ : |f x| < 1}|$ over all nonconstant monic polynomials $f$ such
+that all of its roots are real and contained in $[-1,1]$? -/
 @[category research open, AMS 28]
 theorem erdos_1038.parts.i (n : ℕ) : answer(sorry) =
     ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
@@ -40,8 +40,8 @@ theorem erdos_1038.parts.i (n : ℕ) : answer(sorry) =
     volume {x | |f.1.eval x| < 1} := by
   sorry
 
-/-- The supremum of `|{x ∈ ℝ : |f x| < 1}|` over all monic polynomials `f` such that
-all of its roots are real and contained in `[-1,1]` is `2 * 2 ^ (1 / 2)`. This is proved in
+/-- The supremum of $|{x ∈ ℝ : |f x| < 1}|$ over all monic polynomials $f$ such that
+all of its roots are real and contained in $[-1,1]$ is $2 * 2 ^ (1 / 2)$. This is proved in
 [Tao25]. -/
 @[category research solved, AMS 28]
 theorem erdos_1038.parts.ii (n : ℕ) : 2 * 2 ^ (1 / 2 : ℝ) =
@@ -50,16 +50,16 @@ theorem erdos_1038.parts.ii (n : ℕ) : 2 * 2 ^ (1 / 2 : ℝ) =
     volume {x | |f.1.eval x| < 1} := by
   sorry
 
-/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
-all of its roots are real and contained in `[-1,1]` is `< 1.835`. -/
+/-- The infimum of $|{x ∈ ℝ : |f x| < 1}|$ over all nonconstant monic polynomials $f$ such that
+all of its roots are real and contained in $[-1,1]$ is $< 1.835$. -/
 @[category research solved, AMS 28]
 theorem erdos_1038.variants.inf_upperBound (n : ℕ) : ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧
     (f.roots.filter fun x => x ∈ Set.Icc (-1 : ℝ) 1).card = f.natDegree},
     volume {x | |f.1.eval x| < 1} < 1.835 := by
   sorry
 
-/-- The infimum of `|{x ∈ ℝ : |f x| < 1}|` over all nonconstant monic polynomials `f` such that
-all of its roots are real and contained in `[-1,1]` is `≥ 2 ^ (4 / 3) - 1`. -/
+/-- The infimum of $|{x ∈ ℝ : |f x| < 1}|$ over all nonconstant monic polynomials $f$ such that
+all of its roots are real and contained in $[-1,1]$ is $≥ 2 ^ (4 / 3) - 1$. -/
 @[category research solved, AMS 28]
 theorem erdos_1038.varaints.inf_lowerBound (n : ℕ) : 2 ^ (4 / 3 : ℝ) - 1 ≤
     ⨅ f : {f : Polynomial ℝ // f.Monic ∧ f ≠ 1 ∧

--- a/FormalConjectures/ErdosProblems/1061.lean
+++ b/FormalConjectures/ErdosProblems/1061.lean
@@ -39,8 +39,8 @@ noncomputable abbrev S (x : ℝ) : ℝ :=
       a + b ≤ x ∧ σ 1 a + σ 1 b = σ 1 (a + b)).card
 
 /--
-How many (ordered) solutions are there to `σ(a) + σ(b) = σ(a + b)` with `a + b ≤ x`?
-Is it true that this number is asymptotic to `c * x` for some constant `c > 0`?
+How many (ordered) solutions are there to $σ(a) + σ(b) = σ(a + b)$ with $a + b ≤ x$?
+Is it true that this number is asymptotic to $c * x$ for some constant $c > 0$?
 -/
 @[category research open, AMS 11]
 theorem erdos_1061 : answer(sorry) ↔ ∃ c : ℝ, 0 < c ∧ S ~[atTop] (fun x : ℝ ↦ c * x) := by

--- a/FormalConjectures/ErdosProblems/1062.lean
+++ b/FormalConjectures/ErdosProblems/1062.lean
@@ -41,14 +41,14 @@ noncomputable def f (n : ℕ) : ℕ :=
 
 -- TODO: Add erdos_1062.parts.i: How large can $f(n)$ be?
 
-/-- Erdős asked whether the limiting density `f n / n` exists and, if so, whether it is
+/-- Erdős asked whether the limiting density $f n / n$ exists and, if so, whether it is
 irrational. -/
 @[category research open, AMS 11]
 theorem erdos_1062.parts.ii :
     (∃ l, Tendsto (fun n => (f n : ℝ) / n) atTop (𝓝 l) ∧ Irrational l) ↔ answer(sorry) := by
   sorry
 
-/-- The interval `[⌊n/3⌋, n]` is fork-free, and therefore `f n` is at least `⌈2n / 3⌉`. -/
+/-- The interval $[⌊n/3⌋, n]$ is fork-free, and therefore `f n` is at least $⌈2n / 3⌉$. -/
 @[category research solved, AMS 11]
 theorem erdos_1062.variants.lower_bound (n : ℕ) : ⌈(2 * n / 3 : ℝ)⌉₊ ≤ f n := by
   classical
@@ -74,8 +74,8 @@ theorem erdos_1062.variants.lower_bound (n : ℕ) : ⌈(2 * n / 3 : ℝ)⌉₊ �
   | 0 | 1 | 2 => simp_all
   | k + 3 => grw [← le_add_self] at hk; omega
 
-/-- Lebensold proved that for large `n`, the function `f n` lies between `0.6725 n` and
-`0.6736 n`. -/
+/-- Lebensold proved that for large $n$, the function `f n` lies between $0.6725 n$ and
+$0.6736 n$. -/
 @[category research solved, AMS 11]
 theorem erdos_1062.variants.lebensold_bounds :
     ∀ᶠ n in atTop, (0.6725 : ℝ) * n ≤ f n ∧ f n ≤ (0.6736 : ℝ) * n := by

--- a/FormalConjectures/ErdosProblems/1084.lean
+++ b/FormalConjectures/ErdosProblems/1084.lean
@@ -21,11 +21,11 @@ import FormalConjectures.Util.ProblemImports
 
 *Reference:* [erdosproblems.com/1084](https://www.erdosproblems.com/1084)
 
-Let `f_2(n)` be the maximum number of pairs of points at distance exactly `1`
-among any set of `n` points in `ℝ²`, under the condition that all pairwise
-distances are at least `1`.
+Let $f_2(n)$ be the maximum number of pairs of points at distance exactly $1$
+among any set of $n$ points in $ℝ²$, under the condition that all pairwise
+distances are at least $1$.
 
-Estimate the growth of `f_2(n)`.
+Estimate the growth of $f_2(n)$.
 
 Status: open.
 -/

--- a/FormalConjectures/ErdosProblems/1092.lean
+++ b/FormalConjectures/ErdosProblems/1092.lean
@@ -23,8 +23,8 @@ vertices is the union of a graph with chromatic number $r$ and a graph with $\le
 then $G$ has chromatic number $\leq r+1$.
 
 Erdős asked whether:
-* `f 2 n ≫ n`
-* more generally, `f r n ≫ r * n`
+* $f 2 n ≫ n$
+* more generally, $f r n ≫ r * n$
 
 This problem is currently open.
 

--- a/FormalConjectures/ErdosProblems/1097.lean
+++ b/FormalConjectures/ErdosProblems/1097.lean
@@ -50,7 +50,7 @@ theorem erdos_1097.variants.weaker :
   sorry
 
 /--
-A trivial lower bound: for sufficiently large `n` there exist sets $A$ with $|A| = n$ that contain at least $\Omega(n)$
+A trivial lower bound: for sufficiently large $n$ there exist sets $A$ with $|A| = n$ that contain at least $\Omega(n)$
 distinct common differences of three-term arithmetic progressions.
 -/
 @[category textbook, AMS 11]

--- a/FormalConjectures/ErdosProblems/1102.lean
+++ b/FormalConjectures/ErdosProblems/1102.lean
@@ -41,9 +41,9 @@ def HasPropertyQ (A : Set ℕ) : Prop :=
   {n : ℕ | ∀ a ∈ A, a < n → Squarefree (n + a)}.Infinite
 
 /--
-If `A = {a₁ < a₂ < …}` has property P,
-then `A` has natural density `0`.
-Equivalently, `(a_j / j) → ∞` as `j → ∞`.
+If $A = {a₁ < a₂ < …}$ has property P,
+then $A$ has natural density $0$.
+Equivalently, $(a_j / j) → ∞$ as $j → ∞$.
 --/
 @[category research solved, AMS 11, formal_proof using lean4 at
   "https://github.com/Woett/Lean-files/blob/1e075c4f6e8a907b924647fa88238f978e941742/ErdosProblem1102PropertyP.lean"]
@@ -55,9 +55,9 @@ theorem erdos_1102.density_zero_of_P
   sorry
 
 /--
-Conversely, for any function `f : ℕ → ℕ` that goes to infinity,
-there exists a strictly increasing sequence `A = {a₁ < a₂ < …}`
-with property P such that `(a_j / j) ≤ f(j)` for all `j`.
+Conversely, for any function $f : ℕ → ℕ$ that goes to infinity,
+there exists a strictly increasing sequence $A = {a₁ < a₂ < …}$
+with property P such that $(a_j / j) ≤ f(j)$ for all $j$.
 --/
 @[category research solved, AMS 11, formal_proof using lean4 at
   "https://github.com/Woett/Lean-files/blob/1e075c4f6e8a907b924647fa88238f978e941742/ErdosProblem1102PropertyP.lean"]
@@ -70,7 +70,7 @@ theorem erdos_1102.exists_sequence_with_P
   sorry
 
 /--
-Every sequence with property Q has upper density at most `6 / π^2`.
+Every sequence with property Q has upper density at most $6 / π^2$.
 --/
 @[category research solved, AMS 11, formal_proof using lean4 at
   "https://github.com/Woett/Lean-files/blob/1e075c4f6e8a907b924647fa88238f978e941742/ErdosProblem1102PropertyQDensity.lean"]
@@ -83,8 +83,8 @@ theorem erdos_1102.upper_density_Q
 /--
 There exists an infinite sequence $A = {a₁ < a₂ < …} ⊂ \mathsf{SF}$ where
 $\mathsf{SF} := \mathbb{N} \setminus \bigcup_{p} p^{2}\mathbb{N}$, i.e. the set of
-squarefree numbers. The set `A` has property `Q` and natural density `6 / π^2`.
-Equivalently, `(j / a_j) → 6/π^2` as `j → ∞`.
+squarefree numbers. The set $A$ has property $Q$ and natural density $6 / π^2$.
+Equivalently, $(j / a_j) → 6/π^2$ as $j → ∞$.
 --/
 @[category research solved, AMS 11, formal_proof using lean4 at
   "https://github.com/Woett/Lean-files/blob/1e075c4f6e8a907b924647fa88238f978e941742/ErdosProblem1102PropertyQDensity.lean"]

--- a/FormalConjectures/ErdosProblems/138.lean
+++ b/FormalConjectures/ErdosProblems/138.lean
@@ -43,8 +43,8 @@ def monoAP_guarantee_set (r k : ℕ) : Set ℕ :=
   { N | ∀ coloring : Finset.Icc 1 N → Fin r, ContainsMonoAPofLength coloring k}
 
 /--
-Asserts that for any number of colors `r` and any progression length `k`, there
-always exists some number `N` large enough to guarantee a monochromatic arithmetic progression.
+Asserts that for any number of colors $r$ and any progression length $k$, there
+always exists some number $N$ large enough to guarantee a monochromatic arithmetic progression.
 In other words, the set `monoAP_guarantee_set` is non-empty. This is the fundamental existence
 result that allows for the definition of the van der Waerden numbers.
 -/

--- a/FormalConjectures/ErdosProblems/152.lean
+++ b/FormalConjectures/ErdosProblems/152.lean
@@ -40,7 +40,7 @@ noncomputable def f (n : ℕ) : ℕ :=
   {s : ℕ | s - 1 ∉ A.1 + A.1 ∧ s ∈ A.1 + A.1 ∧ s + 1 ∉ A.1 + A.1}.ncard
 
 /--
-Must `lim f n = ∞`?
+Must $lim f n = ∞$?
 
 This was proved formally by the DeepMind prover agent [DM26a].
 -/
@@ -50,7 +50,7 @@ theorem erdos_152 : answer(True) ↔ Tendsto f atTop atTop := by
   sorry
 
 /--
-Must `f n ≫ n ^ 2`?
+Must $f n ≫ n ^ 2$?
 
 This stronger quadratic variant was also proved formally by the DeepMind prover agent [DM26b].
 -/

--- a/FormalConjectures/ErdosProblems/153.lean
+++ b/FormalConjectures/ErdosProblems/153.lean
@@ -38,7 +38,7 @@ noncomputable def f (n : ℕ) : ℝ := ⨅ A : {A : Finset ℕ | A.card = n ∧ 
   let s := (A.1 + A).orderIsoOfFin rfl
   ∑ i : Set.Ico 1 ((A.1 + A).card), (s ⟨i, i.2.2⟩ - s ⟨i - 1, by grind⟩) ^ 2 / (n : ℝ)
 
-/-- Must `lim f n = ∞`? -/
+/-- Must $lim f n = ∞$? -/
 @[category research open, AMS 5]
 theorem erdos_153 : answer(sorry) ↔ Tendsto f atTop atTop := by
   sorry

--- a/FormalConjectures/ErdosProblems/158.lean
+++ b/FormalConjectures/ErdosProblems/158.lean
@@ -33,7 +33,7 @@ namespace Erdos158
 def B2 (g : ℕ) (A : Set ℕ) : Prop :=
   ∀ n, {x : ℕ × ℕ | x.1 + x.2 = n ∧ x.1 ≤ x.2 ∧ x.1 ∈ A ∧ x.2 ∈ A}.encard ≤ g
 
-/-- A set is `B₂[1]` iff it is Sidon. -/
+/-- A set is $B₂[1]$ iff it is Sidon. -/
 @[category API, AMS 5, simp]
 lemma b2_one {A : Set ℕ} : B2 1 A ↔ IsSidon A where
   mp hA a₁ ha₁ a₂ ha₂ b₁ hb₁ b₂ hb₂ h := by
@@ -51,14 +51,14 @@ lemma b2_one {A : Set ℕ} : B2 1 A ↔ IsSidon A where
     have := hA x.1 q.1 y.1 t.1 x.2 q.2 y.2 t.2 (h.trans r.symm)
     grind
 
-/-- Let `A` be an infinite `B₂[2]` set. Must `liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) = 0`? -/
+/-- Let $A$ be an infinite $B₂[2]$ set. Must $liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) = 0$? -/
 @[category research open, AMS 5]
 theorem erdos_158 : answer(sorry) ↔ ∀ A : Set ℕ, A.Infinite → B2 2 A →
     liminf (fun N : ℕ => (A ∩ .Iio N).ncard * (N : ℝ) ^ (- 1 / 2 : ℝ)) atTop = 0 := by
   sorry
 
-/-- Let `A` be an infinite Sidon set. Then
-`liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) * (log N) ^ (1 / 2) < ∞`. This is proved in [ESS94]. -/
+/-- Let $A$ be an infinite Sidon set. Then
+$liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) * (log N) ^ (1 / 2) < ∞$. This is proved in [ESS94]. -/
 @[category research solved, AMS 5]
 theorem erdos_158.variants.isSidon' {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
     liminf (fun N ↦ ENNReal.ofReal ((A ∩ .Iio N).ncard * N ^ (- 1 / 2 : ℝ) * log N ^ (1 / 2 : ℝ)))
@@ -66,7 +66,7 @@ theorem erdos_158.variants.isSidon' {A : Set ℕ} (hAinf : A.Infinite) (hAsid : 
   sorry
 
 /-- As a corollary of `erdos_158.isSidon'`, we can prove that
-`liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) = 0` for any infinite Sidon set `A`. -/
+$liminf |A ∩ {1, ..., N}| * N ^ (- 1 / 2) = 0$ for any infinite Sidon set $A$. -/
 @[category research solved, AMS 5]
 theorem erdos_158.variants.isSidon {A : Set ℕ} (hAinf : A.Infinite) (hAsid : IsSidon A) :
     liminf (fun N : ℕ => (A ∩ .Iio N).ncard * (N : ℝ) ^ (- 1 / 2 : ℝ)) atTop = 0 := by

--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -53,7 +53,7 @@ lemma F_3 : F 3 = 2 := rfl
 
 /--
 Sanity check: elements of `IntervalNonTernarySets N` are precisely non ternary subsets of
-`{1,...,N}`
+${1,...,N}$
 -/
 @[category API, AMS 5 11]
 lemma mem_IntervalNonTernarySets_iff (N : ℕ) (S : Finset ℕ) :
@@ -64,8 +64,8 @@ lemma mem_IntervalNonTernarySets_iff (N : ℕ) (S : Finset ℕ) :
   exact fun n hn₁ hn₂ hn₃ => h.2 n (h.1 hn₁).1 (h.1 hn₃).2 hn₁ hn₂ hn₃
 
 /--
-Sanity check: if `S` is a maximal non ternary subset of `{1,..., N}` then `F N` is given by the
-cardinality of `S`
+Sanity check: if $S$ is a maximal non ternary subset of ${1,..., N}$ then `F N` is given by the
+cardinality of $S$
 -/
 @[category API, AMS 5 11]
 lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N) (hS' : NonTernary S)

--- a/FormalConjectures/ErdosProblems/234.lean
+++ b/FormalConjectures/ErdosProblems/234.lean
@@ -28,8 +28,8 @@ open scoped NNReal
 namespace Erdos234
 
 /--
-Is it true that for all `c ≥ 0`, the density `f c` of integers for which
-`(p (n + 1) - p n) / log n < c` exists and is a continuous function of `c`?
+Is it true that for all $c ≥ 0$, the density `f c` of integers for which
+$(p (n + 1) - p n) / log n < c$ exists and is a continuous function of $c$?
 -/
 @[category research open, AMS 11]
 theorem erdos_234 : answer(sorry) ↔ ∃ f : ℝ≥0 → ℝ, Continuous f ∧

--- a/FormalConjectures/ErdosProblems/238.lean
+++ b/FormalConjectures/ErdosProblems/238.lean
@@ -28,8 +28,8 @@ open Set Filter Real
 namespace Erdos238
 
 /--
-Let `c₁, c₂ > 0`. Is it true that for any sufficiently large `x`, there exists more than
-`c₁ * log x` many consecutive primes `≤ x` such that the difference between any two is `> c₂`?
+Let $c₁, c₂ > 0$. Is it true that for any sufficiently large $x$, there exists more than
+$c₁ * log x$ many consecutive primes $≤ x$ such that the difference between any two is $> c₂$?
 -/
 @[category research open, AMS 11]
 theorem erdos_238 : answer(sorry) ↔ ∀ᵉ (c₁ > 0) (c₂ > 0), ∀ᶠ (x : ℝ) in atTop, ∃ (k : ℕ),
@@ -38,7 +38,7 @@ theorem erdos_238 : answer(sorry) ↔ ∀ᵉ (c₁ > 0) (c₂ > 0), ∀ᶠ (x : 
   sorry
 
 /--
-It is well-known that the conjecture above is true when `c₁` is sufficiently small.
+It is well-known that the conjecture above is true when $c₁$ is sufficiently small.
 -/
 @[category research solved, AMS 11]
 theorem erdos_238.variants.small_c1 : ∀ c₂ > 0, ∀ᶠ c₁ in 𝓝[>] 0, ∀ᶠ (x : ℝ) in atTop, ∃ (k : ℕ),

--- a/FormalConjectures/ErdosProblems/252.lean
+++ b/FormalConjectures/ErdosProblems/252.lean
@@ -49,39 +49,39 @@ theorem erdos_252 :
     answer(sorry) ↔ ∀ k ≥ 1, Irrational (erdos_252_sum k) := by
   sorry
 
-/-- `∑ σ 0 n / n!` is irrational. This is proved in [ErSt71]. -/
+/-- $∑ σ 0 n / n!$ is irrational. This is proved in [ErSt71]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.k_eq_zero : Irrational (erdos_252_sum 0) := by
   sorry
 
-/-- `∑ σ 1 n / n!` is irrational. This is proved in [ErSt74]. -/
+/-- $∑ σ 1 n / n!$ is irrational. This is proved in [ErSt74]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.k_eq_one : Irrational (erdos_252_sum 1) := by
   sorry
 
 
-/-- `∑ σ 2 n / n!` is irrational. This is proved in [ErKa54]. -/
+/-- $∑ σ 2 n / n!$ is irrational. This is proved in [ErKa54]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.k_eq_two : Irrational (erdos_252_sum 2) := by
   sorry
 
-/-- `∑ σ 3 n / n!` is irrational. This is proved in [ScPu06] and [FLC07]. -/
+/-- $∑ σ 3 n / n!$ is irrational. This is proved in [ScPu06] and [FLC07]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.k_eq_three : Irrational (erdos_252_sum 3) := by
   sorry
 
-/-- `∑ σ 4 n / n!` is irrational. This is proved in [Pr22]. -/
+/-- $∑ σ 4 n / n!$ is irrational. This is proved in [Pr22]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.k_eq_four : Irrational (erdos_252_sum 4) := by
   sorry
 
-/-- For a fixed `k ≥ 5`, is `∑ σ k n / n!` irrational?. -/
+/-- For a fixed $k ≥ 5$, is $∑ σ k n / n!$ irrational?. -/
 @[category research open, AMS 11]
 theorem erdos_252.variants.k_ge_five :
     answer(sorry) ↔ ∀ k ≥ 5, Irrational (erdos_252_sum k) := by
   sorry
 
-/-- If Schinzel's conjecture is true, then `∑ σ k n / n!` is irrational for all `k`. This is proved
+/-- If Schinzel's conjecture is true, then $∑ σ k n / n!$ is irrational for all $k$. This is proved
 in [ScPu06]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.schinzel (hs : ∀ (fs : Finset (Polynomial ℤ)),
@@ -90,7 +90,7 @@ theorem erdos_252.variants.schinzel (hs : ∀ (fs : Finset (Polynomial ℤ)),
     ∀ k, Irrational (erdos_252_sum k) := by
   sorry
 
-/-- If the prime `k`-tuples conjecture is true, then `∑ σ k n / n!` is irrational. This is proved
+/-- If the prime $k$-tuples conjecture is true, then $∑ σ k n / n!$ is irrational. This is proved
 in [FLC07]. -/
 @[category research solved, AMS 11]
 theorem erdos_252.variants.prime_tuples {k : ℕ} (hk : 4 ≤ k) (hp : ∀ (a : Fin k → ℕ+)

--- a/FormalConjectures/ErdosProblems/268.lean
+++ b/FormalConjectures/ErdosProblems/268.lean
@@ -26,9 +26,9 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Erdos268
 
-/-- Let `X` be the set of points in `Fin d → ℝ` of the shape
-`fun i : Fin d => ∑' n : A, (1 : ℝ) / (n + i)` for some infinite subset `A ⊆ ℕ` such that
-`1 / n` is summable over `A`. `X` has nonempty interior. This is proved in [KoTa24].
+/-- Let $X$ be the set of points in $Fin d → ℝ$ of the shape
+$fun i : Fin d => ∑' n : A, (1 : ℝ) / (n + i)$ for some infinite subset $A ⊆ ℕ$ such that
+$1 / n$ is summable over $A$. $X$ has nonempty interior. This is proved in [KoTa24].
 --/
 @[category research solved, AMS 40 54, formal_proof using lean4 at
   "https://gist.githubusercontent.com/madeve-unipi/62a8f68cdb4864b85b81a6752dcb0aa4/raw/5793aaa51089c25c37d8d63f60540367f6abe506/Erdos268.lean"]

--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -50,7 +50,7 @@ structure Group.ExactCovering (G : Type*) [Group G] (ι : Type*) [Fintype ι] wh
   covers : ⋃ i, reps i • (parts i : Set G) = Set.univ
 
 /--
-Does there exist a group `G` with an exact covering by more than one cosets of
+Does there exist a group $G$ with an exact covering by more than one cosets of
 different sizes? (i.e. each element is contained in exactly one of the cosets.)
 -/
 @[category research open, AMS 20]
@@ -60,7 +60,7 @@ theorem erdos_274 : answer(sorry) ↔ ∃ (G : Type*) (h : Group G) (hG : 1 < EN
   sorry
 
 /--
-If `G` is a finite abelian group then there cannot exist an exact covering of `G` by more
+If $G$ is a finite abelian group then there cannot exist an exact covering of $G$ by more
 than one cosets of different sizes? (i.e. each element is contained in exactly one
 of the cosets.)
 -/

--- a/FormalConjectures/ErdosProblems/298.lean
+++ b/FormalConjectures/ErdosProblems/298.lean
@@ -40,7 +40,7 @@ theorem erdos_298 : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → A.HasPosDen
   sorry
 
 /--
-In [Bl21] it is proved under the weaker assumption that `A` only has positive upper density.
+In [Bl21] it is proved under the weaker assumption that $A$ only has positive upper density.
 -/
 @[category research solved, AMS 11]
 theorem erdos_298.variants.upper_density : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → 0 < A.upperDensity →

--- a/FormalConjectures/ErdosProblems/312.lean
+++ b/FormalConjectures/ErdosProblems/312.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos312
 
 /--
-Does there exist a constant `c > 0` such that, for any `K > 1`, whenever `A` is a sufficiently large
+Does there exist a constant $c > 0$ such that, for any $K > 1$, whenever $A$ is a sufficiently large
 finite multiset of integers with $\sum_{n \in A} 1/n > K$ there exists some $S \subseteq A$ such that
 $1 - \exp(-(c*K)) < \sum_{n \in S} 1/n \le 1$?
 -/

--- a/FormalConjectures/ErdosProblems/313.lean
+++ b/FormalConjectures/ErdosProblems/313.lean
@@ -35,8 +35,8 @@ def erdos313Solutions : Set (ℕ × Finset ℕ) :=
   {(m, P) | 2 ≤ m ∧ P.Nonempty ∧ (∀ p ∈ P, p.Prime) ∧ ∑ p ∈ P, (1 : ℚ) / p = 1 - 1 / m}
 
 /--
-Are there infinitely many pairs `(m, P)` where `m ≥ 2` is an integer
-and `P` is a set of distinct primes such that the following equation holds:
+Are there infinitely many pairs $(m, P)$ where $m ≥ 2$ is an integer
+and $P$ is a set of distinct primes such that the following equation holds:
 $\sum_{p \in P} \frac{1}{p} = 1 - \frac{1}{m}$?
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/ErdosProblems/318.lean
+++ b/FormalConjectures/ErdosProblems/318.lean
@@ -43,17 +43,17 @@ def P₁ (A : Set ℕ) : Prop := ∀ (f : ℕ → ℝ),
   Set.range f ⊆ {1, -1} →
   ∃ S : Finset ℕ, S.Nonempty ∧ ↑S ⊆ A \ {0} ∧ ∑ n ∈ S, f n / n = 0
 
-/-- `ℕ` has property `P₁`. This is proved in [ErSt75]. -/
+/-- $ℕ$ has property $P₁$. This is proved in [ErSt75]. -/
 @[category research solved, AMS 11]
 theorem erdos_318.variants.univ : P₁ univ := by
   sorry
 
-/-- Sattler proved in [Sa75] that the set of odd numbers has property `P₁`. -/
+/-- Sattler proved in [Sa75] that the set of odd numbers has property $P₁$. -/
 @[category research solved, AMS 11]
 theorem erdos_318.variants.odd : P₁ {n | Odd n} := by
   sorry
 
-/-- The set of squares does not have property `P₁`. -/
+/-- The set of squares does not have property $P₁$. -/
 @[category test, AMS 11]
 theorem erdos_318.variants.squares : ¬ P₁ ({n | IsSquare n}) := by
   simp only [P₁, not_forall, not_exists, not_and]
@@ -99,28 +99,28 @@ theorem erdos_318.variants.squares : ¬ P₁ ({n | IsSquare n}) := by
     have : p ≠ 1 := by grind
     simp_all [neg_div, zero_lt_iff, (not_iff_not.2 mem_singleton_iff).1 (hs hp).2]
 
-/-- For any set `A` containing exactly one even number, `A` does not have property `P₁`. Sattler
+/-- For any set $A$ containing exactly one even number, $A$ does not have property $P₁$. Sattler
 [Sa82] credits this observation to Erdős, who presumably found this after [ErGr80]. -/
 @[category research solved, AMS 11]
 theorem erdos_318.variants.contain_single_even {A : Set ℕ} (hA : {n | n ∈ A ∧ Even n}.ncard = 1) :
     ¬ P₁ A := by
   sorry
 
-/-- There exists a set `A` with positive density that does not have property `P₁`.
+/-- There exists a set $A$ with positive density that does not have property $P₁$.
 #TODO: prove this lemma by assuming `erdos_318.contain_single_even`. -/
 @[category research solved, AMS 11]
 theorem erdos_318.parts.i : ∃ A : Set ℕ, HasPosDensity A ∧ ¬ P₁ A := by
   sorry
 
-/-- Every infinite arithmetic progression has property `P₁`. This is proved in [Sa82b]. -/
+/-- Every infinite arithmetic progression has property $P₁$. This is proved in [Sa82b]. -/
 @[category research solved, AMS 11]
 theorem erdos_318.variants.infinite_AP {A : Set ℕ} (hA : A.IsAPOfLength ⊤) : P₁ A := by
   sorry
 
 /--
-Does the set of squares excluding 1 have property `P₁`?
+Does the set of squares excluding 1 have property $P₁$?
 
-Larsen [La26] proved that this set does have property `P₁`.
+Larsen [La26] proved that this set does have property $P₁$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_318.parts.ii : answer(True) ↔  P₁ ({n | IsSquare n} \ {1}) := by

--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -41,7 +41,7 @@ theorem erdos_326 : answer(sorry) ↔ ∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 �
   sorry
 
 /--
-Erdős originally asked whether this was true with `A = B`, but this was disproved by Cassels.
+Erdős originally asked whether this was true with $A = B$, but this was disproved by Cassels.
 -/
 -- Formalisation note: This is trivially true for `x = 0` by taking `a = id`. Cassels' proof
 -- shows it for `0 < x` which is more interesting.

--- a/FormalConjectures/ErdosProblems/329.lean
+++ b/FormalConjectures/ErdosProblems/329.lean
@@ -39,8 +39,8 @@ noncomputable def sidonUpperDensity (A : Set ℕ) : ℝ :=
 
 /--
 **Erdős Problem 329.**
-Let `A ⊆ ℕ` be a Sidon set. How large can
-`lim sup_{N → ∞} |A ∩ {1,…,N}| / N^{1/2}`
+Let $A ⊆ ℕ$ be a Sidon set. How large can
+$lim sup_{N → ∞} |A ∩ {1,…,N}| / N^{1/2}$
 be?
 -/
 @[category research open, AMS 5 11]
@@ -49,17 +49,17 @@ theorem erdos_329 : sSup {sidonUpperDensity A | (A : Set ℕ) (_ : IsSidon A)} =
   sorry
 
 /--
-Erdős proved that upper density `1 / 2` can be attained; in particular,
-there exists a Sidon set whose upper density is *at least* `1 / 2`.
+Erdős proved that upper density $1 / 2$ can be attained; in particular,
+there exists a Sidon set whose upper density is *at least* $1 / 2$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_329.variants.lower_bound : ∃ (A : Set ℕ), IsSidon A ∧ sidonUpperDensity A ≥ 1/2 := by
   sorry
 
 /--
-Krückeberg ([Kr61]) exhibited an infinite Sidon set `A` with
-`sidonUpperDensity A = 1 / Real.sqrt 2`, improving Erdős’ earlier
-`1 / 2` lower bound.
+Krückeberg ([Kr61]) exhibited an infinite Sidon set $A$ with
+$sidonUpperDensity A = 1 / Real.sqrt 2$, improving Erdős’ earlier
+$1 / 2$ lower bound.
 
 [Kr61] Krückeberg, Fritz, $B\sb{2}$-Folgen und verwandte Zahlenfolgen. J. Reine Angew. Math. (1961), 53-60.
 -/

--- a/FormalConjectures/ErdosProblems/33.lean
+++ b/FormalConjectures/ErdosProblems/33.lean
@@ -36,9 +36,9 @@ and `n ≥ 0`. -/
 def AdditiveBasisCondition (A : Set ℕ) : Prop :=
   ∀ (k : ℕ), ∃ (n : ℕ) (a : ℕ), a ∈ A ∧ k = a + n^2
 
-/-- Let `A ⊆ ℕ` be a set such that every integer can be written as `n^2 + a`
-for some `a` in `A` and `n ≥ 0`. What is the smallest possible value of
-`lim sup n → ∞ |A ∩ {1, …, N}| / N^(1/2)`?
+/-- Let $A ⊆ ℕ$ be a set such that every integer can be written as $n^2 + a$
+for some $a$ in $A$ and $n ≥ 0$. What is the smallest possible value of
+$lim sup n → ∞ |A ∩ {1, …, N}| / N^(1/2)$?
 -/
 @[category research open, AMS 11]
 theorem erdos_33 : ⨅ A : {A : Set ℕ | AdditiveBasisCondition A}, Filter.atTop.limsup (fun N =>
@@ -54,8 +54,8 @@ theorem erdos_33.variants.one_mem_lowerBounds : ∃ A, AdditiveBasisCondition A 
   sorry
 
 /--
-The smallest possible value of `lim sup n → ∞ |A ∩ {1, …, N}| / N^(1/2)`
-is at most `2φ^(5/2) ≈ 6.66`, with `φ` equal to the golden ratio. Proven by
+The smallest possible value of $lim sup n → ∞ |A ∩ {1, …, N}| / N^(1/2)$
+is at most $2φ^(5/2) ≈ 6.66$, with $φ$ equal to the golden ratio. Proven by
 Wouter van Doorn.
 -/
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/346.lean
+++ b/FormalConjectures/ErdosProblems/346.lean
@@ -31,8 +31,8 @@ open Filter Topology Set
 
 namespace Erdos346
 
-/-- Is it true that for every lacunary, strongly complete sequence `A` that is not complete whenever
-infinitely many terms are removed from it, `lim A (n + 1) / A n = (1 + √5) / 2`? -/
+/-- Is it true that for every lacunary, strongly complete sequence $A$ that is not complete whenever
+infinitely many terms are removed from it, $lim A (n + 1) / A n = (1 + √5) / 2$? -/
 @[category research open, AMS 11]
 theorem erdos_346 : answer(sorry) ↔ ∀ {A : ℕ → ℕ}, IsLacunary A → IsAddStronglyCompleteNatSeq A →
     (∀ B : Set ℕ, B ⊆ range A → B.Infinite → ¬ IsAddComplete (range A \ B)) →
@@ -42,24 +42,24 @@ theorem erdos_346 : answer(sorry) ↔ ∀ {A : ℕ → ℕ}, IsLacunary A → Is
 /-- We define a sequence `f` by the formula `f n = n.fib - (- 1) ^ n`. -/
 def f (n : ℕ) : ℕ := if Even n then n.fib - 1 else n.fib + 1
 
-/-- The sequence `f` is lacunary. -/
+/-- The sequence $f$ is lacunary. -/
 @[category test, AMS 11]
 theorem erdos_346.variants.f_isLacunary : IsLacunary f := by
   sorry
 
-/-- The sequence `f` is strongly complete, and this is proved in [Gr64d]. -/
+/-- The sequence $f$ is strongly complete, and this is proved in [Gr64d]. -/
 @[category research solved, AMS 11]
 theorem erdos_346.variants.f_isAddStronglyCompleteNatSeq : IsAddStronglyCompleteNatSeq f := by
   sorry
 
-/-- The sequence `f` is not complete whenever infinitely many terms are removed from it, and this
+/-- The sequence $f$ is not complete whenever infinitely many terms are removed from it, and this
 is proved in [Gr64d]. -/
 @[category research solved, AMS 11]
 theorem erdos_346.variants.f_not_isAddComplete {B : Set ℕ} (h : B ⊆ range f) (hB : B.Infinite) :
     ¬ IsAddComplete (range f \ B) := by
   sorry
 
-/-- Erdős and Graham [ErGr80] remark that it is easy to see that if `A (n + 1) / A n > (1 + √5) / 2`
+/-- Erdős and Graham [ErGr80] remark that it is easy to see that if $A (n + 1) / A n > (1 + √5) / 2$
 then the second property is automatically satisfied. -/
 @[category research solved, AMS 11]
 theorem erdos_346.variants.gt_goldenRatio_not_IsAddComplete {A : ℕ → ℕ}

--- a/FormalConjectures/ErdosProblems/350.lean
+++ b/FormalConjectures/ErdosProblems/350.lean
@@ -57,7 +57,7 @@ theorem DistinctSubsetSums_iff_DecidableDistinctSubsetSums
   rw [DistinctSubsetSums, DecidableDistinctSubsetSums, Set.Pairwise] ; simp_all
 
 /--
-If `A ⊂ ℕ` is a finite set of integers all of whose subset sums are distinct then `∑ n ∈ A, 1/n < 2`.
+If $A ⊂ ℕ$ is a finite set of integers all of whose subset sums are distinct then $∑ n ∈ A, 1/n < 2$.
 Proved by Ryavec.
 
 This was proved by Ryavec, who did not appear to ever publish the proof. Ryavec's proof is
@@ -75,10 +75,10 @@ theorem erdos_350 (A : Finset ℕ) (hA : DecidableDistinctSubsetSums A) :
   sorry
 
 /--
-If `A ⊂ ℕ` is a finite set of integers all of whose subset sums are distinct then `∑ n ∈ A, 1/n^s < 1/(1 - 2^(-s))`, for any `s > 0`.
+If $A ⊂ ℕ$ is a finite set of integers all of whose subset sums are distinct then $∑ n ∈ A, 1/n^s < 1/(1 - 2^(-s))$, for any $s > 0$.
 Proved by Hanson, Steele, and Stenger [HSS77].
 
-We exlude here the case `s = 0`, because in the informal formulation then the right hand side is to be interpreted as `∞`, while the left hand side counts the elements in `A`.
+We exlude here the case $s = 0$, because in the informal formulation then the right hand side is to be interpreted as $∞$, while the left hand side counts the elements in $A$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_350.variants.strengthening (A : Finset ℕ) (hA : DecidableDistinctSubsetSums A)

--- a/FormalConjectures/ErdosProblems/359.lean
+++ b/FormalConjectures/ErdosProblems/359.lean
@@ -48,16 +48,16 @@ theorem erdos_359.parts.ii (A : ℕ → ℕ) (hA : IsGoodFor A 1) (c : ℝ) (hc 
     atTop.Tendsto (fun k ↦ A k / (k : ℝ) ^ (1 + c)) (nhds 0) := by
   sorry
 
-/-- Suppose monotone sequence $A$ satisfies the following: `A 0 = 1` and for all `j`, `A (j + 1)` is the
-smallest natural number that cannot be written as a sum of consecutive terms of `A 0, ..., A j`.
+/-- Suppose monotone sequence $A$ satisfies the following: $A 0 = 1$ and for all $j$, $A (j + 1)$ is the
+smallest natural number that cannot be written as a sum of consecutive terms of $A 0, ..., A j$.
 Then the first few terms of $A$ are $1,2,4,5,8,10,14,15,...$. -/
 @[category test, AMS 11]
 theorem erdos_359.variants.isGoodFor_1_low_values (A : ℕ → ℕ) (hA : IsGoodFor A 1) :
     A '' (Set.Iic 7) = {1, 2, 4, 5, 8, 10, 14, 15} := by
   sorry
 
-/-- Suppose monotone sequence $A$ satisfies the following: `A 0 = 1` and for all `j`, `A (j + 1)` is the
-smallest natural number that cannot be written as a sum of consecutive terms of `A 0, ..., A j`.
+/-- Suppose monotone sequence $A$ satisfies the following: $A 0 = 1$ and for all $j$, $A (j + 1)$ is the
+smallest natural number that cannot be written as a sum of consecutive terms of $A 0, ..., A j$.
 Then it is conjectured that $$a_k ~ \frac{k \log k}{\log \log k}$$. -/
 @[category research open, AMS 11]
 theorem erdos_359.variants.isGoodFor_1_asymptotic (A : ℕ → ℕ) (hA : IsGoodFor A 1) :

--- a/FormalConjectures/ErdosProblems/373.lean
+++ b/FormalConjectures/ErdosProblems/373.lean
@@ -35,7 +35,7 @@ abbrev S : Set (ℕ × List ℕ) :=
     ∧ l.headI < (n - 1 : ℕ) ∧ ∀ a ∈ l, 1 < a }
 
 /--
-Show that the equation `n!=a_1!a_2!···a_k!`, with `n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k`, has
+Show that the equation $n!=a_1!a_2!···a_k!$, with $n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k$, has
 only finitely many solutions.
 -/
 @[category research open, AMS 11]
@@ -43,8 +43,8 @@ theorem erdos_373 : S.Finite := by
   sorry
 
 /--
-Show that if `P(n(n+1)) / log n → ∞` where `P(m)` denotes the largest prime factor of `m`, then
-the equation `n!=a_1!a_2!···a_k!`, with `n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k`, has only
+Show that if $P(n(n+1)) / log n → ∞$ where $P(m)$ denotes the largest prime factor of $m$, then
+the equation $n!=a_1!a_2!···a_k!$, with $n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k$, has only
 finitely many solutions.
 -/
 @[category research solved, AMS 11]
@@ -60,9 +60,9 @@ theorem erdos_373.variants.of_limit
 -- that no non-trivial solutions hold for any `n` with `n > n_0` and `P(n(n - 1)) > 4 log n`.
 -- So for finiteness, it is enough to assume the inequality holds for sufficiently large `n`.
 /--
-Show that if `P(n(n−1)) > 4 log n` for large enough `n`, where `P(m)` denotes the
-largest prime factor of `m`, then the equation `n!=a_1!a_2!···a_k!`, with
-`n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k`, has only finitely many solutions.
+Show that if $P(n(n−1)) > 4 log n$ for large enough $n$, where $P(m)$ denotes the
+largest prime factor of $m$, then the equation $n!=a_1!a_2!···a_k!$, with
+$n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k$, has only finitely many solutions.
 -/
 @[category research solved, AMS 11]
 theorem erdos_373.variants.of_lower_bound
@@ -71,8 +71,8 @@ theorem erdos_373.variants.of_lower_bound
   sorry
 
 /--
-Hickerson conjectured the largest solution the equation `n!=a_1!a_2!···a_k!`, with
-`n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k`, is `16!=14!5!2!`.
+Hickerson conjectured the largest solution the equation $n!=a_1!a_2!···a_k!$, with
+$n−1 > a_1 ≥ a_2 ≥ ··· ≥ a_k$, is $16!=14!5!2!$.
 -/
 @[category research open, AMS 11]
 theorem erdos_373.variants.maximal_solution :
@@ -80,8 +80,8 @@ theorem erdos_373.variants.maximal_solution :
   sorry
 
 /--
-Surányi was the first to conjecture that the only non-trivial solution to `a!b!=n!`
-is `6!7!=10!`.
+Surányi was the first to conjecture that the only non-trivial solution to $a!b!=n!$
+is $6!7!=10!$.
 -/
 @[category research open, AMS 11]
 theorem erdos_373.variants.suranyi :

--- a/FormalConjectures/ErdosProblems/375.lean
+++ b/FormalConjectures/ErdosProblems/375.lean
@@ -44,8 +44,8 @@ def Erdos375Prop : Prop := ∀ n ≥ 1, ∀ k, (∀ i < k, ¬ (n + i + 1).Prime)
 theorem erdos_375 : answer(sorry) ↔ Erdos375Prop := by
   sorry
 
-/-- If `Erdos375Prop` is true, then `(n + 1).nth Prime - n.nth Prime < (n.nth Prime) ^ (1 / 2 - c)`
-for some `c > 0`. -/
+/-- If `Erdos375Prop` is true, then $(n + 1).nth Prime - n.nth Prime < (n.nth Prime) ^ (1 / 2 - c)$
+for some $c > 0$. -/
 @[category research solved, AMS 11]
 theorem erdos_375.variants.bounded_gap : Erdos375Prop →
     ∃ c > 0, ∀ᶠ n in atTop, (n + 1).nth Nat.Prime - n.nth Nat.Prime
@@ -58,8 +58,8 @@ theorem erdos_375.variants.legendre : Erdos375Prop →
     (∀ᶠ n in atTop, ∃ p ∈ Set.Ioo (n ^ 2) ((n + 1) ^ 2), Nat.Prime p) :=
   fun hp => LegendreConjecture.bounded_gap_legendre (erdos_375.variants.bounded_gap hp)
 
-/-- It is easy to see that for any `n ≥ 1` and `k ≤ 2`, if `n + 1, ..., n + k` are all composite,
-then there are distinct primes `p₁, ... pₖ` such that `pᵢ ∣ n + i` for all `1 ≤ i ≤ k`. -/
+/-- It is easy to see that for any $n ≥ 1$ and $k ≤ 2$, if $n + 1, ..., n + k$ are all composite,
+then there are distinct primes $p₁, ... pₖ$ such that $pᵢ ∣ n + i$ for all $1 ≤ i ≤ k$. -/
 @[category research solved, AMS 11]
 theorem erdos_375.variants.le_two : ∀ n ≥ 1, ∀ k ≤ 2, (∀ i < k, ¬ (n + i + 1).Prime) →
     ∃ p : Fin k → ℕ, p.Injective ∧ ∀ i, (p i).Prime ∧ p i ∣ n + i + 1 := by
@@ -78,11 +78,11 @@ theorem erdos_375.variants.le_two : ∀ n ≥ 1, ∀ k ≤ 2, (∀ i < k, ¬ (n 
       have := (hp 1).1
       simp_all [Nat.not_prime_one]
 
-/-- There exists a constant `c > 0` such that for all `n`, if
-`k < c * (log n / (log (log n))) ^ 3 → (∀ i < k, ¬ (n + i + 1).Prime)`, then
-there are distinct primes `p₁, ... pₖ` such that `pᵢ ∣ n + i` for all `1 ≤ i ≤ k`. This is proved
-in [RST75]. There is no need to only consider sufficiently large `n` because one can always take
-`c` small enough so that `k < c * (log n / (log (log n))) ^ 3` implies that `k = 0` until `n` is
+/-- There exists a constant $c > 0$ such that for all $n$, if
+$k < c * (log n / (log (log n))) ^ 3 → (∀ i < k, ¬ (n + i + 1).Prime)$, then
+there are distinct primes $p₁, ... pₖ$ such that $pᵢ ∣ n + i$ for all $1 ≤ i ≤ k$. This is proved
+in [RST75]. There is no need to only consider sufficiently large $n$ because one can always take
+$c$ small enough so that $k < c * (log n / (log (log n))) ^ 3$ implies that $k = 0$ until $n$ is
 large. -/
 @[category research solved, AMS 11]
 theorem erdos_375.variants.log : ∃ c > 0, ∀ n k : ℕ,

--- a/FormalConjectures/ErdosProblems/387.lean
+++ b/FormalConjectures/ErdosProblems/387.lean
@@ -31,8 +31,8 @@ open Filter
 
 namespace Erdos387
 
-/-- Is there an absolute constant `c > 0` such that, for all `1 ≤ k < n`, the binomial coefficient
-`n.choose k` has a divisor in `(cn, n]`? -/
+/-- Is there an absolute constant $c > 0$ such that, for all $1 ≤ k < n$, the binomial coefficient
+`n.choose k` has a divisor in $(cn, n]$? -/
 @[category research open, AMS 11]
 theorem erdos_387 : answer(sorry) ↔ ∃ c : ℝ, 0 < c ∧ ∀ n k : ℕ, 1 ≤ k → k < n →
     ∃ d : ℕ, (d : ℝ) ∈ Set.Ioc (c * n) n ∧ d ∣ n.choose k := by
@@ -48,7 +48,7 @@ theorem erdos_387.variants.schinzel : answer(sorry) ↔
     ∀ᶠ k in atTop, ¬ IsPrimePow k → ∃ n : ℕ, ∀ i < k, ¬ n - i ∣ n.choose k := by
   sorry
 
-/-- It is easy to see that `n.choose k` has a divisor in `[n / k, n]`. -/
+/-- It is easy to see that `n.choose k` has a divisor in $[n / k, n]$. -/
 @[category research solved, AMS 11]
 theorem erdos_387.variants.easy {n : ℕ} {k : ℕ} (hn : 1 ≤ n) (hk : k ≤ n) : ∃ d : ℕ,
     (d : ℝ) ∈ Set.Icc (n / k : ℝ) n ∧ d ∣ n.choose k := by
@@ -62,8 +62,8 @@ theorem erdos_387.variants.easy {n : ℕ} {k : ℕ} (hn : 1 ≤ n) (hk : k ≤ n
     · cases n <;> cases k <;> simp_all [Nat.add_one_mul_choose_eq]
   · exact Nat.le_of_dvd (by linarith) (gcd_dvd_right _ _)
 
-/-- Is it true for any `c < 1` and all `n` sufficiently large, for all `1 ≤ k < n`, `n.choose k`
-has a divisor in `(cn, n]`? This is a variant of `erdos_387` and appears in [Gu04]. -/
+/-- Is it true for any $c < 1$ and all $n$ sufficiently large, for all $1 ≤ k < n$, `n.choose k`
+has a divisor in $(cn, n]$? This is a variant of `erdos_387` and appears in [Gu04]. -/
 @[category research open, AMS 11]
 theorem erdos_387.variants.guy : answer(sorry) ↔ ∀ c : ℝ, c < 1 → ∀ᶠ n : ℕ in atTop, ∀ k : ℕ, 1 ≤ k →
     k < n → ∃ d : ℕ, (d : ℝ) ∈ Set.Ioc (c * n) n ∧ d ∣ n.choose k := by

--- a/FormalConjectures/ErdosProblems/390.lean
+++ b/FormalConjectures/ErdosProblems/390.lean
@@ -36,13 +36,13 @@ integers greater than n, the largest of which is `f n`. -/
 noncomputable def f (n : ℕ) : ℕ := sInf {m : ℕ | ∃ k, ∃ f : ℕ → ℕ, StrictMono f ∧
   n < f 0 ∧ f (k - 1) = m ∧ ∏ i < k, f i = n !}
 
-/-- `f n - 2 * n = θ (n / log n)`. This is proved in [EGS82]. -/
+/-- $f n - 2 * n = θ (n / log n)$. This is proved in [EGS82]. -/
 @[category research solved, AMS 11]
 theorem erdos_390.variants.theta :
     (fun n => f n - 2 * n : ℕ → ℝ) =Θ[atTop] (fun n => n / log (n : ℝ)) := by
   sorry
 
-/-- Does there exists a constant `c` such that `f n - 2 * n ~ c * (n / log n)`? -/
+/-- Does there exists a constant $c$ such that $f n - 2 * n ~ c * (n / log n)$? -/
 @[category research open, AMS 11]
 theorem erdos_390 :
     answer(sorry) ↔ ∃ c,

--- a/FormalConjectures/ErdosProblems/399.lean
+++ b/FormalConjectures/ErdosProblems/399.lean
@@ -38,11 +38,11 @@ open Nat
 namespace Erdos399
 
 /--
-Is it true that there are no solutions to `n! = x^k ± y^k` with `x,y,n ∈ ℕ`, `x*y > 1`, and
-`k > 2`?
+Is it true that there are no solutions to $n! = x^k ± y^k$ with $x,y,n ∈ ℕ$, $x*y > 1$, and
+$k > 2$?
 
-The answer is no: Jonas Barfield found the counterexample `10! = 48^4 - 36^4` (equivalently,
-`10! + 36^4 = 48^4`).
+The answer is no: Jonas Barfield found the counterexample $10! = 48^4 - 36^4$ (equivalently,
+$10! + 36^4 = 48^4$).
 
 This is discussed in problem D2 of Guy's collection [Gu04].
 

--- a/FormalConjectures/ErdosProblems/41.lean
+++ b/FormalConjectures/ErdosProblems/41.lean
@@ -36,9 +36,9 @@ def NtupleCondition (A : Set α) (n : ℕ) : Prop := ∀ (I : Finset α) (J : Fi
   (∑ i ∈ I, i = ∑ j ∈ J, j) → I = J
 
 /--
-Let `A ⊆ ℕ` be an infinite set such that the triple sums `a + b + c` are all distinct for
-`a, b, c` in `A` (aside from the trivial coincidences). Is it true that
-`liminf n → ∞ |A ∩ {1, …, N}| / N^(1/3) = 0`?
+Let $A ⊆ ℕ$ be an infinite set such that the triple sums $a + b + c$ are all distinct for
+$a, b, c$ in $A$ (aside from the trivial coincidences). Is it true that
+$liminf n → ∞ |A ∩ {1, …, N}| / N^(1/3) = 0$?
 -/
 @[category research open, AMS 11]
 theorem erdos_41 (A : Set ℕ) (h_triple : NtupleCondition A 3) (h_infinite : A.Infinite) :
@@ -47,9 +47,9 @@ theorem erdos_41 (A : Set ℕ) (h_triple : NtupleCondition A 3) (h_infinite : A.
 
 /--
 Erdős proved the following pairwise version.
-Let `A ⊆ ℕ` be an infinite set such that the pairwise sums `a + b` are all distinct for `a, b`
-in `A` (aside from the trivial coincidences).
-Is it true that `liminf n → ∞ |A ∩ {1, …, N}| / N^(1/2) = 0`?
+Let $A ⊆ ℕ$ be an infinite set such that the pairwise sums $a + b$ are all distinct for $a, b$
+in $A$ (aside from the trivial coincidences).
+Is it true that $liminf n → ∞ |A ∩ {1, …, N}| / N^(1/2) = 0$?
 -/
 @[category research solved, AMS 11]
 theorem erdos_41.variants.pairwise (A : Set ℕ) (hA₂ : NtupleCondition A 2) (hA : A.Infinite) :

--- a/FormalConjectures/ErdosProblems/413.lean
+++ b/FormalConjectures/ErdosProblems/413.lean
@@ -23,10 +23,10 @@ import FormalConjectures.Util.ProblemImports
 - [erdosproblems.com/413](https://www.erdosproblems.com/413)
 - [A5236](https://oeis.org/A5236)
 
-Erdős called a natural number `n` a *barrier* for `ω`, the number of distinct prime divisors,
-if `m + ω(m) ≤ n` for all `m < n`. He believed there should be infinitely many such barriers, and
-even posed a relaxed variant asking whether there is some `ε > 0` for which infinitely many `n`
-satisfy `m + ε · ω(m) ≤ n` for every `m < n`.
+Erdős called a natural number $n$ a *barrier* for $ω$, the number of distinct prime divisors,
+if $m + ω(m) ≤ n$ for all $m < n$. He believed there should be infinitely many such barriers, and
+even posed a relaxed variant asking whether there is some $ε > 0$ for which infinitely many $n$
+satisfy $m + ε · ω(m) ≤ n$ for every $m < n$.
 -/
 
 open ArithmeticFunction
@@ -39,7 +39,7 @@ i.e. `(m : ℝ) + f m ≤ (n : ℝ)` for all `m < n`. -/
 def IsBarrier (f : ℕ → ℝ) (n : ℕ) : Prop :=
   ∀ m < n, (m : ℝ) + f m ≤ n
 
-/-- Are there infinitely many barriers for `ω`? -/
+/-- Are there infinitely many barriers for $ω$? -/
 @[category research open, AMS 11]
 theorem erdos_413.parts.i :
     answer(sorry) ↔ { n | IsBarrier (fun m => ω m) n }.Infinite := by
@@ -55,19 +55,19 @@ theorem erdos_413.variants.hasPosDensity_barrier_expProd :
     { n | IsBarrier (fun m => expProd m) n }.HasPosDensity := by
   sorry
 
-/-- Erdős believed there should be infinitely many barriers for `Ω`, the total prime multiplicity. -/
+/-- Erdős believed there should be infinitely many barriers for $Ω$, the total prime multiplicity. -/
 @[category research open, AMS 11]
 theorem erdos_413.variants.bigOmega :
     answer(sorry) ↔ { n | IsBarrier (fun m => Ω m) n }.Infinite := by
   sorry
 
-/-- Selfridge computed that the largest `Ω`-barrier below `10^5` is `99840`. -/
+/-- Selfridge computed that the largest $Ω$-barrier below $10^5$ is $99840$. -/
 @[category research solved, AMS 11]
 theorem erdos_413.variants.bigOmega_largest_barrier_lt_100k :
     IsGreatest {n : ℕ | n < 10 ^ 5 ∧ IsBarrier (fun m => Ω m) n} 99840 := by
   sorry
 
-/-- Does there exist some `ε > 0` such that there are infinitely many `ε`-barriers for `ω`? -/
+/-- Does there exist some $ε > 0$ such that there are infinitely many $ε$-barriers for $ω$? -/
 @[category research open, AMS 11]
 theorem erdos_413.parts.ii :
     answer(sorry) ↔

--- a/FormalConjectures/ErdosProblems/416.lean
+++ b/FormalConjectures/ErdosProblems/416.lean
@@ -32,7 +32,7 @@ noncomputable abbrev V (x : ℝ) : ℝ :=
   (Finset.Icc 1 ⌊x⌋₊ |>.filter (fun n => ∃ (m : ℕ), m.totient = n)).card
 
 /--
-Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable. Does `V(2x)/V(x)→2` ?
+Let $V(x)$ count the number of $n≤x$ such that $ϕ(m)=n$ is solvable. Does $V(2x)/V(x)→2$ ?
 -/
 @[category research open, AMS 11]
 theorem erdos_416.parts.i :
@@ -40,8 +40,8 @@ theorem erdos_416.parts.i :
   sorry
 
 /--
-Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
-Is there an asymptotic formula for `V(x)`?
+Let $V(x)$ count the number of $n≤x$ such that $ϕ(m)=n$ is solvable.
+Is there an asymptotic formula for $V(x)$?
 -/
 @[category research open, AMS 11]
 theorem erdos_416.parts.ii :
@@ -50,8 +50,8 @@ theorem erdos_416.parts.ii :
   sorry
 
 /--
-Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
-Pillai proved `V(x)=o(x)`.
+Let $V(x)$ count the number of $n≤x$ such that $ϕ(m)=n$ is solvable.
+Pillai proved $V(x)=o(x)$.
 Ref: S. Sivasankaranarayana Pillai, _On some functions connected with $\phi(n)$_
 -/
 @[category research solved, AMS 11]
@@ -59,7 +59,7 @@ theorem erdos_416.variants.Pillai : V =o[atTop] id := by
   sorry
 
 /--
-Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
+Let $V(x)$ count the number of $n≤x$ such that $ϕ(m)=n$ is solvable.
 Erdős proved V(x)=x(logx)^(−1+o(1)).
 Ref: Erdős, P., _On the normal number of prime factors of $p-1$ and some related problems concerning Euler's $\varphi$-function._
 -/
@@ -69,8 +69,8 @@ theorem erdos_416.variants.Erdos : ∃ f : ℝ → ℝ, f =o[atTop] (1 : ℝ →
   sorry
 
 /--
-Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
-`V(x)=x/logx * e^((C+o(1))(log log log x)^2)`, for some explicit constant `C>0`.
+Let $V(x)$ count the number of $n≤x$ such that $ϕ(m)=n$ is solvable.
+$V(x)=x/logx * e^((C+o(1))(log log log x)^2)$, for some explicit constant $C>0$.
 Ref:Maier, Helmut and Pomerance, Carl, _On the number of distinct values of Euler's $\phi$-function_.
 -/
 @[category research solved, AMS 11]
@@ -81,8 +81,8 @@ theorem erdos_416.variants.Maier_Pomerance :
   sorry
 
 /--
-Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
-`V(x) ≍ x/log x*e^(C_1*(log log log x − log log log log x)^2+C_2 log log log x − C_3 log log log log x)`
+Let $V(x)$ count the number of $n≤x$ such that $ϕ(m)=n$ is solvable.
+$V(x) ≍ x/log x*e^(C_1*(log log log x − log log log log x)^2+C_2 log log log x − C_3 log log log log x)$
 Ref: Ford, Kevin, _The distribution of totients_.
 -/
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -32,8 +32,8 @@ namespace Erdos42
 
 /--
 **Erdős Problem 42**: Let M ≥ 1 and N be sufficiently large in terms of M. Is it true that for every
-maximal Sidon set `A ⊆ {1,…,N}` there is another Sidon set `B ⊆ {1,…,N}` of size M such that
-`(A - A) ∩ (B - B) = {0}`?
+maximal Sidon set $A ⊆ {1,…,N}$ there is another Sidon set $B ⊆ {1,…,N}$ of size M such that
+$(A - A) ∩ (B - B) = {0}$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_42 : answer(sorry) ↔
@@ -61,7 +61,7 @@ theorem erdos_42.variants.constructive : answer(sorry) ↔
 /-  ## Related results and examples -/
 
 /--
-The set `{1, 2, 4}` is a maximal Sidon set in `{1, ..., 4}`.
+The set ${1, 2, 4}$ is a maximal Sidon set in ${1, ..., 4}$.
 -/
 @[category textbook, AMS 5 11]
 theorem example_maximal_sidon : IsMaximalSidonSetIn {1, 2, 4} 4 := by
@@ -86,7 +86,7 @@ theorem example_maximal_sidon : IsMaximalSidonSetIn {1, 2, 4} 4 := by
     rcases this with ⟨h1, h2⟩ | ⟨h1, h2⟩ <;> omega
 
 /--
-The difference set of `{1, 2, 4}` is `{0, 1, 2, 3}`.
+The difference set of ${1, 2, 4}$ is ${0, 1, 2, 3}$.
 -/
 @[category textbook, AMS 5 11]
 theorem example_difference_set : ({1, 2, 4} : Set ℕ) - {1, 2, 4} = {0, 1, 2, 3} := by

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -27,16 +27,16 @@ open Function Set Finset
 namespace Erdos44
 
 -- Reference: https://arxiv.org/pdf/2103.15850
-/-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `2 * √N`. -/
+/-- The maximum size of a Sidon set in ${1, ..., N}$ is less than or equal to $2 * √N$. -/
 @[category textbook, AMS 5 11]
 theorem maxSidonSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) :
     maxSidonSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
   sorry
 
 /--
-**Erdős Problem 44:** Let N ≥ 1 and `A ⊆ {1,…,N}` be a Sidon set. Is it true that, for any ε > 0,
-there exist M = M(ε) and `B ⊆ {N+1,…,M}` such that `A ∪ B ⊆ {1,…,M}` is a Sidon set
-of size at least `(1−ε)M^{1/2}`?
+**Erdős Problem 44:** Let N ≥ 1 and $A ⊆ {1,…,N}$ be a Sidon set. Is it true that, for any ε > 0,
+there exist M = M(ε) and $B ⊆ {N+1,…,M}$ such that $A ∪ B ⊆ {1,…,M}$ is a Sidon set
+of size at least $(1−ε)M^{1/2}$?
 
 This problem asks whether any Sidon set can be extended to achieve a density
 arbitrarily close to the optimal density for Sidon sets.
@@ -58,7 +58,7 @@ theorem erdos_44.variants.empty_start : answer(sorry) ↔ ∀ᵉ (ε > (0 : ℝ)
 /-  ## Related results and examples -/
 
 /--
-The set `{1, 2, 4, 8, 13}` is a Sidon set in `{1, ..., 13}`.
+The set ${1, 2, 4, 8, 13}$ is a Sidon set in ${1, ..., 13}$.
 -/
 @[category textbook, AMS 5 11]
 theorem example_sidon_set : IsSidon ({1, 2, 4, 8, 13} : Set ℕ) := by
@@ -71,7 +71,7 @@ theorem example_sidon_set : IsSidon ({1, 2, 4, 8, 13} : Set ℕ) := by
   simp_all
 
 /--
-For any `N`, there exists a Sidon set of size at least `√N/2`.
+For any $N$, there exists a Sidon set of size at least $√N/2$.
 -/
 @[category textbook, AMS 5 11]
 theorem sidon_set_lower_bound (N : ℕ) (hN : 1 ≤ N) :
@@ -79,7 +79,7 @@ theorem sidon_set_lower_bound (N : ℕ) (hN : 1 ≤ N) :
   sorry
 
 /--
-The greedy construction gives a Sidon set of size approximately `√N`.
+The greedy construction gives a Sidon set of size approximately $√N$.
 -/
 @[category textbook, AMS 5 11]
 theorem greedy_sidon_construction (N : ℕ) (hN : 1 ≤ N) :

--- a/FormalConjectures/ErdosProblems/454.lean
+++ b/FormalConjectures/ErdosProblems/454.lean
@@ -32,12 +32,12 @@ namespace Erdos454
 noncomputable def f (n : ℕ) : ℕ :=
   if n ≤ 1 then 0 else ⨅ i : {i : Fin n // 0 < (i : ℕ)}, (n + i).nth Prime + (n - i).nth Prime
 
-/-- Is it true that `limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop = ⊤`? -/
+/-- Is it true that $limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop = ⊤$? -/
 @[category research open, AMS 11]
 theorem erdos_454 : answer(sorry) ↔ limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop = ⊤ := by
   sorry
 
-/-- `limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop ≥ 2`, and this is proved in [Po79]. -/
+/-- $limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop ≥ 2$, and this is proved in [Po79]. -/
 @[category research solved, AMS 11]
 theorem erdos_454.variants.two_le_limsup : 2 ≤ limsup (fun n => (f n - 2 * n.nth Prime : ℕ∞)) atTop := by
   sorry

--- a/FormalConjectures/ErdosProblems/455.lean
+++ b/FormalConjectures/ErdosProblems/455.lean
@@ -27,16 +27,16 @@ open Filter ENNReal
 
 namespace Erdos455
 
-/-- Let `q : ℕ → ℕ` be a strictly increasing sequence of primes such that
-`q (n + 2) - q (n + 1) ≥ q (n + 1) - q n`. Must `lim q n / (n ^ 2) = ∞`? -/
+/-- Let $q : ℕ → ℕ$ be a strictly increasing sequence of primes such that
+$q (n + 2) - q (n + 1) ≥ q (n + 1) - q n$. Must $lim q n / (n ^ 2) = ∞$? -/
 @[category research open, AMS 11]
 theorem erdos_455: answer(sorry) ↔ ∀ q : ℕ → ℕ, StrictMono q →
     (∀ n, (q n).Prime ∧ q (n + 2) - q (n + 1) ≥ q (n + 1) - q n) →
     Tendsto (fun n : ℕ => (q n : ℝ) / n ^ 2) atTop atTop := by
   sorry
 
-/--  Let `q : ℕ → ℕ` be a strictly increasing sequence of primes such that
-`q (n + 2) - q (n + 1) ≥ q (n + 1) - q n`. Then `liminf q n / (n ^ 2) > 0.352`, and this is proved in
+/--  Let $q : ℕ → ℕ$ be a strictly increasing sequence of primes such that
+$q (n + 2) - q (n + 1) ≥ q (n + 1) - q n$. Then $liminf q n / (n ^ 2) > 0.352$, and this is proved in
 [Ri76]. -/
 @[category research solved, AMS 11]
 theorem erdos_455.variants.liminf : ∀ q : ℕ → ℕ, StrictMono q →

--- a/FormalConjectures/ErdosProblems/513.lean
+++ b/FormalConjectures/ErdosProblems/513.lean
@@ -33,23 +33,23 @@ namespace Erdos513
 noncomputable def ratio (r : ℝ) (f : ℂ → ℂ) : ℝ :=
   (⨆ n, ‖iteratedDeriv n f 0 * (n ! : ℝ)⁻¹ * r ^ n‖) / (⨆ z : {z : ℂ // ‖z‖ = r}, ‖f z‖)
 
-/-- Let `f` be a transcendental entire function. What is the greatest possible value of
-`liminf (fun r : ℝ => ratio r f) atTop`? -/
+/-- Let $f$ be a transcendental entire function. What is the greatest possible value of
+$liminf (fun r : ℝ => ratio r f) atTop$? -/
 @[category research open, AMS 30]
 theorem erdos_513 : answer(sorry) =
     ⨆ f : {f : ℂ → ℂ // Transcendental ℂ[X] f ∧ Differentiable ℂ f},
     (liminf (fun r : ℝ => ratio r f) atTop) := by
   sorry
 
-/-- For all transcendental entire function `f`, `liminf (fun r : ℝ => ratio r f) atTop ≤ 2 / π - c`
-for some `c > 0`. This is proved in [ClHa64]. -/
+/-- For all transcendental entire function $f$, $liminf (fun r : ℝ => ratio r f) atTop ≤ 2 / π - c$
+for some $c > 0$. This is proved in [ClHa64]. -/
 @[category research solved, AMS 30]
 theorem erdos_513.variants.upper_bound : ∃ c > 0,
     ⨆ f : {f : ℂ → ℂ // Transcendental ℂ[X] f ∧ Differentiable ℂ f},
     (liminf (fun r : ℝ => ratio r f) atTop) ≤ 2 / π - c := by
   sorry
 
-/-- For all transcendental entire function `f`, `liminf (fun r : ℝ => ratio r f) atTop > 1 / 2`. -/
+/-- For all transcendental entire function $f$, $liminf (fun r : ℝ => ratio r f) atTop > 1 / 2$. -/
 @[category research solved, AMS 30]
 theorem erdos_513.variants.lower_bound :
     ⨆ f : {f : ℂ → ℂ // Transcendental ℂ[X] f ∧ Differentiable ℂ f},

--- a/FormalConjectures/ErdosProblems/516.lean
+++ b/FormalConjectures/ErdosProblems/516.lean
@@ -40,8 +40,8 @@ def OfFiniteOrder {E F: Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
 noncomputable def ratio (r : ℝ) (f : ℂ → ℂ) : ℝ :=
   (⨅ z : {z : ℂ // ‖z‖ = r}, ‖f z‖).log / (⨆ z : {z : ℂ // ‖z‖ = r}, ‖f z‖).log
 
-/-- Let `f = ∑ aₖzⁿₖ` be an entire function of finite order such that `nₖ / k → ∞`.
-Then `limsup (fun r => ratio r f) atTop = 1`. This is proved in [Fu63]. -/
+/-- Let $f = ∑ aₖzⁿₖ$ be an entire function of finite order such that $nₖ / k → ∞$.
+Then $limsup (fun r => ratio r f) atTop = 1$. This is proved in [Fu63]. -/
 @[category research solved, AMS 30]
 theorem erdos_516 {f : ℂ → ℂ} {n : ℕ → ℕ}
     (hn : HasFabryGaps n) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)
@@ -49,8 +49,8 @@ theorem erdos_516 {f : ℂ → ℂ} {n : ℕ → ℕ}
     limsup (fun r => ratio r f) atTop = 1 := by
   sorry
 
-/-- Let `f = ∑ aₖzⁿₖ` be an entire function such that `nₖ > k (log k) ^ (2 + c)`.
-Then `limsup (fun r => ratio r f) atTop = 1`. This is proved in [Ko65]. -/
+/-- Let $f = ∑ aₖzⁿₖ$ be an entire function such that $nₖ > k (log k) ^ (2 + c)$.
+Then $limsup (fun r => ratio r f) atTop = 1$. This is proved in [Ko65]. -/
 @[category research solved, AMS 30]
 theorem erdos_516.variants.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → ℕ}
     (hn : ∃ c > (0 : ℝ), ∀ k, n k > k * log k ^ (2 + c)) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)
@@ -58,8 +58,8 @@ theorem erdos_516.variants.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → �
     limsup (fun r => ratio r f) atTop = 1 := by
   sorry
 
-/-- Is it true that for all entire functions `f = ∑ aₖzⁿₖ` such that `∑' 1 / nₖ < ∞`,
-`limsup (fun r => ratio r f) atTop = 1`? -/
+/-- Is it true that for all entire functions $f = ∑ aₖzⁿₖ$ such that $∑' 1 / nₖ < ∞$,
+$limsup (fun r => ratio r f) atTop = 1$? -/
 @[category research open, AMS 30]
 theorem erdos_516.variants.limsup_ratio_eq_one_of_hasFejerGaps : answer(sorry) ↔
     ∀ {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFejerGaps n) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)

--- a/FormalConjectures/ErdosProblems/517.lean
+++ b/FormalConjectures/ErdosProblems/517.lean
@@ -29,16 +29,16 @@ open Set Filter Topology
 
 namespace Erdos517
 
-/-- If `f(z) = ∑ aₖzⁿₖ` is an entire function (with `aₖ ≠ 0` for all `k`) such that `nₖ / k → ∞`,
-is it true that `f` assumes every value infinitely often? -/
+/-- If $f(z) = ∑ aₖzⁿₖ$ is an entire function (with $aₖ ≠ 0$ for all $k$) such that $nₖ / k → ∞$,
+is it true that $f$ assumes every value infinitely often? -/
 @[category research open, AMS 30]
 theorem erdos_517 : answer(sorry) ↔ ∀ {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFabryGaps n)
     {a : ℕ → ℂ} (ha : ∀ k, a k ≠ 0) (hf : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) (z : ℂ),
     {x : ℂ | f x = z}.Infinite := by
   sorry
 
-/-- If `f(z) = ∑ aₖzⁿₖ` is an entire function (with `aₖ ≠ 0` for all `k`) such that `∑ 1 / nₖ < ∞`,
-then `f` assumes every value infinitely often. This theorem is proved in [Bi28]. -/
+/-- If $f(z) = ∑ aₖzⁿₖ$ is an entire function (with $aₖ ≠ 0$ for all $k$) such that $∑ 1 / nₖ < ∞$,
+then $f$ assumes every value infinitely often. This theorem is proved in [Bi28]. -/
 @[category research solved, AMS 30]
 theorem erdos_517.variants.fejer {f : ℂ → ℂ} {n : ℕ → ℕ} (hn : HasFejerGaps n) {a : ℕ → ℂ}
     (ha : ∀ k, a k ≠ 0) (hf : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) (z : ℂ) :

--- a/FormalConjectures/ErdosProblems/522.lean
+++ b/FormalConjectures/ErdosProblems/522.lean
@@ -117,8 +117,8 @@ theorem erdos_522.variants.zero_one :
   sorry
 
 /--
-Erdős and Offord showed that the number of real roots of a random degree `n` polynomial with `±1`
-coefficients is `(2/π+o(1))log n`.
+Erdős and Offord showed that the number of real roots of a random degree $n$ polynomial with $±1$
+coefficients is $(2/π+o(1))log n$.
 -/
 @[category research solved, AMS 12 60]
 theorem erdos_522.variants.number_real_roots : ∃ p o : ℕ → ℝ,
@@ -129,7 +129,7 @@ theorem erdos_522.variants.number_real_roots : ∃ p o : ℕ → ℝ,
   sorry
 
 /--
-Yakir proved that almost all Kac polynomials have `n/2+O(n^(9/10))` many roots in `{z∈C:|z|≤1}`.
+Yakir proved that almost all Kac polynomials have $n/2+O(n^(9/10))$ many roots in ${z∈C:|z|≤1}$.
 -/
 @[category research solved, AMS 12 60]
 theorem erdos_522.variants.yakir_solution :

--- a/FormalConjectures/ErdosProblems/541.lean
+++ b/FormalConjectures/ErdosProblems/541.lean
@@ -47,7 +47,7 @@ theorem erdos_541 : answer(True) ↔ (∀ p, Fact p.Prime → ∀ (a : Fin p →
       (Set.range a).ncard ≤ 2) := by
   sorry
 
-/-- Gao, Hamidoune, and Wang [GHW10] solved this for all moduli `p` (not necessarily prime). -/
+/-- Gao, Hamidoune, and Wang [GHW10] solved this for all moduli $p$ (not necessarily prime). -/
 @[category research solved, AMS 11]
 theorem erdos_541.variants.general_moduli (p : ℕ) (a : Fin p → ZMod p)
     (ha₀ : ∃ r, ∀ (S : Finset (Fin p)), S ≠ ∅ → ∑ i ∈ S, a i = 0 → S.card = r) :

--- a/FormalConjectures/ErdosProblems/56.lean
+++ b/FormalConjectures/ErdosProblems/56.lean
@@ -37,12 +37,12 @@ def WeaklyDivisible (k : ℕ) (A : Finset ℕ) : Prop :=
 lemma weaklyDivisible_empty (k : ℕ): WeaklyDivisible k {} := by
   simp [WeaklyDivisible]
 
-/-- A singleton is `k`-weakly divisble if `k ≠ 0`. -/
+/-- A singleton is $k$-weakly divisble if $k ≠ 0$. -/
 @[category API, AMS 11]
 lemma weaklyDivisible_singleton {k : ℕ} (hk : k ≠ 0) (l : ℕ) : WeaklyDivisible k {l} := by
   simp [WeaklyDivisible, hk]
 
-/-- No non-empty set is `1`-weakly divisible. -/
+/-- No non-empty set is $1$-weakly divisible. -/
 @[category API, AMS 11]
 lemma not_weaklyDivisible_zero {A : _} (h : A.Nonempty) : ¬WeaklyDivisible 0 A := by
   simpa [WeaklyDivisible] using ⟨{_}, by simpa using h.choose_spec⟩
@@ -98,8 +98,8 @@ theorem firstPrimesMultiples_zero_k_card_zero (N : ℕ) : (FirstPrimesMultiples 
   simp [FirstPrimesMultiples]
 
 /--
-An example of a `k`-weakly divisible set is the subset of `{1, ..., N}`
-containing the multiples of the first `k` primes.
+An example of a $k$-weakly divisible set is the subset of ${1, ..., N}$
+containing the multiples of the first $k$ primes.
 -/
 @[category API, AMS 11]
 lemma weaklyDivisible_firstPrimesMultiples (N k : ℕ) :

--- a/FormalConjectures/ErdosProblems/602.lean
+++ b/FormalConjectures/ErdosProblems/602.lean
@@ -59,16 +59,16 @@ def HasPropertyB {α : Type*} (I : Type*) (A : I → Set α) : Prop :=
 Does every almost-disjoint family of countably infinite sets whose pairwise
 intersections all have size ≠ 1 have Property B?
 
-Formally: let `α` be any type, let `(A_i)_{i ∈ I}` be a family of countably infinite subsets
-of `α` such that for all `i ≠ j`, the intersection `A_i ∩ A_j` is finite and
-`|A_i ∩ A_j| ≠ 1`. Does there exist a 2-colouring `f : α → Fin 2` such that no `A_i` is
+Formally: let $α$ be any type, let $(A_i)_{i ∈ I}$ be a family of countably infinite subsets
+of $α$ such that for all $i ≠ j$, the intersection $A_i ∩ A_j$ is finite and
+$|A_i ∩ A_j| ≠ 1$. Does there exist a 2-colouring $f : α → Fin 2$ such that no `A_i` is
 monochromatic?
 
 This is an open question about Property B for almost-disjoint families with a
 forbidden intersection size of 1.
 
-**Note:** This generalises the formulation in which the ground set is `ℕ`. Since every
-countably infinite set is in bijection with `ℕ`, the two formulations are equivalent, but
+**Note:** This generalises the formulation in which the ground set is $ℕ$. Since every
+countably infinite set is in bijection with $ℕ$, the two formulations are equivalent, but
 working over an arbitrary ground type makes the statement apply immediately to, e.g.,
 almost-disjoint families of countable subsets of an uncountable space. -/
 @[category research open, AMS 3 5]
@@ -86,11 +86,11 @@ theorem erdos_602 : answer(sorry) ↔
 **Trivial case: pairwise disjoint families.**
 
 If the `A_i` are pairwise disjoint (all intersections are empty, which in
-particular satisfies `|A_i ∩ A_j| ≠ 1`), then Property B holds trivially.
+particular satisfies $|A_i ∩ A_j| ≠ 1$), then Property B holds trivially.
 
 **Proof sketch:** Since each `A_i` is infinite, it has (at least) two distinct elements
 `a_i` and `b_i`. We can define a colouring that assigns colour 0 to `a_i` and colour 1
-to `b_i` for each `i` (using disjointness, these choices don't conflict), and extend
+to `b_i` for each $i$ (using disjointness, these choices don't conflict), and extend
 arbitrarily elsewhere. Then no `A_i` is monochromatic. -/
 @[category research solved, AMS 3 5]
 theorem erdos_602.variants.disjoint : answer(True) ↔
@@ -162,8 +162,8 @@ theorem erdos_602.variants.countable_index : answer(True) ↔
 /--
 **Intersections of size ≥ 2 suffice.**
 
-For a single countably infinite set `A ⊆ α`, there trivially exists a 2-colouring
-of `α` that makes `A` non-monochromatic: since `A` is infinite, it has two distinct
+For a single countably infinite set $A ⊆ α$, there trivially exists a 2-colouring
+of $α$ that makes $A$ non-monochromatic: since $A$ is infinite, it has two distinct
 elements, so any colouring that assigns them different colours works. -/
 @[category textbook, AMS 3]
 theorem erdos_602.variants.single_set {α : Type*} (A : Set α) (hA : A.Infinite) :
@@ -196,7 +196,7 @@ theorem erdos_602.variants.single_set {α : Type*} (A : Set α) (hA : A.Infinite
 /--
 **Empty index set.**
 
-If the index set `I` is empty (has no elements), then Property B holds vacuously:
+If the index set $I$ is empty (has no elements), then Property B holds vacuously:
 any 2-colouring works, since there are no sets to be made non-monochromatic. -/
 @[category textbook, AMS 3]
 theorem erdos_602.variants.empty_index {α : Type*} :
@@ -209,8 +209,8 @@ theorem erdos_602.variants.empty_index {α : Type*} :
 /--
 **Unique index set.**
 
-If the index set has exactly one element (i.e., `[Unique I]`), then Property B holds:
-any 2-colouring that makes the single set `A (default : I)` non-monochromatic works.
+If the index set has exactly one element (i.e., $[Unique I]$), then Property B holds:
+any 2-colouring that makes the single set $A (default : I)$ non-monochromatic works.
 This follows from the single-set case. -/
 @[category textbook, AMS 3]
 theorem erdos_602.variants.unique_index {α : Type*} (I : Type*) [Unique I]
@@ -226,16 +226,16 @@ theorem erdos_602.variants.unique_index {α : Type*} (I : Type*) [Unique I]
 /--
 **Two infinite sets with pairwise intersection of size ≠ 1.**
 
-If the family consists of exactly two countably infinite sets `A₀` and `A₁` with
-`|A₀ ∩ A₁| ≠ 1` (and finite), then Property B holds.
+If the family consists of exactly two countably infinite sets $A₀$ and $A₁$ with
+$|A₀ ∩ A₁| ≠ 1$ (and finite), then Property B holds.
 
 **Proof sketch:**
-- If `A₀ ∩ A₁ = ∅`: the sets are disjoint. Pick distinct `a, b ∈ A₀` and distinct
-  `c, d ∈ A₁`. Colour `b` and `c` with 1, everything else with 0. Then `A₀` has
-  `a` (colour 0) and `b` (colour 1), and `A₁` has `c` (colour 1) and `d` (colour 0),
+- If $A₀ ∩ A₁ = ∅$: the sets are disjoint. Pick distinct $a, b ∈ A₀$ and distinct
+  $c, d ∈ A₁$. Colour $b$ and $c$ with 1, everything else with 0. Then $A₀$ has
+  $a$ (colour 0) and $b$ (colour 1), and $A₁$ has $c$ (colour 1) and $d$ (colour 0),
   so neither is monochromatic.
-- If `|A₀ ∩ A₁| ≥ 2`: the intersection contains two distinct points `x` and `y`.
-  Assign `x` colour 0 and `y` colour 1. Both `A₀` and `A₁` contain `x` and `y`,
+- If $|A₀ ∩ A₁| ≥ 2$: the intersection contains two distinct points $x$ and $y$.
+  Assign $x$ colour 0 and $y$ colour 1. Both $A₀$ and $A₁$ contain $x$ and $y$,
   so neither is monochromatic. -/
 @[category research solved, AMS 3 5]
 theorem erdos_602.variants.two_sets : answer(True) ↔
@@ -439,10 +439,10 @@ def disjoint_without_infinite_claim : Prop :=
 
 /-- Formal disproof of `disjoint_without_infinite_claim`.
 
-**Counterexample:** Take `α = ℕ`, `I = Fin 2`, with `A 0 = {0}` and `A 1 = {1}`.
+**Counterexample:** Take $α = ℕ$, $I = Fin 2$, with $A 0 = {0}$ and $A 1 = {1}$.
 These are pairwise disjoint, satisfying the only hypothesis. But singleton sets
-are vacuously monochromatic under any colouring: the only pair `(x, y) ∈ {0} × {0}`
-is `(0, 0)`, and `f 0 = f 0` trivially. So any colouring makes `A 0` monochromatic,
+are vacuously monochromatic under any colouring: the only pair $(x, y) ∈ {0} × {0}$
+is $(0, 0)$, and $f 0 = f 0$ trivially. So any colouring makes $A 0$ monochromatic,
 meaning `HasPropertyB` fails. -/
 @[category research solved, AMS 3]
 theorem disjoint_without_infinite_claim.disproof :

--- a/FormalConjectures/ErdosProblems/689.lean
+++ b/FormalConjectures/ErdosProblems/689.lean
@@ -26,9 +26,9 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos689
 
 /--
-Let `n` be sufficiently large. Is there some choice of congruence class `a_p` for all primes
-`2 ≤ p ≤ n` such that every integer in `[1,n]` satisfies at least two of the congruences
-`≡ a_p (mod p)`?
+Let $n$ be sufficiently large. Is there some choice of congruence class `a_p` for all primes
+$2 ≤ p ≤ n$ such that every integer in $[1,n]$ satisfies at least two of the congruences
+$≡ a_p (mod p)$?
 -/
 @[category research open, AMS 11]
 theorem erdos_689 :

--- a/FormalConjectures/ErdosProblems/697.lean
+++ b/FormalConjectures/ErdosProblems/697.lean
@@ -41,8 +41,8 @@ theorem density_exists (m : ℕ) (α : ℝ) : ∃ δ, HasDensity
 divisible by some $d \equiv 1 \pmod{m}$ with $1 < d < exp (m ^ \alpha)$ exists. -/
 noncomputable def δ (m : ℕ) (α : ℝ) : ℝ := (density_exists m α).choose
 
-/-- $\delta < \frac{m ^ \alpha + 1}{m}`. This shows that
-$lim_{m\rightarrow\infty} \delta (m, \alpha) = 0$ for $\alpha < 1$.
+/-- $\delta < \frac{m ^ \alpha + 1}{m}$. This shows that
+$\lim_{m\rightarrow\infty} \delta (m, \alpha) = 0$ for $\alpha < 1$.
 #TODO: prove this theorem. -/
 @[category research solved, AMS 11]
 theorem erdos_697.variants.delta_lt (m : ℕ) (α : ℝ) : δ m α < (m ^ α + 1) / m := by

--- a/FormalConjectures/ErdosProblems/699.lean
+++ b/FormalConjectures/ErdosProblems/699.lean
@@ -43,8 +43,8 @@ theorem erdos_699 : answer(sorry) ↔
       ∃ p : ℕ, p.Prime ∧ i ≤ p ∧ p ∣ Nat.gcd (Nat.choose n i) (Nat.choose n j) := by
   sorry
 
-/-- Erdős and Szekeres conjectured that, apart from a finite exceptional set of triples `(n, i, j)`,
-one can always take `p > i` in the prime divisor statement. -/
+/-- Erdős and Szekeres conjectured that, apart from a finite exceptional set of triples $(n, i, j)$,
+one can always take $p > i$ in the prime divisor statement. -/
 @[category research open, AMS 11]
 theorem erdos_szekeres_strengthening : answer(sorry) ↔
     ∃ E : Finset (ℕ × ℕ × ℕ), ∀ n i j : ℕ,

--- a/FormalConjectures/ErdosProblems/707.lean
+++ b/FormalConjectures/ErdosProblems/707.lean
@@ -25,8 +25,8 @@ import FormalConjectures.Util.ProblemImports
   Sidon subsets of perfect difference sets, featuring a human-assisted proof (2025)
 - [Ha47] Marshall Hall, Jr., Cyclic projective planes, Duke Math. J. 14 (1947), 1079–1090.
 
-Let `A ⊆ ℕ` be a finite Sidon set. Is there some set `B` with `A ⊆ B` which is a perfect
-difference set modulo `p^2 + p + 1` for some prime power `p`?
+Let $A ⊆ ℕ$ be a finite Sidon set. Is there some set $B$ with $A ⊆ B$ which is a perfect
+difference set modulo $p^2 + p + 1$ for some prime power $p$?
 
 This problem is related to Erdős Problem 329 about the maximum density of Sidon sets.
 If this conjecture is true, it would imply that the maximum density of Sidon sets is 1.
@@ -54,7 +54,7 @@ theorem erdos_707 : (∀ (A : Set ℕ) (h : A.Finite), IsSidon A →
 
 /--
 It is false that any finite Sidon set can be embedded in a perfect
-difference set modulo `p^2 + p + 1` for some prime power `p`.
+difference set modulo $p^2 + p + 1$ for some prime power $p$.
 
 As described in [arxiv/2510.19804], a counterexample is provided in [Ha47], see below.
 The proof of this has been formalized.
@@ -68,7 +68,7 @@ theorem erdos_707.variants.prime_power : (∀ (A : Set ℕ) (h : A.Finite), IsSi
 
 /--
 It is false that any finite Sidon set can be embedded in a perfect
-difference set modulo `p^2 + p + 1` for some prime `p`.
+difference set modulo $p^2 + p + 1$ for some prime $p$.
 
 As described in [arxiv/2510.19804], a counterexample is provided in [Ha47], see below.
 The proof of this has been formalized.
@@ -119,7 +119,7 @@ theorem erdos_707.variants.counterexample_hall (A : Set ℕ) (hA : A = {1, 3, 9,
 /-  ## Perfect difference sets and their properties -/
 
 /--
-A perfect difference set modulo `n` must have size `≤ √n + 1`.
+A perfect difference set modulo $n$ must have size $≤ √n + 1$.
 -/
 @[category textbook, AMS 5 11]
 theorem erdos_707.variants.perfect_difference_set_size_bound (B : Set ℕ) (n : ℕ)
@@ -151,7 +151,7 @@ theorem erdos_707.variants.perfect_difference_set_size_bound (B : Set ℕ) (n : 
   have := Set.Infinite.ncard hfin; omega
 
 /--
-The Singer construction gives perfect difference sets for `n = p^2 + p + 1` where `p` is a
+The Singer construction gives perfect difference sets for $n = p^2 + p + 1$ where $p$ is a
 prime power.
 -/
 @[category textbook, AMS 5 11]
@@ -162,7 +162,7 @@ theorem erdos_707.variants.singer_construction (p : ℕ) (hp : IsPrimePow p) :
 /-  ## Examples and special cases -/
 
 /--
-The set `{1, 2, 4}` is a Sidon set.
+The set ${1, 2, 4}$ is a Sidon set.
 -/
 @[category textbook, AMS 5 11]
 theorem erdos_707.variants.example_sidon_set : IsSidon ({1, 2, 4} : Set ℕ) := by
@@ -175,7 +175,7 @@ theorem erdos_707.variants.example_sidon_set : IsSidon ({1, 2, 4} : Set ℕ) := 
   simp_all
 
 /--
-The set `{1, 2, 4}` can be embedded in a perfect difference set modulo 7.
+The set ${1, 2, 4}$ can be embedded in a perfect difference set modulo 7.
 -/
 @[category textbook, AMS 5 11]
 theorem erdos_707.variants.example_embedding : ∃ (B : Set ℕ), {1, 2, 4} ⊆ B ∧

--- a/FormalConjectures/ErdosProblems/74.lean
+++ b/FormalConjectures/ErdosProblems/74.lean
@@ -67,8 +67,8 @@ def SimpleGraph.subgraphEdgeDistsToBipartite (G : SimpleGraph V) (n : ℕ) : Set
     (A : Subgraph G) (_ : A.verts.ncard = n) (_ : A.verts.Finite) }
 
 /--
-The set of minimum edge distances to bipartite for subgraphs of size `n` is bounded above.
-A graph on `n` vertices has at most `n choose 2` edges, and deleting all of them
+The set of minimum edge distances to bipartite for subgraphs of size $n$ is bounded above.
+A graph on $n$ vertices has at most $n choose 2$ edges, and deleting all of them
 makes the graph bipartite, providing a straightforward upper bound.
 -/
 @[category test, AMS 5]

--- a/FormalConjectures/ErdosProblems/75.lean
+++ b/FormalConjectures/ErdosProblems/75.lean
@@ -28,9 +28,9 @@ open Cardinal
 namespace Erdos75
 
 /--
-Is there a graph of chromatic number `ℵ_ 1` with `ℵ_ 1` vertices such that for all
-`ε > 0`, if `n` is sufficiently large and `H` is a subgraph on `n` vertices,
-then `H` contains an independent set of size `> n ^ (1 - ε)`?
+Is there a graph of chromatic number $ℵ_ 1$ with $ℵ_ 1$ vertices such that for all
+$ε > 0$, if $n$ is sufficiently large and $H$ is a subgraph on $n$ vertices,
+then $H$ contains an independent set of size $> n ^ (1 - ε)$?
 -/
 @[category research open, AMS 5]
 theorem erdos_75 :

--- a/FormalConjectures/ErdosProblems/757.lean
+++ b/FormalConjectures/ErdosProblems/757.lean
@@ -41,12 +41,12 @@ theorem erdos_757 {A : Set ℝ} :
     answer(sorry) = sSup {c | IsAdmissible c} := by
   sorry
 
-/-- The supremum is strictly larger than `1 / 2`, which is proved in [GyLe95]. -/
+/-- The supremum is strictly larger than $1 / 2$, which is proved in [GyLe95]. -/
 @[category research solved, AMS 5]
 theorem erdos_757.variants.lowerBound {A : Set ℝ} : 1 / (2 : ℝ) < sSup {c | IsAdmissible c} := by
   sorry
 
-/-- In [GyLe95], the authors also prove that the supremum is smaller than `3 / 5`. -/
+/-- In [GyLe95], the authors also prove that the supremum is smaller than $3 / 5$. -/
 @[category research solved, AMS 5]
 theorem erdos_757.variants.upperBound {A : Set ℝ} : sSup {c | IsAdmissible c} < 3 / (5 : ℝ) := by
   sorry

--- a/FormalConjectures/ErdosProblems/770.lean
+++ b/FormalConjectures/ErdosProblems/770.lean
@@ -37,37 +37,37 @@ are collectively coprime. -/
 noncomputable def h (n : ℕ) : ℕ∞ := sInf {m | 2 < m ∧
   ((Finset.Icc 2 m.toNat).image fun i => (i ^ n - 1)).gcd id = 1}
 
-/-- `n + 1` is prime iff `h n = n + 1`. This is described as 'easy to see' in [Er74b]. -/
+/-- $n + 1$ is prime iff $h n = n + 1$. This is described as 'easy to see' in [Er74b]. -/
 @[category textbook, AMS 11]
 theorem Nat.Prime.h_eq_add_one {n : ℕ} (hn : 2 < n) : h n = n + 1 ↔ (n + 1).Prime := by
   sorry
 
-/-- For odd `n`, the values of `h n` form an unbounded set.
+/-- For odd $n$, the values of `h n` form an unbounded set.
 This is described as 'easy to see' in [Er74b]. -/
 @[category textbook, AMS 11]
 theorem erdos_770.variants.odd_h_unbounded : Unbounded (· ≤ ·) (ENat.toNat '' (h '' Odd)):= by
   sorry
 
 
-/-- For every prime `p`, does the density of integers with `h n = p` exist? -/
+/-- For every prime $p$, does the density of integers with $h n = p$ exist? -/
 @[category research open, AMS 11]
 theorem erdos_770.parts.i : answer(sorry) ↔ ∀ p : ℕ, p.Prime → ∃ a, HasDensity {n | h n = p} a := by
   sorry
 
-/-- Does `liminf h n = ∞`? -/
+/-- Does $liminf h n = ∞$? -/
 @[category research open, AMS 11]
 theorem erdos_770.parts.ii : answer(sorry) ↔ liminf h atTop = ⊤ := by
   sorry
 
-/-- Is it true that if `p` is the greatest prime such that `p - 1 ∣ n` and `p > n ^ ε`, then
-`h n = p`? -/
+/-- Is it true that if $p$ is the greatest prime such that $p - 1 ∣ n$ and $p > n ^ ε$, then
+$h n = p$? -/
 @[category research open, AMS 11]
 theorem erdos_770.parts.iii : answer(sorry) ↔ ∀ ε > 0, ∀ᶠ n in atTop,
     let p := sSup {m : ℕ | m.Prime ∧ m - 1 ∣ n}
     p > (n : ℝ) ^ (ε : ℝ) → h n = p := by
   sorry
 
-/-- It is probably true that `h n = 3` for infinitely many `n`. -/
+/-- It is probably true that $h n = 3$ for infinitely many $n$. -/
 @[category research open, AMS 11]
 theorem erdos_770.variants.three : {n | h n = 3}.Infinite := by
   sorry

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -104,7 +104,7 @@ lemma consecutivePrimesFrom_two_one : consecutivePrimesFrom 2 1 = {2, 3} := by
 -- Reworded slightly using https://users.renyi.hu/~p_erdos/1969-14.pdf p. 81
 -- See https://users.renyi.hu/~p_erdos/1965-02.pdf p. 182 for the multiplicity one condition
 /--
-Let $\epsilon > 0$ be given. Then, for a sufficiently large prime `p`, take the sequence of
+Let $\epsilon > 0$ be given. Then, for a sufficiently large prime $p$, take the sequence of
 consecutive primes $p_1 < \cdots < p_k$ such that
 $$
 \sum_{i=1}^k \frac{1}{p_i} < 1 < \sum_{i=1}^{k + 1} \frac{1}{p_i},

--- a/FormalConjectures/ErdosProblems/835.lean
+++ b/FormalConjectures/ErdosProblems/835.lean
@@ -155,7 +155,7 @@ theorem johnsonGraph_chromaticNumber_odd_of_johnson_chromaticNumber_composite :
   · exact even_iff_two_dvd.mp (Odd.add_one h_odd)
   · omega
 
-/-- Is the chromatic number of `J(2 * k, k)` always at least `k + 2`? -/
+/-- Is the chromatic number of $J(2 * k, k)$ always at least $k + 2$? -/
 @[category research open, AMS 5]
 theorem johnson_chromaticNumber : answer(sorry) ↔
     ∀ k ≥ 3, k + 2 ≤ J(2 * k, k).chromaticNumber :=

--- a/FormalConjectures/ErdosProblems/846.lean
+++ b/FormalConjectures/ErdosProblems/846.lean
@@ -43,11 +43,11 @@ end Prelims
 
 /--
 **Erdős Problem 846**
-Let `A ⊂ ℝ²` be an infinite set for which there exists some `ϵ>0` such that in any subset of `A`
-of size `n` there are always at least `ϵn` with no three on a line.
-Is it true that `A` is the union of a finite number of sets where no three are on a line?
+Let $A ⊂ ℝ²$ be an infinite set for which there exists some $ϵ>0$ such that in any subset of $A$
+of size $n$ there are always at least `ϵn` with no three on a line.
+Is it true that $A$ is the union of a finite number of sets where no three are on a line?
 
-In other words, prove or disprove the following statement: every infinite `ε`-non-trilinear subset of the
+In other words, prove or disprove the following statement: every infinite $ε$-non-trilinear subset of the
 plane is weakly non-trilinar.
 -/
 @[category research solved, AMS 11, formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/2404258180688283e5141021c75464dc2acfb798/FormalConjectures/ErdosProblems/846.lean"]

--- a/FormalConjectures/ErdosProblems/848.lean
+++ b/FormalConjectures/ErdosProblems/848.lean
@@ -52,7 +52,7 @@ def Erdos848For (N : ℕ) : Prop :=
 /-- Is the maximum size of a set $A ⊆ \{1, \dots, N\}$ such that $ab + 1$ is never squarefree
 (for all $a, b ∈ A$) achieved by taking those $n ≡ 7 \pmod{25}$?
 
-This asks whether `Erdos848 N` holds for all $N$ (formulated using `A ⊆ Finset.range N`).
+This asks whether `Erdos848 N` holds for all $N$ (formulated using $A ⊆ Finset.range N$).
 
 This was solved for all sufficiently large $N$ by Sawhney in this note. In fact, Sawhney proves
 something slightly stronger, that there exists some constant $c>0$ such that if

--- a/FormalConjectures/ErdosProblems/851.lean
+++ b/FormalConjectures/ErdosProblems/851.lean
@@ -33,9 +33,9 @@ prime divisors.
 def TwoPowAddSet (r : ℕ) := {(2 ^ k + n) | (k : ℕ) (n : ℕ) (_ : n.primeFactors.card ≤ r)}
 
 /--
-The set of integers of the form `2^k+p` (where `p` is prime) has positive lower density.
+The set of integers of the form $2^k+p$ (where $p$ is prime) has positive lower density.
 
-Formalisation note: here we also allow `p = 1` since this simplifies the code and is equivalent
+Formalisation note: here we also allow $p = 1$ since this simplifies the code and is equivalent
 to the original statement.
 -/
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/859.lean
+++ b/FormalConjectures/ErdosProblems/859.lean
@@ -33,8 +33,8 @@ def DivisorSumSet (t : ℕ) := { n : ℕ | ∃ s ⊆ Nat.divisors n, t = ∑ i �
 open Asymptotics Filter
 
 /-- A weaker version of the problem proved by Erdos:
-The density `dₜ` of `DivisorSumSet (t : ℕ)` is bounded from below by `1 / log (t) ^ c₃` and
-from above by `1 / log (t) ^ c₄` for some positive constants `c₃` and `c₄`.
+The density $dₜ$ of $DivisorSumSet (t : ℕ)$ is bounded from below by $1 / log (t) ^ c₃$ and
+from above by $1 / log (t) ^ c₄$ for some positive constants $c₃$ and $c₄$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_859.variants.erdos_upper_lower_bounds : ∃ᵉ (c₃ > (0 : ℝ)) (c₄ > (0 : ℝ)) (t₀ : ℕ),
@@ -56,14 +56,14 @@ theorem erdos_859 :
   sorry
 
 /--
-A case where we can easily calculate the density of `DivisorSumSet t` is that of `t=0`.
+A case where we can easily calculate the density of `DivisorSumSet t` is that of $t=0$.
 -/
 @[category textbook, AMS 11]
 lemma erdos_859.variants.trivial_case : DivisorSumSet 0 = Set.univ := by
   simp [DivisorSumSet, Exists.intro ∅]
 
 /--
-An easy sanity check is to prove that for every natural number `t` the density `dₜ` is
+An easy sanity check is to prove that for every natural number $t$ the density $dₜ$ is
 a positive number.
 Hint: investigate some multiplicative structure of `DivisorSumSet t`.
 -/

--- a/FormalConjectures/ErdosProblems/881.lean
+++ b/FormalConjectures/ErdosProblems/881.lean
@@ -40,11 +40,11 @@ def IsMinimalAsymptoticAddBasisOfOrder (k : ℕ) (A : Set ℕ) : Prop :=
     ∀ ⦃B : Set ℕ⦄, B ⊆ A → B.Infinite → ¬ (A \ B).IsAsymptoticAddBasisOfOrder k
 
 /--
-Let `A ⊂ ℕ` be an additive basis of order `k` which is minimal in the sense that
-if `B ⊂ A` is any infinite set, then `A \ B` is not a basis of order `k`.
+Let $A ⊂ ℕ$ be an additive basis of order $k$ which is minimal in the sense that
+if $B ⊂ A$ is any infinite set, then `A \ B` is not a basis of order $k$.
 
-Must there exist an infinite `B ⊂ A` such that `A \ B`
-is an additive basis of order `k + 1`?
+Must there exist an infinite $B ⊂ A$ such that `A \ B`
+is an additive basis of order $k + 1$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_881 :

--- a/FormalConjectures/ErdosProblems/884.lean
+++ b/FormalConjectures/ErdosProblems/884.lean
@@ -50,7 +50,7 @@ in increasing order.
 Does it hold that
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \ll 1 + \sum_{1 \le i < \tau(n)}
  \frac{1}{d_{i + 1} - d_i}$
-for $n \to \infty`, i.e.
+for $n \to \infty$, i.e.
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \in O \left( 1 + \sum_{1 \le i < \tau(n)}
  \frac{1}{d_{i + 1} - d_i}) \right)$?
 
@@ -68,7 +68,7 @@ in increasing order.
 Does it hold that
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \ll 1 + \sum_{1 \le i < \tau(n)}
  \frac{1}{d_{i + 1} - d_i}$
-for $n \to \infty`, i.e.
+for $n \to \infty$, i.e.
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \in O \left( 1 + \sum_{1 \le i < \tau(n)}
  \frac{1}{d_{i + 1} - d_i}) \right)$?
 

--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -38,18 +38,18 @@ and cardinality `k` exists. -/
 def p (n : ℕ) (k : ℕ) : Prop := ∃ A : Finset ℕ, RequiredCondition A n ∧ A.card = k
 
 
-/-- What is the size of the largest subset `A` of `{1,...,n}` such that if
-`a ≤ b ≤ c ≤ d ∈ A` and `abcd` square then `ad=bc` -/
+/-- What is the size of the largest subset $A$ of ${1,...,n}$ such that if
+$a ≤ b ≤ c ≤ d ∈ A$ and `abcd` square then $ad=bc$ -/
 @[category research open, AMS 11]
 theorem erdos_888 : ∀ n, Nat.findGreatest (p n) n = (answer(sorry) : ℕ → ℕ) n := by
   sorry
 
-/--`|A|=o(n)`. -/
+/--$|A|=o(n)$. -/
 @[category research solved, AMS 11]
 theorem erdos_888.variants.sarkozy : (fun n ↦ (Nat.findGreatest (p n) n : ℝ)) =o[atTop] (Nat.cast : ℕ → ℝ) := by
   sorry
 
-/-- The primes show that `|A| ≫ n/log n` is possible. -/
+/-- The primes show that $|A| ≫ n/log n$ is possible. -/
 @[category research solved, AMS 11]
 theorem erdos_888.variants.primes : (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ )) ≫ (fun n : ℕ ↦ n / (n : ℝ).log) := by
   sorry

--- a/FormalConjectures/ErdosProblems/906.lean
+++ b/FormalConjectures/ErdosProblems/906.lean
@@ -24,8 +24,8 @@ import FormalConjectures.Util.ProblemImports
 
 namespace Erdos906
 
-/-- Does there exists an entire non-zero transcendental function `f : ℂ → ℂ` such that for any
-sequence `n₀ < n₁ < ...`, `{ z | ∃ k, iteratedDeriv (n k) f z = 0 }` is dense. -/
+/-- Does there exists an entire non-zero transcendental function $f : ℂ → ℂ$ such that for any
+sequence $n₀ < n₁ < ...$, ${ z | ∃ k, iteratedDeriv (n k) f z = 0 }$ is dense. -/
 @[category research open, AMS 30]
 theorem erdos_906 : answer(sorry) ↔ ∃ f : ℂ → ℂ, Transcendental (Polynomial ℂ) f ∧
     Differentiable ℂ f ∧ ∀ n : ℕ → ℕ, StrictMono n →

--- a/FormalConjectures/ErdosProblems/92.lean
+++ b/FormalConjectures/ErdosProblems/92.lean
@@ -52,8 +52,8 @@ noncomputable def possible_f_values (n : ℕ) : Set ℕ :=
   {k | ∃ (points : Finset ℝ²) (_ : points.card = n), hasMinEquidistantProperty k points}
 
 /--
-A sanity check to ensure the set of possible `f(n)` values is bounded above. A trivial bound is
-`n-1`, since any point can have at most `n-1` other points equidistant from it.
+A sanity check to ensure the set of possible $f(n)$ values is bounded above. A trivial bound is
+$n-1$, since any point can have at most $n-1$ other points equidistant from it.
 This ensures `sSup` is well-defined.
 -/
 @[category test, AMS 52]

--- a/FormalConjectures/ErdosProblems/939.lean
+++ b/FormalConjectures/ErdosProblems/939.lean
@@ -27,10 +27,10 @@ namespace Erdos939
 
 /--
 A set `S` belongs to `Erdos939Sums r` if it meets the following criteria:
-- The size of the set is `$|S| = r - 2$`.
+- The size of the set is $|S| = r - 2$.
 - The elements of the set are coprime (their greatest common divisor is 1).
-- Every element in `S` is an `$r$-powerful` number.
-- The sum of the elements in `S`, i.e., `$\sum_{s \in S} s$`, is also an `$r$-powerful` number.
+- Every element in $S$ is an $r$-powerful number.
+- The sum of the elements in $S$, i.e., $\sum_{s \in S} s$, is also an $r$-powerful number.
 -/
 def Erdos939Sums (r : ℕ) :=
     {S : Finset ℕ | S.card = r - 2 ∧ S.Coprime ∧ r.Full (∑ s ∈ S, s) ∧ ∀ s ∈ S, r.Full s}

--- a/FormalConjectures/ErdosProblems/946.lean
+++ b/FormalConjectures/ErdosProblems/946.lean
@@ -41,7 +41,7 @@ namespace Erdos946
 
 /--
 There are infinitely many $n$ such that $τ(n) = τ(n+1)$. Proved in [He84].
-Here τ is the divisor counting function, which is `σ 0` in mathlib.
+Here τ is the divisor counting function, which is $σ 0$ in mathlib.
 -/
 @[category research solved, AMS 11]
 theorem erdos_946 : {n : ℕ | σ 0 n = σ 0 (n + 1)}.Infinite := by

--- a/FormalConjectures/ErdosProblems/951.lean
+++ b/FormalConjectures/ErdosProblems/951.lean
@@ -36,7 +36,7 @@ at least one apart. -/
 def Erdos951Prop (a : ℕ → ℝ) : Prop :=
   ∀ (k ℓ : ℕ →₀ ℕ), k ≠ ℓ → |beurlingInteger a k - beurlingInteger a ℓ| ≥ 1
 
-/-- If `a` has property `Erdos951Prop` and `1 < a 0`, then `a` is a set of Beurling
+/-- If $a$ has property `Erdos951Prop` and $1 < a 0$, then $a$ is a set of Beurling
 prime numbers. -/
 @[category API, AMS 11]
 theorem erdos_951.variants.isBeurlingPrimes {a : ℕ → ℝ} (ha : 1 < a 0)
@@ -54,15 +54,16 @@ theorem erdos_951.variants.isBeurlingPrimes {a : ℕ → ℝ} (ha : 1 < a 0)
     simpa using he (.single (N + 1) 1) (.single N 1) (by simpa [Finsupp.ext_iff] using ⟨N, by simp⟩)
   linarith [abs_lt.1 (hN N le_rfl), abs_lt.1 (hN (N + 1) (by grind))]
 
-/-- If `1 < a 0 < ...` has property `Erdos951Prop`, is it true that `#{a i ≤ x} ≤ π x`? -/
+/-- If $1 < a_0 < \cdots$ has property `Erdos951Prop`, is it true that
+$\#\{i : a_i \le x\} \le \pi x$? -/
 @[category research open, AMS 11]
 theorem erdos_951 : answer(sorry) ↔
     ∀ a : ℕ → ℝ, 1 < a 0 → StrictMono a → Erdos951Prop a →
       ∀ᶠ (x : ℝ) in Filter.atTop, {i : ℕ | a i ≤ x}.ncard ≤ π ⌊x⌋₊ := by
   sorry
 
-/-- Beurling conjectured that if the number of Beurling integer in `[1, x]`
-is `x + o(log x)`, then `a` must be the sequence of primes. -/
+/-- Beurling conjectured that if the number of Beurling integer in $[1, x]$
+is $x + o(log x)$, then $a$ must be the sequence of primes. -/
 @[category research solved, AMS 11]
 theorem erdos_951.variants.beurling :
     ∀ a : ℕ → ℝ, IsBeurlingPrimes a →

--- a/FormalConjectures/ErdosProblems/968.lean
+++ b/FormalConjectures/ErdosProblems/968.lean
@@ -19,12 +19,12 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 968
 
-Let `uₙ = pₙ / n`, where `pₙ` is the `n`th prime. Does the set of `n` such that `uₙ < uₙ₊₁`
+Let $uₙ = pₙ / n$, where $pₙ$ is the $n$th prime. Does the set of $n$ such that $uₙ < uₙ₊₁$
 have positive density?
 
-Erdős and Prachar also proved that `∑_{pₙ < x} |uₙ₊₁ - uₙ| ≍ (log x)^2`, and that the set of `n`
-such that `uₙ > uₙ₊₁` has positive density. Erdős also asked whether there are infinitely many
-increasing triples `uₙ < uₙ₊₁ < uₙ₊₂` or decreasing triples `uₙ > uₙ₊₁ > uₙ₊₂`.
+Erdős and Prachar also proved that $∑_{pₙ < x} |uₙ₊₁ - uₙ| ≍ (log x)^2$, and that the set of $n$
+such that $uₙ > uₙ₊₁$ has positive density. Erdős also asked whether there are infinitely many
+increasing triples $uₙ < uₙ₊₁ < uₙ₊₂$ or decreasing triples $uₙ > uₙ₊₁ > uₙ₊₂$.
 
 *Reference:* [erdosproblems.com/968](https://www.erdosproblems.com/968)
 
@@ -48,16 +48,16 @@ noncomputable def u (n : ℕ) : ℝ :=
   (n.nth Nat.Prime : ℝ) / (n + 1)
 
 /--
-Does the set `{n | u n < u (n+1)}` have positive natural density?
+Does the set ${n | u n < u (n+1)}$ have positive natural density?
 -/
 @[category research open, AMS 11]
 theorem erdos_968 : answer(sorry) ↔ {n : ℕ | u n < u (n + 1)}.HasPosDensity := by
   sorry
 
 /--
-Erdős and Prachar proved `∑_{pₙ < x} |u (n+1) - u n| ≍ (log x)^2` (see [ErPr61]).
+Erdős and Prachar proved $∑_{pₙ < x} |u (n+1) - u n| ≍ (log x)^2$ (see [ErPr61]).
 
-We encode `∑_{pₙ < x}` as a sum over `n < Nat.primeCounting' x` (the number of primes `< x`).
+We encode $∑_{pₙ < x}$ as a sum over $n < Nat.primeCounting' x$ (the number of primes $< x$).
 -/
 @[category research solved, AMS 11]
 theorem erdos_968.variants.sum_abs_diff_isTheta_log_sq :
@@ -67,7 +67,7 @@ theorem erdos_968.variants.sum_abs_diff_isTheta_log_sq :
   sorry
 
 /--
-Erdős and Prachar proved that the set `{n | u n > u (n+1)}` has positive natural density
+Erdős and Prachar proved that the set ${n | u n > u (n+1)}$ has positive natural density
 (see [ErPr61]).
 -/
 @[category research solved, AMS 11]
@@ -76,7 +76,7 @@ theorem erdos_968.variants.decreasingSteps_hasPosDensity :
   sorry
 
 /--
-Erdős asked whether there are infinitely many solutions to `uₙ < uₙ₊₁ < uₙ₊₂`.
+Erdős asked whether there are infinitely many solutions to $uₙ < uₙ₊₁ < uₙ₊₂$.
 -/
 @[category research open, AMS 11]
 theorem erdos_968.variants.infinite_increasingTriples :
@@ -84,7 +84,7 @@ theorem erdos_968.variants.infinite_increasingTriples :
   sorry
 
 /--
-Erdős asked whether there are infinitely many solutions to `uₙ > uₙ₊₁ > uₙ₊₂`.
+Erdős asked whether there are infinitely many solutions to $uₙ > uₙ₊₁ > uₙ₊₂$.
 -/
 @[category research open, AMS 11]
 theorem erdos_968.variants.infinite_decreasingTriples :

--- a/FormalConjectures/ErdosProblems/971.lean
+++ b/FormalConjectures/ErdosProblems/971.lean
@@ -31,9 +31,9 @@ noncomputable def leastCongruentPrime (a d : ℕ) : ℕ :=
   sInf {p : ℕ | p.Prime ∧ p ≡ a [MOD d]}
 
 /--
-Let `p(a, d)` be the least prime congruent to `a (mod d)`.
-Does there exist a constant `c > 0` such that for all large `d`,
-`p(a, d) > (1 + c) * φ(d) * log d` for `≫ φ(d)` many values of `a`?
+Let $p(a, d)$ be the least prime congruent to $a (mod d)$.
+Does there exist a constant $c > 0$ such that for all large $d$,
+$p(a, d) > (1 + c) * φ(d) * log d$ for $≫ φ(d)$ many values of $a$?
 -/
 @[category research open, AMS 11]
 theorem erdos_971 : answer(sorry) ↔
@@ -43,7 +43,7 @@ theorem erdos_971 : answer(sorry) ↔
   sorry
 
 /--
-Erdős [Er49c] proved that the statement in `erdos_971` holds for infinitely many values of `d`.
+Erdős [Er49c] proved that the statement in `erdos_971` holds for infinitely many values of $d$.
 
 [Er49c] Erdős, P., _On some applications of Brun's method_. Acta Univ. Szeged. Sect. Sci. Math.
 (1949), 57--63.
@@ -57,8 +57,8 @@ theorem erdos_971.variants.infinite_sequence :
   sorry
 
 /--
-Erdős [Er49c] proved that for any `ε > 0` we have `p(a, d) < ε * φ(d) * log d` for `≫_ε φ(d)` many
-values of `a` (for all large `d`).
+Erdős [Er49c] proved that for any $ε > 0$ we have $p(a, d) < ε * φ(d) * log d$ for $≫_ε φ(d)$ many
+values of $a$ (for all large $d$).
 
 [Er49c] Erdős, P., _On some applications of Brun's method_. Acta Univ. Szeged. Sect. Sci. Math.
 (1949), 57--63.

--- a/FormalConjectures/ErdosProblems/978.lean
+++ b/FormalConjectures/ErdosProblems/978.lean
@@ -30,18 +30,18 @@ open Polynomial Set
 
 namespace Erdos978
 
-/-- Let `f ∈ ℤ[X]` be an irreducible polynomial with positive leading coefficient. Suppose that the
-degree `k` of `f` is larger than `2` and is not equal to a power of `2`. Then the set of `n` such
-that `f n` is `(k - 1)`-th power free is infinite, and this is proved in [Er53]. -/
+/-- Let $f ∈ ℤ[X]$ be an irreducible polynomial with positive leading coefficient. Suppose that the
+degree $k$ of $f$ is larger than $2$ and is not equal to a power of $2$. Then the set of $n$ such
+that `f n` is $(k - 1)$-th power free is infinite, and this is proved in [Er53]. -/
 @[category research solved, AMS 11]
 theorem erdos_978.variants.sub_one {f : ℤ[X]} (hi : Irreducible f) (hd : 2 < f.natDegree)
     (hp : ∀ (x : ℕ), f.natDegree ≠ 2 ^ x) (hlc : 0 < f.leadingCoeff) :
     {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))}.Infinite := by
   sorry
 
-/-- Let `f ∈ ℤ[X]` be an irreducible polynomial with positive leading coefficient. Suppose that the
-degree `k` of `f` is larger than `2`, is not equal to a power of `2`, and `f n` has no fixed
-`(k - 1)`-th power divisors other than `1`. Then the set of `n` such that `f n` is `(k - 1)`-th
+/-- Let $f ∈ ℤ[X]$ be an irreducible polynomial with positive leading coefficient. Suppose that the
+degree $k$ of $f$ is larger than $2$, is not equal to a power of $2$, and `f n` has no fixed
+$(k - 1)$-th power divisors other than $1$. Then the set of $n$ such that `f n` is $(k - 1)$-th
 power free has positive density, and this is proved in [Ho67]. -/
 @[category research solved, AMS 11]
 theorem erdos_978.parts.i {f : ℤ[X]} (hi : Irreducible f) (hd : 2 < f.natDegree)
@@ -50,8 +50,8 @@ theorem erdos_978.parts.i {f : ℤ[X]} (hi : Irreducible f) (hd : 2 < f.natDegre
     HasPosDensity {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))} := by
   sorry
 
-/-- If the degree `k` of `f` is larger than or equal to `9`, then the set of `n` such that `f n` is
-`(k - 2)`-th power free has infinitely many elements. This result is proved in [Br11]. -/
+/-- If the degree $k$ of $f$ is larger than or equal to $9$, then the set of $n$ such that `f n` is
+$(k - 2)$-th power free has infinitely many elements. This result is proved in [Br11]. -/
 @[category research solved, AMS 11]
 theorem erdos_978.variants.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : 9 ≤ f.natDegree)
     (hp : ∀ (p : ℕ), p.Prime → ∃ n : ℕ, ¬ (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
@@ -85,7 +85,7 @@ theorem erdos_978.parts.ii : answer(sorry) ↔
     {n : ℕ | Powerfree (f.natDegree - 2) (f.eval (n : ℤ))}.Infinite := by
   sorry
 
-/-- Does `n ^ 4 + 2` represent infinitely many squarefree numbers? -/
+/-- Does $n ^ 4 + 2$ represent infinitely many squarefree numbers? -/
 @[category research open, AMS 11]
 theorem erdos_978.parts.iii : answer(sorry) ↔ {n : ℕ | Squarefree (n ^ 4 + 2)}.Infinite := by
   sorry

--- a/FormalConjectures/ErdosProblems/996.lean
+++ b/FormalConjectures/ErdosProblems/996.lean
@@ -35,9 +35,9 @@ noncomputable def fourierPartial {T : ℝ} [hT : Fact (0 < T)] (f : Lp ℂ 2 (@h
     (k : ℕ) : AddCircle T → ℂ :=
   fun x => ∑ i ∈ Icc (-k : ℤ) k, fourierCoeff f k • fourier i x
 
-/-- Does there exists a positive constant `C` such that for all `f ∈ L²[0,1]` and all lacunary
-sequences `n`, if `‖f - fₖ‖₂ = O(1 / log log log k ^ C)`, then for almost every `x`,
-`lim ∑ k ∈ Finset.range N, f (n k • x)) / N = ∫ t, f t ∂t`? -/
+/-- Does there exists a positive constant $C$ such that for all $f ∈ L²[0,1]$ and all lacunary
+sequences $n$, if $‖f - fₖ‖₂ = O(1 / log log log k ^ C)$, then for almost every $x$,
+$lim ∑ k ∈ Finset.range N, f (n k • x)) / N = ∫ t, f t ∂t$? -/
 @[category research open, AMS 42]
 theorem erdos_996 : answer(sorry) ↔
     ∃ (C : ℝ), 0 < C ∧ ∀ (f : Lp ℂ 2 (haarAddCircle (T := 1))) (n : ℕ → ℕ),

--- a/FormalConjectures/GreensOpenProblems/35.lean
+++ b/FormalConjectures/GreensOpenProblems/35.lean
@@ -22,8 +22,8 @@ import FormalConjectures.Util.ProblemImports
 Estimate the infimum of the $L^p$ norm of the self-convolution of a nonnegative integrable
 function supported on $[0,1]$ with total integral $1$.
 
-We model a function `f : [0,1] → ℝ≥0` as a function `f : ℝ → ℝ` that is nonnegative, integrable,
-supported on `[0,1]`, and has total integral `1`.
+We model a function $f : [0,1] → ℝ≥0$ as a function $f : ℝ → ℝ$ that is nonnegative, integrable,
+supported on $[0,1]$, and has total integral $1$.
 
 *References:*
 - [Ben Green's Open Problem 35](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.35)
@@ -68,7 +68,7 @@ theorem green_35.upper :
 /-  Known bounds and comparisons. -/
 namespace variants
 
-/-- Lower bound for $c(2)$ from Green's first paper ([Gr01]); the constant is `sqrt(4/7)` (about 0.7559). -/
+/-- Lower bound for $c(2)$ from Green's first paper ([Gr01]); the constant is $sqrt(4/7)$ (about 0.7559). -/
 @[category research solved, AMS 26 28 42]
 theorem c_2_lower : ENNReal.ofReal (Real.sqrt (4 / 7)) ≤ c 2 := by
   sorry

--- a/FormalConjectures/GreensOpenProblems/37.lean
+++ b/FormalConjectures/GreensOpenProblems/37.lean
@@ -19,8 +19,8 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Ben Green's Open Problem 37
 
-What is the smallest subset of `ℕ` containing, for each `d = 1, …, N`,
-an arithmetic progression of length `k` with common difference `d`?
+What is the smallest subset of $ℕ$ containing, for each $d = 1, …, N$,
+an arithmetic progression of length $k$ with common difference $d$?
 
 *References:*
 - [Ben Green's Open Problem 37](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.37)
@@ -41,8 +41,8 @@ noncomputable def m (N k : ℕ) : ℕ :=
   sInf { m | ∃ A : Finset ℕ, A.card = m ∧ IsAPCover (A : Set ℕ) N k }
 
 /--
-Given a natural number `N`, what is the smallest size of a subset of `ℕ` that contains, for each `d = 1, …, N`,
-an arithmetic progression of length `k` with common difference `d`.
+Given a natural number $N$, what is the smallest size of a subset of $ℕ$ that contains, for each $d = 1, …, N$,
+an arithmetic progression of length $k$ with common difference $d$.
 -/
 @[category research open, AMS 5 11]
 theorem green_37 (N k : ℕ) :
@@ -50,27 +50,27 @@ theorem green_37 (N k : ℕ) :
   sorry
 
 /--
-Asymptotic version: determine the asymptotic behavior of `m(N, k)` as `N` grows.
-The solver should determine what function `f : ℕ → ℝ` eventually equals `(fun N ↦ (m N k : ℝ))`.
+Asymptotic version: determine the asymptotic behavior of $m(N, k)$ as $N$ grows.
+The solver should determine what function $f : ℕ → ℝ$ eventually equals $(fun N ↦ (m N k : ℝ))$.
 -/
 @[category research open, AMS 5 11]
 theorem green_37_asymptotic (k : ℕ) :
     ∀ᶠ N in atTop, (m N k : ℝ) = (answer(sorry) : ℕ → ℝ) N := by
   sorry
 
-/-- Determine the asymptotic equivalence class (theta) of `m(N, k)`. -/
+/-- Determine the asymptotic equivalence class (theta) of $m(N, k)$. -/
 @[category research open, AMS 5 11]
 theorem green_37_theta (k : ℕ) :
     (fun N ↦ (m N k : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
-/-- Determine an upper bound (big O) for `m(N, k)`. -/
+/-- Determine an upper bound (big O) for $m(N, k)$. -/
 @[category research open, AMS 5 11]
 theorem green_37_bigO (k : ℕ) :
     (fun N ↦ (m N k : ℝ)) =O[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
-/-- Determine a strict upper bound (little o) for `m(N, k)`. -/
+/-- Determine a strict upper bound (little o) for $m(N, k)$. -/
 @[category research open, AMS 5 11]
 theorem green_37_littleO (k : ℕ) :
     (fun N ↦ (m N k : ℝ)) =o[atTop] (answer(sorry) : ℕ → ℝ) := by

--- a/FormalConjectures/GreensOpenProblems/50.lean
+++ b/FormalConjectures/GreensOpenProblems/50.lean
@@ -23,7 +23,7 @@ Suppose that $A \subset \mathbb{F}_2^n$ is a set of density $\alpha$. Does $10A$
 of some subspace of dimension at least $n - O(\log(1/\alpha))$?
 
 Here $kA$ denotes the $k$-fold iterated sumset, i.e., the set of all sums of $k$ elements from $A$
-(with repetition allowed). In `Mathlib`, this is denoted `k • A` using pointwise scalar
+(with repetition allowed). In `Mathlib`, this is denoted $k • A$ using pointwise scalar
 multiplication on sets.
 
 *Reference:* [Ben Green's Open Problem 50](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.6 Problem 50)
@@ -42,9 +42,9 @@ nonempty $A \subseteq \mathbb{F}_2^n$ with density $\alpha > 0$, the sumset $10A
 of some subspace of dimension at least $n - C \log_2(1/\alpha)$?
 
 The sumset $10A$ is defined as $\{a_1 + a_2 + \cdots + a_{10} : a_i \in A\}$, using the pointwise
-scalar multiplication notation `10 • A` where `•` denotes the iterated addition of a set.
+scalar multiplication notation $10 • A$ where $•$ denotes the iterated addition of a set.
 
-Note: We model $\mathbb{F}_2^n$ as `Fin n → ZMod 2`, which is an $n$-dimensional vector space
+Note: We model $\mathbb{F}_2^n$ as $Fin n → ZMod 2$, which is an $n$-dimensional vector space
 over $\mathbb{F}_2$.
 -/
 @[category research open, AMS 5 11]

--- a/FormalConjectures/GreensOpenProblems/94.lean
+++ b/FormalConjectures/GreensOpenProblems/94.lean
@@ -29,7 +29,7 @@ open Set MeasureTheory
 namespace Green94
 
 /--
-Let `A ⊂ R` be a set of positive outer measure. Does $A$ contain an affine copy of `{1, 1/2, 1/4, . . . }`?
+Let $A ⊂ R$ be a set of positive outer measure. Does $A$ contain an affine copy of ${1, 1/2, 1/4, . . . }$?
 
 The answer is "no".
 -/
@@ -41,7 +41,7 @@ theorem green_94_outer_measure :
   sorry
 
 /--
-Let `A ⊂ R` be a set of positive measure. Does $A$ contain an affine copy of `{1, 1/2, 1/4, . . . }`?
+Let $A ⊂ R$ be a set of positive measure. Does $A$ contain an affine copy of ${1, 1/2, 1/4, . . . }$?
 -/
 @[category research open, AMS 28]
 theorem green_94 :

--- a/FormalConjectures/HilbertProblems/5.lean
+++ b/FormalConjectures/HilbertProblems/5.lean
@@ -22,7 +22,7 @@ import FormalConjectures.Util.ProblemImports
 The **Hilbert–Smith conjecture** states that a locally compact topological group acting
 continuously and faithfully on a connected finite-dimensional topological manifold must be a
 Lie group. It remains open in general; Pardon proved it for 3-manifolds in 2013.
-An equivalent formulation: no p-adic integer group `ℤ_[p]` can act faithfully on any
+An equivalent formulation: no p-adic integer group $ℤ_[p]$ can act faithfully on any
 connected finite-dimensional topological manifold.
 
 *References:*
@@ -72,7 +72,7 @@ theorem hilbert_smith_conjecture
     AdmitsLieGroupStructure G := by
   sorry
 
-/-- The conjecture holds when `G` acts by isometries on a Riemannian manifold, since `G`
+/-- The conjecture holds when $G$ acts by isometries on a Riemannian manifold, since $G$
 embeds as a closed subgroup of the isometry group, which is a Lie group by Myers–Steenrod. -/
 @[category research solved, AMS 22 53 57 58]
 theorem hilbert_smith_conjecture.variants.riemannian
@@ -94,7 +94,7 @@ theorem hilbert_smith_conjecture.variants.dimension_three {X : Type*}
     AdmitsLieGroupStructure G := by
   sorry
 
-/-- Equivalent p-adic formulation: the p-adic integers `ℤ_[p]` cannot act continuously and
+/-- Equivalent p-adic formulation: the p-adic integers $ℤ_[p]$ cannot act continuously and
 faithfully on any connected finite-dimensional topological manifold. By the Gleason–Yamabe
 theorem, this is equivalent to `hilbert_smith_conjecture`. -/
 @[category research open, AMS 22 57 58]

--- a/FormalConjectures/Mathoverflow/1973.lean
+++ b/FormalConjectures/Mathoverflow/1973.lean
@@ -34,7 +34,7 @@ abbrev unitSphere (n : ℕ) : Set (EuclideanSpace ℝ (Fin (n + 1))) := Metric.s
 
 /--
 Does the 6-sphere admit a complex structure, i.e. an atlas of holomorphically compatible charts
-relating it to `EuclideanSpace ℂ (Fin 3)`?
+relating it to $EuclideanSpace ℂ (Fin 3)$?
 -/
 @[category research open, AMS 32]
 theorem mathoverflow_1973 :

--- a/FormalConjectures/Mathoverflow/34145.lean
+++ b/FormalConjectures/Mathoverflow/34145.lean
@@ -25,7 +25,7 @@ Can the unit square be covered by $1/k$-by-$1/(k+1)$ rectangles (across $1 \le k
 
 I am deliberately not requiring that the rotations can only be $0^\circ, 90^\circ, 180^\circ, \text{ or } 270^\circ$.
 
-Because of indexing, since `n : ℕ` starts at 0, we change the side lengths to $1 / (n + 1)$ and
+Because of indexing, since $n : ℕ$ starts at 0, we change the side lengths to $1 / (n + 1)$ and
 $1 / (n + 2)$, so that the first rectangle is $1/1$ by $1/2$, the second is $1/2$ by $1/3$, etc.
 
 *Reference:* [mathoverflow/34145](https://mathoverflow.net/q/34145)
@@ -72,7 +72,7 @@ def Rectangle.toSet (r : Rectangle) : Set (ℝ × ℝ) :=
 noncomputable abbrev lbMeasure : Measure (ℝ × ℝ) :=
   (Basis.finTwoProd ℝ).addHaar
 
-/-- `lbMeasure` is invariant under `rigidMotion start θ`. -/
+/-- `lbMeasure` is invariant under $rigidMotion start θ$. -/
 @[category test, AMS 51]
 lemma lbMeasure_rigidMotion (start : ℝ × ℝ) (θ : Angle) (s : Set (ℝ × ℝ)) :
     lbMeasure (rigidMotion start θ '' s) = lbMeasure s := by
@@ -99,7 +99,7 @@ lemma lbMeasure_scale (x y : ℝ) (s : Set (ℝ × ℝ)) :
     ext i j; unfold scaleLinear; fin_cases i <;> fin_cases j <;> simp [LinearMap.toMatrix_apply]
   simp [h₁, ← LinearMap.det_toMatrix (Basis.finTwoProd ℝ), h₂]
 
-/-- The Lebesgue measure of the unit square is `1`. -/
+/-- The Lebesgue measure of the unit square is $1$. -/
 @[category test, AMS 51]
 lemma lbMeasure_unitSquare : lbMeasure unitSquare = 1 := by
   convert (Basis.addHaar_eq_iff (Basis.finTwoProd ℝ) _).1 rfl
@@ -110,7 +110,7 @@ lemma lbMeasure_unitSquare : lbMeasure unitSquare = 1 := by
   exact ⟨fun h ↦ ⟨![p.1, p.2], by simp [Fin.forall_fin_succ, h]⟩,
     fun ⟨t, ht⟩ ↦ ht.2 ▸ ⟨ht.1.1 0, ht.1.2 0, ht.1.1 1, ht.1.2 1⟩⟩
 
-/-- The Lebesgue measure of the a rectangle `r` is `r.width * r.height` -/
+/-- The Lebesgue measure of the a rectangle $r$ is $r.width * r.height$ -/
 @[category test, AMS 51]
 lemma lbMeasure_rectangle_toSet (r : Rectangle) :
     lbMeasure r.toSet = .ofReal |r.width * r.height| := by
@@ -139,20 +139,20 @@ structure Configuration : Type where
 def Configuration.IsPacking (c : Configuration) : Prop :=
   Pairwise fun m n ↦ interior (c.rect m).toSet ∩ interior (c.rect n).toSet = ∅
 
-/-- Can a unit square be covered by rectangles of width `1 / (n + 1)` and height `1 / (n + 2)`? -/
+/-- Can a unit square be covered by rectangles of width $1 / (n + 1)$ and height $1 / (n + 2)$? -/
 @[category research open, AMS 51]
 theorem rectangles_cover_unit_square :
     answer(sorry) ↔ ∃ c : Configuration, ∀ p ∈ unitSquare, ∃ n, p ∈ (c.rect n).toSet := by
   sorry
 
-/-- Equivalently, can a unit square be packed with rectangles of width `1 / (n + 1)` and height
-`1 / (n + 2)`? -/
+/-- Equivalently, can a unit square be packed with rectangles of width $1 / (n + 1)$ and height
+$1 / (n + 2)$? -/
 @[category research open, AMS 51]
 theorem rectangles_pack_unit_square :
     answer(sorry) ↔ ∃ c : Configuration, (∀ n, (c.rect n).toSet ⊆ unitSquare) ∧ c.IsPacking := by
   sorry
 
-/-- It is known that packing the rectangles into a square of side length `133/132` is possible.
+/-- It is known that packing the rectangles into a square of side length $133/132$ is possible.
 
 Reference: https://www.sciencedirect.com/science/article/pii/0097316594901163
 -/
@@ -163,7 +163,7 @@ theorem rectangles_pack_square_133_div_132 :
       c.IsPacking) := by
   sorry
 
-/-- It is known that packing the rectangles into a square of side length `501/500` is possible.
+/-- It is known that packing the rectangles into a square of side length $501/500$ is possible.
 
 Reference: https://www.sciencedirect.com/science/article/pii/S0167506008706009
 -/

--- a/FormalConjectures/Mathoverflow/75792.lean
+++ b/FormalConjectures/Mathoverflow/75792.lean
@@ -19,13 +19,13 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Mathoverflow 75792
 
-Various questions about integer complexity, which is the minimum number of `1`s needed to express a natural number using addition, multiplication, and parentheses.
+Various questions about integer complexity, which is the minimum number of $1$s needed to express a natural number using addition, multiplication, and parentheses.
 
-Let `‖n‖` denote the integer complexity of `n > 0`.
-* It is known that `‖3^n‖ = 3n` for `n > 0`.
-* Is it true that `‖2^n‖ = 2n` for `n > 0`?
-* The corresponding conjecture for `5` is false, because
-  `5^6 = 15625 = 1 + 2^3 * 3^2 * (1 + 2^3 * 3^3)`!
+Let $‖n‖$ denote the integer complexity of $n > 0$.
+* It is known that $‖3^n‖ = 3n$ for $n > 0$.
+* Is it true that $‖2^n‖ = 2n$ for $n > 0$?
+* The corresponding conjecture for $5$ is false, because
+  $5^6 = 15625 = 1 + 2^3 * 3^2 * (1 + 2^3 * 3^3)$!
 
 We have chosen to formalise this using an inductive type.
 
@@ -179,7 +179,7 @@ theorem Reachable.pow (m n : ℕ) (hm : 0 < m) (hn : 0 < n) : Reachable (m ^ n) 
 theorem Reachable.pow' (m n : ℕ+) : Reachable (m ^ (n : ℕ) : ℕ) (m * n) :=
   .pow _ _ m.pos n.pos
 
-/-- `5^6 = 15625 = 1 + 2^3 * 3^2 * (1 + 2^3 * 3^3)`! -/
+/-- $5^6 = 15625 = 1 + 2^3 * 3^2 * (1 + 2^3 * 3^3)$! -/
 @[category test, AMS 11]
 theorem Reachable.five_pow_six : Reachable (5^6) 29 :=
   have h8 : Reachable 8 6 := .pow' 2 3
@@ -187,13 +187,13 @@ theorem Reachable.five_pow_six : Reachable (5^6) 29 :=
   have h27 : Reachable 27 9 := .pow' 3 3
   .add .one <| .mul h8 <| .mul h9 <| .add .one <| .mul h8 h27
 
-/-- Is `5n` the complexity of `5^n` for `0 < n`? Answer: No. -/
+/-- Is $5n$ the complexity of $5^n$ for $0 < n$? Answer: No. -/
 @[category research solved, AMS 11]
 theorem complexity_five_pow : answer(False) ↔ ∀ n : ℕ, 0 < n → complexity (5 ^ n) = 5 * n := by
   simp [false_iff, not_forall]
   exact ⟨6, by decide, fun h ↦ absurd (h ▸ Reachable.five_pow_six.complexity_le) (by decide)⟩
 
-/-- Is `3n` the complexity of `3^n` for `0 < n`? Answer: Yes, by John Selfridge.
+/-- Is $3n$ the complexity of $3^n$ for $0 < n$? Answer: Yes, by John Selfridge.
 
 Reference: https://arxiv.org/abs/1207.4841
 -/
@@ -201,7 +201,7 @@ Reference: https://arxiv.org/abs/1207.4841
 theorem complexity_three_pow : answer(True) ↔ ∀ n : ℕ, 0 < n → complexity (3 ^ n) = 3 * n := by
   sorry
 
-/-- Is `2n` the complexity of `2^n` for `0 < n`? -/
+/-- Is $2n$ the complexity of $2^n$ for $0 < n$? -/
 @[category research open, AMS 11]
 theorem complexity_two_pow : answer(sorry) ↔ ∀ n : ℕ, 0 < n → complexity (2 ^ n) = 2 * n := by
   sorry

--- a/FormalConjectures/Millenium/RiemannHypothesis.lean
+++ b/FormalConjectures/Millenium/RiemannHypothesis.lean
@@ -30,7 +30,7 @@ Dirichlet characters.
 Note: the **Extended Riemann Hypothesis** (ERH) for Dedekind zeta functions is intentionally
 **not** stated here. Mathlib's `NumberField.dedekindZeta` is the naive Dirichlet series
 (`LSeries`), not a meromorphic continuation; outside the region of absolute convergence
-`tsum` returns junk `0`, producing spurious zeros that make the naive foramlisation of the
+`tsum` returns junk $0$, producing spurious zeros that make the naive foramlisation of the
 conjecture provably false. The ERH should be added once Mathlib provides a meromorphic
 continuation of the Dedekind zeta function.
 
@@ -53,7 +53,7 @@ This is the official Millennium Prize Problem as posed by the
 [Clay Mathematics Institute](https://www.claymath.org/wp-content/uploads/2022/05/riemann.pdf).
 
 This uses the `RiemannHypothesis` type from Mathlib, which is defined as
-`∀ (s : ℂ), riemannZeta s = 0 → (¬∃ n : ℕ, s = -2 * (n + 1)) → s ≠ 1 → s.re = 1 / 2`. -/
+$∀ (s : ℂ), riemannZeta s = 0 → (¬∃ n : ℕ, s = -2 * (n + 1)) → s ≠ 1 → s.re = 1 / 2$. -/
 @[category research open, AMS 11]
 theorem riemannHypothesis : RiemannHypothesis := by
   sorry

--- a/FormalConjectures/OpenQuantumProblems/13.lean
+++ b/FormalConjectures/OpenQuantumProblems/13.lean
@@ -40,7 +40,7 @@ $\mu(d) := \max \{ k : \text{there exist } k \text{ pairwise mutually unbiased
 orthonormal bases in } \mathbb{C}^d \}$.
 
 In this file, an orthonormal basis is represented by a unitary matrix whose columns are the
-basis vectors. For two such bases `U` and `V`, the matrix `relativeUnitary U V`, which is
+basis vectors. For two such bases $U$ and $V$, the matrix `relativeUnitary U V`, which is
 $U^\dagger V$, contains all cross-basis overlaps as its entries. Since Lean works more
 smoothly with squared norms, we formalize mutual unbiasedness by requiring
 $\| (relativeUnitary\ U\ V)_{ij} \|^2 = 1 / d$
@@ -188,7 +188,7 @@ def phaseMatrix (ζ : ℂ) : Matrix (Fin 2) (Fin 2) ℂ :=
   !![1, 1;
     ζ, -ζ]
 
-/-- The squared norm of `ω` is $1/2$. -/
+/-- The squared norm of $ω$ is $1/2$. -/
 @[category API, AMS 5 15 81 94]
 lemma omega_norm_sq : ‖ω‖ ^ (2 : ℕ) = (2 : ℝ)⁻¹ := by
   rw [RCLike.norm_sq_eq_def]
@@ -398,7 +398,7 @@ lemma firstCol_normSq (U : UMat 2) :
   exact_mod_cast h00'
 
 /-- The real part of $z \overline{w}$ is the Euclidean dot product of the coordinate pairs of
-`z` and `w`. -/
+$z$ and $w$. -/
 @[category API, AMS 5 15 81 94]
 lemma re_mul_conj (z w : ℂ) :
     Complex.re (z * star w) = Complex.re z * Complex.re w + Complex.im z * Complex.im w := by

--- a/FormalConjectures/OpenQuantumProblems/23.lean
+++ b/FormalConjectures/OpenQuantumProblems/23.lean
@@ -29,7 +29,7 @@ existence of a symmetric informationally complete POVM in every finite dimension
 
 A SIC-POVM in dimension $d$ can be represented by a family of $d^2$ normalized
 vectors in $\mathbb{C}^d$ whose pairwise squared overlaps are all equal to
-$(d + 1)^{-1}$. We encode such a family as a map `Fin (d ^ 2) → StateVector d`.
+$(d + 1)^{-1}$. We encode such a family as a map $Fin (d ^ 2) → StateVector d$.
 
 ## Background
 SIC-POVMs are a basic structure in finite-dimensional quantum information.
@@ -45,15 +45,15 @@ More precisely, it contains the following layers.
 
 ### Core API
 The main definitions formalized in this file are:
-- `StateVector d`: a state vector in `ℂ^d`;
+- `StateVector d`: a state vector in $ℂ^d$;
 - `mkStateVector`: constructor from coordinates in the computational basis;
 - `IsNormalized ψ`: normalization predicate for a state vector;
-- `overlapSq φ ψ`: squared magnitude of the inner-product overlap;
+- $overlapSq φ ψ$: squared magnitude of the inner-product overlap;
 - `HasConstantOverlapSq c Φ`: constant pairwise squared-overlap condition;
-- `sicOverlapSq d`: the SIC overlap value `(d + 1)⁻¹`;
-- `IsSICFamily d Φ`: the predicate that a family of `d^2` vectors in `ℂ^d`
+- `sicOverlapSq d`: the SIC overlap value $(d + 1)⁻¹$;
+- `IsSICFamily d Φ`: the predicate that a family of $d^2$ vectors in $ℂ^d$
   is a SIC family;
-- `HasSICPOVM d`: existence of a SIC family in dimension `d`.
+- `HasSICPOVM d`: existence of a SIC family in dimension $d$.
 
 In addition, the file includes explicit witness families and convenient
 constructors used in the low-dimensional benchmark cases:
@@ -64,15 +64,15 @@ constructors used in the low-dimensional benchmark cases:
 
 ### Complete open conjecture
 The main open theorem is:
-- `sicPOVMs`, expressing the conjecture that for every `d ≥ 1`, there exists a
-  SIC-POVM in dimension `d`.
+- `sicPOVMs`, expressing the conjecture that for every $d ≥ 1$, there exists a
+  SIC-POVM in dimension $d$.
 
 ### Special cases
 The file also isolates several special cases:
 - solved low-dimensional benchmark cases:
   `hasSICPOVM_zero`, `hasSICPOVM_one`, `hasSICPOVM_two`, `hasSICPOVM_three`;
 - a negative benchmark result:
-  `bb84Family_not_isSICFamily`, showing that the BB84 family in dimension `2`
+  `bb84Family_not_isSICFamily`, showing that the BB84 family in dimension $2$
   does not form a SIC family;
 - selected open benchmark dimensions:
   `hasSICPOVM_56`, `hasSICPOVM_58`, `hasSICPOVM_59`, `hasSICPOVM_60`,

--- a/FormalConjectures/OpenQuantumProblems/35.lean
+++ b/FormalConjectures/OpenQuantumProblems/35.lean
@@ -62,13 +62,13 @@ This file formalizes the problem of determining for which pairs $(n,d)$ there ex
 absolutely maximally entangled pure state $\mathrm{AME}(n,d)$.
 
 We represent an $n$-partite state of local dimension $d$ by the finite-dimensional Hilbert space
-`EuclideanSpace ℂ (Config n d)`, whose coordinates in the computational basis are amplitudes.
+$EuclideanSpace ℂ (Config n d)$, whose coordinates in the computational basis are amplitudes.
 The helper `mkStateVector` turns an amplitude function into such a state, and normalization is
 imposed explicitly via `IsNormalized`, i.e. via the ambient $L^2$ norm.
 
 The main reusable lemma is `reducedDensityFirst_of_completion`: if a state is a
 uniform superposition over the graph of an injective completion function
-`completion : Config m d → Config (n - m) d`,
+$completion : Config m d → Config (n - m) d$,
 then the reduced state on the first $m$ parties is maximally mixed.
 
 As demonstration, we show that the Bell states with $n=2$ and GHZ states with $n=3$ are
@@ -304,7 +304,7 @@ theorem not_isConstantConfig_example :
 noncomputable def diagonalState (n d : ℕ) : StateVector n d :=
   mkStateVector fun x => if IsConstantConfig x then uniformCoeff d else 0
 
-/-- Evaluating the diagonal state returns the uniform coefficient on constant strings and `0` otherwise. -/
+/-- Evaluating the diagonal state returns the uniform coefficient on constant strings and $0$ otherwise. -/
 @[simp, category API, AMS 5 15 81 94]
 lemma diagonalState_apply {n d : ℕ} (x : Config n d) :
     diagonalState n d x = if IsConstantConfig x then uniformCoeff d else 0 := by

--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -56,10 +56,10 @@ The first 10 values of $(a_n, b_n)$ are $(1, 2), (3, 1), (2, 6), (5, 4), (1, 18)
 (7, 14), (15, 7), (8, 30), (17, 22)$.
 
 [BMO#1](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#1._1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE_(bbch)) is equivalent to asking whether the 6-state Turing machine
-[`1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE`](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
+[$1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE$](https://wiki.bbchallenge.org/wiki/1RB1RE_1LC0RA_0RD1LB_---1RC_1LF1RE_0LB0LE) halts or not.
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated
-using `answer(sorry) ↔`.
+using $answer(sorry) ↔$.
 
 The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor Jason Yuen on
 June 25th 2024.
@@ -85,7 +85,7 @@ with, so it might be solvable, although seems quite hard because of its Collatz-
 The underlying Collatz-like map has been studied independently in the past,
 see doi:[10.1017/S0017089508004655](https://doi.org/10.1017/S0017089508004655) (Corollary 4).
 
-It is equivalent to non-termination of the [`1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA`](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape). Note that the conjecture
+It is equivalent to non-termination of the [$1RB1RA_0LC1LE_1LD1LC_1LA0LB_1LF1RE_---0RA$](https://wiki.bbchallenge.org/wiki/Antihydra) 6-state Turing machine (from all-0 tape). Note that the conjecture
 that the machine does not halt is based on [a probabilistic argument](https://wiki.bbchallenge.org/wiki/Antihydra#Trajectory).
 
 This machine and its mathematical reformulations were found by [bbchallenge.org](bbchallenge.org)
@@ -129,7 +129,7 @@ a_{n-1}+2^{v_2(a_{n-1})+2}-1 & \text{if } n \ge 1
 for all non-negative integers $n$. Is there an integer $n$ such that $a_n=4^k$ for
 some positive integer $k$?
 
-[BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [`1RB0RB3LA4LA2RA_2LB3RA---3RA4RB`](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
+[BMO#3][https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#3._1RB0RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)_and_1RB1RB3LA4LA2RA_2LB3RA---3RA4RB_(bbch)] is equivalent to the non-termination of 2-state 5-symbol Turing machine [$1RB0RB3LA4LA2RA_2LB3RA---3RA4RB$](https://wiki.bbchallenge.org/wiki/1RB0RB3LA4LA2RA_2LB3RA---3RA4RB) (from all-0 tape).
 
 The machine was found and informally proven not to halt by [bbchallenge.org](bbchallenge.org)
 contributor Daniel Yuan on June 18th 2024; see [Discord discussion](https://discord.com/channels/960643023006490684/1084047886494470185/1252634913220591728).
@@ -158,7 +158,7 @@ becomes $1\text{ (mod 3)}$. If Bonnie sticks to her plan, will she ever finish?
 
 [BMO#4](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#4._1RB3RB---1LB0LA_2LA4RA3LA4RB1LB_(bbch))
 is equivalent to the non-termination of 2-state 5-symbol Turing machine
-[`1RB3RB---1LB0LA_2LA4RA3LA4RB1LB`](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
+[$1RB3RB---1LB0LA_2LA4RA3LA4RB1LB$](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) (from all-0 tape).
 
 The machine was informally proven not to halt [bbchallenge.org](bbchallenge.org)
 contributor Daniel Yuan on July 19th 2024; see [sketched proof](https://wiki.bbchallenge.org/wiki/1RB3RB---1LB0LA_2LA4RA3LA4RB1LB) and [Discord discussion](https://discord.com/channels/960643023006490684/960643023530762343/1263666591900631210).
@@ -187,10 +187,10 @@ where $f(x)=10\cdot 2^x-1$ for all non-negative integers $x$.
 Does there exist a positive integer $i$ such that $b_i = f(a_i)-1$?
 
 [BMO#5](https://wiki.bbchallenge.org/wiki/Beaver_Math_Olympiad#5._1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE_(bbch)) is equivalent to asking whether the 6-state Turing machine
-[`1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE`](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.
+[$1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE$](https://wiki.bbchallenge.org/wiki/1RB0LD_1LC0RA_1RA1LB_1LA1LE_1RF0LC_---0RE) halts or not.
 
 There is presently no consensus on whether the machine halts or not, hence the problem is formulated
-using `answer(sorry) ↔`.
+using $answer(sorry) ↔$.
 
 The machine was discovered by [bbchallenge.org](bbchallenge.org) contributor mxdys
 on August 7th 2024.

--- a/FormalConjectures/Other/SchurTruncatedExponential.lean
+++ b/FormalConjectures/Other/SchurTruncatedExponential.lean
@@ -44,11 +44,11 @@ noncomputable def truncatedExp (n : ℕ) : ℚ[X] :=
 
 /--
 **Schur's Theorem (1924):**
-Let `f_n(x) = ∑_{j=0}^n x^j/j!` be the `n`-th truncated
-exponential polynomial over `ℚ`. Then for `n ≥ 2`:
+Let $f_n(x) = ∑_{j=0}^n x^j/j!$ be the $n$-th truncated
+exponential polynomial over $ℚ$. Then for $n ≥ 2$:
 
-- If `n ≡ 0 (mod 4)`, the Galois group of `f_n` is isomorphic to the alternating group `A_n`
-- If `n ≢ 0 (mod 4)`, the Galois group of `f_n` is isomorphic to the symmetric group `S_n`
+- If $n ≡ 0 (mod 4)$, the Galois group of `f_n` is isomorphic to the alternating group `A_n`
+- If $n ≢ 0 (mod 4)$, the Galois group of `f_n` is isomorphic to the symmetric group `S_n`
 -/
 @[category research solved, AMS 12]
 theorem schur_truncatedExp_galoisGroup_equiv (n : ℕ) (hn : n ≥ 2) :

--- a/FormalConjectures/Paper/CasasAlvero.lean
+++ b/FormalConjectures/Paper/CasasAlvero.lean
@@ -22,16 +22,16 @@ import FormalConjectures.Util.ProblemImports
 * [The Casas-Alvero conjecture for infinitely many degrees](https://arxiv.org/pdf/math/0605090)
 * [MathOverflow](https://mathoverflow.net/questions/27851)
 
-The Casas-Alvero conjecture states that if a univariate polynomial `P` of degree `d` over a field
-of characteristic zero shares a non-trivial factor with its Hasse derivatives up to order `d-1`,
-then `P` must be of the form `(X - α)ᵈ` for some `α` in the field.
+The Casas-Alvero conjecture states that if a univariate polynomial $P$ of degree $d$ over a field
+of characteristic zero shares a non-trivial factor with its Hasse derivatives up to order $d-1$,
+then $P$ must be of the form $(X - α)ᵈ$ for some $α$ in the field.
 
 The conjecture has been proven for:
-* Degrees `d ≤ 8`
-* Degrees of the form `p^k` where `p` is prime
-* Degrees of the form `2p^k` where `p` is prime
+* Degrees $d ≤ 8$
+* Degrees of the form $p^k$ where $p$ is prime
+* Degrees of the form $2p^k$ where $p$ is prime
 
-The conjecture is false in positive characteristic `p` for polynomials of degree `p+1`.
+The conjecture is false in positive characteristic $p$ for polynomials of degree $p+1$.
 
 The conjecture is now claimed to be proven in this paper:
 * [Proof of the Casas-Alvero conjecture: Soham Ghosh)](https://arxiv.org/pdf/2501.09272)
@@ -116,8 +116,8 @@ variable [CharZero K] (P : K[X]) (hP : Monic P)
 include hP
 
 /--
-The Casas-Alvero conjecture states that in characteristic zero, if a monic polynomial `P`
-has the Casas-Alvero property, then `P = (X - α)ᵈ` for some `α`.
+The Casas-Alvero conjecture states that in characteristic zero, if a monic polynomial $P$
+has the Casas-Alvero property, then $P = (X - α)ᵈ$ for some $α$.
 -/
 @[category research open, AMS 12]
 theorem casas_alvero_conjecture (hP' : HasCasasAlveroProp P) :
@@ -136,7 +136,7 @@ theorem casas_alvero.prime_power (p k : ℕ) (hp : p.Prime) (hd : P.natDegree = 
   sorry
 
 /--
-The Casas-Alvero conjecture holds for polynomials of degree `2p^k` where `p` is prime.
+The Casas-Alvero conjecture holds for polynomials of degree $2p^k$ where $p$ is prime.
 This was proved by Graf von Bothmer, Labs, Schicho, and van de Woestijne.
 
 Reference: [The Casas-Alvero conjecture for infinitely many degrees](https://arxiv.org/pdf/math/0605090)
@@ -149,7 +149,7 @@ theorem casas_alvero.double_prime_power (p k : ℕ) (hp : p.Prime) (hd : P.natDe
 end conjecture
 
 /--
-The Casas-Alvero conjecture fails in positive characteristic `p` for polynomials of degree `p + 1`.
+The Casas-Alvero conjecture fails in positive characteristic $p$ for polynomials of degree $p + 1$.
 This was shown by Graf von Bothmer, Labs, Schicho, and van de Woestijne.
 
 Reference: [The Casas-Alvero conjecture for infinitely many degrees](https://arxiv.org/pdf/math/0605090)

--- a/FormalConjectures/Paper/CatchUpConjecture.lean
+++ b/FormalConjectures/Paper/CatchUpConjecture.lean
@@ -20,18 +20,18 @@ import FormalConjectures.Util.ProblemImports
 # The Catch-Up game and conjecture
 
 The game **Catch-Up** (Isaksen–Ismail–Brams–Nealen, 2015) is a two-player, perfect-information game
-played on a finite nonempty set `S` of positive integers. Each time a player removes a number from
-`S`, that number is added to the player’s score.
+played on a finite nonempty set $S$ of positive integers. Each time a player removes a number from
+$S$, that number is added to the player’s score.
 
 **Rules.**
-* The scores start at `0`. Player `p1` starts by removing **exactly one** number from `S`.
+* The scores start at $0$. Player `p1` starts by removing **exactly one** number from $S$.
 * After the first move, players alternate turns. On a turn, the current player removes **one or more**
-  numbers from `S`, one at a time, and must keep removing numbers until their score becomes
+  numbers from $S$, one at a time, and must keep removing numbers until their score becomes
   **at least** the opponent’s score; before the final pick they must remain **strictly behind**.
 * If the current player cannot catch up (in particular, even taking all remaining numbers would still
   leave them behind), the game ends immediately: the current player receives all remaining numbers.
 
-When `S` is empty, the player with higher score wins; equal scores give a draw.
+When $S$ is empty, the player with higher score wins; equal scores give a draw.
 
 In this file we define:
 * `Player` and `Outcome`,
@@ -39,8 +39,8 @@ In this file we define:
 * the conjecture `value_of_even_mul_succ_self_div_two`.
 
 ## Example
-For `S = {1,2,3,4}` one play is: `p1` takes `2`, `p2` takes `1` then `4`, and `p1` takes `3`,
-ending with scores `(5,5)`.
+For $S = {1,2,3,4}$ one play is: `p1` takes $2$, `p2` takes $1$ then $4$, and `p1` takes $3$,
+ending with scores $(5,5)$.
 
 ## References
 A. Isaksen, M. Ismail, S. J. Brams, A. Nealen,
@@ -105,7 +105,7 @@ Define the recursive game value functions.
 The result is the game-theoretic value from the current player’s point of view:
 `.win` / `.loss` / `.draw`, assuming optimal play from both sides.
 
-We model a single *turn* (which may consist of several picks `$x_1,...,x_k$`) by recursion:
+We model a single *turn* (which may consist of several picks $x_1,\ldots,x_k$) by recursion:
 the current player chooses one number `x`; if they are still strictly behind after taking it, they must
 continue the same turn (so the recursive call keeps the same “current player”);
 once they catch up (score ≥ opponent), the turn ends and we swap players.
@@ -125,13 +125,14 @@ noncomputable def valueAux (remaining : Finset ℕ) (s_me s_opp : ℕ) (isFirstM
   else
     -- Terminal rule / pruning:
     -- If even taking *all* remaining numbers would still leave the current player behind,
-    -- then there is no legal catch-up sequence (in the TeX: no `$x_1,...,x_k$` with final sum ≥ gap).
+    -- then there is no legal catch-up sequence (in the TeX: no $x_1,\ldots,x_k$
+    -- with final sum ≥ gap).
     -- By the rules, the current player takes everything and the game ends immediately,
     -- but under this inequality they must still lose.
     if s_me + remaining.sum (fun x => x) < s_opp then
       .loss
     else
-      -- Otherwise, the current player can pick some `$x \in$ remaining`.
+      -- Otherwise, the current player can pick some $x$ in `remaining`.
       -- We evaluate every possible next pick under optimal play, then take the best outcome.
       let moves := remaining.attach.toList
       let outcomes := moves.map (fun ⟨x, _⟩ =>
@@ -173,7 +174,7 @@ noncomputable def value (S : Finset ℕ) : Outcome :=
 /--
 Let \(T_N = \sum_{k=1}^{N} k = \frac{N(N+1)}{2}\).
 If \(T_N\) is even (equivalently \(N \equiv 0 \pmod 4\) or \(N \equiv 3 \pmod 4\)),
-then under optimal play the game `Catch-Up(\(\{1, \ldots, N\}\))` ends in a draw.
+then under optimal play the game $\operatorname{Catch-Up}(\{1, \ldots, N\})$ ends in a draw.
 -/
 @[category research open, AMS 11 91]
 theorem value_of_even_mul_succ_self_div_two

--- a/FormalConjectures/Paper/ClaudesCycles.lean
+++ b/FormalConjectures/Paper/ClaudesCycles.lean
@@ -22,14 +22,14 @@ import FormalConjectures.Util.ProblemImports
 *Reference:* [Claude's Cycles](https://www-cs-faculty.stanford.edu/~knuth/papers/claude-cycles.pdf)
 by *Donald E. Knuth* (2026)
 
-Fix `m ≥ 2`. Consider the directed graph with vertex set `(ZMod m)³`, where from each vertex
-`(i, j, k)` there are directed arcs to `(i+1, j, k)`, `(i, j+1, k)`, and `(i, j, k+1)`
-(arithmetic mod `m`). The goal is to partition all `3m³` directed arcs into three
-edge-disjoint directed Hamiltonian cycles (each of length `m³`).
+Fix $m ≥ 2$. Consider the directed graph with vertex set $(ZMod m)³$, where from each vertex
+$(i, j, k)$ there are directed arcs to $(i+1, j, k)$, $(i, j+1, k)$, and $(i, j, k+1)$
+(arithmetic mod $m$). The goal is to partition all $3m³$ directed arcs into three
+edge-disjoint directed Hamiltonian cycles (each of length $m³$).
 
 Knuth describes an explicit construction, found by Claude (Anthropic), that achieves this
-decomposition for all odd `m ≥ 3`. The case `m = 2` is known to be impossible [Aub82].
-The even case `m > 2` remains open.
+decomposition for all odd $m ≥ 3$. The case $m = 2$ is known to be impossible [Aub82].
+The even case $m > 2$ remains open.
 
 ## References
 
@@ -66,21 +66,21 @@ def HasHamiltonianArcDecomposition (m : ℕ) [NeZero m] : Prop :=
     (∀ c, IsDirectedHamiltonianCycle (cubeAdj (m := m)) (σ c)) ∧
     (∀ v : Vertex m, ∀ b : Fin 3, ∃! c : Fin 3, σ c v = bumpAt b v)
 
-/-- For odd `m > 1`, the cube digraph on `(ZMod m)³` has a Hamiltonian arc decomposition
+/-- For odd $m > 1$, the cube digraph on $(ZMod m)³$ has a Hamiltonian arc decomposition
 into three directed cycles [Knu26]. -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/kim-em/KnuthClaudeLean"]
 theorem cube_hamiltonian_arc_decomposition {m : ℕ} [NeZero m] (hm : Odd m) (hm' : 1 < m) :
     HasHamiltonianArcDecomposition m := by
   sorry
 
-/-- The case `m = 2` is impossible: the cube digraph on `(ZMod 2)³` does not have a
+/-- The case $m = 2$ is impossible: the cube digraph on $(ZMod 2)³$ does not have a
 Hamiltonian arc decomposition [Aub82]. -/
 @[category research solved, AMS 5]
 theorem cube_hamiltonian_arc_decomposition_impossible_m2 :
     ¬ HasHamiltonianArcDecomposition 2 := by
   sorry
 
-/-- For even `m > 2`, it is open whether the cube digraph on `(ZMod m)³` has a Hamiltonian
+/-- For even $m > 2$, it is open whether the cube digraph on $(ZMod m)³$ has a Hamiltonian
 arc decomposition. -/
 @[category research open, AMS 5]
 theorem cube_hamiltonian_arc_decomposition_even :

--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -50,7 +50,7 @@ namespace DegreeSequencesTriangleFree
 variable (d : ℕ → ℕ) (n k r : ℕ)
 
 /-- **Lemma 1 (a)**
-If a sequence `d` is nondecreasing and no three terms are equal, then terms at distance 2 differ by at least 1. -/
+If a sequence $d$ is nondecreasing and no three terms are equal, then terms at distance 2 differ by at least 1. -/
 @[category API, AMS 5]
 lemma lemma1_a
     (h_mono : Monotone d)
@@ -61,7 +61,7 @@ lemma lemma1_a
   omega
 
 /-- **Lemma 1 (b)**
-If a sequence `d` is nondecreasing and no three terms are equal, then terms at distance `2 * r` differ by at least `r`. -/
+If a sequence $d$ is nondecreasing and no three terms are equal, then terms at distance $2 * r$ differ by at least $r$. -/
 @[category API, AMS 5]
 lemma lemma1_b
     (h_mono : Monotone d)
@@ -137,8 +137,8 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 def HasCompactdegreeSequence (G : SimpleGraph α) [DecidableRel G.Adj] : Prop :=
   DegreeSequencesTriangleFree.IsCompactSequenceOn (fun k => (degreeSequence G).getD k 0) {k | k + 2 < Fintype.card α}
 
-/-- **Theorem 1.** If a triangle-free graph has `f = 2`,
-then it is bipartite, has minimum degree `1`, and
+/-- **Theorem 1.** If a triangle-free graph has $f = 2$,
+then it is bipartite, has minimum degree $1$, and
 its degree sequence is compact. -/
 @[category research solved, AMS 5]
 theorem theorem1 (G : SimpleGraph α) (h_conn: G.Connected) [DecidableRel G.Adj]
@@ -146,19 +146,19 @@ theorem theorem1 (G : SimpleGraph α) (h_conn: G.Connected) [DecidableRel G.Adj]
     G.IsBipartite ∧ G.minDegree = 1 ∧ HasCompactdegreeSequence G := by
   sorry
 
-/-- **Lemma 3.** For every `n` there exists a bipartite graph with
-`8 n` vertices, minimum degree `n + 1`, and `f = 3`. -/
+/-- **Lemma 3.** For every $n$ there exists a bipartite graph with
+$8 n$ vertices, minimum degree $n + 1$, and $f = 3$. -/
 @[category API, AMS 5]
 lemma lemma3 (n : ℕ) (hn : 0 < n) :
     ∃ (G : SimpleGraph (Fin (8 * n))) (_ : DecidableRel G.Adj),
       G.IsBipartite ∧ G.minDegree = n + 1 ∧ degreeSequenceMultiplicity G = 3 := by
   sorry
 
-/-- **Lemma 4.** Let `G` be a triangle-free graph with `n` vertices and let `v` be a vertex of `G`.
-There exists a triangle-free graph `H` containing `G` as an induced subgraph such that:
-(i) the degree of `v` in `H` is one more than its degree in `G`;
-(ii) for every vertex `w` of `G` other than `v` the degree of `w` in `H` is the same as its degree in `G`;
-(iii) if `J` is the subgraph of `H` induced by the vertices not in `G`, then `f(J)=3` and `δ(J) ≥ 2n`. -/
+/-- **Lemma 4.** Let $G$ be a triangle-free graph with $n$ vertices and let $v$ be a vertex of $G$.
+There exists a triangle-free graph $H$ containing $G$ as an induced subgraph such that:
+(i) the degree of $v$ in $H$ is one more than its degree in $G$;
+(ii) for every vertex $w$ of $G$ other than $v$ the degree of $w$ in $H$ is the same as its degree in $G$;
+(iii) if $J$ is the subgraph of $H$ induced by the vertices not in $G$, then $f(J)=3$ and $δ(J) ≥ 2n$. -/
 @[category API, AMS 5]
 lemma lemma4 (G : SimpleGraph α) [DecidableRel G.Adj] (h_conn: G.Connected)
     (h₁ : G.CliqueFree 3) (v : α) :
@@ -171,7 +171,7 @@ lemma lemma4 (G : SimpleGraph α) [DecidableRel G.Adj] (h_conn: G.Connected)
   sorry
 
 /-- **Theorem 2.** Every triangle-free graph is an induced subgraph of one
-with `f = 3`. -/
+with $f = 3$. -/
 @[category research solved, AMS 5]
 theorem theorem2 (G : SimpleGraph α) [DecidableRel G.Adj] (h_conn: G.Connected)
     (h : G.CliqueFree 3) :

--- a/FormalConjectures/Paper/FusibleNumber.lean
+++ b/FormalConjectures/Paper/FusibleNumber.lean
@@ -54,17 +54,17 @@ theorem isFusible_one : IsFusible (1 : ℚ) := by
   norm_num at h
   exact h
 
-/-- If `x` is a fusible number and `y` is its successor, then the interval `[x + 1, y + 1)` can be
-divided into intervals `[ℓₙ, ℓₙ₊₁)`, such that the fusible numbers in `[ℓₙ, ℓₙ₊₁)` are obtained by
-fusing the `n + 1`st successor of `x` with a fusible number.
+/-- If $x$ is a fusible number and $y$ is its successor, then the interval $[x + 1, y + 1)$ can be
+divided into intervals $[ℓₙ, ℓₙ₊₁)$, such that the fusible numbers in $[ℓₙ, ℓₙ₊₁)$ are obtained by
+fusing the $n + 1$st successor of $x$ with a fusible number.
 This formalization differs from Conjecture 7.1 in the paper in four ways:
-(1) it is obtained from Conjecture 7.1 by plugging in `n + 1` into `n`, which simplifies the expressions
-  and removes the need to assume `n ≥ 1`;
-(2) the `n + 1`st successor `s^(n+1)(x)` is replaced by the explicit value `x + (2 - 1 / 2 ^ n) * m`;
-(3) instead of defining `y` to be the successor of `x`, we assert that there is no fusible number
-  strictly between `x` and `y`;
-(4) instead of using `∃ z, IsFusible z ∧ q = s^(n+1)(x) ~ z` we use the value of `z` determined by the equality,
-  namely `z = 2 * q - 1 - s^(n+1)(x)`, and it is easy to see `z ∈ [x + 1 - m / 2 ^ n, x + 1)` as required. -/
+(1) it is obtained from Conjecture 7.1 by plugging in $n + 1$ into $n$, which simplifies the expressions
+  and removes the need to assume $n ≥ 1$;
+(2) the $n + 1$st successor $s^(n+1)(x)$ is replaced by the explicit value $x + (2 - 1 / 2 ^ n) * m$;
+(3) instead of defining $y$ to be the successor of $x$, we assert that there is no fusible number
+  strictly between $x$ and $y$;
+(4) instead of using $∃ z, IsFusible z ∧ q = s^(n+1)(x) ~ z$ we use the value of $z$ determined by the equality,
+  namely $z = 2 * q - 1 - s^(n+1)(x)$, and it is easy to see $z ∈ [x + 1 - m / 2 ^ n, x + 1)$ as required. -/
 @[category research open, AMS 5]
 theorem conj_7_1 (x y q : ℚ) (n : ℕ) (fus_x : IsFusible x) (fus_y : IsFusible y) (lt : x < y)
     (nmem_Ioo : ∀ z, IsFusible z → z ∉ Set.Ioo x y) :

--- a/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
+++ b/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
@@ -22,8 +22,8 @@ import FormalConjectures.Util.ProblemImports
 This file studies the existence of *monochromatic quantum graphs*: edge-coloured, edge-weighted
 complete graphs whose perfect matchings induce vertex colourings, with the property that
 
-- every **non-monochromatic** inherited vertex colouring has total weight `0`, while
-- each of the `D` **monochromatic** colourings has total weight `1`.
+- every **non-monochromatic** inherited vertex colouring has total weight $0$, while
+- each of the $D$ **monochromatic** colourings has total weight $1$.
 
 In the quantum-optics motivation, such a construction corresponds to generating high-dimensional
 multipartite GHZ-type states using probabilistic pair sources and linear optics (without additional
@@ -31,22 +31,22 @@ resources), where interference patterns can be expressed as weighted sums over p
 
 ## Main questions (informal)
 
-- For `N = 4` and `D ≥ 4`, does there exist such a graph/weighting?
-- For even `N ≥ 6` and `D ≥ 3`, does there exist such a graph/weighting?
+- For $N = 4$ and $D ≥ 4$, does there exist such a graph/weighting?
+- For even $N ≥ 6$ and $D ≥ 3$, does there exist such a graph/weighting?
 
 ## Formalisation sketch
 
-A quantum graph with `N` vertices and `D` colours can be encoded by a weight function
-`W : EdgeN N D α → α` (for a coefficient domain `α`).
+A quantum graph with $N$ vertices and $D$ colours can be encoded by a weight function
+$W : EdgeN N D α → α$ (for a coefficient domain $α$).
 
-For each assignment of vertex indices `ι : V N → Fin D`, we define a perfect-matching sum
-`pmSumN N D W ι` (a sum over perfect matchings, where each matching contributes the product of the
-corresponding edge weights determined by `ι`). The equation system `EqSystemN N D W` requires
+For each assignment of vertex indices $ι : V N → Fin D$, we define a perfect-matching sum
+$pmSumN N D W ι$ (a sum over perfect matchings, where each matching contributes the product of the
+corresponding edge weights determined by $ι$). The equation system `EqSystemN N D W` requires
 
-`pmSumN N D W ι = 1` iff `ι` is constant (all entries equal), and `0` otherwise.
+$pmSumN N D W ι = 1$ iff $ι$ is constant (all entries equal), and $0$ otherwise.
 
-The open conjectures in this file ask for non-existence/existence of such `W` over various
-coefficient domains (e.g. `ℂ`, `ℝ`, `ℤ`, and restricted integer weights).
+The open conjectures in this file ask for non-existence/existence of such $W$ over various
+coefficient domains (e.g. $ℂ$, $ℝ$, $ℤ$, and restricted integer weights).
 
 ## References
 
@@ -218,7 +218,7 @@ def Witness4_d2 : WeightsN 4 2 α :=
     if e = mkEdge 1 3 1 1 then (1 : α) else
     (0 : α)
 
-/-- Sanity check over `ℕ` using `native_decide`. -/
+/-- Sanity check over $ℕ$ using `native_decide`. -/
 @[category test, AMS 5 14 81]
 private theorem eqSystem4_d2_nat :
     EqSystemN 4 2 (Witness4_d2 (α := ℕ)) := by
@@ -256,7 +256,7 @@ def Witness4_d3 : WeightsN 4 3 α :=
     if e = mkEdge 1 2 2 2 then (1 : α) else
     (0 : α)
 
-/-- Sanity check over `ℕ` using `native_decide`. -/
+/-- Sanity check over $ℕ$ using `native_decide`. -/
 @[category test, AMS 5 14 81]
 private theorem eqSystem4_d3_nat :
     EqSystemN 4 3 (Witness4_d3 (α := ℕ)) := by
@@ -295,7 +295,7 @@ def Witness6_d2 : WeightsN 6 2 α :=
     if e = mkEdge 3 4 1 1 then (1 : α) else
     (0 : α)
 
-/-- Sanity check over `ℕ` using `native_decide`. -/
+/-- Sanity check over $ℕ$ using `native_decide`. -/
 @[category test, AMS 5 14 81]
 private theorem eqSystem6_d2_nat :
     EqSystemN 6 2 (Witness6_d2 (α := ℕ)) := by

--- a/FormalConjectures/Paper/PrimeTuples.lean
+++ b/FormalConjectures/Paper/PrimeTuples.lean
@@ -27,9 +27,9 @@ open Nat
 
 namespace PrimeTuplesConjecture
 
-/-- For any `k ≥ 2`, let `a₁,...,aₖ` and `b₁,...,bₖ` be integers with `aᵢ > 0`. Suppose that for
-every prime `p` there exists an integer `n` such that `p ∤ ∏ i, (aᵢ n + bᵢ)`. Then there exist
-infinitely many `n` such that `aᵢ n + bᵢ` is prime for all `i`. -/
+/-- For any $k ≥ 2$, let $a₁,...,aₖ$ and $b₁,...,bₖ$ be integers with $aᵢ > 0$. Suppose that for
+every prime $p$ there exists an integer $n$ such that $p ∤ ∏ i, (aᵢ n + bᵢ)$. Then there exist
+infinitely many $n$ such that $aᵢ n + bᵢ$ is prime for all $i$. -/
 @[category research open, AMS 11]
 theorem prime_tuples_conjecture {k : ℕ} (hk : 2 ≤ k) (a : Fin k → ℕ+) (b : Fin k → ℕ)
     (hab : ∀ p, p.Prime → ∃ n, ¬ p ∣ ∏ i, (a i * n + b i)) :

--- a/FormalConjectures/Paper/StrongSensitivityConjecture.lean
+++ b/FormalConjectures/Paper/StrongSensitivityConjecture.lean
@@ -17,15 +17,15 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Strong Sensitivity Conjecture (`bs(f) ≤ s(f)^2`)
+# Strong Sensitivity Conjecture ($bs(f) ≤ s(f)^2$)
 
 This file formalizes the *strong* sensitivity conjecture, asserting:
 
-For every Boolean function `f : {0,1}^n → {0,1}`,
-`bs(f) ≤ s(f)^2`,
+For every Boolean function $f : {0,1}^n → {0,1}$,
+$bs(f) ≤ s(f)^2$,
 where bs(f) denotes block sensitivity and s(f) denotes sensitivity.
 
-Huang's theorem proves a *quartic* upper bound, `bs(f) ≤ s(f)^4`, thereby
+Huang's theorem proves a *quartic* upper bound, $bs(f) ≤ s(f)^4$, thereby
 resolving the most widely known form of the sensitivity conjecture.
 
 We now ask whether a stronger upper bound holds. Interestingly, the original
@@ -35,7 +35,7 @@ relation. On the lower bound side, Rubinstein
 (https://link.springer.com/article/10.1007/BF01200762) constructed Boolean functions
 exhibiting the first quadratic separation. The best currently
 known gap, due to Ambainis and Sun (https://arxiv.org/abs/1108.3494), is
-`bs(f) ≥ (2/3)⋅s(f)^2`.
+$bs(f) ≥ (2/3)⋅s(f)^2$.
 
 *References:*
 * [Induced Subgraphs of Hypercubes and a Proof of the Sensitivity Conjecture](https://arxiv.org/abs/1907.00847)
@@ -88,13 +88,13 @@ noncomputable def blockSensitivity (f : (Fin n → Bool) → Bool) : ℕ :=
   univ.sup (blockSensitivityAt f)
 
 /-- Strong Sensitivity Conjecture,
-for every Boolean function `f : {0,1}^n → {0,1}`,
-`bs(f) ≤ s(f)^2`.
+for every Boolean function $f : {0,1}^n → {0,1}$,
+$bs(f) ≤ s(f)^2$.
 
 We call this the *strong* sensitivity conjecture because the original sensitivity
-conjecture only asked for a polynomial bound in terms of `s(f)`. Huang's
+conjecture only asked for a polynomial bound in terms of $s(f)$. Huang's
 celebrated result (often called the sensitivity theorem) gives a quartic bound,
-`bs(f) ≤ s(f)^4`, thereby settling the original conjecture. -/
+$bs(f) ≤ s(f)^4$, thereby settling the original conjecture. -/
 @[category research open, AMS 68]
 theorem strong_sensitivity_conjecture {n : ℕ} (f : (Fin n → Bool) → Bool) :
     blockSensitivity f ≤ sensitivity f ^ 2 := by
@@ -114,17 +114,17 @@ def nisanExample (n : ℕ) (x : Fin n → Bool) : Bool :=
   let w := #{i | x i}
   decide ((w : ℚ) ∈ ({(n / 2 : ℚ), (n / 2 : ℚ) + 1} : Finset ℚ))
 
-/-- Assuming `n` is a multiple of 4, the sensitivity of `nisanExample`
-is `n/2`, achieved by any `x` with Hamming weight `n/2`. -/
+/-- Assuming $n$ is a multiple of 4, the sensitivity of `nisanExample`
+is $n/2$, achieved by any $x$ with Hamming weight $n/2$. -/
 @[category test, AMS 68]
 lemma nisanExample_sensitivity (n : ℕ) (hn : 4 ∣ n) :
     sensitivity (nisanExample n) = n / 2 := by
   sorry
 
-/-- Assuming `n` is a multiple of 4, the block sensitivity of `nisanExample`
-is `3n/4`, achieved by any `x` with Hamming weight `n/2`.
-An optimal block configuration uses all `n/2` 1-bits as singleton blocks
-and forms `n/4` disjoint size-2 blocks from the 0-bits. -/
+/-- Assuming $n$ is a multiple of 4, the block sensitivity of `nisanExample`
+is $3n/4$, achieved by any $x$ with Hamming weight $n/2$.
+An optimal block configuration uses all $n/2$ 1-bits as singleton blocks
+and forms $n/4$ disjoint size-2 blocks from the 0-bits. -/
 @[category test, AMS 68]
 lemma nisanExample_blockSensitivity (n : ℕ) (hn : 4 ∣ n) :
     blockSensitivity (nisanExample n) = 3 * n / 4 := by

--- a/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
+++ b/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
@@ -120,7 +120,7 @@ Conjecture: Voronovskaja-type formula for Bézier-Bernstein operators
 with shape parameter $\alpha > 0$, $\alpha \neq 1$.
 
 The source asks for sufficiently smooth functions. This concrete version uses
-`ContDiffOn ℝ 2 f I` as a readable baseline regularity assumption; since the
+$ContDiffOn ℝ 2 f I$ as a readable baseline regularity assumption; since the
 domain is the compact interval $[0,1]$, this also explains why no separate
 boundedness assumption is included here. The variants below record the unknown
 smoothness threshold more explicitly.
@@ -166,7 +166,7 @@ theorem voronovskaja_theorem.bezier_bernstein_operators.variants.eventually_smoo
 
 /--
 Variant of the Bézier-Bernstein Voronovskaja problem with the required smoothness order itself
-left as an answer. Replacing `(answer(sorry) : ℕ)` by a concrete value lets one state the
+left as an answer. Replacing $(answer(sorry) : ℕ)$ by a concrete value lets one state the
 conjecture for a chosen regularity threshold.
 -/
 @[category research open, AMS 26 40 47]

--- a/FormalConjectures/Util/Answer.lean
+++ b/FormalConjectures/Util/Answer.lean
@@ -22,13 +22,13 @@ import Batteries.Lean.Expr
 
 
 /-!
-# The `answer( )` elaborator
+# The $answer( )$ elaborator
 
 This file provides syntax for marking up answers in a problem statement.
 
 Note: certain problems also providing an answer, and can be formalised
 using `answer(sorry)` as a placeholder. While providing a proof simply requires
-finding any way to replace `:= sorry`, providing an answer is not just finding
+finding any way to replace $:= sorry$, providing an answer is not just finding
 any way to replace `answer(sorry)`: it requires evaluation of mathematical meaning,
 which is a job for human mathematicians, not Lean alone.
 -/

--- a/FormalConjectures/Util/Attributes/AMS.lean
+++ b/FormalConjectures/Util/Attributes/AMS.lean
@@ -25,12 +25,12 @@ import Qq
 This file defines some tools used by the `ProblemSubject` attribute in order classify
 problems by their corresponding AMS Subject.
 
-The `AMSDescription` has one term for each number `n ∈ {1, ..., 96}` that has a corresponding
-AMS subject, namely `AMSDescription.«n»`. Note that not all values of `n` in this interval
+The `AMSDescription` has one term for each number $n ∈ {1, ..., 96}$ that has a corresponding
+AMS subject, namely `AMSDescription.«n»`. Note that not all values of $n$ in this interval
 are assigned a subject.
 
-To extract the value corresponding to `n`, one can use `numToAMSDescriptions n`. This is useful
-for getting the doctring that corresponds to the subject `n` when parsing the attribute.
+To extract the value corresponding to $n$, one can use `numToAMSDescriptions n`. This is useful
+for getting the doctring that corresponds to the subject $n$ when parsing the attribute.
 
 Finally, to access the list of subjects and their corresponding number when editing Lean files,
 we implement a `#AMS` command that prints this list.

--- a/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
+++ b/FormalConjectures/Util/Linters/ExistsImplicationLinter.lean
@@ -21,10 +21,10 @@ import Lean.Linter.Basic
 
 /-! # The Exists Implication Linter
 
-Many misformalisations stem from using a pattern of the form `∃ x, P x → Q` instead of
-`∃ x, P x ∧ Q` (e.g. when formalising something of the form "there is positive `x` such that ...").
-This is almost always incorrect (and trivial to prove) since it then suffices to pick an `x` that
-does not satisfy `P`. This linter flags occurences of this patter to the user and proposes a
+Many misformalisations stem from using a pattern of the form $∃ x, P x → Q$ instead of
+$∃ x, P x ∧ Q$ (e.g. when formalising something of the form "there is positive $x$ such that ...").
+This is almost always incorrect (and trivial to prove) since it then suffices to pick an $x$ that
+does not satisfy $P$. This linter flags occurences of this patter to the user and proposes a
 corrected syntax.
 
 -/

--- a/FormalConjectures/Wikipedia/ABC.lean
+++ b/FormalConjectures/Wikipedia/ABC.lean
@@ -54,7 +54,7 @@ Quality `q(a, b, c)` of the triple `(a, b, c)` is defined as `q(a,b,c) = log (c)
 noncomputable def quality (a b c : ℕ) : ℝ := (c : ℝ).log / (radical <| a * b * c : ℝ).log
 
 /--
-For every positive real number `ε`, there exist only finitely many triples `(a, b, c)` of coprime positive integers, with `a + b = c`, such that `c > rad(abc)^(1+ε)`
+For every positive real number $ε$, there exist only finitely many triples $(a, b, c)$ of coprime positive integers, with $a + b = c$, such that $c > rad(abc)^(1+ε)$
 -/
 @[category research open, AMS 11]
 theorem abc (ε : ℝ) (hε : 0 < ε) :
@@ -63,7 +63,7 @@ theorem abc (ε : ℝ) (hε : 0 < ε) :
   sorry
 
 /--
-For every positive real number ε, there exists a constant `K_ε` such that for all triples (a, b, c) of coprime positive integers, with a + b = c we have `c < K_ε rad(abc)^(1+ε)`.
+For every positive real number ε, there exists a constant $K_ε$ such that for all triples (a, b, c) of coprime positive integers, with a + b = c we have $c < K_ε rad(abc)^(1+ε)$.
 -/
 @[category research open, AMS 11]
 theorem abc.variants.lt_constant_mul (ε : ℝ) (hε : 0 < ε) : ∃ K,
@@ -72,7 +72,7 @@ theorem abc.variants.lt_constant_mul (ε : ℝ) (hε : 0 < ε) : ∃ K,
   sorry
 
 /--
-For every positive real number ε, there exist only finitely many triples `(a, b, c)` of coprime positive integers with `a + b = c` such that `q(a, b, c) > 1 + ε`.
+For every positive real number ε, there exist only finitely many triples $(a, b, c)$ of coprime positive integers with $a + b = c$ such that $q(a, b, c) > 1 + ε$.
 -/
 @[category research open, AMS 11]
 theorem abc.variants.quality (ε : ℝ) (hε : 0 < ε) :

--- a/FormalConjectures/Wikipedia/AgohGiuga.lean
+++ b/FormalConjectures/Wikipedia/AgohGiuga.lean
@@ -132,8 +132,8 @@ theorem squarefree_of_isCarmichael {a : ℕ} (ha₁ : a.Composite) (ha₂ : IsCa
     ((ZMod.natCast_eq_zero_iff _ _).not.mp (by simp [le_of_lt ha₁.1]))
 
 -- Wikipedia URL: https://en.wikipedia.org/wiki/Carmichael_number
-/-- A composite number `a` is Carmichael if and only if it is squarefree
-and, for all prime `p` dividing `a`, we have `p - 1 ∣ a - 1`. -/
+/-- A composite number $a$ is Carmichael if and only if it is squarefree
+and, for all prime $p$ dividing $a$, we have $p - 1 ∣ a - 1$. -/
 @[category textbook, AMS 11]
 theorem korselts_criterion (a : ℕ) (ha₁ : a.Composite) :
     IsCarmichael a ↔ Squarefree a ∧
@@ -178,8 +178,8 @@ theorem korselts_criterion (a : ℕ) (ha₁ : a.Composite) :
     · simp_all
 
 /--
-Giuga showed that a number `n` is strong Giuga if and only if it is
-Carmichael and `∑_{p|n} 1/p - 1/n ∈ ℕ` (i.e., if and only if it is Carmichael
+Giuga showed that a number $n$ is strong Giuga if and only if it is
+Carmichael and $∑_{p|n} 1/p - 1/n ∈ ℕ$ (i.e., if and only if it is Carmichael
 and weak Giuga).
 Ref: G. Giuga, _Su una presumibile proprieta caratteristica dei numeri primi_
 -/
@@ -236,9 +236,9 @@ theorem agoh_giuga.variants._13000_le_digits_length_of_isStrongGiuga
 
 open Classical in
 /--
-Let `G(X)` denote the number of exceptions `n ≤ X` to Giuga’s conjecture.
-Then for `X` larger than an absolute constant which can be made
-explicit, `G(X) ≪ X^{1/2} log X`.
+Let $G(X)$ denote the number of exceptions $n ≤ X$ to Giuga’s conjecture.
+Then for $X$ larger than an absolute constant which can be made
+explicit, $G(X) ≪ X^{1/2} log X$.
 Ref: Vicentiu Tipu, _A Note on Giuga’s Conjecture_
 -/
 @[category research solved, AMS 11]

--- a/FormalConjectures/Wikipedia/BrocardConjecture.lean
+++ b/FormalConjectures/Wikipedia/BrocardConjecture.lean
@@ -30,7 +30,7 @@ namespace Brocard
 
 /--
 **Brocard's Conjecture**
-For every `n ≥ 2`, between the squares of the `n`-th and `(n+1)`-th primes,
+For every $n ≥ 2$, between the squares of the $n$-th and $(n+1)$-th primes,
 there are at least four prime numbers.
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/Wikipedia/ClassNumberProblem.lean
+++ b/FormalConjectures/Wikipedia/ClassNumberProblem.lean
@@ -31,8 +31,8 @@ def IsClassNumberOne (d : ℤ) : Prop :=
   NumberField.classNumber (AdjoinRoot (X ^ 2 - C (d : ℚ))) = 1
 
 /--
-There are infinitely many real quadratic fields `ℚ(√d)` with class number one,
-where `d > 1` is a squarefree integer.
+There are infinitely many real quadratic fields $ℚ(√d)$ with class number one,
+where $d > 1$ is a squarefree integer.
 -/
 @[category research open, AMS 11]
 theorem class_number_problem :
@@ -40,8 +40,8 @@ theorem class_number_problem :
   sorry
 
 /--
-**Stark–Heegner theorem** : For any squarefree integer `d < 0`, the class number of the imaginary
-quadratic field Q(√d) is one if and only if `d ∈ {-1, -2, -3, -7, -11, -19, -43, -67, -163}`.
+**Stark–Heegner theorem** : For any squarefree integer $d < 0$, the class number of the imaginary
+quadratic field Q(√d) is one if and only if $d ∈ {-1, -2, -3, -7, -11, -19, -43, -67, -163}$.
 -/
 @[category research solved, AMS 11]
 theorem class_number_problem.variants.imaginary :

--- a/FormalConjectures/Wikipedia/Conway99Graph.lean
+++ b/FormalConjectures/Wikipedia/Conway99Graph.lean
@@ -37,7 +37,7 @@ lemma completeGraphIsClique (s : Finset V) : (⊤ : SimpleGraph V).IsClique s :=
 
 variable [Fintype V]
 
-/-- The only clique of size `n` in a complete graph on `n` vertices is the entire set of vertices. -/
+/-- The only clique of size $n$ in a complete graph on $n$ vertices is the entire set of vertices. -/
 @[category textbook, AMS 5]
 lemma completeGraph_cliqueSet :
     (⊤ : SimpleGraph V).cliqueSet (Fintype.card V) = {Set.univ.toFinset} := by

--- a/FormalConjectures/Wikipedia/DedekindNumber.lean
+++ b/FormalConjectures/Wikipedia/DedekindNumber.lean
@@ -19,8 +19,8 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Dedekind Numbers
 
-A Dedekind number `M(n)` counts the number of monotone Boolean functions on `n` variables,
-or equivalently, the number of antichains (Sperner families) in the Boolean lattice `2^[n]`.
+A Dedekind number $M(n)$ counts the number of monotone Boolean functions on $n$ variables,
+or equivalently, the number of antichains (Sperner families) in the Boolean lattice $2^[n]$.
 
 For example,
 $$M ( 0 ) = 2 , M ( 1 ) = 3 , M ( 2 ) = 6 , and M ( 3 ) = 20 .$$
@@ -32,10 +32,10 @@ $$M ( 9 ) = 286386577668298411128469151667598498812366$$
 (computed in 2023).
 
 We formalize two definitions:
-- `M n`: the number of monotone Boolean functions `(Fin n → Bool) → Bool`
-- `M' n`: the number of antichains (Sperner families) of `Finset (Fin n)`
+- `M n`: the number of monotone Boolean functions $(Fin n → Bool) → Bool$
+- `M' n`: the number of antichains (Sperner families) of $Finset (Fin n)$
 
-We prove their values for small `n` and show that the two definitions agree for all `n`.
+We prove their values for small $n$ and show that the two definitions agree for all $n$.
 
 The problem is to determine the exact values of $M(n)$ for $n ≥ 10$.
 In particular, the value of $M(10)$ is currently unknown.
@@ -270,7 +270,7 @@ theorem M_eq : M = answer(sorry) := by
   sorry
 
 /--
-  In particular, the Dedekind number for `n = 10` is currently unknown.
+  In particular, the Dedekind number for $n = 10$ is currently unknown.
 -/
 @[category research open, AMS 5 6]
 theorem Dedekind_10 : M 10 = answer(sorry) := by sorry

--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -80,7 +80,7 @@ open scoped Topology
 open Filter (atTop)
 
 /-- Formula (5.1.1) of [PPVW2016]: The number of elliptic curves over ℚ with naïve height at most
-`H` is asymptotically `2^(4/3)*3^(-3/2)/ζ(10) * H^(5/6)`. -/
+$H$ is asymptotically $2^(4/3)*3^(-3/2)/ζ(10) * H^(5/6)$. -/
 @[category textbook, AMS 11 14]
 theorem card_heightLE_div_pow_five_div_six_tensto :
     atTop.Tendsto (fun H ↦ (heightLE H).ncard / (H : ℝ) ^ (5 / 6 : ℝ))
@@ -133,10 +133,10 @@ Notice that this contradicts the previous conjecture. -/
 theorem finite_twentyone_lt_finrank : {E : RatEllipticCurve | 21 < E.rank}.Finite := by
   sorry
 
-/-- [PPVW2016] 8.2(b): for 1 ≤ r ≤ 20, the number of elliptic curves over ℚ with rank `r` and
-naïve height at most `H` is asymptotically `H ^ ((21 - r) / 24 + o(1))`.
+/-- [PPVW2016] 8.2(b): for 1 ≤ r ≤ 20, the number of elliptic curves over ℚ with rank $r$ and
+naïve height at most $H$ is asymptotically $H ^ ((21 - r) / 24 + o(1))$.
 Note: ℰ_H in 8.2(b) should be ℰ_{≤H}, see the statement of Theorem 7.3.3.
-When `r = 1`, the exponent is `20 / 24 = 5 / 6`, which agrees with the exponent in
+When $r = 1$, the exponent is $20 / 24 = 5 / 6$, which agrees with the exponent in
 `card_heightLE_div_pow_five_div_six_tensto` and is consistent with
 `half_rank_zero_and_half_rank_one`. -/
 @[category research open, AMS 11 14]
@@ -146,7 +146,7 @@ theorem rank_height_count_asymptotic (r : ℕ) (h₁ : 1 ≤ r) (h₂ : r ≤ 20
   sorry
 
 /-- [PPVW2016] 8.2(c): the number of elliptic curves over ℚ with rank ≥ 21 and naïve height
-at most `H` is asymptotically at most `H ^ o(1)`. -/
+at most $H$ is asymptotically at most $H ^ o(1)$. -/
 @[category research open, AMS 11 14]
 theorem twentyone_le_rank_height_count_asymptotic :
     ∃ f : ℕ → ℝ, atTop.Tendsto f (𝓝 0) ∧

--- a/FormalConjectures/Wikipedia/Fermat.lean
+++ b/FormalConjectures/Wikipedia/Fermat.lean
@@ -25,7 +25,7 @@ import FormalConjectures.Util.ProblemImports
 namespace Fermat
 
 /--
-Are Fermat numbers composite for all `n > 4`?
+Are Fermat numbers composite for all $n > 4$?
 -/
 @[category research open, AMS 11]
 theorem fermat_number_are_composite : answer(sorry) ↔ ∀ n > 4, ¬Prime n.fermatNumber := by

--- a/FormalConjectures/Wikipedia/GromovPolynomialGrowth.lean
+++ b/FormalConjectures/Wikipedia/GromovPolynomialGrowth.lean
@@ -98,7 +98,7 @@ lemma cayleyBall_mul (S : Set G) {g h : G} {m n : ℕ}
     | inl h => simp [lgSubS s h]
     | inr h => simp [lhSubS s h]
 
-/-- If `g ∈ CayleyBall S n`, then `g⁻¹ ∈ CayleyBall S n`. -/
+/-- If $g ∈ CayleyBall S n$, then $g⁻¹ ∈ CayleyBall S n$. -/
 @[category API, AMS 20]
 lemma cayleyBall_inv (S : Set G) {g : G} {n : ℕ}
     (hg : g ∈ CayleyBall S n) :
@@ -152,10 +152,10 @@ theorem tendsto_atTop_growthFunction_of_infinite [Infinite G] {S : Set G} (hS : 
     refine ⟨N, fun a ha ↦ ?_⟩
     simpa using cayleyBall_monotone S (Finset.le_max' _ _ (by aesop)) (hn ⟨a, ha⟩)
 
-/-- Infinite groups do not satisfy polynomial growth over `ℕ` for any degree `d` because when
-`d = 0` this reduces to the unbounded nature of `growthFunction` while `n = 0` works when `d ≠ 0`.
+/-- Infinite groups do not satisfy polynomial growth over $ℕ$ for any degree $d$ because when
+$d = 0$ this reduces to the unbounded nature of `growthFunction` while $n = 0$ works when $d ≠ 0$.
 Thus a finitely-generated infinite nilpotent group would be a counter-example to
-Gromov's theorem when quantifying over all of `ℕ`, and so `n = 0` should be excluded. -/
+Gromov's theorem when quantifying over all of $ℕ$, and so $n = 0$ should be excluded. -/
 @[category test, AMS 20]
 theorem growthFunction_not_polynomial_of_infinite [Infinite G] {S : Set G} (hS : S.Finite)
     (h : Subgroup.closure S = ⊤) {C : ℝ} (d : ℕ) :

--- a/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
+++ b/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
@@ -37,10 +37,10 @@ structure ClosedInvariantSubspace [Module ℂ H] (T : H →L[ℂ] H) where
   is_fixed : toSubspace.map T.toLinearMap ≤ toSubspace
 
 /--
-Show that every bounded linear operator `T : H → H` on a separable Hilbert space `H` of dimension
-at least 2 has a non-trivial closed `T`-invariant subspace: a closed linear subspace `W` of `H`,
-which is different from `H` and from `{0}`, such that `T ( W ) ⊂ W`. One needs the assumption that
-the dimension of `H` is at least 2 because otherwise any subspace would be either `H` or `{0}`. -/
+Show that every bounded linear operator $T : H → H$ on a separable Hilbert space $H$ of dimension
+at least 2 has a non-trivial closed $T$-invariant subspace: a closed linear subspace $W$ of $H$,
+which is different from $H$ and from ${0}$, such that $T ( W ) ⊂ W$. One needs the assumption that
+the dimension of $H$ is at least 2 because otherwise any subspace would be either $H$ or ${0}$. -/
 @[category research open, AMS 47]
 theorem Invariant_subspace_problem [InnerProductSpace ℂ H] [TopologicalSpace.SeparableSpace H]
     [CompleteSpace H] (hdim : 2 ≤ Module.rank ℂ H) (T : H →L[ℂ] H) :
@@ -48,8 +48,8 @@ theorem Invariant_subspace_problem [InnerProductSpace ℂ H] [TopologicalSpace.S
   sorry
 
 /--
-Every (bounded) linear operator `T : H → H` on a finite-dimensional linear space `H` of dimension
-at least 2 has a non-trivial (closed) `T`-invariant subspace. This can be solved using the Jordan
+Every (bounded) linear operator $T : H → H$ on a finite-dimensional linear space $H$ of dimension
+at least 2 has a non-trivial (closed) $T$-invariant subspace. This can be solved using the Jordan
 normal form, which is
 [not yet in mathlib](https://leanprover-community.github.io/undergrad_todo.html). -/
 @[category research solved, AMS 47]
@@ -65,8 +65,8 @@ lemma TopologicalSpace.nontrivial_of_not_separableSpace {H : Type*} [Topological
   infer_instance
 
 /--
-Every bounded linear operator `T : H → H` on a non-separable Hilbert space `H` has a
-non-trivial closed `T`-invariant subspace. Such an invariant space is given by considering the
+Every bounded linear operator $T : H → H$ on a non-separable Hilbert space $H$ has a
+non-trivial closed $T$-invariant subspace. Such an invariant space is given by considering the
 closure of the linear span of the orbit of any single non-zero vector. -/
 @[category research solved, AMS 47, formal_proof using formal_conjectures at ""]
 theorem Invariant_subspace_problem_non_separable [InnerProductSpace ℂ H] [CompleteSpace H]
@@ -98,9 +98,9 @@ theorem Invariant_subspace_problem_non_separable [InnerProductSpace ℂ H] [Comp
             exact ⟨n + 1, by simp [pow_succ']⟩
 
 /--
-Every normal linear operator `T : H → H` on a Hilbert space `H` of dimension at least 2 has a
-non-trivial closed `T`-invariant subspace. If `T` is a multiple of the identity, one can take any
-non-trivial subspace . If not, one can take any nontrivial spectral subspace of `T`. -/
+Every normal linear operator $T : H → H$ on a Hilbert space $H$ of dimension at least 2 has a
+non-trivial closed $T$-invariant subspace. If $T$ is a multiple of the identity, one can take any
+non-trivial subspace . If not, one can take any nontrivial spectral subspace of $T$. -/
 @[category research solved, AMS 47]
 theorem Invariant_subspace_problem_normal_operator [InnerProductSpace ℂ H] [CompleteSpace H]
     (hdim : 2 ≤ Module.rank ℂ H) (T : H →L[ℂ] H) [IsStarNormal T]:
@@ -108,8 +108,8 @@ theorem Invariant_subspace_problem_normal_operator [InnerProductSpace ℂ H] [Co
   sorry
 
 /--
-There exists a bounded linear operator `T` on the l1 space `(lp (fun (_ : ℕ) => ℂ) 1))` without
-non-trivial closed `T`-invariant subspace [Read 1985](https://doi.org/10.1112/blms/17.4.305), see
+There exists a bounded linear operator $T$ on the l1 space $(lp (fun (_ : ℕ) => ℂ) 1))$ without
+non-trivial closed $T$-invariant subspace [Read 1985](https://doi.org/10.1112/blms/17.4.305), see
 also the first counterexample by Enflo [Enflo 1987](https://doi.org/10.1007%2FBF02392260), submitted
 in 1981. -/
 @[category research solved, AMS 47]

--- a/FormalConjectures/Wikipedia/InverseGalois.lean
+++ b/FormalConjectures/Wikipedia/InverseGalois.lean
@@ -88,7 +88,7 @@ theorem inverse_galois_problem.variants.complex_rational_functions
 
 /--
 Every finite group is realisable over the field of rational functions
-with coefficients `K`, where `K` is any field of characteristic 0.
+with coefficients $K$, where $K$ is any field of characteristic 0.
 -/
 @[category research solved, AMS 12]
 theorem inverse_galois_problem.variants.complex_function_field

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -65,9 +65,9 @@ open RegularFunction
 variable {σ : Type*} [Fintype σ]
 
 /-- The **Jacobian Conjecture**: any regular function
-(i.e. vector valued polynomial function from) `kⁿ → kᵐ`
+(i.e. vector valued polynomial function from) $kⁿ → kᵐ$
 whose Jacobian is a non-zero constant has an inverse that
-is given by a regular function, where `k` is a field of characteristic `0`-/
+is given by a regular function, where $k$ is a field of characteristic $0$-/
 @[category research open, AMS 14]
 theorem jacobian_conjecture (F : RegularFunction k σ σ)
     (H : IsUnit F.Jacobian.det) :

--- a/FormalConjectures/Wikipedia/Kakeya.lean
+++ b/FormalConjectures/Wikipedia/Kakeya.lean
@@ -38,7 +38,7 @@ def IsKakeya {n : ℕ} (S : Set (ℝ^n)) : Prop :=
   ∀ v, ‖v‖ = 1 → ∃ a, affineSegment ℝ a (a + v) ⊆ S
 
 /--
-A trivial example: the closed ball of radius 1 in `ℝⁿ` is a Kakeya set.
+A trivial example: the closed ball of radius 1 in $ℝⁿ$ is a Kakeya set.
 -/
 @[category test, AMS 42]
 theorem isKakeya_closedBall (n : ℕ) : IsKakeya (closedBall (0 : ℝ^n) 1) := by
@@ -90,10 +90,10 @@ def IsKakeyaFinite {F : Type*} [Field F] [Fintype F] {n : ℕ} (S : Finset (Fin 
 
 open Fintype in
 /--
-The finite field Kakeya conjecture asserts that any Kakeya set in `𝔽_qⁿ` has size at
-least `c_n · qⁿ` for some constant `c_n` depending only on `n`.
+The finite field Kakeya conjecture asserts that any Kakeya set in $𝔽_qⁿ$ has size at
+least $c_n · qⁿ$ for some constant `c_n` depending only on $n$.
 This was first proved by Dvir [Dv08]. The best known bound to date, due to Bukh and Chao [BuCh21],
-establishes that any Kakeya set in `𝔽_qⁿ` has size at least `qⁿ / (2 - 1/q)^(n - 1)`.
+establishes that any Kakeya set in $𝔽_qⁿ$ has size at least $qⁿ / (2 - 1/q)^(n - 1)$.
 
 [Dv08] Dvir, Z., _On the size of Kakeya sets in finite fields_. Journal of the American Mathematical Society 22 (2009), no. 4, 1093–1097.
 [BuCh21] Bukh, B. and Chao, T.-W., _Sharp density bounds on the finite field Kakeya problem_. Discrete Analysis 26 (2021), 9 pp.

--- a/FormalConjectures/Wikipedia/Kaplansky.lean
+++ b/FormalConjectures/Wikipedia/Kaplansky.lean
@@ -31,7 +31,7 @@ namespace Kaplansky
 /--
 **The zero-divisor conjecture**
 
-If `G` is torsion-free, then the group algebra `K[G]` has no non-trivial zero divisors.
+If $G$ is torsion-free, then the group algebra $K[G]$ has no non-trivial zero divisors.
 -/
 @[category research open, AMS 16 20]
 theorem zero_divisor_conjecture : NoZeroDivisors (MonoidAlgebra K G) := by
@@ -40,7 +40,7 @@ theorem zero_divisor_conjecture : NoZeroDivisors (MonoidAlgebra K G) := by
 /--
 **The idempotent conjecture**
 
-If `G` is torsion-free, then `K[G]` has no non-trivial idempotents.
+If $G$ is torsion-free, then $K[G]$ has no non-trivial idempotents.
 -/
 @[category research open, AMS 16 20]
 theorem idempotent_conjecture (a : MonoidAlgebra K G) (h : IsIdempotentElem a) :

--- a/FormalConjectures/Wikipedia/Koethe.lean
+++ b/FormalConjectures/Wikipedia/Koethe.lean
@@ -56,21 +56,21 @@ theorem KotherConjecture.variants.le_KotherRadical {I : Ideal R} (hI : IsNil I) 
     (I : Set R) ⊆ KotheRadical R := by
   sorry
 
-/-- The **Köthe conjecture**: for any nil ideal `I` of `R`, the matrix ideal `M_n(I)` is a nil ideal
-of the matrix ring `M_n(R)`. -/
+/-- The **Köthe conjecture**: for any nil ideal $I$ of $R$, the matrix ideal $M_n(I)$ is a nil ideal
+of the matrix ring $M_n(R)$. -/
 @[category research open, AMS 16]
 theorem KotherConjecture.variants.general_matrix {I : TwoSidedIdeal R} (hI : IsNil I)
     (n : Type*) [Fintype n] : IsNil (matrix n I) := by
   sorry
 
-/-- The **Köthe conjecture**: for any nil ideal `I` of `R`, the matrix ideal `M_2(I)` is a nil ideal
-of the matrix ring `M_2(R)`. -/
+/-- The **Köthe conjecture**: for any nil ideal $I$ of $R$, the matrix ideal $M_2(I)$ is a nil ideal
+of the matrix ring $M_2(R)$. -/
 @[category research open, AMS 16]
 theorem KotherConjecture.variants.two_by_two_matrix {I : TwoSidedIdeal R} (hI : IsNil I) :
     IsNil (matrix (Fin 2) I) := by
   sorry
 
-/-- The **Köthe conjecture**: for any positive integer `n`, the Köthe radical of `R` is the matrix ideal `M_2(Nil*(R))`. -/
+/-- The **Köthe conjecture**: for any positive integer $n$, the Köthe radical of $R$ is the matrix ideal $M_2(Nil*(R))$. -/
 @[category research open, AMS 16]
 theorem KotherConjecture.variants.matrixOver_KotherRadical
     {I : TwoSidedIdeal R} (hI : IsNil I) (n : Type*) [Fintype n] :
@@ -83,7 +83,7 @@ Sanity check that the current mathlib definition is what I want.
 -/
 
 /--
-The **Amitsur Conjecture**: If `J` is a nil ideal in `R`, then `J[x]` is a nil ideal of the polynomial ring `R[x]`.
+The **Amitsur Conjecture**: If $J$ is a nil ideal in $R$, then $J[x]$ is a nil ideal of the polynomial ring $R[x]$.
 This is known to be false, see Agata Smoktunowicz, _Polynomial rings over nil rings need not be nil_.
 -/
 @[category research solved, AMS 16]

--- a/FormalConjectures/Wikipedia/LegendreConjecture.lean
+++ b/FormalConjectures/Wikipedia/LegendreConjecture.lean
@@ -38,8 +38,8 @@ theorem legendre_conjecture :
   sorry
 
 /--
-If there exists a constant `c > 0` such that
-`(n + 1).nth Nat.Prime - n.nth Nat.Prime < (n.nth Nat.Prime) ^ (1 / 2 - c)` for all large `n`,
+If there exists a constant $c > 0$ such that
+$(n + 1).nth Nat.Prime - n.nth Nat.Prime < (n.nth Nat.Prime) ^ (1 / 2 - c)$ for all large $n$,
 then Legendre's conjecture is asymptotically true.
 
 Formal proof linked here provided by AlphaProof.

--- a/FormalConjectures/Wikipedia/LehmerMahlerMeasureProblem.lean
+++ b/FormalConjectures/Wikipedia/LehmerMahlerMeasureProblem.lean
@@ -37,8 +37,8 @@ noncomputable def mahlerMeasureZ (f : ℤ[X]) : ℝ :=
   mahlerMeasure (f.map (algebraMap ℤ ℂ))
 
 /--
-Let `M(f)` denote the Mahler measure of `f`.
-There exists a constant `μ>1` such that for any `f(x)∈ℤ[x], M(f)>1 → M(f)≥μ`.
+Let $M(f)$ denote the Mahler measure of $f$.
+There exists a constant $μ>1$ such that for any $f(x)∈ℤ[x], M(f)>1 → M(f)≥μ$.
 -/
 @[category research open, AMS 11]
 theorem lehmer_mahler_measure_problem :
@@ -49,7 +49,7 @@ theorem lehmer_mahler_measure_problem :
 noncomputable def lehmerPolynomial : ℤ[X] := X^10 + X^9 - X^7 - X^6 - X^5 - X^4 - X^3 + X + 1
 
 /--
-`μ=M(X^10 + X^9 - X^7 - X^6 - X^5 - X^4 - X^3 + X + 1)` is the best value for `lehmer_mahler_measure_problem`.
+$μ=M(X^10 + X^9 - X^7 - X^6 - X^5 - X^4 - X^3 + X + 1)$ is the best value for `lehmer_mahler_measure_problem`.
 -/
 @[category research open, AMS 11]
 theorem lehmer_mahler_measure_problem.variants.best (f : ℤ[X])

--- a/FormalConjectures/Wikipedia/LeinsterGroup.lean
+++ b/FormalConjectures/Wikipedia/LeinsterGroup.lean
@@ -88,7 +88,7 @@ theorem abelian_is_leinster_iff_cyclic_perfect (G : Type*) [CommGroup G] [Fintyp
 /--
 Non-abelian Leinster groups exist.
 
-For example, `S₃ × C₅` (order 30) and `A₅ × C₁₅₁₂₈` are Leinster groups.
+For example, $S₃ × C₅$ (order 30) and $A₅ × C₁₅₁₂₈$ are Leinster groups.
 
 Reference: Leinster, Tom (2001). "Perfect numbers and groups".
 -/
@@ -99,7 +99,7 @@ theorem exists_nonabelian_leinster_group :
   sorry
 
 /--
-The dihedral group `DihedralGroup n` (of order `2n`) is a Leinster group if and only if `n` is
+The dihedral group `DihedralGroup n` (of order $2n$) is a Leinster group if and only if $n$ is
 an odd perfect number. This gives a one-to-one correspondence between dihedral Leinster groups
 and odd perfect numbers.
 

--- a/FormalConjectures/Wikipedia/LychrelNumbers.lean
+++ b/FormalConjectures/Wikipedia/LychrelNumbers.lean
@@ -25,7 +25,7 @@ iteration
 $$a_{0} = n, \qquad a_{k+1} = a_k + \operatorname{rev}_{10}(a_k).$$
 
 One commonly stated conjectural direction is that there are no Lychrel numbers in base 10.
-The smallest widely studied open case is `196`.
+The smallest widely studied open case is $196$.
 
 *References:*
 * [Wikipedia: Lychrel number](https://en.wikipedia.org/wiki/Lychrel_number)
@@ -72,7 +72,7 @@ theorem no_lychrel_numbers_base10 :
   sorry
 
 /--
-The first widely studied open case: whether `196` is a base-10 Lychrel number.
+The first widely studied open case: whether $196$ is a base-10 Lychrel number.
 -/
 @[category research open, AMS 11]
 theorem isLychrel10_196 : answer(sorry) ↔ IsLychrel10 196 := by
@@ -95,23 +95,23 @@ theorem eventually_palindrome_base10 :
     exact h n hn this
 
 
-/-- Sanity check: digit reversal of `120` is `21`. -/
+/-- Sanity check: digit reversal of $120$ is $21$. -/
 @[category test, AMS 11]
 theorem rev10_120 : rev10 120 = 21 := by
   native_decide
 
-/-- Sanity check: `121` is a base-10 palindrome. -/
+/-- Sanity check: $121$ is a base-10 palindrome. -/
 @[category test, AMS 11]
 theorem palindrome_121 : IsPalindrome10 121 := by
   dsimp [IsPalindrome10]
   native_decide
 
-/-- Sanity check: `56 → 121` in one Lychrel step. -/
+/-- Sanity check: $56 → 121$ in one Lychrel step. -/
 @[category test, AMS 11]
 theorem lychrelIter_56_one : lychrelStep^[1] 56 = 121 := by
   native_decide
 
-/-- Sanity check: the Lychrel iteration at `56` reaches a palindrome. -/
+/-- Sanity check: the Lychrel iteration at $56$ reaches a palindrome. -/
 @[category test, AMS 11]
 theorem eventually_palindrome_56 : ∃ k : ℕ, IsPalindrome10 (lychrelStep^[k] 56) := by
   refine ⟨1, ?_⟩

--- a/FormalConjectures/Wikipedia/Mahler32.lean
+++ b/FormalConjectures/Wikipedia/Mahler32.lean
@@ -44,13 +44,13 @@ def IsZNumber (x : ℝ) : Prop :=
 theorem mahler_conjecture (x : ℝ) (h : x ≠ 0) (hx : IsZNumber x) : False := by
   sorry
 
-/-- If Mahler's conjecture is true, i.e. there are no Z-numbers, then `Ω(3/2)` exceeds `1/2`. -/
+/-- If Mahler's conjecture is true, i.e. there are no Z-numbers, then $Ω(3/2)$ exceeds $1/2$. -/
 @[category textbook, AMS 11]
 theorem mahler_conjecture.variants.consequence (H : type_of% mahler_conjecture) :
     1 / 2 < Ω (3 / 2) := by
   sorry
 
-/-- It is known that for all rational `p/q > 1` in lowest terms, we have `Ω(p/q) > 1/p`. -/
+/-- It is known that for all rational $p/q > 1$ in lowest terms, we have $Ω(p/q) > 1/p$. -/
 @[category research solved, AMS 11]
 theorem mahler_conjecture.variants.flatto_lagarias_pollington (p q : ℕ) (hq : 1 < q)
     (hpq : p.Coprime q) (hpq' : q < p) : 1 / p < Ω (p / q) := by

--- a/FormalConjectures/Wikipedia/Mandelbrot.lean
+++ b/FormalConjectures/Wikipedia/Mandelbrot.lean
@@ -45,8 +45,8 @@ set of all parameters `c : ℂ` for which `0` does not escape to infinity under 
 of `z ↦ z ^ 2 + c`. -/
 abbrev mandelbrotSet := multibrotSet 2
 
-/-- The `multibrotSet n` is equivalently the set of all parameters `c` for which the orbit of `0`
-under `z ↦ z ^ n + c` does not leave the closed disk of radius `2 ^ (n - 1)⁻¹` around the origin. -/
+/-- The `multibrotSet n` is equivalently the set of all parameters $c$ for which the orbit of $0$
+under $z ↦ z ^ n + c$ does not leave the closed disk of radius $2 ^ (n - 1)⁻¹$ around the origin. -/
 @[category API, AMS 37]
 theorem multibrotSet_eq {n : ℕ} (hn : 2 ≤ n) :
     multibrotSet n = {c | ∀ k, ‖(fun z ↦ z ^ n + c)^[k] 0‖ ≤ 2 ^ (n - 1 : ℝ)⁻¹} := by
@@ -97,8 +97,8 @@ theorem multibrotSet_eq {n : ℕ} (hn : 2 ≤ n) :
     rw [mem_map, mem_atTop_sets] at h'; replace ⟨n, h'⟩ := h'
     exact not_lt_of_ge (h n) (by simpa using h' n)
 
-/-- The mandelbrot set is equivalently the set of all parameters `c` for which the orbit of `0`
-under `z ↦ z ^ 2 + c` does not leave the closed disk of radius two around the origin. -/
+/-- The mandelbrot set is equivalently the set of all parameters $c$ for which the orbit of $0$
+under $z ↦ z ^ 2 + c$ does not leave the closed disk of radius two around the origin. -/
 @[category API, AMS 37]
 theorem mandelbrotSet_eq : mandelbrotSet = {c | ∀ k, ‖(fun z ↦ z ^ 2 + c)^[k] 0‖ ≤ 2} := by
   simpa [show (2 - 1 : ℝ) = 1 by norm_num] using multibrotSet_eq le_rfl
@@ -109,8 +109,8 @@ theorem MLC : LocallyConnectedSpace mandelbrotSet := by
   sorry
 
 /-- A stronger version of the MLC conjecture, stating that all multibrots are locally connected.
-Note that we don't need to require `2 ≤ n` because the conjecture holds in the trivial cases `n = 0`
-and `n = 1` too. -/
+Note that we don't need to require $2 ≤ n$ because the conjecture holds in the trivial cases $n = 0$
+and $n = 1$ too. -/
 @[category research open, AMS 37]
 theorem MLC_general_exponent (n : ℕ) : LocallyConnectedSpace (multibrotSet n) := by
   sorry
@@ -121,33 +121,33 @@ strictly less than one, and `n > 0`. -/
 def IsAttractingCycle (f : ℂ → ℂ) (n : ℕ) (z : ℂ) : Prop :=
   (0 < n) ∧ f.IsPeriodicPt n z ∧ DifferentiableAt ℂ f^[n] z ∧ ‖deriv f^[n] z‖ < 1
 
-/-- For example, `0` is part of an attracting `2`-cycle of `z ↦ z ^ 2 - 1`. -/
+/-- For example, $0$ is part of an attracting $2$-cycle of $z ↦ z ^ 2 - 1$. -/
 @[category test, AMS 37]
 theorem isAttractingCycle_z_squared_minus_one : IsAttractingCycle (fun z ↦ z ^ 2 - 1) 2 0 :=
   ⟨by decide, by simp [IsPeriodicPt, IsFixedPt], by fun_prop, by simp [deriv_comp]⟩
 
-/-- On the other hand, while `2` is part of a `1`-cycle of `z ↦ z ^ 2 - 2`, that cycle is not
+/-- On the other hand, while $2$ is part of a $1$-cycle of $z ↦ z ^ 2 - 2$, that cycle is not
 attracting. -/
 @[category test, AMS 37]
 theorem not_isAttractingCycle_z_squared_minus_two : ¬ IsAttractingCycle (fun z ↦ z ^ 2 - 2) 1 2 := by
   simp [IsAttractingCycle, show (1 : ℝ) ≤ 2 * 2 by norm_num]
 
-/-- No function has an attracting cycle of period `0`. This is important in that it means we don't
-need to require `0 < n` in the conjectures below. -/
+/-- No function has an attracting cycle of period $0$. This is important in that it means we don't
+need to require $0 < n$ in the conjectures below. -/
 @[category test, AMS 37]
 theorem no_attractingCycle_period_zero (f : ℂ → ℂ) (z : ℂ) : ¬ IsAttractingCycle f 0 z := by
   simp [IsAttractingCycle]
 
-/-- The density of hyperbolicity conjecture, stating that the set of all parameters `c` for which
-`fun z ↦ z ^ 2 + c` has an attracting cycle is dense in the Mandelbrot set. -/
+/-- The density of hyperbolicity conjecture, stating that the set of all parameters $c$ for which
+$fun z ↦ z ^ 2 + c$ has an attracting cycle is dense in the Mandelbrot set. -/
 @[category research open, AMS 37]
 theorem density_of_hyperbolicity :
     mandelbrotSet ⊆ closure {c | ∃ m z, IsAttractingCycle (fun z ↦ z ^ 2 + c) m z} := by
   sorry
 
 /-- The density of hyperbolicity conjecture for Multibrot sets, stating that the set of all
-parameters `c` for which `fun z ↦ z ^ n + c` has an attracting cycle is dense in `multibrotSet n`.
-Note that we need to require `2 ≤ n` because the conjecture is trivially false for `n = 1`. -/
+parameters $c$ for which $fun z ↦ z ^ n + c$ has an attracting cycle is dense in `multibrotSet n`.
+Note that we need to require $2 ≤ n$ because the conjecture is trivially false for $n = 1$. -/
 @[category research open, AMS 37]
 theorem density_of_hyperbolicity_general_exponent {n : ℕ} (hn : 2 ≤ n) :
     multibrotSet n ⊆ closure {c | ∃ m z, IsAttractingCycle (fun z ↦ z ^ n + c) m z} := by
@@ -164,7 +164,7 @@ theorem volume_frontier_mandelbrotSet_eq_zero : volume (frontier mandelbrotSet) 
   sorry
 
 /-- The boundary of any Multibrot set is conjectured to have zero area.
-Note that we don't need to exclude the trivial cases `n = 0` and `n = 1` because the conjecture
+Note that we don't need to exclude the trivial cases $n = 0$ and $n = 1$ because the conjecture
 holds for them. -/
 @[category research open, AMS 37]
 theorem volume_frontier_multibrotSet_eq_zero {n : ℕ} : volume (frontier (multibrotSet n)) = 0 := by

--- a/FormalConjectures/Wikipedia/MeanValueProblem.lean
+++ b/FormalConjectures/Wikipedia/MeanValueProblem.lean
@@ -29,10 +29,10 @@ there is a critical point $c$ of $p$, such that $|p(z)-p(c)|/|z-c| ≤ K* |p'(z)
 
 
 The conjecture has been proven for:
-* `K = 4`
+* $K = 4$
   [The fundamental theorem of algebra and complexity theory](https://www.ams.org/journals/bull/1981-04-01/S0273-0979-1981-14858-8/)
   by *Steve Smale*
-* `K = (d-1)/d` if $p$ has real roots or all the roots of $p$ have the same norm.
+* $K = (d-1)/d$ if $p$ has real roots or all the roots of $p$ have the same norm.
   [Critical points and values of complex polynomials](https://doi.org/10.1016/0885-064X(89)90019-8)
   by *David Tischler*
 -/

--- a/FormalConjectures/Wikipedia/Mersenne.lean
+++ b/FormalConjectures/Wikipedia/Mersenne.lean
@@ -62,11 +62,11 @@ def NewMersenneConjectureStatement (p : ℕ) : Prop :=
   (p.GivesWagstaffPrime ∧ p.IsSpecialForm → p.GivesMersennePrime)
 
 /--
-For any odd natural number `p` if two of the following conditions hold,
+For any odd natural number $p$ if two of the following conditions hold,
 then all three must hold:
 1. $2^p-1$ is prime
 2. $(2^p+1)/3$ is prime
-3. Exists a number `k` such that $p = 2^k \\pm 1$ or $p = 4^k \\pm 3$
+3. Exists a number $k$ such that $p = 2^k \\pm 1$ or $p = 4^k \\pm 3$
 -/
 @[category research open, AMS 11]
 theorem new_mersenne_conjecture (p : ℕ) (hp : Odd p) :

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -24,9 +24,9 @@ every rational elliptic curve is modular, meaning that it can be
 associated with a modular form. We state the `a_p` version of the conjecture, which relates the
 coefficients of the modular form to the number of points on the elliptic curve over finite fields.
 
-Since we don't have the conductor of the elliptic curve, our definition of `a_p(E)` differs from
+Since we don't have the conductor of the elliptic curve, our definition of $a_p(E)$ differs from
 that in the literature at primes of bad reduction. For this reason, we state the conjecture with the
-assumption that `p ∤ N`, in order to give an equivalent statement.
+assumption that $p ∤ N$, in order to give an equivalent statement.
 
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Modularity_theorem)

--- a/FormalConjectures/Wikipedia/NoetherProblem.lean
+++ b/FormalConjectures/Wikipedia/NoetherProblem.lean
@@ -33,8 +33,8 @@ class IsRationalExtension (K L ι : Type*)
   pure_transcendental :
     Nonempty (L ≃ₐ[K] ((FractionRing (MvPolynomial ι K))))
 
-/-- If the index set `ι` is empty, then `IsRationalExtension K L ι` means that
-`K, L` are isomorphic as `K` algebras. -/
+/-- If the index set $ι$ is empty, then `IsRationalExtension K L ι` means that
+$K, L$ are isomorphic as $K$ algebras. -/
 @[category test, AMS 12]
 theorem rationalExtension_empty_index (K L ι : Type*) [Field K] [Field L] [Algebra K L] [IsEmpty ι]
     [IsRationalExtension K L ι] :
@@ -57,8 +57,8 @@ def HasNoetherProperty (K L ι : Type) [Field K] [Field L] [Fintype ι]
     IsRationalExtension K (IntermediateField.fixedField H) ι'
 
 /--
-The **Noether Problem**: let `L` be the field of rational functions in `n`
-indeterminates over `K`. Is it true that `L/K` has the Noether property?
+The **Noether Problem**: let $L$ be the field of rational functions in $n$
+indeterminates over $K$. Is it true that $L/K$ has the Noether property?
 
 Solution: False.
 -/

--- a/FormalConjectures/Wikipedia/PebblingNumberConjecture.lean
+++ b/FormalConjectures/Wikipedia/PebblingNumberConjecture.lean
@@ -91,7 +91,7 @@ noncomputable def PebblingNumber [Fintype V] (G : SimpleGraph V) : ℕ :=
   sInf { n | ∀ D, NumberOfPebbles D = n → ∀ v, ∃ D', IsReachable G D D' ∧ 1 ≤ D' v }
 
 /--
-The pebbling number of the complete graph on `n` vertices is `n`.
+The pebbling number of the complete graph on $n$ vertices is $n$.
 -/
 @[category API, AMS 5]
 theorem PebblingNumber_completeGraph [Fintype V] :

--- a/FormalConjectures/Wikipedia/PierceBirkhoff.lean
+++ b/FormalConjectures/Wikipedia/PierceBirkhoff.lean
@@ -26,7 +26,7 @@ as a maximum of finite minima of finite collections of polynomials. It was first
 by Garrett Birkhoff and Richard S. Pierce, though the modern rigorous formulation is due to
 Melvin Henriksen and John R. Isbell.
 
-The conjecture has been proved for `n = 1` and `n = 2` by Louis Mahé.
+The conjecture has been proved for $n = 1$ and $n = 2$ by Louis Mahé.
 -/
 
 namespace PierceBirkhoff
@@ -80,8 +80,8 @@ def IsPiecewisePolynomial (f : ℝ → ℝ) : Prop :=
 
 /--
 The Pierce-Birkhoff conjecture states that for every real piecewise-polynomial function
-`f : ℝⁿ → ℝ`, there exists a finite set of polynomials `gᵢⱼ ∈ ℝ[x₁, ..., xₙ]` such that
-`f = supᵢ infⱼ(gᵢⱼ)`.
+$f : ℝⁿ → ℝ$, there exists a finite set of polynomials $gᵢⱼ ∈ ℝ[x₁, ..., xₙ]$ such that
+$f = supᵢ infⱼ(gᵢⱼ)$.
 -/
 @[category research open, AMS 13]
 theorem pierce_birkhoff_conjecture {n : ℕ} (f : (Fin n → ℝ) → ℝ)
@@ -91,7 +91,7 @@ theorem pierce_birkhoff_conjecture {n : ℕ} (f : (Fin n → ℝ) → ℝ)
   sorry
 
 /--
-The Pierce-Birkhoff conjecture holds for `n = 1`.
+The Pierce-Birkhoff conjecture holds for $n = 1$.
 This was proved by Louis Mahé.
 -/
 @[category research solved, AMS 13]
@@ -102,7 +102,7 @@ theorem pierce_birkhoff_conjecture_dim_one (f : ℝ → ℝ)
   sorry
 
 /--
-The Pierce-Birkhoff conjecture holds for `n = 2`.
+The Pierce-Birkhoff conjecture holds for $n = 2$.
 This was proved by Louis Mahé.
 -/
 @[category research solved, AMS 13]

--- a/FormalConjectures/Wikipedia/RamanujanTau.lean
+++ b/FormalConjectures/Wikipedia/RamanujanTau.lean
@@ -21,9 +21,9 @@ import FormalConjectures.Util.ProblemImports
 
 There are two conjectures related to the Ramanujan τ-function:
 
-- Ramanujan-Petersson conjecture: For every prime `p`, the absolute value of the
-  Ramanujan τ-function at `p` is bounded by `2 * p^(11/2)`.
-- Lehmer's conjecture: The Ramanujan τ-function is never zero for any positive integer `n`.
+- Ramanujan-Petersson conjecture: For every prime $p$, the absolute value of the
+  Ramanujan τ-function at $p$ is bounded by $2 * p^(11/2)$.
+- Lehmer's conjecture: The Ramanujan τ-function is never zero for any positive integer $n$.
 
 *References:*
 - [Ramanujan-Petersson conjecture](https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Petersson_conjecture)

--- a/FormalConjectures/Wikipedia/RamseyNumbers.lean
+++ b/FormalConjectures/Wikipedia/RamseyNumbers.lean
@@ -27,7 +27,7 @@ We formalize the classical open problem of determining $R(5,5)$, together with t
 known bounds $43 \le R(5,5) \le 46$.
 
 Note: the diagonal Ramsey number $R(n,n)$ can also be formulated in terms of 2-colorings of
-$2$-subsets, as `Combinatorics.hypergraphRamsey 2 n` (see `FormalConjecturesForMathlib/Combinatorics/Ramsey.lean`).
+$2$-subsets, as $Combinatorics.hypergraphRamsey 2 n$ (see `FormalConjecturesForMathlib/Combinatorics/Ramsey.lean`).
 
 *References:*
 - [Wikipedia: Ramsey number](https://en.wikipedia.org/wiki/Ramsey_number)

--- a/FormalConjectures/Wikipedia/RegularPrimes.lean
+++ b/FormalConjectures/Wikipedia/RegularPrimes.lean
@@ -20,7 +20,7 @@ import FormalConjectures.Util.ProblemImports
 # Infinite Regular Primes
 
 We define the notion of regular primes, which are prime numbers that are coprime with the
-cardinality of the class group of the `p`-th cyclotomic field. We also state that there are
+cardinality of the class group of the $p$-th cyclotomic field. We also state that there are
 infinitely many regular primes.
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Regular_prime)
@@ -59,8 +59,8 @@ lemma small_regular_primes :
 theorem not_isRegularPrime_37_second : ¬ @IsRegularPrime 37 (by decide) := by
   sorry
 
-/-- An equivanlent definitions of regualr prime `p` is that it does not divide the numerator of the
-first `p-3` Bernoulli numbers. Not in Mathlib. -/
+/-- An equivanlent definitions of regualr prime $p$ is that it does not divide the numerator of the
+first $p-3$ Bernoulli numbers. Not in Mathlib. -/
 @[category textbook, AMS 11]
 theorem isRegularPrime_iff_Bernoulli (p : ℕ) [Fact p.Prime] :
     IsRegularPrime p ↔ ∀ k ∈ Finset.Icc 2 (p - 3), ¬ (p : ℤ) ∣ (bernoulli' k).num := by

--- a/FormalConjectures/Wikipedia/Selfridge.lean
+++ b/FormalConjectures/Wikipedia/Selfridge.lean
@@ -122,7 +122,7 @@ Known terms: 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 4, 5
 def fermatFactors (n : ℕ) : ℕ := n.fermatNumber.primeFactors.card
 
 /--
-Selfridge conjectured that the number of prime factors of the `n`-th Fermat number does not grow
+Selfridge conjectured that the number of prime factors of the $n$-th Fermat number does not grow
 monotonically in $n$.
 -/
 @[category research open, AMS 11]
@@ -130,7 +130,7 @@ theorem selfridge_seq_conjecture : ¬ Monotone fermatFactors := by
   sorry
 
 /--
-Selfridge conjectured that the number of prime factors of the `n`-th Fermat number does not grow
+Selfridge conjectured that the number of prime factors of the $n$-th Fermat number does not grow
 monotonically in $n$.
 
 A sufficient condition for this conjecture to hold is that there exists a Fermat prime larger than

--- a/FormalConjectures/Wikipedia/SumOfThreeCubes.lean
+++ b/FormalConjectures/Wikipedia/SumOfThreeCubes.lean
@@ -19,8 +19,8 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Sum of three cubes
 
-An integer `n : ℤ` can be written as a sum of three cubes (of integers) if and only if
-`n` is not `4` or `5` mod `9`.
+An integer $n : ℤ$ can be written as a sum of three cubes (of integers) if and only if
+$n$ is not $4$ or $5$ mod $9$.
 
 *References:*
  - [Wikipedia](https://en.wikipedia.org/wiki/Sums_of_three_cubes)
@@ -84,8 +84,8 @@ theorem isSumOfThreeCubesRat_any (r : ℚ) : IsSumOfThreeCubes r := by
     ring
 
 
-/-- An integer `n : ℤ` can be written as a sum of three cubes (of integers) if and only if
-`n` is not `4` or `5` mod `9`. -/
+/-- An integer $n : ℤ$ can be written as a sum of three cubes (of integers) if and only if
+$n$ is not $4$ or $5$ mod $9$. -/
 @[category research open, AMS 11]
 theorem isSumOfThreeCubes_iff_mod_9 :
     answer(sorry) ↔ ∀ n : ℤ, IsSumOfThreeCubes n ↔ ¬(n ≡ 4 [ZMOD 9] ∨ n ≡ 5 [ZMOD 9]) := by

--- a/FormalConjectures/Wikipedia/Superperfectnumbers.lean
+++ b/FormalConjectures/Wikipedia/Superperfectnumbers.lean
@@ -19,7 +19,7 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # (m,k)-perfect numbers
 
-An integer `n : ℤ` is `(m,k)-perfect` if `σᵐ(n) = kn` where `σᵐ` is the mᵗʰ iterate of the
+An integer $n : ℤ$ is $(m,k)-perfect$ if $σᵐ(n) = kn$ where $σᵐ$ is the mᵗʰ iterate of the
 sum of divisors function.
 
 *References:*

--- a/FormalConjectures/Wikipedia/Transcendental.lean
+++ b/FormalConjectures/Wikipedia/Transcendental.lean
@@ -190,7 +190,7 @@ theorem transcendental_gamma_one_div_six : Transcendental ℚ (1 / 6 : ℝ).Gamm
   sorry
 
 /--
-$\Gamma(1/n)$ for `n ≥ 2` is transcendental.
+$\Gamma(1/n)$ for $n ≥ 2$ is transcendental.
 -/
 @[category research open, AMS 33]
 theorem transcendental_gamma_one_div (n : ℕ) (hn : 2 ≤ n) : Transcendental ℚ (1 / n : ℝ).Gamma := by

--- a/FormalConjectures/Wikipedia/UnionClosed.lean
+++ b/FormalConjectures/Wikipedia/UnionClosed.lean
@@ -90,7 +90,8 @@ theorem union_closed.variants.univ_card
 /--
 Roberts and Simpson [Ro10] showed that the union-closed sets conjecture holds for set families of
 size at most 46.
-Their method, however, combined with the result of [Vu17], further shows that it holds for `#A ≤ 50`
+Their method, however, combined with the result of [Vu17], further shows that it holds for
+$|A| \le 50$
 as well.
 [Ro10] Roberts, Ian; Simpson, Jamie (2010). "A note on the union-closed sets conjecture" (PDF). Australas. J. Combin. 47: 265–267.
 [Vu17] Vuckovic, Bojan; Zivkovic, Miodrag (2017). "The 12-Element Case of Frankl's Conjecture" (PDF). IPSI BGD Transactions on Internet Research. 13 (1): 65.
@@ -145,7 +146,7 @@ theorem union_closed.variants.singleton_mem
   norm_cast
 
 /--
-The union-closed sets conjecture is sharp in the sense that if we replace the constant `1/2` with
+The union-closed sets conjecture is sharp in the sense that if we replace the constant $1/2$ with
 any larger constant, then the conjecture fails.
 -/
 @[category research solved, AMS 5]
@@ -199,7 +200,7 @@ theorem union_closed.variants.sharpness [Fintype n] (c : ℝ) (hc : 1 / 2 < c) :
   simp at this
 
 /--
-If the UC conjecture is tight for some family `A` then $|A| = 2^k$ for some $k$.
+If the UC conjecture is tight for some family $A$ then $|A| = 2^k$ for some $k$.
 
 Reference: Conjecture 3 in https://www.nieuwarchief.nl/serie5/pdf/naw5-2023-24-4-225.pdf.
 -/

--- a/FormalConjectures/Wikipedia/WoodalPrimes.lean
+++ b/FormalConjectures/Wikipedia/WoodalPrimes.lean
@@ -26,7 +26,7 @@ References:
 
 namespace WoodallPrimes
 
-/-- There are infinitely many prime numbers of the form `k * 2 ^ k - 1` for `k > 1`. -/
+/-- There are infinitely many prime numbers of the form $k * 2 ^ k - 1$ for $k > 1$. -/
 @[category research open, AMS 11]
 theorem infinitely_many_woodall_primes : {k : ℕ | 1 < k ∧ (k * 2 ^ k - 1).Prime}.Infinite := by
   sorry

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture1.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture1.lean
@@ -30,9 +30,9 @@ open SimpleGraph
 /--
 WOWII [Conjecture 1](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G` the maximum number of leaves of a spanning
-tree satisfies `Ls(G) ≥ n(G) + 1 - 2·m(G)` where `n(G)` counts vertices and
-`m(G)` is the size of a maximum matching.
+For a simple connected graph $G$ the maximum number of leaves of a spanning
+tree satisfies $Ls(G) ≥ n(G) + 1 - 2·m(G)$ where $n(G)$ counts vertices and
+$m(G)$ is the size of a maximum matching.
 -/
 
 @[category research solved, AMS 5]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture13.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture13.lean
@@ -33,10 +33,10 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 13](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, the size `b(G)` of a largest induced bipartite subgraph
-satisfies `b(G) ≥ diam(G) + max_{v ∈ V} l(v) - 1`, where `diam(G)` is the diameter
-of `G` and `l(v) = indepNeighborsCard G v` is the independence number of the
-neighbourhood of `v`.
+For a simple connected graph $G$, the size $b(G)$ of a largest induced bipartite subgraph
+satisfies $b(G) ≥ diam(G) + max_{v ∈ V} l(v) - 1$, where $diam(G)$ is the diameter
+of $G$ and $l(v) = indepNeighborsCard G v$ is the independence number of the
+neighbourhood of $v$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture13 (G : SimpleGraph α) (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture141.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture141.lean
@@ -32,11 +32,11 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 141](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`,
-`tree(G) ≥ ⌊girth(G) / 2⌋ - 1 + max_v l(v)`
-where `tree(G)` is the number of vertices of a largest induced tree subgraph,
-`girth(G)` is the length of the shortest cycle (0 if acyclic), and
-`l(v) = indepNeighbors G v` is the independence number of the neighbourhood of `v`.
+For a simple connected graph $G$,
+$tree(G) ≥ ⌊girth(G) / 2⌋ - 1 + max_v l(v)$
+where $tree(G)$ is the number of vertices of a largest induced tree subgraph,
+$girth(G)$ is the length of the shortest cycle (0 if acyclic), and
+$l(v) = indepNeighbors G v$ is the independence number of the neighbourhood of $v$.
 -/
 @[category research open, AMS 5]
 theorem conjecture141 (G : SimpleGraph α) (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture16.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture16.lean
@@ -33,10 +33,10 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 16](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, the size `b(G)` of a largest induced bipartite subgraph
-satisfies `b(G) ≥ 2 * (rad(G) - 1) + max_{v ∈ V} l(v)`, where `rad(G)` is the radius
-of `G` (the minimum eccentricity) and `l(v) = indepNeighborsCard G v` is the independence
-number of the neighbourhood of `v`.
+For a simple connected graph $G$, the size $b(G)$ of a largest induced bipartite subgraph
+satisfies $b(G) ≥ 2 * (rad(G) - 1) + max_{v ∈ V} l(v)$, where $rad(G)$ is the radius
+of $G$ (the minimum eccentricity) and $l(v) = indepNeighborsCard G v$ is the independence
+number of the neighbourhood of $v$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture16 (G : SimpleGraph α) (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture17.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture17.lean
@@ -33,9 +33,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 17](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, the size `b(G)` of a largest induced bipartite subgraph
-satisfies `b(G) ≥ α(G) + ⌈diam(G) / 3⌉`, where `α(G)` is the independence number of `G`
-and `diam(G)` is the diameter of `G`.
+For a simple connected graph $G$, the size $b(G)$ of a largest induced bipartite subgraph
+satisfies $b(G) ≥ α(G) + ⌈diam(G) / 3⌉$, where $α(G)$ is the independence number of $G$
+and $diam(G)$ is the diameter of $G$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture17 (G : SimpleGraph α) (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
@@ -35,10 +35,10 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 19](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-If `G` is connected then the size `b(G)` of a largest induced bipartite subgraph
+If $G$ is connected then the size $b(G)$ of a largest induced bipartite subgraph
 satisfies
-`b(G) ≥ FLOOR((∑ ecc(v))/(|V|) + sSup (range (l G)))`, where `ecc(v)` denotes
-eccentricity and `l(G)` is the independence number of neighbourhoods.
+$b(G) ≥ FLOOR((∑ ecc(v))/(|V|) + sSup (range (l G)))$, where $ecc(v)$ denotes
+eccentricity and $l(G)$ is the independence number of neighbourhoods.
 -/
 @[category research open, AMS 5]
 theorem conjecture19 (G : SimpleGraph α) [Nontrivial α] (h_conn : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture194.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture194.lean
@@ -32,9 +32,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 194](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, if `α(G) ≤ 1 + l_avg(G)`, then `G` has a Hamiltonian path.
-Here `α(G) = G.indepNum` is the independence number, and
-`l_avg(G) = averageIndepNeighbors G` is the average over all vertices of the independence number
+For a simple connected graph $G$, if $α(G) ≤ 1 + l_avg(G)$, then $G$ has a Hamiltonian path.
+Here $α(G) = G.indepNum$ is the independence number, and
+$l_avg(G) = averageIndepNeighbors G$ is the average over all vertices of the independence number
 of the neighbourhood.
 A Hamiltonian path is a walk visiting every vertex exactly once.
 -/

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture198a.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture198a.lean
@@ -32,9 +32,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 198a](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, if `b(G) ≤ 2 + ecc_avg(G)`, then `G` has a Hamiltonian path.
-Here `b(G)` is the number of vertices in a largest induced bipartite subgraph, and
-`ecc_avg(G)` is the average eccentricity of `G`.
+For a simple connected graph $G$, if $b(G) ≤ 2 + ecc_avg(G)$, then $G$ has a Hamiltonian path.
+Here $b(G)$ is the number of vertices in a largest induced bipartite subgraph, and
+$ecc_avg(G)$ is the average eccentricity of $G$.
 A Hamiltonian path is a walk visiting every vertex exactly once.
 -/
 @[category research open, AMS 5]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
@@ -33,9 +33,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 2](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`,
-`Ls(G) ≥ 2 · (l(G) - 1)` where `l(G)` is the average independence number of
-the neighbourhoods of the vertices of `G`.
+For a simple connected graph $G$,
+$Ls(G) ≥ 2 · (l(G) - 1)$ where $l(G)$ is the average independence number of
+the neighbourhoods of the vertices of $G$.
 -/
 @[category research open, AMS 5]
 theorem conjecture2 (G : SimpleGraph α) (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture20.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture20.lean
@@ -32,9 +32,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 20](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `b(G) ≥ n(G) / ⌊deg_avg(G)⌋`, where `b(G)` is
-the size of a largest induced bipartite subgraph, `n(G)` is the number of vertices,
-and `deg_avg(G) = (∑ v, deg(v)) / n(G)` is the average degree.
+For a simple connected graph $G$, $b(G) ≥ n(G) / ⌊deg_avg(G)⌋$, where $b(G)$ is
+the size of a largest induced bipartite subgraph, $n(G)$ is the number of vertices,
+and $deg_avg(G) = (∑ v, deg(v)) / n(G)$ is the average degree.
 -/
 @[category research solved, AMS 5]
 theorem conjecture20 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture200.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture200.lean
@@ -32,9 +32,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 200](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, if `tree(G) = ⌈1 + l_avg(G)⌉`, then `G` has a Hamiltonian path.
-Here `tree(G)` is the number of vertices of a largest induced tree subgraph, and
-`l_avg(G) = averageIndepNeighbors G` is the average over all vertices of the independence number
+For a simple connected graph $G$, if $tree(G) = ⌈1 + l_avg(G)⌉$, then $G$ has a Hamiltonian path.
+Here $tree(G)$ is the number of vertices of a largest induced tree subgraph, and
+$l_avg(G) = averageIndepNeighbors G$ is the average over all vertices of the independence number
 of the neighbourhood.
 A Hamiltonian path is a walk visiting every vertex exactly once.
 -/

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
@@ -32,13 +32,13 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 23](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `b(G) ≥ ⌊α(G) + dist_avg(M, V) / 2⌋`, where `b(G)` is
-the size of a largest induced bipartite subgraph, `α(G)` is the independence number,
-and `M` is the set of maximum-degree vertices, and `dist_avg(M, V)` is the average
-distance from all vertices to `M`.
+For a simple connected graph $G$, $b(G) ≥ ⌊α(G) + dist_avg(M, V) / 2⌋$, where $b(G)$ is
+the size of a largest induced bipartite subgraph, $α(G)$ is the independence number,
+and $M$ is the set of maximum-degree vertices, and $dist_avg(M, V)$ is the average
+distance from all vertices to $M$.
 
-This conjecture is false; there is a counterexample with `b(G) = 19`, `α(G) = 15`,
-and `dist_avg(M, V) = 10`.
+This conjecture is false; there is a counterexample with $b(G) = 19$, $α(G) = 15$,
+and $dist_avg(M, V) = 10$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture23 : answer(False) ↔

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture3.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture3.lean
@@ -35,9 +35,9 @@ variable {α : Type u} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 3](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a connected simple graph `G`, the number of leaves in a maximum spanning
-tree satisfies `Ls(G) ≥ gi(G) * MaxTemp(G)`, where `gi(G)` is the independent
-domination number and `MaxTemp(G)` is `max_v deg(v)/(n(G) - deg(v))`.
+For a connected simple graph $G$, the number of leaves in a maximum spanning
+tree satisfies $Ls(G) ≥ gi(G) * MaxTemp(G)$, where $gi(G)$ is the independent
+domination number and $MaxTemp(G)$ is $max_v deg(v)/(n(G) - deg(v))$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture3 {G : SimpleGraph α} [DecidableEq α] [DecidableRel G.Adj] [Nontrivial α]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture315.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture315.lean
@@ -34,8 +34,8 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 315](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-Let `G` be a simple connected graph and let `P` denote the set of pendant vertices
-(vertices of degree 1). If `α(G) = |P|`, then `G` is well totally dominated.
+Let $G$ be a simple connected graph and let $P$ denote the set of pendant vertices
+(vertices of degree 1). If $α(G) = |P|$, then $G$ is well totally dominated.
 -/
 @[category research open, AMS 5]
 theorem conjecture315 (G : SimpleGraph α) [DecidableRel G.Adj] (hG : G.Connected)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture316.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture316.lean
@@ -31,9 +31,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 316](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-Let `G` be a simple connected graph and let `P` denote the set of pendant vertices
-(vertices of degree 1). If `|P| ≥ deg_avg(G)`, then `G` is well totally dominated,
-where `deg_avg(G)` is the average degree of `G`.
+Let $G$ be a simple connected graph and let $P$ denote the set of pendant vertices
+(vertices of degree 1). If $|P| ≥ deg_avg(G)$, then $G$ is well totally dominated,
+where $deg_avg(G)$ is the average degree of $G$.
 -/
 @[category research open, AMS 5]
 theorem conjecture316 (G : SimpleGraph α) [DecidableRel G.Adj] (hG : G.Connected)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture32.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture32.lean
@@ -32,9 +32,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 32](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `path(G) ≥ ⌈2 · dist_avg(M, V)⌉`, where `path(G)`
-is the floor of the average distance of `G`, `M` is the set of maximum-degree vertices,
-and `dist_avg(M, V)` is the average distance from all vertices to `M`.
+For a simple connected graph $G$, $path(G) ≥ ⌈2 · dist_avg(M, V)⌉$, where $path(G)$
+is the floor of the average distance of $G$, $M$ is the set of maximum-degree vertices,
+and $dist_avg(M, V)$ is the average distance from all vertices to $M$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture32 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
@@ -34,12 +34,12 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 322](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-Let `G` be a simple connected graph on `n ≥ 5` vertices. If the maximum over all
-vertices `v` of `l(v)` — the independence number of the neighborhood `N(v)` of `v`
-— is at most 1, then `G` is well totally dominated.
+Let $G$ be a simple connected graph on $n ≥ 5$ vertices. If the maximum over all
+vertices $v$ of $l(v)$ — the independence number of the neighborhood $N(v)$ of $v$
+— is at most 1, then $G$ is well totally dominated.
 
-Here `l(v) = α(G[N(v)])` is the independence number of the subgraph induced by the
-open neighborhood of `v`.
+Here $l(v) = α(G[N(v)])$ is the independence number of the subgraph induced by the
+open neighborhood of $v$.
 -/
 @[category research open, AMS 5]
 theorem conjecture322 (G : SimpleGraph α) [DecidableRel G.Adj] (hG : G.Connected)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture327.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture327.lean
@@ -31,9 +31,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 327](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-Let `G` be a simple connected graph. If `3 · γ(G) = γ_i(G)`, then `G` is well
-totally dominated, where `γ(G)` is the domination number of `G` and `γ_i(G)` is
-the independent domination number of `G`.
+Let $G$ be a simple connected graph. If $3 · γ(G) = γ_i(G)$, then $G$ is well
+totally dominated, where $γ(G)$ is the domination number of $G$ and $γ_i(G)$ is
+the independent domination number of $G$.
 -/
 @[category research open, AMS 5]
 theorem conjecture327 (G : SimpleGraph α) [DecidableRel G.Adj] (hG : G.Connected)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture33.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture33.lean
@@ -32,10 +32,10 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 33](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `path(G) ≥ ⌈dist_avg(C, V) + dist_avg(M, V)⌉`,
-where `path(G)` is the floor of the average distance of `G`, `C` is the set of center
-vertices (those with minimum eccentricity), `M` is the set of maximum-degree vertices,
-and `dist_avg(S, V)` is the average distance from all vertices to the set `S`.
+For a simple connected graph $G$, $path(G) ≥ ⌈dist_avg(C, V) + dist_avg(M, V)⌉$,
+where $path(G)$ is the floor of the average distance of $G$, $C$ is the set of center
+vertices (those with minimum eccentricity), $M$ is the set of maximum-degree vertices,
+and $dist_avg(S, V)$ is the average distance from all vertices to the set $S$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture33 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -37,9 +37,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 34](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-Let `path(G)` be the floor of the average distance of a connected graph `G`.
+Let $path(G)$ be the floor of the average distance of a connected graph $G$.
 Then
-`path(G) ≥ ceil( distavg(G, center) + distavg(G, maxEccentricityVertices G) )`.
+$path(G) ≥ ceil( distavg(G, center) + distavg(G, maxEccentricityVertices G) )$.
 -/
 @[category research open, AMS 5]
 theorem conjecture34 [Nontrivial α] (G : SimpleGraph α) (h_conn : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture4.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture4.lean
@@ -33,9 +33,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /--
 WOWII [Conjecture 4](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-If `G` is a connected graph then the maximum number of leaves over all spanning
-trees satisfies `Ls(G) ≥ NG(G) - 1` where `NG(G)` is the minimal neighbourhood
-size of a non-edge of `G`.
+If $G$ is a connected graph then the maximum number of leaves over all spanning
+trees satisfies $Ls(G) ≥ NG(G) - 1$ where $NG(G)$ is the minimal neighbourhood
+size of a non-edge of $G$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture4 (G : SimpleGraph α) [DecidableRel G.Adj] [Nontrivial α] (h_conn : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture40.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture40.lean
@@ -33,9 +33,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α] (G : SimpleG
 /--
 WOWII [Conjecture 40](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a nontrivial connected graph `G` the size `f(G)` of a largest induced forest
-satisfies `f(G) ≥ ceil((p(G) + b(G) + 1)/2)` where `p(G)` is the path cover
-number and `b(G)` is the largest induced bipartite subgraph size.
+For a nontrivial connected graph $G$ the size $f(G)$ of a largest induced forest
+satisfies $f(G) ≥ ceil((p(G) + b(G) + 1)/2)$ where $p(G)$ is the path cover
+number and $b(G)$ is the largest induced bipartite subgraph size.
 -/
 @[category research open, AMS 5]
 theorem conjecture40 (h_conn : G.Connected) (h_nontrivial : 1 < Fintype.card α) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
@@ -35,8 +35,8 @@ open Classical
 /--
 WOWII [Conjecture 5](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `Ls(G)` is bounded below by the maximal size
-of a sphere of radius `radius(G)` around the centres of `G`.
+For a simple connected graph $G$, $Ls(G)$ is bounded below by the maximal size
+of a sphere of radius $radius(G)$ around the centres of $G$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture5 (G : SimpleGraph V) (h_conn : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture58.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture58.lean
@@ -33,9 +33,9 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α] (G : SimpleG
 /--
 WOWII [Conjecture 58](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a connected graph `G`, the size `f(G)` of a largest induced forest satisfies
-`f(G) ≥ ceil( b(G) / average l(v) )` where `b(G)` is the largest induced
-bipartite subgraph and `l(v)` is the independence number of `G.neighborSet v`.
+For a connected graph $G$, the size $f(G)$ of a largest induced forest satisfies
+$f(G) ≥ ceil( b(G) / average l(v) )$ where $b(G)$ is the largest induced
+bipartite subgraph and $l(v)$ is the independence number of `G.neighborSet v`.
 -/
 @[category research open, AMS 5]
 theorem conjecture58 (hG : G.Connected) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture6.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture6.lean
@@ -31,8 +31,8 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 6](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a connected graph `G` we have
-`Ls(G) ≥ 1 + n(G) - m(G) - a(G)` where `a(G)` is defined via independent sets.
+For a connected graph $G$ we have
+$Ls(G) ≥ 1 + n(G) - m(G) - a(G)$ where $a(G)$ is defined via independent sets.
 -/
 @[category research solved, AMS 5]
 theorem conjecture6 (G : SimpleGraph α) [DecidableRel G.Adj] (h_conn : G.Connected) :

--- a/FormalConjecturesForMathlib/Analysis/SpecialFunctions/NthRoot.lean
+++ b/FormalConjecturesForMathlib/Analysis/SpecialFunctions/NthRoot.lean
@@ -23,9 +23,9 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Real
 /-!
 # nth root operations
 
-This file provides `Real.nthRoot n` to compute `ⁿ√`,
-which operates as expected on negative values when `n` is odd.
-The trap this avoids is that using `rpow`, `(-8 : ℝ) ^ (1/3 : ℝ) = 1`.
+This file provides `Real.nthRoot n` to compute $ⁿ√$,
+which operates as expected on negative values when $n$ is odd.
+The trap this avoids is that using `rpow`, $(-8 : ℝ) ^ (1/3 : ℝ) = 1$.
 
 This is being upstreamed to Mathlib in leanprover-community/mathlib4#26935.
 -/

--- a/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
@@ -27,19 +27,19 @@ open scoped Classical
 /-! # Arithmetic Progressions
 
 Main definitions:
-- `Set.IsAPOfLengthWith (s : Set α) (l : ℕ∞) (a d : α)` : predicate asserting that `s` is the
-  set consisting of an arithmetic progression of length `l` (possibly infinite) with first term
-  `a` and difference `d`. Useful for cases in which additional conditions need to be applied to
+- $Set.IsAPOfLengthWith (s : Set α) (l : ℕ∞) (a d : α)$ : predicate asserting that $s$ is the
+  set consisting of an arithmetic progression of length $l$ (possibly infinite) with first term
+  $a$ and difference $d$. Useful for cases in which additional conditions need to be applied to
   the individual terms and/or difference.
-- `Set.IsAPOfLength (s : Set α) (l : ℕ∞)` : predicate asserting that `s` is the set consisting
-  of an arithmetic progression of length `l`, for some some first term and difference.
+- $Set.IsAPOfLength (s : Set α) (l : ℕ∞)$ : predicate asserting that $s$ is the set consisting
+  of an arithmetic progression of length $l$, for some some first term and difference.
 -/
 
 variable {α : Type*} [AddCommMonoid α]
 
 /--
 A set $S$ is an arithmetic progression of length $l$ with first term $a$ and difference $d$
-if $S = \{a, a + d, ..., a + (l - 1)d\}$, if $l$ if finite, else $S = \{a, a + d, a + 2d, ...\}.
+if $S = \{a, a + d, ..., a + (l - 1)d\}$, if $l$ if finite, else $S = \{a, a + d, a + 2d, ...\}$.
 This can be written as `s.IsAPOfLengthWith l a d`, where `l : ℕ∞` may take the infinite
 value `⊤`.
 -/
@@ -60,13 +60,13 @@ variable {s : Set α} {l : ℕ∞} {a d : α}
 theorem card (h : s.IsAPOfLengthWith l a d) : ENat.card s = l := h.1
 theorem eq (h : s.IsAPOfLengthWith l a d) : s = {a + n • d | (n : ℕ) (_ : n < l)} := h.2
 
-/-- An arithmetic progression with first term `a` and difference `d` is of length zero if and only
-if `s` is empty. -/
+/-- An arithmetic progression with first term $a$ and difference $d$ is of length zero if and only
+if $s$ is empty. -/
 @[simp]
 theorem zero : s.IsAPOfLengthWith 0 a d ↔ s = ∅ := by simp [IsAPOfLengthWith]
 
-/-- An arithmetic progression with first term `a` and difference `d` is of length one if and only
-if `s` is a singleton. -/
+/-- An arithmetic progression with first term $a$ and difference $d$ is of length one if and only
+if $s$ is a singleton. -/
 @[simp]
 theorem one : s.IsAPOfLengthWith 1 a d ↔ s = {a} := by simp +contextual [IsAPOfLengthWith]
 
@@ -79,22 +79,22 @@ variable {s : List α} {l : ℕ} {a d : α}
 theorem length (h : s.IsAPOfLengthWith l a d) : s.length = l := by
   cases h <;> simp_all
 
-/-- An arithmetic progression with first term `a` and difference `d` is of length zero if and only
-if `s` is empty. -/
+/-- An arithmetic progression with first term $a$ and difference $d$ is of length zero if and only
+if $s$ is empty. -/
 @[simp]
 theorem zero : s.IsAPOfLengthWith 0 a d ↔ s = [] := by
   simp [IsAPOfLengthWith]
 
-/-- An arithmetic progression with first term `a` and difference `d` is of length one if and only
-if `s` is a singleton. -/
+/-- An arithmetic progression with first term $a$ and difference $d$ is of length one if and only
+if $s$ is a singleton. -/
 @[simp]
 theorem one : s.IsAPOfLengthWith 1 a d ↔ s = [a] := by
   simp [IsAPOfLengthWith]
 
 end List.IsAPOfLengthWith
 
-/-- In an abelian additive group `α`, the set `{a, b}` with `a ≠ b` is an arithmetic progression of
-length `2` with first term `a` and difference `b - a`. -/
+/-- In an abelian additive group $α$, the set ${a, b}$ with $a ≠ b$ is an arithmetic progression of
+length $2$ with first term $a$ and difference $b - a$. -/
 theorem Set.isAPOfLengthWith_pair {α : Type*} [DecidableEq α] [AddCommGroup α]
     {a b : α} (hab : a ≠ b) :
     Set.IsAPOfLengthWith {a, b} 2 a (b - a) := by
@@ -108,8 +108,8 @@ theorem Set.isAPOfLengthWith_pair {α : Type*} [DecidableEq α] [AddCommGroup α
 
 -- Formalisation note: separate result needed for `ℕ` since this is not covered by
 -- the `AddCommGroup` result above.
-/-- The set `{a, b} : Set ℕ` with `a < b` is an arithmetic progression of length `2` with
-first term `a` and difference `b - a`. -/
+/-- The set ${a, b} : Set ℕ$ with $a < b$ is an arithmetic progression of length $2$ with
+first term $a$ and difference $b - a$. -/
 theorem Nat.isAPOfLengthWith_pair {a b : ℕ} (hab : a < b) :
     Set.IsAPOfLengthWith {a, b} 2 a (b - a) := by
   let ⟨n, h⟩ := Nat.exists_eq_add_of_lt hab
@@ -148,7 +148,7 @@ theorem eq (h : s.IsAPOfLength l) : ∃ a d : α, s = {a + n • d | (n : ℕ) (
 /-- Only singletons are finite arithmetic progressions of length $1$. -/
 @[simp] theorem one : s.IsAPOfLength 1 ↔ ∃ a, s = {a} := by simp [IsAPOfLength]
 
-/-- If a set is an arithmetic progression of lengths `l₁` and `l₂`, then the lengths are
+/-- If a set is an arithmetic progression of lengths $l₁$ and $l₂$, then the lengths are
 equal. -/
 theorem congr {s : Set α} {l₁ l₂ : ℕ∞}
     (h₁ : s.IsAPOfLength l₁) (h₂ : s.IsAPOfLength l₂) :
@@ -173,7 +173,7 @@ theorem length (h : s.IsAPOfLength l) : s.length = l := by
 /-- Only singletons are finite arithmetic progressions of length $1$. -/
 @[simp] theorem one : s.IsAPOfLength 1 ↔ ∃ a, s = [a] := by simp [IsAPOfLength]
 
-/-- If a list is an arithmetic progression of lengths `l₁` and `l₂`, then the lengths are
+/-- If a list is an arithmetic progression of lengths $l₁$ and $l₂$, then the lengths are
 equal. -/
 theorem congr {s : List α} {l₁ l₂ : ℕ}
     (h₁ : s.IsAPOfLength l₁) (h₂ : s.IsAPOfLength l₂) :
@@ -200,11 +200,11 @@ non-trivial arithmetic progressions of length `l`. Written as `Set.IsAPOfLengthF
 def Set.IsAPOfLengthFree (s : Set α) (l : ℕ∞) : Prop :=
   ∀ t ⊆ s, t.IsAPOfLength l → l ≤ 1
 
-/-- Any set is free of arithmetic progressions of length `1`, because such APs are all trivial. -/
+/-- Any set is free of arithmetic progressions of length $1$, because such APs are all trivial. -/
 theorem Set.isAPOfLengthFree_one (s : Set α) : s.IsAPOfLengthFree 1 := by
   simp [Set.IsAPOfLengthFree]
 
-/-- Any set is free of arithmetic progressions of length `0`, because such APs are all trivial. -/
+/-- Any set is free of arithmetic progressions of length $0$, because such APs are all trivial. -/
 theorem Set.isAPOfLengthFree_zero (s : Set α) : s.IsAPOfLengthFree 0 := by
   simp [Set.IsAPOfLengthFree]
 

--- a/FormalConjecturesForMathlib/Combinatorics/Additive/Basis.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Additive/Basis.lean
@@ -57,7 +57,7 @@ lemma isMulBasisOfOrder_iff :
   have := Set.mem_finset_prod (t := .univ) (f := fun _ : Fin n ↦ A)
   simp_all [IsMulBasisOfOrder]
 
-/-- No set is a multiplicative basis of order `0`. -/
+/-- No set is a multiplicative basis of order $0$. -/
 @[to_additive (attr := simp) /-- No set is an additive basis of order `0`. -/]
 lemma not_isMulBasisOfOrder_zero [Nontrivial M] : ¬A.IsMulBasisOfOrder 0 := by
   simp [isMulBasisOfOrder_iff, eq_comm, exists_ne]
@@ -66,7 +66,7 @@ lemma not_isMulBasisOfOrder_zero [Nontrivial M] : ¬A.IsMulBasisOfOrder 0 := by
 lemma isMulBasisOfOrder_one_iff : A.IsMulBasisOfOrder 1 ↔ A = univ := by
   simp [IsMulBasisOfOrder, eq_univ_iff_forall]
 
-/-- A set `A : Set M` is a multiplicative basis of order `2` if every `a : M` belongs to `A * A`. -/
+/-- A set `A : Set M` is a multiplicative basis of order $2$ if every `a : M` belongs to $A * A$. -/
 @[to_additive
 /-- A set `A : Set M` is an additive basis of order `2` if every `a : M` belongs to `A + A`. -/]
 lemma isMulBasisOfOrder_two_iff : A.IsMulBasisOfOrder 2 ↔ ∀ a, a ∈ A * A := by
@@ -95,8 +95,8 @@ lemma IsMulBasisOfOrder.isAsymptoticMulBasisOfOrder (hA : IsMulBasisOfOrder A n)
 lemma IsMulBasis.isAsymptoticMulBasis (hA : IsMulBasis A) : A.IsAsymptoticMulBasis := by
   obtain ⟨n, hn⟩ := hA; exact ⟨n, hn.isAsymptoticMulBasisOfOrder⟩
 
-/-- A set `A : Set M` is an asymptotic multiplicative basis of order `n` if a cofinite set of
-`a : M` can be written as `a = a₁ * ... * aₙ`, where each `aᵢ ∈ A`. -/
+/-- A set `A : Set M` is an asymptotic multiplicative basis of order $n$ if a cofinite set of
+`a : M` can be written as $a = a₁ * ... * aₙ$, where each $aᵢ ∈ A$. -/
 @[to_additive
 /-- A set `A : Set M` is an asymptotic additive basis of order `n` if a cofinite set of
 `a : M` can be written as `a = a₁ + ... + aₙ`, where each `aᵢ ∈ A`. -/]
@@ -106,8 +106,8 @@ lemma isAsymptoticMulBasisOfOrder_iff_prod :
   have := Set.mem_finset_prod (t := .univ) (f := fun _ : Fin n ↦ A)
   simp_all [IsAsymptoticMulBasisOfOrder]
 
-/-- A set `A : Set M` is an asymptotic multiplicative basis of order `2` if a cofinite set of
-`a : M` belongs to `A * A`. -/
+/-- A set `A : Set M` is an asymptotic multiplicative basis of order $2$ if a cofinite set of
+`a : M` belongs to $A * A$. -/
 @[to_additive
 /-- A set `A : Set M` is an asymptotic additive basis of order `2` if a cofinite set of
 `a : M` belongs to `A + A`. -/]
@@ -119,7 +119,7 @@ lemma isAsymptoticMulBasisOfOrder_two_iff :
 protected lemma IsAsymptoticMulBasisOfOrder.of_finite [Finite M] :
     IsAsymptoticMulBasisOfOrder A n := by simp [IsAsymptoticMulBasisOfOrder]
 
-/-- If `M` is infinite, then no set `A` is an asymptotic multiplicative basis of order `0`. -/
+/-- If $M$ is infinite, then no set $A$ is an asymptotic multiplicative basis of order $0$. -/
 @[to_additive (attr := simp)
 /-- If `M` is infinite, then no set `A` is an asymptotic additive basis of order `0`. -/]
 lemma not_isAsymptoticMulBasisOfOrder_zero [Infinite M] : ¬IsAsymptoticMulBasisOfOrder A 0 := by
@@ -167,7 +167,7 @@ lemma IsAsymptoticMulBasisOfOrder.mono [CanonicallyOrderedMul M] [IsCancelMul M]
   contrapose! hb
   exact smul_set_subset_mul (pow_mem_pow ha) hb.1
 
-/-- For `M` equipped with a directed order, a set is an asymptotic multiplicative basis of order `1`
+/-- For $M$ equipped with a directed order, a set is an asymptotic multiplicative basis of order $1$
 if it contains an infinite tail of elements. -/
 @[to_additive
 /-- For `M` equipped with a directed order, a set is an asymptotic additive basis of order `1`
@@ -178,7 +178,7 @@ lemma isAsymptoticMulBasisOfOrder_one_iff_Ioi :
 
 variable [SuccOrder M] [NoMaxOrder M]
 
-/-- For `M` equipped with a directed order, a set is an asymptotic multiplicative basis of order `1`
+/-- For $M$ equipped with a directed order, a set is an asymptotic multiplicative basis of order $1$
 if it contains an infinite tail of elements. -/
 @[to_additive
 /-- For `M` equipped with a directed order, a set is an asymptotic additive basis of order `1`

--- a/FormalConjecturesForMathlib/Combinatorics/Additive/Convolution.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Additive/Convolution.lean
@@ -23,7 +23,7 @@ public import Mathlib.RingTheory.PowerSeries.Basic
 /-!
 # Convolution of Functions on ℕ
 
-This file defines the sum (`∗`) convolution of functions `ℕ → R`.
+This file defines the sum (`∗`) convolution of functions $ℕ → R$.
 
 ## Main Definitions
 * `AdditiveCombinatorics.sumConv`: The sum convolution `f ∗ g`.

--- a/FormalConjecturesForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Basic.lean
@@ -114,8 +114,8 @@ theorem IsSidon.insert {A : Set α} {m : α} [IsRightCancelAdd α] [IsLeftCancel
 /-!
 Maximal Sidon sets in an interval.
 
-We follow the convention that `IsMaximalSidonSetIn A N` means `A ⊆ {1, …, N}` is Sidon and
-is inclusion-maximal among subsets of `Set.Icc 1 N` with the Sidon property.
+We follow the convention that `IsMaximalSidonSetIn A N` means $A ⊆ {1, …, N}$ is Sidon and
+is inclusion-maximal among subsets of $Set.Icc 1 N$ with the Sidon property.
 -/
 
 /-- `IsMaximalSidonSetIn A N` means `A ⊆ {1, …, N}` is Sidon and cannot be extended within
@@ -126,11 +126,11 @@ def IsMaximalSidonSetIn (A : Set ℕ) (N : ℕ) : Prop :=
 
 namespace IsMaximalSidonSetIn
 
-/-- If `A` is a maximal Sidon set in `{1, …, N}`, then `A ⊆ {1, …, N}`. -/
+/-- If $A$ is a maximal Sidon set in ${1, …, N}$, then $A ⊆ {1, …, N}$. -/
 theorem subset {A : Set ℕ} {N : ℕ} (hA : IsMaximalSidonSetIn A N) :
     A ⊆ Set.Icc 1 N := hA.1
 
-/-- If `A` is a maximal Sidon set in `{1, …, N}`, then `A` is Sidon. -/
+/-- If $A$ is a maximal Sidon set in ${1, …, N}$, then $A$ is Sidon. -/
 theorem isSidon {A : Set ℕ} {N : ℕ} (hA : IsMaximalSidonSetIn A N) : IsSidon A := hA.2.1
 
 /-- Maximality condition unpacked. -/
@@ -153,7 +153,7 @@ instance (A : Finset α) [DecidableEq α] : Decidable (IsSidon (A : Set α)) := 
 def maxSidonSubsetCard (A : Finset α) [DecidableEq α] : ℕ :=
   (A.powerset.filter fun B : Finset α ↦ IsSidon (B : Set α)).sup Finset.card
 
-/-- If `A` is finite Sidon, then `A ∪ {s}` is also Sidon provided `s ≥ A.max + 1`. -/
+/-- If $A$ is finite Sidon, then $A ∪ {s}$ is also Sidon provided $s ≥ A.max + 1$. -/
 theorem IsSidon.insert_ge_max' {A : Finset ℕ} (h : A.Nonempty) (hA : IsSidon (A : Set ℕ)) {s : ℕ}
     (hs : 2 * A.max' h + 1 ≤ s) :
     IsSidon (A ∪ {s}) := by

--- a/FormalConjecturesForMathlib/Combinatorics/Ramsey.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Ramsey.lean
@@ -24,7 +24,7 @@ public import Mathlib.Data.Nat.Lattice
 /-!
 # Hypergraph Ramsey Numbers
 
-This file defines the `r`-uniform hypergraph Ramsey number `R_r(n)`.
+This file defines the $r$-uniform hypergraph Ramsey number $R_r(n)$.
 -/
 
 namespace Combinatorics
@@ -39,7 +39,7 @@ noncomputable def hypergraphRamsey (r n : ℕ) : ℕ :=
     ∃ (S : Finset (Fin m)), S.card = n ∧
       ∃ (color : Bool), ∀ (e : Finset (Fin m)), e ⊆ S → e.card = r → c e = color }
 
-/-- `n ≤ hypergraphRamsey r n` when the set is nonempty. -/
+/-- $n ≤ hypergraphRamsey r n$ when the set is nonempty. -/
 theorem le_hypergraphRamsey (r n : ℕ) (hne : { m | ∀ (c : Finset (Fin m) → Bool),
     ∃ (S : Finset (Fin m)), S.card = n ∧
       ∃ (color : Bool), ∀ (e : Finset (Fin m)), e ⊆ S → e.card = r → c e = color }.Nonempty) :
@@ -52,7 +52,7 @@ theorem le_hypergraphRamsey (r n : ℕ) (hne : { m | ∀ (c : Finset (Fin m) →
     _ ≤ Fintype.card (Fin m) := Finset.card_le_univ S
     _ = m := Fintype.card_fin m
 
-/-- `hypergraphRamsey r r = r` for any `r`. -/
+/-- $hypergraphRamsey r r = r$ for any $r$. -/
 theorem hypergraphRamsey_self (r : ℕ) : hypergraphRamsey r r = r := by
   have h_mem : r ∈ { m | ∀ (c : Finset (Fin m) → Bool),
       ∃ (S : Finset (Fin m)), S.card = m ∧

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CompleteGraphEdgeCount.lean
@@ -22,7 +22,7 @@ public import Mathlib.Combinatorics.SimpleGraph.Finite
 namespace SimpleGraph
 
 /--
-The number of edges of the complete graph on a finite vertex type `V` is `#V choose 2`.
+The number of edges of the complete graph on a finite vertex type $V$ is $\binom{|V|}{2}$.
 
 This is a thin `completeGraph`-flavoured restatement of Mathlib's
 `SimpleGraph.card_edgeFinset_top_eq_card_choose_two`, useful when a downstream definition

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/DiamExtra.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/DiamExtra.lean
@@ -27,7 +27,7 @@ variable {α : Type*} {G G' : SimpleGraph α}
 
 /--
 The diameter is the greatest distance between any two vertices. If the graph is disconnected,
-this will be `0`.
+this will be $0$.
 -/
 lemma diam_eq_zero_of_subsingleton [Subsingleton α] : G.diam = 0 := by
   simp [diam, ediam_eq_zero_iff_subsingleton.mpr (by assumption)]

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Domination.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/Domination.lean
@@ -28,10 +28,10 @@ This file introduces dominating sets and related invariants.
 Main definitions
 
 * `SimpleGraph.IsDominating`   : A set of vertices that dominates all vertices.
-* `SimpleGraph.IsNDominatingSet` : A dominating set with `n` vertices.
+* `SimpleGraph.IsNDominatingSet` : A dominating set with $n$ vertices.
 * `SimpleGraph.dominationNumber` : The domination number of a graph.
 * `SimpleGraph.IsTotalDominating` : A total dominating set.
-* `SimpleGraph.IsTotalNDominatingSet` : A total dominating set with `n` vertices.
+* `SimpleGraph.IsTotalNDominatingSet` : A total dominating set with $n$ vertices.
 * `SimpleGraph.totalDominationNumber` : The total domination number.
 
 Future work should extend this file with connected, independent, and power

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/WellTotallyDominated.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/GraphConjectures/WellTotallyDominated.lean
@@ -23,15 +23,15 @@ public import Mathlib.Combinatorics.SimpleGraph.Finite
 /-!
 # Well totally dominated graphs
 
-A *total dominating set* of `G` is a set `S` of vertices such that every vertex of `G`
-(including vertices in `S`) has a neighbor in `S`. A total dominating set `S` is
-*minimal* if no proper subset of `S` is also a total dominating set.
+A *total dominating set* of $G$ is a set $S$ of vertices such that every vertex of $G$
+(including vertices in $S$) has a neighbor in $S$. A total dominating set $S$ is
+*minimal* if no proper subset of $S$ is also a total dominating set.
 
-A graph `G` is *well totally dominated* if every minimal total dominating set has the
+A graph $G$ is *well totally dominated* if every minimal total dominating set has the
 same cardinality; equivalently, the total domination number equals the maximum
 cardinality of a minimal total dominating set.
 
-The *pendant vertices* (also called *leaves*) of `G` are the vertices of degree 1.
+The *pendant vertices* (also called *leaves*) of $G$ are the vertices of degree 1.
 -/
 
 namespace SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HomDensity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HomDensity.lean
@@ -25,8 +25,8 @@ public import Mathlib.Combinatorics.SimpleGraph.Maps
 # Homomorphism density for finite simple graphs
 
 Mathlib does not (as of 2026-04) provide `SimpleGraph.homDensity`. We define a lightweight
-version here, specialised to finite vertex types on the host `G`, and prove the basic
-`homDensity H G ≤ 1` upper bound used as a sanity check in Sidorenko-style arguments.
+version here, specialised to finite vertex types on the host $G$, and prove the basic
+$homDensity H G ≤ 1$ upper bound used as a sanity check in Sidorenko-style arguments.
 
 The extension to infinite hosts uses the same formula with `Fintype.card` replaced by
 measure-theoretic integrals; we do not need that generality here.
@@ -48,10 +48,10 @@ noncomputable def homDensity [Fintype V] [Fintype W] [DecidableEq V] [DecidableE
     (H : SimpleGraph V) (G : SimpleGraph W) [DecidableRel H.Adj] [DecidableRel G.Adj] : ℝ :=
   (homCount H G : ℝ) / (Fintype.card W : ℝ) ^ (Fintype.card V)
 
-/-- The homomorphism density `t(H, G)` is at most `1`.
+/-- The homomorphism density $t(H, G)$ is at most $1$.
 
-Proof outline: the underlying function of a `H →g G`-homomorphism is an element of
-`V → W`, which has `|W|^|V|` elements, so `homCount H G ≤ |W|^|V|`. Divide. -/
+Proof outline: the underlying function of a $H →g G$-homomorphism is an element of
+$V → W$, which has $|W|^|V|$ elements, so $homCount H G ≤ |W|^|V|$. Divide. -/
 lemma homDensity_le_one {V W : Type*} [Fintype V] [Fintype W] [Nonempty W]
     [DecidableEq V] [DecidableEq W]
     (H : SimpleGraph V) (G : SimpleGraph W)

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SizeRamsey.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SizeRamsey.lean
@@ -29,8 +29,8 @@ This file defines the size Ramsey number for simple graphs.
 
 ## Definition
 
-The size Ramsey number `r̂(G, H)` is the minimum number of edges in a graph `F`
-such that any 2-coloring of `F`'s edges contains a copy of `G` in one color or `H` in the other.
+The size Ramsey number $r̂(G, H)$ is the minimum number of edges in a graph $F$
+such that any 2-coloring of $F$'s edges contains a copy of $G$ in one color or $H$ in the other.
 -/
 
 namespace SimpleGraph

--- a/FormalConjecturesForMathlib/Computability/TuringMachine/Notation.lean
+++ b/FormalConjecturesForMathlib/Computability/TuringMachine/Notation.lean
@@ -24,26 +24,26 @@ public meta section
 
 This module provides a parser for defining a Turing machine from a simple string description.
 The main entry point is the `turing_machine%` elaborator, which takes a string representing the
-machine's transitions and constructs a term of type `Machine (Fin m) StateType` where `StateType`
+machine's transitions and constructs a term of type $Machine (Fin m) StateType$ where `StateType`
 is an inductive type generated on the fly.
 
 ## Encoding format
 
 The machine's transitions are encoded as a single string, with each state's transitions
 separated by an underscore (`_`).
-For each state, a `3m`-character substring defines the behavior:
-- The first 3 characters `"ABC"` describe the action when the head reads `0`:
-  - `A`: The symbol to write (`0, 1, ..., m-1`).
-  - `B`: The direction to move the head (`L` or `R`).
-  - `C`: The new state (`A` through `Z`).
-- The next 3 characters `"DEF"` describe the action when the head reads `1` using the same format.
-- The next 3 characters `"GHI"` describe the action when the head reads `2` using the same format.
+For each state, a $3m$-character substring defines the behavior:
+- The first 3 characters `"ABC"` describe the action when the head reads $0$:
+  - $A$: The symbol to write ($0, 1, ..., m-1$).
+  - $B$: The direction to move the head ($L$ or $R$).
+  - $C$: The new state ($A$ through $Z$).
+- The next 3 characters `"DEF"` describe the action when the head reads $1$ using the same format.
+- The next 3 characters `"GHI"` describe the action when the head reads $2$ using the same format.
 - So on...
 
-The character `Z` is reserved for the halting state. The string `"---"` can be used to represent
+The character $Z$ is reserved for the halting state. The string `"---"` can be used to represent
 a transition to the halting state without writing or moving.
 
-Example of a tape: `1RA0LB_0LA---`
+Example of a tape: $1RA0LB_0LA---$
 
 There are more examples in `ForMathlib/Test/Computability`.
 -/

--- a/FormalConjecturesForMathlib/Data/Nat/Squarefree.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/Squarefree.lean
@@ -54,7 +54,7 @@ theorem squarefreePart_ne_zero (n : ℕ) : n.squarefreePart ≠ 0 := by
 theorem squarefreePart_zero : squarefreePart 0 = 1 := by
   simp [squarefreePart]
 
-/-- If `n` is squarefree, then its squarefree part is itself. -/
+/-- If $n$ is squarefree, then its squarefree part is itself. -/
 theorem squarefreePart_of_squarefree {n : ℕ} (hn : Squarefree n) :
     squarefreePart n = n := by
   nth_rw 2 [← n.factorization_prod_pow_eq_self fun _ ↦ by simp_all]
@@ -62,7 +62,7 @@ theorem squarefreePart_of_squarefree {n : ℕ} (hn : Squarefree n) :
   exact Finset.prod_congr rfl fun p hp ↦ by
     rw [factorization_eq_one_of_squarefree hn (mem_primeFactors.1 hp).1 (mem_primeFactors.1 hp).2.1]
 
-/-- The squarefree part of any square is `1`. -/
+/-- The squarefree part of any square is $1$. -/
 theorem squarefreePart_of_isSquare {n : ℕ} (hn : IsSquare n) :
     squarefreePart n = 1 := by
   rcases eq_or_ne n 0 with (rfl | h₀); exact squarefreePart_zero

--- a/FormalConjecturesForMathlib/Data/Set/Density.lean
+++ b/FormalConjecturesForMathlib/Data/Set/Density.lean
@@ -145,7 +145,7 @@ namespace Nat
 open Set
 
 /--
-The natural density of the set of even numbers is `1 / 2`.
+The natural density of the set of even numbers is $1 / 2$.
 -/
 theorem hasDensity_even : {n : ℕ | Even n}.HasDensity (1 / 2) := by
   simp [HasDensity, partialDensity]

--- a/FormalConjecturesForMathlib/NumberTheory/AdditivelyComplete.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/AdditivelyComplete.lean
@@ -29,7 +29,7 @@ open scoped List
 def subsetSums (A : Set M) : Set M :=
   {n | ∃ B : Finset M, ↑B ⊆ A ∧ n = ∑ i ∈ B, i}
 
-/-- If `A ⊆ B`, then `subsetSums A ⊆ subsetSums B`. -/
+/-- If $A ⊆ B$, then $subsetSums A ⊆ subsetSums B$. -/
 @[gcongr]
 theorem subsetSums_mono {A B : Set M} (h : A ⊆ B) : subsetSums A ⊆ subsetSums B :=
   fun _ ⟨C, hC⟩ => ⟨C, hC.1.trans h, hC.2⟩
@@ -44,7 +44,7 @@ variable [Preorder M]
 def IsAddComplete (A : Set M) : Prop :=
   ∀ᶠ k in Filter.atTop, k ∈ subsetSums A
 
-/-- If `A ⊆ B` and `A` is complete, then `B` is also complete. -/
+/-- If $A ⊆ B$ and $A$ is complete, then $B$ is also complete. -/
 @[gcongr]
 theorem IsAddComplete.mono {A B : Set M} (h : A ⊆ B) (ha : IsAddComplete A) : IsAddComplete B := by
   filter_upwards [ha] with x hx
@@ -58,7 +58,7 @@ def IsAddStronglyComplete (A : Set M) : Prop :=
 theorem IsAddStronglyComplete.isAddComplete {A : Set M} (hA : IsAddStronglyComplete A) :
     IsAddComplete A := by simpa using hA Set.finite_empty
 
-/-- If `A ⊆ B` and `A` is strongly complete, then `B` is also strongly complete. -/
+/-- If $A ⊆ B$ and $A$ is strongly complete, then $B$ is also strongly complete. -/
 theorem IsAddStronglyComplete.mono {A B : Set M} (h : A ⊆ B) (ha : IsAddStronglyComplete A) :
     IsAddStronglyComplete B := fun C hC => (ha hC).mono (by grind)
 
@@ -72,13 +72,13 @@ theorem IsAddStronglyCompleteNatSeq.isAddComplete {A : ℕ → M}
     IsAddComplete (Set.range A) := by simpa using hA 0
 
 open Classical in
-/-- If the range of a sequence `A` is strongly complete, then `A` is strongly complete. -/
+/-- If the range of a sequence $A$ is strongly complete, then $A$ is strongly complete. -/
 theorem IsAddStronglyCompleteNatSeq.of_isAddStronglyComplete {A : ℕ → M}
     (h : IsAddStronglyComplete (.range A)) : IsAddStronglyCompleteNatSeq A :=
   fun n => (h (Finset.finite_toSet _)).mono (A := .range A \ ((Finset.range n).image A))
     (fun _ ⟨⟨y, hy⟩, q⟩ => ⟨y - n, by grind⟩)
 
-/-- If `A` is strongly complete and the preimage of each element is finite, then the range of `A`
+/-- If $A$ is strongly complete and the preimage of each element is finite, then the range of $A$
 is strongly complete. -/
 theorem IsAddStronglyCompleteNatSeq.isAddStronglyComplete {A : ℕ → M}
     (h : IsAddStronglyCompleteNatSeq A) (hA : ∀ m, (A ⁻¹' {m}).Finite) :

--- a/FormalConjecturesForMathlib/NumberTheory/BeurlingPrimes.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/BeurlingPrimes.lean
@@ -49,7 +49,7 @@ def BeurlingIntegers (a : ℕ → ℝ) : Set ℝ := .range (beurlingInteger a)
 theorem beurlingInteger_mem (a k) : beurlingInteger a k ∈ BeurlingIntegers a := by
   simpa using ⟨k, rfl⟩
 
-/-- Every element of the sequence `a` is a Beurling integer. -/
+/-- Every element of the sequence $a$ is a Beurling integer. -/
 lemma generator_mem_beurling (a : ℕ → ℝ) (i : ℕ) : a i ∈ BeurlingIntegers a :=
   ⟨Finsupp.single i 1, by aesop⟩
 

--- a/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
@@ -38,9 +38,9 @@ classical constants such as $\pi$, $e$, or $\sqrt{2}$ are normal in any base.
 
 ## Main definitions
 
-* `digitSeq`: the sequence of digits in the base-`b` fractional expansion of a real number.
-* `IsNormalInBase`: a real number is normal in base `b`.
-* `IsAbsolutelyNormal`: a real number is normal in every base `b ≥ 2`.
+* `digitSeq`: the sequence of digits in the base-$b$ fractional expansion of a real number.
+* `IsNormalInBase`: a real number is normal in base $b$.
+* `IsAbsolutelyNormal`: a real number is normal in every base $b ≥ 2$.
 -/
 
 open Real Filter

--- a/FormalConjecturesForMathlib/NumberTheory/Primitive.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Primitive.lean
@@ -23,25 +23,25 @@ public import Mathlib.Data.Nat.Squarefree
 /-!
 # Primitive elements of a set with respect to divisibility
 
-An element `n` is *primitive* in a set `S ⊆ ℕ` if `n ∈ S` and no proper divisor of `n` is in `S`.
+An element $n$ is *primitive* in a set $S ⊆ ℕ$ if $n ∈ S$ and no proper divisor of $n$ is in $S$.
 
 This concept appears naturally when studying sequences closed under "divisor inheritance" -
-if every member `n` of a sequence has the property that `m * n` is also in the sequence
-for coprime `m`, then the primitive elements generate the entire sequence.
+if every member $n$ of a sequence has the property that $m * n$ is also in the sequence
+for coprime $m$, then the primitive elements generate the entire sequence.
 
 ## Main definitions
 
-* `Set.IsPrimitive`: A natural number `n` is primitive in `S` if `n ∈ S` and
-  `n.properDivisors` is disjoint from `S`.
-* `Set.primitives`: The set of primitive elements of `S`.
+* `Set.IsPrimitive`: A natural number $n$ is primitive in $S$ if $n ∈ S$ and
+  `n.properDivisors` is disjoint from $S$.
+* `Set.primitives`: The set of primitive elements of $S$.
 
 ## Main results
 
 * `Set.IsPrimitive.mem`: A primitive element is in the set.
 * `Set.IsPrimitive.not_mem_of_properDivisor`: Proper divisors of a primitive element are not
   in the set.
-* `Set.one_isPrimitive_iff`: `1` is primitive in `S` iff `1 ∈ S`.
-* `Set.prime_isPrimitive_iff`: A prime `p` is primitive in `S` iff `p ∈ S` and `1 ∉ S`.
+* `Set.one_isPrimitive_iff`: $1$ is primitive in $S$ iff $1 ∈ S$.
+* `Set.prime_isPrimitive_iff`: A prime $p$ is primitive in $S$ iff $p ∈ S$ and $1 ∉ S$.
 -/
 
 namespace Set

--- a/FormalConjecturesForMathlib/Order/Filter/Cofinite.lean
+++ b/FormalConjecturesForMathlib/Order/Filter/Cofinite.lean
@@ -44,7 +44,7 @@ lemma cofinite_hasBasis_Ioi {α : Type*} [LinearOrder α] [LocallyFiniteOrder α
 
 /--
 Note(csonne): According to a TODO in `Mathlib.Order.Interval.Finset.Defs`, Assuming `SuccOrder α`
-should not be necessary as an instance should follow from `[LocallyFiniteOrder α] [OrderBot α]`.
+should not be necessary as an instance should follow from $[LocallyFiniteOrder α] [OrderBot α]$.
 This has not been implemented in mathlib however.
 -/
 lemma cofinite_hasBasis_Ici {α : Type*} [LinearOrder α] [LocallyFiniteOrder α] [OrderBot α]

--- a/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
+++ b/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
@@ -27,19 +27,19 @@ public import Mathlib.Data.Real.Basic
 This file provides the core averaging lemma underlying the elementary form of Erdős's
 **probabilistic method**:
 
-> If the sum of a `ℕ`-valued function `f` over a finite set `s` is strictly less than the
-> cardinality of `s`, then `f` vanishes somewhere on `s`.
+> If the sum of a $ℕ$-valued function $f$ over a finite set $s$ is strictly less than the
+> cardinality of $s$, then $f$ vanishes somewhere on $s$.
 
-Interpreting `f a` as "the number of bad configurations caused by choice `a`", and sampling
-`a` uniformly from `s`, the expected number of bad configurations is `(∑ f) / |s| < 1`,
-so there must exist at least one `a ∈ s` with `f a = 0`.
+Interpreting `f a` as "the number of bad configurations caused by choice $a$", and sampling
+$a$ uniformly from $s$, the expected number of bad configurations is $(∑ f) / |s| < 1$,
+so there must exist at least one $a ∈ s$ with $f a = 0$.
 
 This is used by:
 - `FormalConjectures/Probabilistic/RamseyDiagonalLowerBound.lean`
-  to close the `R(k,k) > 2^{k/2}` lower bound (Erdős 1947).
+  to close the $R(k,k) > 2^{k/2}$ lower bound (Erdős 1947).
 - downstream deletion-method / alteration-method arguments.
 
-Both the `ℕ`-form and a convenience `ℝ`-form are provided; the latter is useful when the
+Both the $ℕ$-form and a convenience $ℝ$-form are provided; the latter is useful when the
 expectation bound is derived via `rpow`/`log` manipulations on the reals and only later
 cast back to counting.
 
@@ -56,10 +56,10 @@ open Finset
 
 /-- **Finite probabilistic method (integer form).**
 
-If `∑ x ∈ s, f x < s.card`, then there exists `a ∈ s` with `f a = 0`.
+If $∑ x ∈ s, f x < s.card$, then there exists $a ∈ s$ with $f a = 0$.
 
-**Proof idea.** Contrapositive: if every value is at least `1`, the sum is at least
-`s.card · 1 = s.card`, contradicting the hypothesis. -/
+**Proof idea.** Contrapositive: if every value is at least $1$, the sum is at least
+$s.card · 1 = s.card$, contradicting the hypothesis. -/
 theorem Finset.exists_eq_zero_of_sum_lt_card
     {α : Type*} {s : Finset α} {f : α → ℕ} (h : ∑ x ∈ s, f x < s.card) :
     ∃ a ∈ s, f a = 0 := by
@@ -75,10 +75,10 @@ theorem Finset.exists_eq_zero_of_sum_lt_card
 
 /-- **Finite probabilistic method (real form).**
 
-If `(∑ x ∈ s, (f x : ℝ)) < s.card`, then there exists `a ∈ s` with `f a = 0`.
+If $(∑ x ∈ s, (f x : ℝ)) < s.card$, then there exists $a ∈ s$ with $f a = 0$.
 
 This is the same statement as `Finset.exists_eq_zero_of_sum_lt_card` after casting the
-counting inequality to `ℝ`; it is the convenient entry point when `f` arises as an expectation
+counting inequality to $ℝ$; it is the convenient entry point when $f$ arises as an expectation
 whose bound was computed in the reals (e.g. via `Real.rpow` / `Real.log`). -/
 theorem Finset.exists_eq_zero_of_real_sum_lt_card
     {α : Type*} {s : Finset α} {f : α → ℕ}

--- a/FormalConjecturesForMathlib/Topology/MetricSpace/MetricSeparated.lean
+++ b/FormalConjecturesForMathlib/Topology/MetricSpace/MetricSeparated.lean
@@ -30,7 +30,7 @@ variable {X : Type*} [PseudoEMetricSpace X]
 /-!
 ### Metric-separated sets
 
-In this section we define the predicate `Metric.IsSeparated'` for `ε`-separated sets.
+In this section we define the predicate `Metric.IsSeparated'` for $ε$-separated sets.
 -/
 
 /-- A set `s` is `≥ ε`-separated if its elements are pairwise at distance greater or equal to

--- a/site/README.md
+++ b/site/README.md
@@ -27,6 +27,12 @@ formal-conjectures repo (Lean 4)
 
 3. **Site build.** A push to `data/conjectures.json` triggers this repo's GitHub Actions workflow (`.github/workflows/deploy.yml`), which runs `node build.js` and deploys the output to GitHub Pages.
 
+During the site build, `build.js` also reads the repository's git history to
+attach file-level contributor metadata to each theorem page. If `GITHUB_TOKEN`
+or `GH_TOKEN` is available, the build enriches matching contributors with their
+GitHub username, profile URL, and avatar URL; otherwise it falls back to the
+display names available in git history.
+
 ## Repository layout
 
 ```

--- a/site/build.js
+++ b/site/build.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 // Base path for deployment (e.g. '/formal-conjectures' for GitHub Pages project sites).
 // Set via BASE_PATH env var. Must NOT have a trailing slash.
@@ -105,6 +106,7 @@ const SOURCE_COLLECTIONS = {
 };
 
 const GITHUB_BASE = 'https://github.com/google-deepmind/formal-conjectures/blob/main';
+const GITHUB_API_BASE = 'https://api.github.com/repos/google-deepmind/formal-conjectures';
 
 // ---------------------------------------------------------------------------
 // Data processing helpers
@@ -256,6 +258,270 @@ function writePage(destPath, html) {
 }
 
 // ---------------------------------------------------------------------------
+// Contributor metadata
+// ---------------------------------------------------------------------------
+
+function getGitRoot() {
+  if (process.env.FORMAL_CONJECTURES_ROOT) {
+    return process.env.FORMAL_CONJECTURES_ROOT;
+  }
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch (_) {
+    return null;
+  }
+}
+
+function parseContributorLine(line) {
+  const [sha, name, email, rawEmail, date] = line.split('\x1f');
+  if (!sha || !name || !date) return null;
+  return { sha, name, email: email || '', rawEmail: rawEmail || '', date };
+}
+
+function contributorKey(name, email) {
+  return (email || name || 'unknown').trim().toLowerCase();
+}
+
+function dateOnly(isoDate) {
+  return isoDate ? isoDate.slice(0, 10) : null;
+}
+
+function getContributorHistory(repoRoot, githubPath) {
+  let output = '';
+  try {
+    output = execFileSync('git', [
+      '-C', repoRoot,
+      'log',
+      '--follow',
+      '--no-merges',
+      '--format=%H%x1f%aN%x1f%aE%x1f%ae%x1f%aI',
+      '--',
+      githubPath,
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  } catch (_) {
+    return [];
+  }
+
+  const commits = output
+    .split('\n')
+    .map(line => parseContributorLine(line.trim()))
+    .filter(Boolean);
+  if (commits.length === 0) return [];
+
+  const originalKey = contributorKey(commits[commits.length - 1].name, commits[commits.length - 1].email);
+  const byAuthor = new Map();
+
+  for (const commit of commits) {
+    const key = contributorKey(commit.name, commit.email);
+    let contributor = byAuthor.get(key);
+    if (!contributor) {
+      contributor = {
+        _key: key,
+        name: commit.name,
+        email: commit.email,
+        rawEmail: commit.rawEmail,
+        emails: new Set([commit.email, commit.rawEmail].filter(Boolean)),
+        latestCommit: commit.sha,
+        commitCount: 0,
+        firstCommitDate: dateOnly(commit.date),
+        lastCommitDate: dateOnly(commit.date),
+        originalAuthor: key === originalKey,
+      };
+      byAuthor.set(key, contributor);
+    }
+
+    contributor.commitCount += 1;
+    if (commit.email) contributor.emails.add(commit.email);
+    if (commit.rawEmail) contributor.emails.add(commit.rawEmail);
+    contributor.firstCommitDate = dateOnly(commit.date);
+  }
+
+  return Array.from(byAuthor.values()).sort((a, b) => {
+    if (a.originalAuthor !== b.originalAuthor) return a.originalAuthor ? -1 : 1;
+    return b.commitCount - a.commitCount || a.name.localeCompare(b.name);
+  });
+}
+
+function githubUserFromNoreply(email) {
+  const numbered = email.match(/^(\d+)\+([A-Za-z0-9-]+)@users\.noreply\.github\.com$/);
+  if (numbered) {
+    const [, id, login] = numbered;
+    return {
+      login,
+      profileUrl: `https://github.com/${login}`,
+      avatarUrl: `https://avatars.githubusercontent.com/u/${id}?v=4`,
+    };
+  }
+
+  const legacy = email.match(/^([A-Za-z0-9-]+)@users\.noreply\.github\.com$/);
+  if (legacy) {
+    const [, login] = legacy;
+    return {
+      login,
+      profileUrl: `https://github.com/${login}`,
+      avatarUrl: null,
+    };
+  }
+
+  return null;
+}
+
+async function lookupCommitAuthor(sha, token) {
+  if (!token || typeof fetch !== 'function') return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const headers = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'formal-conjectures-site-build',
+    };
+    headers.Authorization = `Bearer ${token}`;
+
+    const resp = await fetch(`${GITHUB_API_BASE}/commits/${encodeURIComponent(sha)}`, {
+      headers,
+      signal: controller.signal,
+    });
+    if (!resp.ok) return null;
+
+    const data = await resp.json();
+    if (!data.author || !data.author.login) return null;
+
+    return {
+      login: data.author.login,
+      profileUrl: data.author.html_url || `https://github.com/${data.author.login}`,
+      avatarUrl: data.author.avatar_url || null,
+    };
+  } catch (_) {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function enrichContributorsWithGitHub(contributors) {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
+  let resolved = 0;
+
+  for (const contributor of contributors) {
+    const fromEmail = Array.from(contributor.emails || [contributor.email])
+      .map(githubUserFromNoreply)
+      .find(Boolean);
+    if (fromEmail) {
+      Object.assign(contributor, fromEmail);
+      resolved += 1;
+    }
+  }
+
+  if (!token) {
+    console.log('  Skipping GitHub contributor profile lookup (no GITHUB_TOKEN or GH_TOKEN).');
+    return resolved;
+  }
+
+  for (const contributor of contributors) {
+    if (contributor.login || !contributor.latestCommit) continue;
+    const fromCommit = await lookupCommitAuthor(contributor.latestCommit, token);
+    if (fromCommit) {
+      Object.assign(contributor, fromCommit);
+      resolved += 1;
+    }
+  }
+
+  return resolved;
+}
+
+function publicContributor(contributor) {
+  const login = contributor.login || null;
+  return {
+    name: contributor.name,
+    login,
+    profileUrl: contributor.profileUrl || (login ? `https://github.com/${login}` : null),
+    avatarUrl: contributor.avatarUrl || null,
+    commitCount: contributor.commitCount,
+    firstCommitDate: contributor.firstCommitDate,
+    lastCommitDate: contributor.lastCommitDate,
+    originalAuthor: contributor.originalAuthor,
+  };
+}
+
+function rememberContributorIdentity(identities, contributor) {
+  let identity = identities.get(contributor._key);
+  if (!identity) {
+    identity = {
+      _key: contributor._key,
+      name: contributor.name,
+      email: contributor.email,
+      rawEmail: contributor.rawEmail,
+      emails: new Set(contributor.emails || []),
+      latestCommit: contributor.latestCommit,
+      lastCommitDate: contributor.lastCommitDate,
+    };
+    identities.set(contributor._key, identity);
+    return;
+  }
+
+  for (const email of contributor.emails || []) identity.emails.add(email);
+  if (!identity.lastCommitDate || contributor.lastCommitDate > identity.lastCommitDate) {
+    identity.name = contributor.name;
+    identity.email = contributor.email;
+    identity.rawEmail = contributor.rawEmail;
+    identity.latestCommit = contributor.latestCommit;
+    identity.lastCommitDate = contributor.lastCommitDate;
+  }
+}
+
+function applyContributorProfile(contributor, identity) {
+  return {
+    ...contributor,
+    login: identity?.login || contributor.login,
+    profileUrl: identity?.profileUrl || contributor.profileUrl,
+    avatarUrl: identity?.avatarUrl || contributor.avatarUrl,
+  };
+}
+
+async function buildContributorMetadata(conjectures) {
+  const repoRoot = getGitRoot();
+  if (!repoRoot) {
+    console.log('  No git repository found; skipping contributor metadata.');
+    return {};
+  }
+
+  const paths = Array.from(new Set(conjectures.map(c => c.githubPath).filter(Boolean)));
+  const contributorsByPath = {};
+  const contributorsByIdentity = new Map();
+
+  for (const githubPath of paths) {
+    const contributors = getContributorHistory(repoRoot, githubPath);
+    if (contributors.length === 0) continue;
+
+    contributorsByPath[githubPath] = contributors;
+    for (const contributor of contributors) {
+      rememberContributorIdentity(contributorsByIdentity, contributor);
+    }
+  }
+
+  const uniqueContributors = Array.from(contributorsByIdentity.values());
+  const resolvedCount = await enrichContributorsWithGitHub(uniqueContributors);
+
+  for (const [githubPath, contributors] of Object.entries(contributorsByPath)) {
+    contributorsByPath[githubPath] = contributors.map(contributor =>
+      publicContributor(applyContributorProfile(contributor, contributorsByIdentity.get(contributor._key)))
+    );
+  }
+
+  console.log(`  Loaded contributor history for ${Object.keys(contributorsByPath).length} files (${resolvedCount}/${uniqueContributors.length} GitHub profiles resolved).`);
+  return contributorsByPath;
+}
+
+// ---------------------------------------------------------------------------
 // HTML snippet generators
 // ---------------------------------------------------------------------------
 
@@ -296,7 +562,7 @@ function subjectListHTML(bySubject) {
 // Main build
 // ---------------------------------------------------------------------------
 
-function main() {
+async function main() {
   console.log('Building Formal Conjectures website...');
 
   // Read raw data
@@ -314,6 +580,7 @@ function main() {
 
   const conjectures = rawData.map(processEntry);
   const stats = computeStats(conjectures);
+  const contributors = await buildContributorMetadata(conjectures);
 
   // Load Verso literate fragments (module docstrings + const links)
   let versoFragments = { moduleDocs: {}, constLinks: {} };
@@ -340,7 +607,7 @@ function main() {
   ensureDir('site/data');
   fs.writeFileSync(
     'site/data/conjectures.json',
-    JSON.stringify({ conjectures, stats, amsSubjects: AMS_SUBJECTS, versoFragments }),
+    JSON.stringify({ conjectures, stats, amsSubjects: AMS_SUBJECTS, versoFragments, contributors }),
   );
 
   // ---- Landing page ----
@@ -395,4 +662,7 @@ function applyBasePath(html) {
   return html;
 }
 
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/site/src/css/style.css
+++ b/site/src/css/style.css
@@ -686,6 +686,77 @@ a.cat-stat:hover { text-decoration: none; opacity: 0.8; }
   border-top: 1px solid var(--color-border);
 }
 
+.contributor-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.contributor-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  max-width: 100%;
+  min-height: 2rem;
+  padding: 0.18rem 0.65rem 0.18rem 0.22rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg-alt);
+  color: var(--color-text);
+  font-size: 0.88rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.contributor-chip:hover {
+  border-color: var(--color-link);
+  color: var(--color-link);
+  text-decoration: none;
+}
+
+.contributor-chip--static:hover {
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.contributor-chip__avatar {
+  width: 1.55rem;
+  height: 1.55rem;
+  flex: 0 0 1.55rem;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #dbeafe;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.contributor-chip__avatar--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.contributor-chip__name {
+  max-width: 14rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.contributor-chip__tag {
+  margin-left: 0.1rem;
+  padding-left: 0.45rem;
+  border-left: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 /* Module siblings list */
 .siblings-list { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem; }
 .sibling-item {

--- a/site/src/js/theorem.js
+++ b/site/src/js/theorem.js
@@ -40,8 +40,9 @@ async function init() {
   document.title = `${theorem.displayTheorem} — Formal Conjectures`;
   const siblings = data.conjectures.filter(c => c.module === theorem.module);
   const verso = data.versoFragments || { moduleDocs: {}, constLinks: {} };
+  const contributors = data.contributors?.[theorem.githubPath] || [];
 
-  renderDetail(theorem, siblings, verso);
+  renderDetail(theorem, siblings, verso, contributors);
 }
 
 /**
@@ -378,7 +379,44 @@ function renderError(msg) {
     </div>`;
 }
 
-function renderDetail(theorem, siblings, verso) {
+function contributorTitle(contributor) {
+  const parts = [];
+  const name = contributor.login ? `@${contributor.login}` : contributor.name;
+  if (name) parts.push(name);
+  if (contributor.originalAuthor) parts.push('original file author');
+  if (contributor.commitCount) {
+    parts.push(`${contributor.commitCount} commit${contributor.commitCount === 1 ? '' : 's'} to this file`);
+  }
+  if (contributor.firstCommitDate && contributor.lastCommitDate) {
+    parts.push(`${contributor.firstCommitDate} to ${contributor.lastCommitDate}`);
+  }
+  return parts.join(' · ');
+}
+
+function contributorChipHTML(contributor) {
+  const label = contributor.login ? `@${contributor.login}` : contributor.name || 'Unknown contributor';
+  const title = contributorTitle(contributor);
+  const avatar = contributor.avatarUrl
+    ? `<img class="contributor-chip__avatar" src="${FC.escapeHTML(contributor.avatarUrl)}" alt="" width="28" height="28" loading="lazy">`
+    : '<span class="contributor-chip__avatar contributor-chip__avatar--fallback" aria-hidden="true">?</span>';
+  const added = contributor.originalAuthor
+    ? '<span class="contributor-chip__tag">Added</span>'
+    : '';
+  const content = `
+    ${avatar}
+    <span class="contributor-chip__name">${FC.escapeHTML(label)}</span>
+    ${added}
+  `;
+
+  if (contributor.profileUrl) {
+    return `<a class="contributor-chip" href="${FC.escapeHTML(contributor.profileUrl)}" target="_blank" rel="noopener"
+      title="${FC.escapeHTML(title)}" aria-label="${FC.escapeHTML(title || label)}">${content}</a>`;
+  }
+
+  return `<span class="contributor-chip contributor-chip--static" title="${FC.escapeHTML(title)}">${content}</span>`;
+}
+
+function renderDetail(theorem, siblings, verso, contributors) {
   const catMeta = FC.getCategoryMeta(theorem.category);
 
   // Subject pills
@@ -450,6 +488,14 @@ function renderDetail(theorem, siblings, verso) {
       </div>
     </div>` : '';
 
+  const contributorsSection = contributors.length ? `
+    <div class="theorem-detail__section">
+      <div class="detail-label">File contributors</div>
+      <div class="contributor-list">
+        ${contributors.map(contributorChipHTML).join('\n')}
+      </div>
+    </div>` : '';
+
   detailEl.innerHTML = `
     <div class="theorem-detail__breadcrumb">
       <a href="${_base}/browse/">&larr; Browse</a>
@@ -468,7 +514,7 @@ function renderDetail(theorem, siblings, verso) {
 
     ${codeSection}
 
-
+    ${contributorsSection}
 
     <div class="theorem-detail__section">
       <div class="detail-label">Source collection</div>


### PR DESCRIPTION
- Convert mathematical content in theorem/module docstrings from Markdown code spans to LaTeX math notation.
- Preserve backticks for Lean declaration names, attributes, paths, and code-oriented references.
- Clean up a few malformed mixed Markdown/LaTeX docstring snippets found during the audit.
