### PR TITLE
feat(Wikipedia/MoserWorm): prove `disc_mem_worm_covers`

### DIFF
--- a/FormalConjectures/Wikipedia/MoserWorm.lean
+++ b/FormalConjectures/Wikipedia/MoserWorm.lean
@@ -48,7 +48,21 @@ This follows by translating the center of the disc to the midpoint of the worm.
 -/
 @[category textbook, AMS 52]
 theorem disc_mem_worm_covers : Metric.closedBall 0 0.5 ∈ WormCovers := by
-  sorry
+  refine ⟨measurableSet_closedBall, ?_⟩
+  rintro w ⟨f, hf, rfl⟩
+  refine ⟨LinearIsometryEquiv.refl ℝ _, f ⟨1/2, by constructor <;> norm_num⟩,
+    LinearEquiv.det_refl .., ?_⟩
+  rintro _ ⟨t, rfl⟩
+  refine ⟨f t - f ⟨1/2, by constructor <;> norm_num⟩, ?_, by simp⟩
+  simp only [Metric.mem_closedBall, dist_zero_right]
+  have h := hf.dist_le_mul t ⟨1/2, by constructor <;> norm_num⟩
+  simp only [NNReal.coe_one, one_mul] at h
+  rw [dist_eq_norm] at h
+  refine h.trans ?_
+  obtain ⟨t, ht1, ht2⟩ := t
+  simp only [Subtype.dist_eq, Real.dist_eq]
+  rw [abs_le]
+  constructor <;> linarith
 
 /--
 **Moser's Worm Problem**


### PR DESCRIPTION
Closes #4140.

Proves the textbook-tagged `disc_mem_worm_covers`: the closed disc of radius 1/2 is a worm cover.

**Proof idea.** Take the identity isometry and translate the disc center to `f(1/2)`. Since `f` is 1-Lipschitz, every `f(t)` lies within distance `|t - 1/2| ≤ 1/2` of `f(1/2)`, so the translated worm fits inside the disc.

**Verification.**
- `lake build FormalConjectures.Wikipedia.MoserWorm` succeeds.
- `#print axioms MoserWorm.disc_mem_worm_covers` → `[propext, Classical.choice, Quot.sound]`.