### PR TITLE
doc: fix citation info and add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Formal Conjectures
 
 [![.github/workflows/push_master.yml](https://github.com/google-deepmind/formal-conjectures/actions/workflows/build-and-docs.yml/badge.svg)](https://github.com/google-deepmind/formal-conjectures/actions/workflows/build-and-docs.yml)
+[![arXiv](https://img.shields.io/badge/arXiv-1234.56789-b31b1b.svg)](https://arxiv.org/abs/2605.13171)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/google-deepmind/formal-conjectures)
 
 A collection of formalised statements of conjectures in
@@ -100,7 +101,7 @@ benchmark version but instead go into `v{N+1}`.
 If your work has used formal-conjectures, please consider citing it via
 ```
 @misc{FormalConjectures,
-  author       = {The Formal Conjectures Authors}
+  author       = {{The Formal Conjectures Authors}}
   title        = {{T}he {F}ormal {C}onjectures {R}epository},
   year         = {2025},
   url          = {https://github.com/google-deepmind/formal-conjectures},


### PR DESCRIPTION
Without the `{}`, this abbreviates as `T. F. C. Authors`