### PR TITLE
feat(ErdosProblems/385): prove `trivial_ub`

### DIFF
--- a/FormalConjectures/ErdosProblems/385.lean
+++ b/FormalConjectures/ErdosProblems/385.lean
@@ -33,7 +33,21 @@ noncomputable def F (n : ℕ) : ℕ := sSup {m + m.minFac | (m < n) (_ : m.Compo
 /-- Note that trivially $F(n) \leq n + \sqrt{n}$. -/
 @[category test, AMS 11]
 theorem trivial_ub (n : ℕ) : F n ≤ n + √n := by
-  sorry
+  have hkey : F n ≤ n + n.sqrt := by
+    apply csSup_le'
+    rintro x ⟨m, hm, hcomp, rfl⟩
+    have h1 : 0 < m := by have := hcomp.1; omega
+    have hsq : m.minFac ^ 2 ≤ m := Nat.minFac_sq_le_self h1 hcomp.2
+    have hmf : m.minFac ≤ m.sqrt := Nat.le_sqrt.mpr (by rw [← sq]; exact hsq)
+    have hmn : m.sqrt ≤ n.sqrt := Nat.sqrt_le_sqrt hm.le
+    omega
+  calc (F n : ℝ) ≤ ((n + n.sqrt : ℕ) : ℝ) := by exact_mod_cast hkey
+    _ = n + (n.sqrt : ℝ) := by push_cast; ring
+    _ ≤ n + √n := by
+        gcongr
+        rw [show ((n.sqrt : ℕ) : ℝ) = √((n.sqrt ^ 2 : ℕ) : ℝ) from by
+          push_cast; rw [Real.sqrt_sq (Nat.cast_nonneg _)]]
+        exact Real.sqrt_le_sqrt (by exact_mod_cast Nat.sqrt_le' n)
 
 /-- Let $F(n) := \max\{m + p(m) \mid  \textrm{$m < n$ composite}\}\}$ where $p(m)$ is the least
 prime divisor of $m$. Is it true that $F(n)>n$ for all sufficiently large $n$? -/


### PR DESCRIPTION
Closes #4146.

Proves the trivial upper bound `F n ≤ n + √n` for the Erdős–Eggleton–Selfridge function `F(n) := max { m + p(m) | m < n composite }`.

**Proof.** For composite `m ≥ 2`, `Nat.minFac_sq_le_self` gives `minFac m ^ 2 ≤ m`, so `minFac m ≤ Nat.sqrt m ≤ Nat.sqrt n`. Bound the `sSup` via `csSup_le'`, then cast `Nat.sqrt n ≤ √n` to get the real-valued bound.

**Verification.**
- `lake build FormalConjectures.ErdosProblems.«385»` succeeds.
- `#print axioms Erdos385.trivial_ub` → `[propext, Classical.choice, Quot.sound]`.