### PR TITLE
feat(Wikipedia/Oppermann): prove `oppermann_implies_brocard`

### DIFF
--- a/FormalConjectures/Wikipedia/Oppermann.lean
+++ b/FormalConjectures/Wikipedia/Oppermann.lean
@@ -62,7 +62,41 @@ theorem oppermann_implies_brocard (n : ℕ) (hn : 1 ≤ n) (P : type_of% opperma
     letI prev := n.nth Nat.Prime
     letI next := (n+1).nth Nat.Prime
     4 ≤ ((Ioo (prev ^ 2) (next ^ 2)).filter Nat.Prime).card := by
-  sorry
+  set prev := n.nth Nat.Prime with hprev_def
+  set next := (n+1).nth Nat.Prime with hnext_def
+  have hprev_prime : prev.Prime := Nat.prime_nth_prime n
+  have hnext_prime : next.Prime := Nat.prime_nth_prime (n+1)
+  have hprev_ge : 3 ≤ prev := Nat.nth_prime_one_eq_three ▸
+    (Nat.nth_le_nth Nat.infinite_setOf_prime).mpr hn
+  have hlt : prev < next :=
+    Nat.nth_strictMono Nat.infinite_setOf_prime (Nat.lt_succ_self n)
+  have hgap : prev + 2 ≤ next := by
+    rcases hprev_prime.odd_of_ne_two (by omega) with ⟨k, hk⟩
+    rcases hnext_prime.odd_of_ne_two (by omega) with ⟨m, hm⟩
+    omega
+  obtain ⟨_, p1, hp1mem, hp1p⟩ := P prev (by omega)
+  obtain ⟨⟨p2, hp2mem, hp2p⟩, p3, hp3mem, hp3p⟩ := P (prev+1) (by omega)
+  obtain ⟨p4, hp4mem, hp4p⟩ := (P (prev+2) (by omega)).1
+  simp only [Finset.mem_Ioo, show prev + 1 - 1 = prev from rfl,
+    show prev + 2 - 1 = prev + 1 from rfl, show prev + 1 + 1 = prev + 2 from rfl]
+    at hp1mem hp2mem hp3mem hp4mem
+  have hsq : (prev + 2)^2 ≤ next^2 := Nat.pow_le_pow_left hgap 2
+  have hsq1 : (prev + 1)^2 ≤ next^2 := Nat.pow_le_pow_left (by omega) 2
+  have hb0 : prev * (prev + 1) < (prev + 1)^2 := by nlinarith
+  have hb1 : (prev + 1) * (prev + 2) < (prev + 2)^2 := by nlinarith
+  have h12 : p1 < p2 := by linarith [hp1mem.2, hp2mem.1]
+  have h23 : p2 < p3 := by linarith [hp2mem.2, hp3mem.1]
+  have h34 : p3 < p4 := by linarith [hp3mem.2, hp4mem.1]
+  refine ((show ({p1, p2, p3, p4} : Finset ℕ).card = 4 from ?_) ▸
+    Finset.card_le_card (s := {p1, p2, p3, p4}) ?_)
+  · simp [Finset.card_insert_of_notMem, h12.ne, (h12.trans h23).ne,
+      (h12.trans (h23.trans h34)).ne, h23.ne, (h23.trans h34).ne, h34.ne]
+  · intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl | rfl <;>
+      refine Finset.mem_filter.mpr ⟨Finset.mem_Ioo.mpr ⟨?_, ?_⟩, by assumption⟩ <;>
+      linarith [hp1mem.1, hp1mem.2, hp2mem.1, hp2mem.2, hp3mem.1, hp3mem.2,
+        hp4mem.1, hp4mem.2, hb0, hb1, hsq, hsq1]
 
 /-- Oppermann's conjecture implies Legendre's conjecture. -/
 @[category textbook, AMS 11]


### PR DESCRIPTION
Closes #4142.

Proves that Oppermann's conjecture implies Brocard's conjecture: for `n ≥ 1`, the open interval between consecutive prime squares contains at least 4 primes.

**Proof idea.** Let `prev := n.nth Prime` and `next := (n+1).nth Prime`. Then `prev ≥ 3` (via `Nat.nth_prime_one_eq_three` and monotonicity) and both `prev, next` are odd primes, so `next ≥ prev + 2`. Applying Oppermann at `x ∈ {prev, prev+1, prev+1, prev+2}` yields four primes `p₁ < p₂ < p₃ < p₄` lying in the four consecutive disjoint subintervals of `(prev², (prev+2)²) ⊆ (prev², next²)`. The cardinality bound follows from `Finset.card_le_card` applied to the inclusion `{p₁, p₂, p₃, p₄} ⊆ filter Prime (Ioo prev² next²)`.

**Verification.**
- `lake build FormalConjectures.Wikipedia.Oppermann` succeeds.
- `#print axioms Oppermann.oppermann_implies_brocard` → `[propext, Classical.choice, Quot.sound]`.