### PR TITLE
feat(OpenQuantumProblems/23): prove `hesseFamily_normalized`

### DIFF
--- a/FormalConjectures/OpenQuantumProblems/23.lean
+++ b/FormalConjectures/OpenQuantumProblems/23.lean
@@ -256,10 +256,27 @@ lemma qubitSICFamily_pairwise :
 @[category test, AMS 15 47 81]
 theorem hasSICPOVM_two : HasSICPOVM 2 := by sorry
 
+/-- The unit complex number `ω` (primitive cube root) has norm `1`. -/
+@[category API, AMS 15 47 81]
+private lemma omega_norm : ‖ω‖ = 1 := by
+  rw [Complex.norm_def, ω]
+  simp [Complex.normSq_apply]
+  have : Real.sqrt 3 * Real.sqrt 3 = 3 := Real.mul_self_sqrt (by norm_num)
+  rw [show (-1 / 2 : ℝ) * (-1 / 2) + Real.sqrt 3 / 2 * (Real.sqrt 3 / 2) = 1
+    from by nlinarith]
+
 /-- Every vector in the Hesse qutrit SIC family is normalized. -/
 @[category test, AMS 15 47 81]
 lemma hesseFamily_normalized (i : Fin 9) :
-    IsNormalized (hesseFamily i) := by sorry
+    IsNormalized (hesseFamily i) := by
+  have h2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have sqrt2_pos : (0:ℝ) < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+  have omega2_norm : ‖ω ^ 2‖ = 1 := by rw [norm_pow, omega_norm]; ring
+  fin_cases i <;>
+    simp [IsNormalized, hesseFamily, vec3, mkStateVector,
+      EuclideanSpace.norm_eq, Fin.sum_univ_three, hesseS,
+      omega_norm, omega2_norm, abs_of_pos sqrt2_pos]
+  all_goals (try (field_simp; linarith [h2]))
 
 /-- The Hesse qutrit SIC family has the correct constant pairwise overlap. -/
 @[category test, AMS 15 47 81]


### PR DESCRIPTION
Closes #4158.

Proves `hesseFamily_normalized`: every vector in the 9-element Hesse qutrit SIC family is L²-normalized.

**Proof.** Private helper `omega_norm` (`‖ω‖ = 1` for the primitive cube root; same lemma introduced by #4155 — duplicated here since #4155 hasn't merged). Main proof: `fin_cases` over 9 vectors of the form `vec3 0 s (−s·ω^k)` and cyclic permutations (where `s = √(1/2)`). `EuclideanSpace.norm_eq` + `Fin.sum_univ_three` reduces each to `|s|² + |s·ω^k|² + 0 = 1`; `‖ω‖ = ‖ω²‖ = 1` peels off the unit factor; `field_simp; linarith` closes `1/2 + 1/2 = 1`. 18-line proof.

**Verification.**
- `lake build FormalConjectures.OpenQuantumProblems.«23»` succeeds.
- `#print axioms OpenQuantumProblem23.hesseFamily_normalized` → `[propext, Classical.choice, Quot.sound]`.

**Note on overlap with #4155.** This branch and #4155 both introduce `omega_norm` privately. When one merges the other can drop the duplicate; alternatively they can be merged together.