### PR TITLE
fix(ErdosProblems/274): use per-index quantifier to avoid vacuous witness

### DIFF
--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -56,7 +56,7 @@ different sizes? (i.e. each element is contained in exactly one of the cosets.)
 @[category research open, AMS 20]
 theorem erdos_274 : answer(sorry) ↔ ∃ (G : Type*) (h : Group G) (hG : 1 < ENat.card G)
     (ι : Type*) (_ : Fintype ι) (P : Group.ExactCovering G ι),
-      1 < Fintype.card ι ∧ (Set.range P.parts).Pairwise fun A B ↦ #A ≠ #B := by
+      1 < Fintype.card ι ∧ ∃ i j, i ≠ j ∧ #(P.parts i) ≠ #(P.parts j) := by
   sorry
 
 /--


### PR DESCRIPTION
The condition `(Set.range P.parts).Pairwise fun A B ↦ #A ≠ #B` on `FormalConjectures/ErdosProblems/274.lean` line 59 is vacuously true when `P.parts` is constant. A trivial witness (`G = ZMod 2`, `ι = Fin 2`, both parts `⊥`) satisfies it without matching the Erdős/Herzog–Schönheim intent of cosets of *distinct* sizes.

This PR replaces the condition with the per-index existential already used by `erdos_274.variants.abelian` and `herzog_schonheim` in the same file:

```diff
-      1 < Fintype.card ι ∧ (Set.range P.parts).Pairwise fun A B ↦ #A ≠ #B := by
+      1 < Fintype.card ι ∧ ∃ i j, i ≠ j ∧ #(P.parts i) ≠ #(P.parts j) := by
```

Fixes #4045.