### PR TITLE
feat(ErdosProblems/1097): prove the two textbook variants

### DIFF
--- a/FormalConjectures/ErdosProblems/1097.lean
+++ b/FormalConjectures/ErdosProblems/1097.lean
@@ -47,7 +47,18 @@ A weaker bound has been proven: there are always at most $n^2$ such values of $d
 @[category textbook, AMS 11]
 theorem erdos_1097.variants.weaker :
     ∀ A, (CommonDifferencesThreeTermAP A).ncard ≤ A.card ^ 2 := by
-  sorry
+  intro A
+  set D := Finset.image (fun p : ℤ × ℤ => p.2 - p.1) (A ×ˢ A)
+  have h_sub : CommonDifferencesThreeTermAP A ⊆ (D : Set ℤ) := by
+    rintro d ⟨-, a, ha, b, hb, -, -, hab, -⟩
+    exact Finset.mem_coe.mpr (Finset.mem_image.mpr
+      ⟨(a, b), Finset.mem_product.mpr ⟨ha, hb⟩, hab⟩)
+  calc (CommonDifferencesThreeTermAP A).ncard
+      ≤ (D : Set ℤ).ncard := Set.ncard_le_ncard h_sub D.finite_toSet
+    _ = D.card := Set.ncard_coe_finset _
+    _ ≤ (A ×ˢ A).card := Finset.card_image_le
+    _ = A.card * A.card := Finset.card_product _ _
+    _ = A.card ^ 2 := (sq _).symm
 
 /--
 A trivial lower bound: for sufficiently large `n` there exist sets $A$ with $|A| = n$ that contain at least $\Omega(n)$
@@ -56,6 +67,46 @@ distinct common differences of three-term arithmetic progressions.
 @[category textbook, AMS 11]
 theorem erdos_1097.variants.lower_bound : ∃ c > (0 : ℝ), ∀ᶠ n in Filter.atTop, ∃ (A : Finset ℤ),
     A.card = n ∧ c * (n : ℝ) ≤ (CommonDifferencesThreeTermAP A).ncard := by
-  sorry
+  refine ⟨1/4, by norm_num, ?_⟩
+  rw [Filter.eventually_atTop]
+  refine ⟨4, fun n hn => ?_⟩
+  refine ⟨(Finset.range n).image (fun k : ℕ => (k : ℤ)), ?_, ?_⟩
+  · rw [Finset.card_image_of_injective _ Nat.cast_injective, Finset.card_range]
+  set A := (Finset.range n).image (fun k : ℕ => (k : ℤ))
+  set k : ℕ := (n - 1) / 2 with hk_def
+  set D : Finset ℤ := (Finset.range k).image (fun i : ℕ => ((i + 1 : ℕ) : ℤ))
+  have hk_ge_nat : 4 * k ≥ n := by simp [hk_def]; omega
+  have hD_card : D.card = k := by
+    rw [Finset.card_image_of_injective _, Finset.card_range]
+    intro a b h
+    simp only at h
+    have : (a + 1 : ℤ) = (b + 1 : ℤ) := by exact_mod_cast h
+    omega
+  have h_finite : (CommonDifferencesThreeTermAP A).Finite := by
+    apply Set.Finite.subset
+      (Finset.image (fun p : ℤ × ℤ => p.2 - p.1) (A ×ˢ A)).finite_toSet
+    rintro d ⟨-, a, ha, b, hb, -, -, hab, -⟩
+    exact Finset.mem_coe.mpr (Finset.mem_image.mpr
+      ⟨(a, b), Finset.mem_product.mpr ⟨ha, hb⟩, hab⟩)
+  have hD_sub : (D : Set ℤ) ⊆ CommonDifferencesThreeTermAP A := by
+    intro d hd
+    rw [Finset.mem_coe, Finset.mem_image] at hd
+    obtain ⟨i, hi, rfl⟩ := hd
+    rw [Finset.mem_range] at hi
+    have h2d_lt : 2 * (i + 1) < n := by simp [hk_def] at hi; omega
+    refine ⟨by push_cast; positivity, 0, ?_, ((i + 1 : ℕ) : ℤ), ?_,
+      ((2 * (i + 1) : ℕ) : ℤ), ?_, by push_cast; ring, by push_cast; ring⟩
+    · exact Finset.mem_image.mpr ⟨0, Finset.mem_range.mpr (by omega), by push_cast⟩
+    · exact Finset.mem_image.mpr ⟨i + 1, Finset.mem_range.mpr (by omega), rfl⟩
+    · exact Finset.mem_image.mpr ⟨2 * (i + 1), Finset.mem_range.mpr h2d_lt, rfl⟩
+  calc (1 / 4 : ℝ) * n
+      = (n : ℝ) / 4 := by ring
+    _ ≤ (k : ℝ) := by
+        have : (4 : ℝ) * k ≥ n := by exact_mod_cast hk_ge_nat
+        linarith
+    _ = (D.card : ℝ) := by rw [hD_card]
+    _ = ((D : Set ℤ).ncard : ℝ) := by rw [Set.ncard_coe_finset]
+    _ ≤ ((CommonDifferencesThreeTermAP A).ncard : ℝ) := by
+        exact_mod_cast Set.ncard_le_ncard hD_sub h_finite
 
 end Erdos1097


### PR DESCRIPTION
## Summary

Replaces the `sorry` in both `erdos_1097.variants.weaker` and
`erdos_1097.variants.lower_bound` with complete proofs. The main
`erdos_1097` statement (the open problem itself) is unchanged and
still carries `answer(sorry)`. Both proven variants retain their
existing `@[category textbook, AMS 11]` attributes.

## Proof sketches

- **`weaker`** (12 proof lines): for any `A : Finset ℤ`,
  `(CommonDifferencesThreeTermAP A).ncard ≤ A.card ^ 2`. The set of
  common differences embeds into the difference set
  `D = image (λp. p.2 - p.1) (A ×ˢ A)`; then
  `ncard ≤ |D| ≤ |A ×ˢ A| = |A|²`.

- **`lower_bound`** (40 proof lines): existential with `c = 1/4`.
  For `n ≥ 4`, take `A_n = {0, 1, …, n-1} ⊆ ℤ`. Each
  `d ∈ {1, 2, …, ⌊(n-1)/2⌋}` is a common difference witnessed by the
  3-AP `(0, d, 2d)` inside `A_n`, giving `|D_n| = ⌊(n-1)/2⌋ ≥ n/4`.

Both proofs fit comfortably under the
[25–50 line per-proof guideline](../blob/main/CONTRIBUTING.md#ways-to-contribute).

## Verification

- `lake build FormalConjectures.ErdosProblems."1097"` succeeds on the
  pinned `leanprover/lean4:v4.27.0`.
- `#print axioms` confirms both proofs depend only on
  `[propext, Classical.choice, Quot.sound]` (standard kernel; no
  `sorryAx`, no `native_decide`, no admits).

## CLA

Signed.

## AI usage disclosure

Per the [Mathlib AI usage
conventions](https://leanprover-community.github.io/contribute/index.html)
referenced from this repo's `CONTRIBUTING.md`:

- The two proof bodies were drafted with the assistance of Anthropic's
  Claude (Opus 4.7), iterated against `lake build` until the file
  compiled cleanly, and then reviewed line-by-line by me.
- I take full responsibility for the proofs as committed; no AI output
  was accepted without compilation and human review.
- No part of the original `theorem` statements, `def`s, or comments was
  changed by the AI; only the two `sorry`s were replaced.
