### PR TITLE
Prove erdos_1063.variants.small_values (n₂=4, n₃=6, n₄=9, n₅=12)

### DIFF
--- a/FormalConjectures/ErdosProblems/1063.lean
+++ b/FormalConjectures/ErdosProblems/1063.lean
@@ -63,7 +63,42 @@ theorem erdos_1063.variants.exists_exception {n k : ℕ} (hk : 2 ≤ k) (h : 2 *
 @[category research solved, AMS 11]
 theorem erdos_1063.variants.small_values :
     n 2 = 4 ∧ n 3 = 6 ∧ n 4 = 9 ∧ n 5 = 12 := by
-  sorry
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- n 2 = 4 : every element of the set is ≥ 2 * 2 = 4, and 4 itself lies in the set
+    apply le_antisymm
+    · exact Nat.sInf_le (by decide)
+    · apply le_csInf ⟨4, by decide⟩
+      rintro b hb
+      have : 2 * 2 ≤ b := hb.1
+      omega
+  · -- n 3 = 6
+    apply le_antisymm
+    · exact Nat.sInf_le (by decide)
+    · apply le_csInf ⟨6, by decide⟩
+      rintro b hb
+      have : 2 * 3 ≤ b := hb.1
+      omega
+  · -- n 4 = 9 : the only candidate below 9 is m = 8, where both 8 and 6 fail to divide C(8,4) = 70
+    apply le_antisymm
+    · exact Nat.sInf_le (by decide)
+    · apply le_csInf ⟨9, by decide⟩
+      rintro b hb
+      have hb8 : 8 ≤ b := by have := hb.1; omega
+      by_contra h
+      push_neg at h
+      interval_cases b
+      · exact absurd hb (by decide)
+  · -- n 5 = 12 : the candidates below 12 are m = 10, 11, both of which fail
+    apply le_antisymm
+    · exact Nat.sInf_le (by decide)
+    · apply le_csInf ⟨12, by decide⟩
+      rintro b hb
+      have hb10 : 10 ≤ b := by have := hb.1; omega
+      by_contra h
+      push_neg at h
+      interval_cases b
+      · exact absurd hb (by decide)
+      · exact absurd hb (by decide)
 
 /-- Monier observed that $n_k \le k!$ for $k \ge 3$ ([Mo85]).
 TODO: Find reference


### PR DESCRIPTION
Fills the `sorry` in `erdos_1063.variants.small_values` with a proof that the initial values of the sequence (Erdős–Selfridge, Amer. Math. Monthly Problem 6447; Guy B31) are n₂=4, n₃=6, n₄=9, n₅=12.

The proof uses `Nat.sInf_le` / `le_csInf` together with `decide` on the (decidable) membership predicate, ruling out the boundary candidates below each value (m=8 for n₄; m=10, 11 for n₅).

Verification:
- `lake build FormalConjectures.ErdosProblems.«1063» --wfail` passes.
- `#print axioms erdos_1063.variants.small_values` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).