### PR TITLE
ErdosProblems/389: prove `mehta_four`

### DIFF
--- a/FormalConjectures/ErdosProblems/389.lean
+++ b/FormalConjectures/ErdosProblems/389.lean
@@ -44,6 +44,10 @@ theorem erdos_389.variants.mehta_four :
     IsLeast
       { k | 1 ≤ k ∧ ∏ i ∈ Finset.range k, (4 + i) ∣ ∏ i ∈ Finset.range k, (4 + k + i) }
       207 := by
-  sorry
+  refine ⟨⟨by norm_num, by native_decide⟩, ?_⟩
+  intro k ⟨_, hdvd⟩
+  by_contra hlt
+  push_neg at hlt
+  interval_cases k <;> revert hdvd <;> native_decide
 
 end Erdos389


### PR DESCRIPTION
Closes #4130.

Proves the textbook variant `erdos_389.variants.mehta_four`, which records that 207 is the minimal `k` such that $\prod_{i<k} (4+i) \mid \prod_{i<k} (4+k+i)$.

### Proof

```lean
refine ⟨⟨by norm_num, by native_decide⟩, ?_⟩
intro k ⟨_, hdvd⟩
by_contra hlt
push_neg at hlt
interval_cases k <;> revert hdvd <;> native_decide
```

Same template as the `a_one` / `a_two` / `a_three` proofs in `FormalConjectures/OEIS/87719.lean`:

- Split `IsLeast` into the membership half (`1 ≤ 207` by `norm_num`, the divisibility by `native_decide`) and the lower-bound half.
- For the lower bound, `interval_cases k` enumerates `k = 1, ..., 206`; `revert hdvd <;> native_decide` discharges each case by reducing the negation of the divisibility to `False` via native code.

### Verification

- `lake build FormalConjectures.ErdosProblems.«389»` succeeds in ~25 s on M2.
- `#print axioms Erdos389.erdos_389.variants.mehta_four` reports `[propext, Classical.choice, Quot.sound, Lean.ofReduceBool]` (the standard `native_decide` axiom set; no `sorryAx`).

Cost is dominated by the 206 `native_decide` calls, each reducing a divisibility of products with multi-hundred-digit operands to a single `mod` on bignums.