### PR TITLE
feat: add welcome bot

### DIFF
--- a/.github/workflows/labels_from_comments.yml
+++ b/.github/workflows/labels_from_comments.yml
@@ -2,10 +2,11 @@
 # by commenting on the PR or issue.
 #
 # To remove a label: comment with "-labelname" (e.g., "-awaiting-author")
-# To add a label: comment with "labelname" (e.g., "awaiting-author")
+# To add a label: comment with "+labelname" (e.g., "+awaiting-author")
+# For compatibility, adding with "labelname" also works.
 #
 # The script reacts to lines in the comment whose entire content is, up to whitespace,
-# the label name, optionally preceded by `-`.
+# the label name, optionally preceded by `+` or `-`.
 # For each label, the bot follows the instruction of the *last* line that matches the label.
 
 name: Manage Labels from Comments
@@ -46,7 +47,7 @@ jobs:
           label="${labelArray[$i]}"
           printf $'\nProcessing label \'%s\'\n' "${label}"
           # extract the last line that, up to leading/trailing whitespace, matches the current label
-          inComment="$(printf '%s' "${COMMENT}" | grep "[-]\?${label}$" | tail -1)"
+          inComment="$(printf '%s' "${COMMENT}" | grep -E "^[+-]?${label}$" | tail -1)"
           if [ -n "${inComment}" ]
           then
             printf $'Found \'%s\'\n' "${inComment}"

--- a/.github/workflows/welcome_pull_request.yml
+++ b/.github/workflows/welcome_pull_request.yml
@@ -42,7 +42,7 @@ jobs:
             '',
             `- Please take a look at the [style guidelines](${styleGuideUrl}), especially the conventions for references, categories, AMS tags, and \`answer(sorry)\`.`,
             '- You can manage some PR labels by leaving a comment with `+label-name` or `-label-name`; for example, `+awaiting-author` or `-awaiting-author`.',
-            '- This repository is mainly for formalised statements. Proofs longer than about 25-50 lines are usually out of scope; longer proofs can be hosted elsewhere and linked using the `formal_proof` mechanism.',
+            '- This repository is mainly for formalised _statements_. Proofs longer than about 25-50 lines are usually out of scope; longer proofs are welcome to be included/linked via the `formal_proof` mechanism.',
             '',
             'Thanks again for helping improve Formal Conjectures.'
           ].join('\n')

--- a/.github/workflows/welcome_pull_request.yml
+++ b/.github/workflows/welcome_pull_request.yml
@@ -36,6 +36,7 @@ jobs:
             `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/CONTRIBUTING.md#style-guidelines`
 
           const body = [
+            '👋 *This is an automated welcome message.* 🤖'
             'Thanks for the contributions!',
             '',
             'A few friendly reminders while the review gets started:',

--- a/.github/workflows/welcome_pull_request.yml
+++ b/.github/workflows/welcome_pull_request.yml
@@ -1,0 +1,55 @@
+# Copyright 2026 The Formal Conjectures Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Welcome Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  welcome:
+    name: Post welcome comment
+    runs-on: ubuntu-latest
+    steps:
+    - name: Post polite guidance comment
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const defaultBranch = context.payload.repository.default_branch
+          const styleGuideUrl =
+            `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/CONTRIBUTING.md#style-guidelines`
+
+          const body = [
+            'Thanks for the contributions!',
+            '',
+            'A few friendly reminders while the review gets started:',
+            '',
+            `- Please take a look at the [style guidelines](${styleGuideUrl}), especially the conventions for references, categories, AMS tags, and \`answer(sorry)\`.`,
+            '- You can manage some PR labels by leaving a comment with `+label-name` or `-label-name`; for example, `+awaiting-author` or `-awaiting-author`.',
+            '- This repository is mainly for formalised statements. Proofs longer than about 25-50 lines are usually out of scope; longer proofs can be hosted elsewhere and linked using the `formal_proof` mechanism.',
+            '',
+            'Thanks again for helping improve Formal Conjectures.'
+          ].join('\n')
+
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            body,
+          })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,10 +358,11 @@ Any user can add or remove certain labels on pull requests and issues by
 leaving a comment. The supported labels are: `awaiting-author`, `WIP`, `Easy`,
 and `documentation`.
 
-- **To add a label**: Leave a comment with the exact label name on a line by
-  itself. For example:
+- **To add a label**: Leave a comment with `+` followed by the exact label
+  name on a line by itself. For compatibility, the exact label name without
+  `+` also works. For example:
   ```text
-  awaiting-author
+  +awaiting-author
   ```
 - **To remove a label**: Leave a comment with `-` followed by the exact label
   name on a line by itself. For example:


### PR DESCRIPTION
This PR adds a welcome bot for new contributions with a few helpful pointers and reminders. This also changes the behaviour of the mechanism for adding labels to PRs (new behaviour is `+foo` to add the tag, rather than just `foo`)