### PR TITLE
feat(ErdosProblems/470): prove `smallest_weird_eq_70`

### DIFF
--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -56,12 +56,30 @@ that the set of weird numbers has positive density.
 theorem erdos_470.variants.weird_pos_density : {n : ℕ | n.Weird}.HasPosDensity := by
   sorry
 
+/-- Local decidability scaffolding for `Nat.Pseudoperfect`/`Nat.Weird`.
+  `Nat.Pseudoperfect n` is `0 < n ∧ ∃ s ⊆ properDivisors n, ∑ i ∈ s, i = n`. The
+  inner existential ranges over arbitrary `Finset ℕ`, so type-class search does
+  not find a `Decidable` instance automatically; we rewrite the bounded
+  existential into one over `(properDivisors n).powerset`, which is a finite set
+  and decidable.
+-/
+instance (n : ℕ) : Decidable n.Abundant := by
+  unfold Nat.Abundant; infer_instance
+
+instance (n : ℕ) : Decidable n.Pseudoperfect :=
+  decidable_of_iff (0 < n ∧ ∃ s ∈ (n.properDivisors).powerset, ∑ i ∈ s, i = n)
+    (by unfold Nat.Pseudoperfect; simp [Finset.mem_powerset])
+
+instance (n : ℕ) : Decidable n.Weird := by
+  unfold Nat.Weird; infer_instance
+
 /--
 The smallest weird number is 70.
 -/
 @[category textbook, AMS 11]
 theorem erdos_470.variants.smallest_weird_eq_70 : (∀ n < 70, ¬n.Weird) ∧ (70).Weird := by
-  sorry
+  refine ⟨fun n hn => ?_, by native_decide⟩
+  interval_cases n <;> native_decide
 
 /--
 Melfi [Me15](https://mathscinet.ams.org/mathscinet/relay-station?mr=3276337) has proved that there


### PR DESCRIPTION
Closes #4122.

## Summary

Proves the textbook variant in `FormalConjectures/ErdosProblems/470.lean`:

```lean
@[category textbook, AMS 11]
theorem erdos_470.variants.smallest_weird_eq_70 :
    (∀ n < 70, ¬ n.Weird) ∧ (70).Weird
```

i.e. $70$ is the smallest weird number (abundant but not pseudoperfect). Mathlib already provides `Nat.weird_seventy : Weird 70` in `Mathlib.NumberTheory.FactorisationProperties`; this PR fills in the remaining direction.

## Proof

```lean
refine ⟨fun n hn => ?_, by native_decide⟩
interval_cases n <;> native_decide
```

plus three small local `Decidable` instances (one each for `Nat.Abundant`, `Nat.Pseudoperfect`, `Nat.Weird`).

### Why the local `Decidable` scaffolding

Mathlib does not auto-derive `Decidable n.Weird` because `Nat.Pseudoperfect n` is

```lean
0 < n ∧ ∃ s ⊆ properDivisors n, ∑ i ∈ s, i = n
```

and the inner existential ranges over arbitrary `Finset ℕ`, not over a finite set. Rewriting it as `∃ s ∈ (properDivisors n).powerset, ∑ i ∈ s, i = n` makes the bound finite, after which type-class search produces a `Decidable` instance.

## Verification

```
lake build FormalConjectures.ErdosProblems.«470»   # succeeds in ~4 s
```

`#print axioms erdos_470.variants.smallest_weird_eq_70` reports `[propext, Classical.choice, Quot.sound, Lean.ofReduceBool]` — the standard axiom set including the `native_decide` axiom. No `sorryAx`.

## Notes

22 added lines (3 instances + 1 proof + a docstring explaining the scaffolding). The `Decidable` instances might also be a candidate upstream contribution to `Mathlib.NumberTheory.FactorisationProperties` itself, but they are kept local here to keep the PR self-contained.