### PR TITLE
WrittenOnTheWallII/316: resolve as disproved (P₅ counterexample)

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture316.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture316.lean
@@ -28,18 +28,59 @@ open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
+/-- The path `0-1-2-3-4` on five vertices, `P₅`, as an explicit `SimpleGraph (Fin 5)`. -/
+def P5 : SimpleGraph (Fin 5) where
+  Adj a b := a.val + 1 = b.val ∨ b.val + 1 = a.val
+  symm := fun _ _ h => h.symm
+  loopless := fun _ h => by rcases h with h | h <;> omega
+
+instance : DecidableRel P5.Adj := fun a b =>
+  inferInstanceAs (Decidable (a.val + 1 = b.val ∨ b.val + 1 = a.val))
+
+private lemma P5_connected : P5.Connected := by decide
+
+private lemma P5_hyp : (averageDegree P5 : ℚ) ≤ (pendantVertices P5).card := by
+  have hp : (pendantVertices P5).card = 2 := by decide
+  have hd : (∑ v : Fin 5, P5.degree v) = 8 := by decide
+  unfold averageDegree
+  rw [← Nat.cast_sum, hd, hp]
+  norm_num [Fintype.card_fin]
+
+/-- `{1, 2, 3}` is a minimal total dominating set of `P₅` (of size 3). -/
+private lemma P5_min_3 : IsMinimalTotalDominatingSet P5 {1, 2, 3} := by
+  unfold IsMinimalTotalDominatingSet IsTotalDominatingSet; decide
+
+/-- `{0, 1, 3, 4}` is a minimal total dominating set of `P₅` (of size 4): every total
+dominating set must contain `1` and `3` to dominate the leaves `0` and `4`. -/
+private lemma P5_min_4 : IsMinimalTotalDominatingSet P5 {0, 1, 3, 4} := by
+  unfold IsMinimalTotalDominatingSet IsTotalDominatingSet; decide
+
+/-- `P₅` has minimal total dominating sets of sizes 3 and 4, so it is not WTD. -/
+private lemma P5_not_wtd : ¬ IsWellTotallyDominated P5 := fun h => by
+  have e : ({1, 2, 3} : Finset (Fin 5)).card = ({0, 1, 3, 4} : Finset (Fin 5)).card :=
+    h _ _ P5_min_3 P5_min_4
+  revert e; decide
+
 /--
 WOWII [Conjecture 316](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
 Let `G` be a simple connected graph and let `P` denote the set of pendant vertices
 (vertices of degree 1). If `|P| ≥ deg_avg(G)`, then `G` is well totally dominated,
 where `deg_avg(G)` is the average degree of `G`.
+
+This is **false**. The path on five vertices `P₅` is a counterexample: it is connected with
+`deg_avg(P₅) = 8/5 ≤ 2 = |P|`, yet it is not well totally dominated, since `{1, 2, 3}` and
+`{0, 1, 3, 4}` are both minimal total dominating sets, of sizes 3 and 4 respectively. (That a
+path on five vertices is not WTD is also recorded in Bahadır–Ekim–Gözüpek, *Well-Totally-
+Dominated Graphs*, arXiv:2010.02341; the same `P₅` already disproves WOWII Conjecture 32 in
+this repository.)
 -/
-@[category research open, AMS 5]
-theorem conjecture316 (G : SimpleGraph α) [DecidableRel G.Adj] (hG : G.Connected)
-    (h : (averageDegree G : ℚ) ≤ (pendantVertices G).card) :
-    IsWellTotallyDominated G := by
-  sorry
+@[category research solved, AMS 5]
+theorem conjecture316 : answer(False) ↔
+    ∀ (α : Type) [Fintype α] [DecidableEq α] (G : SimpleGraph α) [DecidableRel G.Adj],
+      G.Connected → (averageDegree G : ℚ) ≤ (pendantVertices G).card →
+      IsWellTotallyDominated G :=
+  ⟨False.elim, fun h => P5_not_wtd (h (Fin 5) P5 P5_connected P5_hyp)⟩
 
 -- Sanity checks
 


### PR DESCRIPTION
Resolves #4133.

`WrittenOnTheWallII.GraphConjecture316.conjecture316` was tagged `@[category research open]`, but the statement is false. This PR reclassifies it to `research solved` with a sorry-free proof, following the repo's existing disproof convention (cf. `GraphConjecture32`, which is disproved by the same graph).

### The counterexample: P₅ (path `0-1-2-3-4`)

- Connected, n = 5 > 1.
- Hypothesis holds: degrees `(1,2,2,2,1)` ⇒ `deg_avg = 8/5 = 1.6`; pendants `{0,4}` ⇒ `|P| = 2`, and `1.6 ≤ 2`.
- Conclusion fails: `{1,2,3}` (size 3) and `{0,1,3,4}` (size 4) are both **minimal** total dominating sets, so not all minimal TDS have equal size ⇒ `¬ IsWellTotallyDominated P₅`.

### Verification

- Compiles clean; the proof uses only kernel `decide`/`norm_num` (no `native_decide`).
- `#print axioms conjecture316` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `ofReduceBool`).

### Note on the formulation

I bound `α` *inside* the universal (`∀ (α : Type) [Fintype α] [DecidableEq α] (G : SimpleGraph α) …`) rather than as an ambient section variable. With an ambient `α` (as in `GraphConjecture32`), `answer(False) ↔ ∀ G : SimpleGraph α, …` is not provable for small `α` where no counterexample of that size exists — which is why `GraphConjecture32` is left `sorry`. Binding `α` inside makes the negation `∃ α G, …`, which P₅ discharges. Happy to adjust to match house style if you'd prefer.

### Context

That a path on five vertices is not WTD is also recorded in Bahadır–Ekim–Gözüpek, *Well-Totally-Dominated Graphs* (arXiv:2010.02341); the sibling conjectures 315 and 322 appear to hold (no counterexample among all connected graphs up to 8 vertices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
