### PR TITLE
Prove erdos_1054 f_undefined_at_2 (f 2 = 0)

### DIFF
--- a/FormalConjectures/ErdosProblems/1054.lean
+++ b/FormalConjectures/ErdosProblems/1054.lean
@@ -33,6 +33,26 @@ noncomputable def f (n : ℕ) : ℕ :=
     Nat.find h
   else 0
 
+/-- The smallest divisor of a positive number is `1` (`nth` index `0`). -/
+@[category API, AMS 11]
+lemma nth_divisors_zero {m : ℕ} (hm : m ≠ 0) : Nat.nth (· ∈ m.divisors) 0 = 1 := by
+  rw [Nat.nth_zero]
+  exact IsLeast.csInf_eq ⟨Nat.one_mem_divisors.mpr hm, fun y hy => Nat.pos_of_mem_divisors hy⟩
+
+/-- Every divisor enumerated after index `0` is at least `2`. -/
+@[category API, AMS 11]
+lemma two_le_nth_divisors {m : ℕ} (hm : m ≠ 0) {i : ℕ} (hi : i ≠ 0)
+    (h : Nat.nth (· ∈ m.divisors) i ≠ 0) : 2 ≤ Nat.nth (· ∈ m.divisors) i := by
+  have hfin : (setOf (· ∈ m.divisors)).Finite := Set.toFinite _
+  have hpos : 1 ≤ Nat.nth (· ∈ m.divisors) i := Nat.pos_of_mem_divisors (Nat.nth_mem_of_ne_zero h)
+  rcases hpos.lt_or_eq with h2 | h1
+  · omega
+  · exact absurd (Nat.nth_injOn hfin
+      (Set.mem_Iio.mpr (Nat.lt_card_toFinset_of_nth_ne_zero h hfin))
+      (Set.mem_Iio.mpr (Nat.lt_card_toFinset_of_nth_ne_zero
+        (show Nat.nth (· ∈ m.divisors) 0 ≠ 0 by rw [nth_divisors_zero hm]; norm_num) hfin))
+      (by rw [nth_divisors_zero hm]; omega)) hi
+
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors
 of $m$ for some $k\geq 1$. Is it true that $f(n)=o(n)$?-/
 @[category research open, AMS 11]
@@ -57,7 +77,20 @@ theorem erdos_1054.parts.iii : answer(sorry) ↔ ∃ (A : Set ℕ), A.HasDensity
 of $m$ for some $k\geq 1$. Show that $f$ is undefined at $n=2$, i.e. we get the junk value $0$. -/
 @[category textbook, AMS 11]
 theorem f_undefined_at_2 : f 2 = 0 := by
-  sorry
+  rw [f, dif_neg]
+  rintro ⟨m, k, hk, hsum⟩
+  rcases eq_or_ne m 0 with rfl | hm
+  · simp at hsum
+  · -- For `m ≠ 0` the smallest divisor is `1` and every later term is `≥ 2`, so the sum of the
+    -- `k` smallest divisors is `1` or `≥ 3`, never `2`.
+    have hk0 : (0 : ℕ) ∈ Finset.Iio k := Finset.mem_Iio.mpr (by omega)
+    rw [← Finset.add_sum_erase _ _ hk0, nth_divisors_zero hm] at hsum
+    obtain ⟨i, hi_mem, hi_ne⟩ :=
+      Finset.exists_ne_zero_of_sum_ne_zero (s := (Finset.Iio k).erase 0)
+        (f := Nat.nth (· ∈ m.divisors)) (by omega)
+    have h2 := two_le_nth_divisors hm (Finset.ne_of_mem_erase hi_mem) hi_ne
+    have := h2.trans (Finset.single_le_sum (fun j _ => Nat.zero_le _) hi_mem)
+    omega
 
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors
 of $m$ for some $k\geq 1$. Show that $f$ is undefined at $n=5$, i.e. we get the junk value $0$. -/

--- a/FormalConjectures/ErdosProblems/1054.lean
+++ b/FormalConjectures/ErdosProblems/1054.lean
@@ -33,26 +33,6 @@ noncomputable def f (n : ℕ) : ℕ :=
     Nat.find h
   else 0
 
-/-- The smallest divisor of a positive number is `1` (`nth` index `0`). -/
-@[category API, AMS 11]
-lemma nth_divisors_zero {m : ℕ} (hm : m ≠ 0) : Nat.nth (· ∈ m.divisors) 0 = 1 := by
-  rw [Nat.nth_zero]
-  exact IsLeast.csInf_eq ⟨Nat.one_mem_divisors.mpr hm, fun y hy => Nat.pos_of_mem_divisors hy⟩
-
-/-- Every divisor enumerated after index `0` is at least `2`. -/
-@[category API, AMS 11]
-lemma two_le_nth_divisors {m : ℕ} (hm : m ≠ 0) {i : ℕ} (hi : i ≠ 0)
-    (h : Nat.nth (· ∈ m.divisors) i ≠ 0) : 2 ≤ Nat.nth (· ∈ m.divisors) i := by
-  have hfin : (setOf (· ∈ m.divisors)).Finite := Set.toFinite _
-  have hpos : 1 ≤ Nat.nth (· ∈ m.divisors) i := Nat.pos_of_mem_divisors (Nat.nth_mem_of_ne_zero h)
-  rcases hpos.lt_or_eq with h2 | h1
-  · omega
-  · exact absurd (Nat.nth_injOn hfin
-      (Set.mem_Iio.mpr (Nat.lt_card_toFinset_of_nth_ne_zero h hfin))
-      (Set.mem_Iio.mpr (Nat.lt_card_toFinset_of_nth_ne_zero
-        (show Nat.nth (· ∈ m.divisors) 0 ≠ 0 by rw [nth_divisors_zero hm]; norm_num) hfin))
-      (by rw [nth_divisors_zero hm]; omega)) hi
-
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest divisors
 of $m$ for some $k\geq 1$. Is it true that $f(n)=o(n)$?-/
 @[category research open, AMS 11]
