### PR TITLE
fix: correct arXiv shield text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Formal Conjectures
 
 [![.github/workflows/push_master.yml](https://github.com/google-deepmind/formal-conjectures/actions/workflows/build-and-docs.yml/badge.svg)](https://github.com/google-deepmind/formal-conjectures/actions/workflows/build-and-docs.yml)
-[![arXiv](https://img.shields.io/badge/arXiv-1234.56789-b31b1b.svg)](https://arxiv.org/abs/2605.13171)
+[![arXiv](https://img.shields.io/badge/arXiv-2605.13171-b31b1b.svg)](https://arxiv.org/abs/2605.13171)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/google-deepmind/formal-conjectures)
 
 A collection of formalised statements of conjectures in


### PR DESCRIPTION
It was previously 1234.56789, corrected to the actual arXiv identifier