### PR TITLE
feat(Wikipedia/Pell): prove `pellNumber_sq_add_pellNumber_succ_sq`

### DIFF
--- a/FormalConjectures/Wikipedia/Pell.lean
+++ b/FormalConjectures/Wikipedia/Pell.lean
@@ -54,7 +54,37 @@ P_{2n+1} = P_n ^ 2 + P_{n+1} ^ 2 -/
 @[category textbook, AMS 11]
 theorem pellNumber_sq_add_pellNumber_succ_sq (n : ℕ) :
     pellNumber (2 * n + 1) = pellNumber n ^ 2 + pellNumber (n + 1) ^ 2 := by
-  sorry
+  -- Prove jointly with the even-index companion
+  --   P(2n+2) = 2 · P(n+1) · (P(n) + P(n+1)),
+  -- since each successive case needs both formulas at the previous index.
+  suffices h : ∀ n,
+      pellNumber (2 * n + 1) = pellNumber n ^ 2 + pellNumber (n + 1) ^ 2 ∧
+      pellNumber (2 * n + 2) =
+        2 * pellNumber (n + 1) * (pellNumber n + pellNumber (n + 1)) by
+    exact (h n).1
+  intro n
+  induction n with
+  | zero => refine ⟨?_, ?_⟩ <;> rfl
+  | succ k ih =>
+    obtain ⟨hA, hB⟩ := ih
+    -- The Pell recursion at the next pair of indices.
+    have hstep1 : pellNumber (2 * (k + 1) + 1) =
+        2 * pellNumber (2 * k + 2) + pellNumber (2 * k + 1) := by
+      show pellNumber (2 * k + 1 + 1 + 1) =
+        2 * pellNumber (2 * k + 1 + 1) + pellNumber (2 * k + 1)
+      rfl
+    have hstep2 : pellNumber (2 * (k + 1) + 2) =
+        2 * pellNumber (2 * (k + 1) + 1) + pellNumber (2 * k + 2) := by
+      show pellNumber (2 * k + 2 + 1 + 1) =
+        2 * pellNumber (2 * k + 2 + 1) + pellNumber (2 * k + 2)
+      rfl
+    have hk2 : pellNumber (k + 2) = 2 * pellNumber (k + 1) + pellNumber k := rfl
+    -- A(k+1): prove once, use as first conjunct and inside the B(k+1) step.
+    have hA' : pellNumber (2 * (k + 1) + 1) =
+        pellNumber (k + 1) ^ 2 + pellNumber (k + 2) ^ 2 := by
+      rw [hstep1, hA, hB, hk2]; ring
+    refine ⟨hA', ?_⟩
+    rw [hstep2, hA', hB, hk2]; ring
 
 /-- An explicit formula for Pell numbers, similar to Binet's formula -/
 @[category textbook, AMS 11]


### PR DESCRIPTION
Closes #4112.

## Summary

Proves the textbook Pell-number squared-sum identity in `FormalConjectures/Wikipedia/Pell.lean`:

$$P_{2n+1} = P_n^2 + P_{n+1}^2,$$

the Pell analogue of the well-known Fibonacci identity $F_{2n+1} = F_n^2 + F_{n+1}^2$. The Binet-formula sibling (`coe_pellNumber_eq`) and the research-open `infinite_pellNumber_primes` are untouched.

## Proof sketch

Joint induction with the even-index companion:

$$P_{2n+2} = 2 P_{n+1} (P_n + P_{n+1}).$$

Each inductive step needs both formulas at the previous index: the odd-index recursion $P_{2n+3} = 2 P_{2n+2} + P_{2n+1}$ folds the even companion in, and vice versa. After substituting all three of (i) the inductive hypothesis at the previous index, (ii) the just-proved odd identity at the current index (for the even step), and (iii) the Pell recursion $P_{k+2} = 2 P_{k+1} + P_k$, both sub-goals reduce to polynomial identities in $P_k$ and $P_{k+1}$ closed by `ring`:

- Odd step: both sides expand to $P_k^2 + 4 P_k P_{k+1} + 5 P_{k+1}^2$.
- Even step: both sides expand to $2 P_k^2 + 10 P_k P_{k+1} + 12 P_{k+1}^2$.

No new imports; only the standard `Nat`/`ring` machinery already pulled in by `ProblemImports`.

## Verification

```
lake build FormalConjectures.Wikipedia.Pell   # succeeds
```

`#print axioms pellNumber_sq_add_pellNumber_succ_sq` yields `[propext, Classical.choice, Quot.sound]`; no `sorryAx`, no `native_decide`.