@@ -84,11 +64,11 @@ theorem f_undefined_at_2 : f 2 = 0 := by
   · -- For `m ≠ 0` the smallest divisor is `1` and every later term is `≥ 2`, so the sum of the
     -- `k` smallest divisors is `1` or `≥ 3`, never `2`.
     have hk0 : (0 : ℕ) ∈ Finset.Iio k := Finset.mem_Iio.mpr (by omega)
-    rw [← Finset.add_sum_erase _ _ hk0, nth_divisors_zero hm] at hsum
+    rw [← Finset.add_sum_erase _ _ hk0, Nat.nth_divisors_zero hm] at hsum
     obtain ⟨i, hi_mem, hi_ne⟩ :=
       Finset.exists_ne_zero_of_sum_ne_zero (s := (Finset.Iio k).erase 0)
         (f := Nat.nth (· ∈ m.divisors)) (by omega)
-    have h2 := two_le_nth_divisors hm (Finset.ne_of_mem_erase hi_mem) hi_ne
+    have h2 := Nat.two_le_nth_divisors hm (Finset.ne_of_mem_erase hi_mem) hi_ne
     have := h2.trans (Finset.single_le_sum (fun j _ => Nat.zero_le _) hi_mem)
     omega
 

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -100,6 +100,7 @@ public import FormalConjecturesForMathlib.NumberTheory.Amicable
 public import FormalConjecturesForMathlib.NumberTheory.BeurlingPrimes
 public import FormalConjecturesForMathlib.NumberTheory.CoveringSystem
 public import FormalConjecturesForMathlib.NumberTheory.DirichletCharacter.Basic
+public import FormalConjecturesForMathlib.NumberTheory.Divisors
 public import FormalConjecturesForMathlib.NumberTheory.Lacunary
 public import FormalConjecturesForMathlib.NumberTheory.LegendreSymbol.Basic
 public import FormalConjecturesForMathlib.NumberTheory.NormalNumber

--- a/FormalConjecturesForMathlib/NumberTheory/Divisors.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Divisors.lean
@@ -1,0 +1,50 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Nat.Nth
+public import Mathlib.NumberTheory.Divisors
+
+@[expose] public section
+
+/-!
+# The increasing enumeration of the divisors of a natural number
+
+Basic facts about `Nat.nth (· ∈ n.divisors)`, the increasing enumeration of the divisors of `n`.
+-/
+
+namespace Nat
+
+/-- The smallest divisor of a positive number is `1`, i.e. the `0`th entry of the increasing
+enumeration of its divisors. -/
+lemma nth_divisors_zero {n : ℕ} (hn : n ≠ 0) : Nat.nth (· ∈ n.divisors) 0 = 1 := by
+  rw [Nat.nth_zero]
+  exact IsLeast.csInf_eq ⟨Nat.one_mem_divisors.mpr hn, fun y hy => Nat.pos_of_mem_divisors hy⟩
+
+/-- Every divisor enumerated after index `0` is at least `2`. -/
+lemma two_le_nth_divisors {n : ℕ} (hn : n ≠ 0) {i : ℕ} (hi : i ≠ 0)
+    (h : Nat.nth (· ∈ n.divisors) i ≠ 0) : 2 ≤ Nat.nth (· ∈ n.divisors) i := by
+  have hfin : (setOf (· ∈ n.divisors)).Finite := Set.toFinite _
+  have hpos : 1 ≤ Nat.nth (· ∈ n.divisors) i := Nat.pos_of_mem_divisors (Nat.nth_mem_of_ne_zero h)
+  rcases hpos.lt_or_eq with h2 | h1
+  · omega
+  · exact absurd (Nat.nth_injOn hfin
+      (Set.mem_Iio.mpr (Nat.lt_card_toFinset_of_nth_ne_zero h hfin))
+      (Set.mem_Iio.mpr (Nat.lt_card_toFinset_of_nth_ne_zero
+        (show Nat.nth (· ∈ n.divisors) 0 ≠ 0 by rw [nth_divisors_zero hn]; omega) hfin))
+      (by rw [nth_divisors_zero hn]; omega)) hi
+
+end Nat


### PR DESCRIPTION
Fills the `sorry` in `Erdos1054.f_undefined_at_2`: `f 2 = 0`.

Here `f n` is the least `m` such that `n` is a sum of the `k` smallest divisors of `m` for some `k ≥ 1`. The smallest divisor of any positive `m` is `1` and every later divisor is `≥ 2`, so such a sum is `1` (for `k = 1`) or `≥ 3`, never `2`; for `m = 0` it is `0`. Hence no `(m, k)` works and `f 2` is the junk value `0`. Cross-checked numerically: no `m < 5000` has `2` as a sum of its `k` smallest divisors.

Adds two small `@[category API]` helper lemmas about `Nat.nth (· ∈ m.divisors)`. `f_undefined_at_3` (`f 5 = 0`) is left for a follow-up.

Verification:
- `lake build FormalConjectures.ErdosProblems.«1054» --wfail` passes.
- `#print axioms … f_undefined_at_2` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).