### PR TITLE
feat: add graceful tree conjecture (Ringel-Kotzig)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Salvatore Mercuri
 Seewoo Lee
 The bbchallenge Collaboration (bbchallenge.org)
 Thomas Hubert
+Walid K. Elkersh
 Wojciech Nawrocki
 Yan Yablonovskiy
 Yoh Tanimoto

--- a/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
+++ b/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
@@ -40,7 +40,7 @@ and together cover every edge of `K_{2n+1}` (`⨆ i, T.map (f i) = ⊤`).
 -/
 @[category research solved, AMS 5]
 theorem ringel_conjecture :
-    ∀ᶠ (n : ℕ) in Filter.atTop, ∀ {V : Type*} [Fintype V] (T : SimpleGraph V),
+    ∀ᶠ (n : ℕ) in Filter.atTop, ∀ {V : Type*} [Finite V] (T : SimpleGraph V),
       T.IsTree → T.edgeSet.ncard = n →
       ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
         Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧

--- a/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
+++ b/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
@@ -1,0 +1,51 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Ringel's Conjecture
+
+*Reference:* [arxiv/2001.02665](https://arxiv.org/abs/2001.02665)
+**A proof of Ringel's Conjecture**
+by *Richard Montgomery, Alexey Pokrovskiy, Benny Sudakov*
+
+Ringel's Conjecture (1963) asserts that for any tree `T` with `n` edges, the complete graph
+`K_{2n+1}` on `2 * n + 1` vertices decomposes into `2 * n + 1` edge-disjoint copies of `T`.
+It was proved for all sufficiently large `n` in the referenced paper.
+-/
+namespace Arxiv.«2001.02665»
+
+open SimpleGraph
+
+/--
+**Ringel's Conjecture.** For any tree `T` with `n` edges, the complete graph on `2 * n + 1`
+vertices decomposes into `2 * n + 1` edge-disjoint copies of `T`.
+
+A "copy" of `T` is the image `T.map (f i)` of `T` under a vertex embedding
+`f i : V ↪ Fin (2 * n + 1)`; the copies are pairwise edge-disjoint (`Pairwise ... Disjoint`)
+and together cover every edge of `K_{2n+1}` (`⨆ i, T.map (f i) = ⊤`).
+-/
+@[category research solved, AMS 5]
+theorem ringel_conjecture {V : Type*} [Fintype V]
+    (T : SimpleGraph V) (hT : T.IsTree)
+    (n : ℕ) (hn : T.edgeSet.ncard = n) :
+    ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
+      Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
+      ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
+  sorry
+
+end Arxiv.«2001.02665»

--- a/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
+++ b/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
@@ -17,7 +17,7 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Ringel's Conjecture for large `n`
+# Ringel's Conjecture and Kotzig's Conjecture for large `n`
 
 *Reference:* [arxiv/2001.02665](https://arxiv.org/abs/2001.02665)
 **A proof of Ringel's Conjecture**
@@ -25,6 +25,10 @@ by *Richard Montgomery, Alexey Pokrovskiy, Benny Sudakov*
 
 The original conjecture of Ringel (1963), which remains open, is stated in
 `Books/RingelConjecture.lean`. The referenced paper proves it for all sufficiently large `n`.
+
+Montgomery–Pokrovskiy–Sudakov actually prove the strictly stronger statement conjectured by
+Kotzig: the decomposition can always be realized by cyclic shifts of a single copy of `T`.
+Kotzig's conjecture (all `n`) remains open; see `Books/KotzigConjecture.lean`.
 -/
 namespace Arxiv.«2001.02665»
 
@@ -37,12 +41,36 @@ For all sufficiently large `n`, the complete graph on `2 * n + 1` vertices decom
 A "copy" of `T` is the image `T.map (f i)` of `T` under a vertex embedding
 `f i : V ↪ Fin (2 * n + 1)`; the copies are pairwise edge-disjoint (`Pairwise ... Disjoint`)
 and together cover every edge of `K_{2n+1}` (`⨆ i, T.map (f i) = ⊤`).
+
+This follows from `kotzig_conjecture_large`; see `Books/RingelConjecture.lean` for the open form.
 -/
 @[category research solved, AMS 5]
 theorem ringel_conjecture :
     ∀ᶠ (n : ℕ) in Filter.atTop, ∀ {V : Type*} [Finite V] (T : SimpleGraph V),
       T.IsTree → T.edgeSet.ncard = n →
       ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
+        Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
+        ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
+  sorry
+
+/--
+For all sufficiently large `n`, the complete graph on `2 * n + 1` vertices decomposes into
+`2 * n + 1` edge-disjoint copies of any tree `T` with `n` edges via cyclic shifts of a single
+embedding.
+
+The `2 * n + 1` copies are `f 0, f 1, …, f (2n)` where `f i v = f 0 v + i` for all vertices
+`v` — that is, each copy is obtained by adding `i` (mod `2 * n + 1`) to every vertex of the
+base copy. This is strictly stronger than `ringel_conjecture`.
+
+Kotzig conjectured this holds for all `n`; see `Books/KotzigConjecture.lean`. Montgomery,
+Pokrovskiy, and Sudakov prove it for all sufficiently large `n`.
+-/
+@[category research solved, AMS 5]
+theorem kotzig_conjecture_large :
+    ∀ᶠ (n : ℕ) in Filter.atTop, ∀ {V : Type*} [Finite V] (T : SimpleGraph V),
+      T.IsTree → T.edgeSet.ncard = n →
+      ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
+        (∀ i v, f i v = f 0 v + i) ∧
         Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
         ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
   sorry

--- a/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
+++ b/FormalConjectures/Arxiv/2001.02665/RingelConjecture.lean
@@ -17,35 +17,34 @@ limitations under the License.
 import FormalConjectures.Util.ProblemImports
 
 /-!
-# Ringel's Conjecture
+# Ringel's Conjecture for large `n`
 
 *Reference:* [arxiv/2001.02665](https://arxiv.org/abs/2001.02665)
 **A proof of Ringel's Conjecture**
 by *Richard Montgomery, Alexey Pokrovskiy, Benny Sudakov*
 
-Ringel's Conjecture (1963) asserts that for any tree `T` with `n` edges, the complete graph
-`K_{2n+1}` on `2 * n + 1` vertices decomposes into `2 * n + 1` edge-disjoint copies of `T`.
-It was proved for all sufficiently large `n` in the referenced paper.
+The original conjecture of Ringel (1963), which remains open, is stated in
+`Books/RingelConjecture.lean`. The referenced paper proves it for all sufficiently large `n`.
 -/
 namespace Arxiv.«2001.02665»
 
 open SimpleGraph
 
 /--
-**Ringel's Conjecture.** For any tree `T` with `n` edges, the complete graph on `2 * n + 1`
-vertices decomposes into `2 * n + 1` edge-disjoint copies of `T`.
+For all sufficiently large `n`, the complete graph on `2 * n + 1` vertices decomposes into
+`2 * n + 1` edge-disjoint copies of any tree `T` with `n` edges.
 
 A "copy" of `T` is the image `T.map (f i)` of `T` under a vertex embedding
 `f i : V ↪ Fin (2 * n + 1)`; the copies are pairwise edge-disjoint (`Pairwise ... Disjoint`)
 and together cover every edge of `K_{2n+1}` (`⨆ i, T.map (f i) = ⊤`).
 -/
 @[category research solved, AMS 5]
-theorem ringel_conjecture {V : Type*} [Fintype V]
-    (T : SimpleGraph V) (hT : T.IsTree)
-    (n : ℕ) (hn : T.edgeSet.ncard = n) :
-    ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
-      Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
-      ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
+theorem ringel_conjecture :
+    ∀ᶠ (n : ℕ) in Filter.atTop, ∀ {V : Type*} [Fintype V] (T : SimpleGraph V),
+      T.IsTree → T.edgeSet.ncard = n →
+      ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
+        Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
+        ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
   sorry
 
 end Arxiv.«2001.02665»

--- a/FormalConjectures/Books/KotzigConjecture.lean
+++ b/FormalConjectures/Books/KotzigConjecture.lean
@@ -1,0 +1,52 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Kotzig's Conjecture
+
+*Reference:* A. Kotzig, cited in A. Rosa, *On certain valuations of the vertices of a graph*,
+Theory of Graphs (Internat. Sympos., Rome, 1966), Gordon and Breach, 1967, pp. 349–355.
+
+Kotzig conjectured that for every `n`, the complete graph `K_{2n+1}` decomposes into copies of
+any `n`-edge tree via cyclic shifts of a single embedding. This is strictly stronger than
+Ringel's conjecture; see `Books/RingelConjecture.lean`. The large-`n` case is proved by
+Montgomery–Pokrovskiy–Sudakov; see `Arxiv/2001.02665/RingelConjecture.lean`.
+-/
+namespace KotzigConjecture
+
+open SimpleGraph
+
+/--
+For any tree `T` with `n` edges, the complete graph on `2 * n + 1` vertices decomposes into
+`2 * n + 1` edge-disjoint copies of `T` via cyclic shifts of a single embedding.
+
+The `2 * n + 1` copies are `f 0, f 1, …, f (2n)` where `f i v = f 0 v + i` for all vertices
+`v` — each copy is obtained by adding `i` (mod `2 * n + 1`) to every vertex of the base copy.
+This is strictly stronger than `RingelConjecture.ringel_conjecture`.
+-/
+@[category research open, AMS 5]
+theorem kotzig_conjecture {V : Type*} [Finite V]
+    (T : SimpleGraph V) (hT : T.IsTree)
+    (n : ℕ) (hn : T.edgeSet.ncard = n) :
+    ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
+      (∀ i v, f i v = f 0 v + i) ∧
+      Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
+      ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
+  sorry
+
+end KotzigConjecture

--- a/FormalConjectures/Books/RingelConjecture.lean
+++ b/FormalConjectures/Books/RingelConjecture.lean
@@ -39,7 +39,7 @@ A "copy" of `T` is the image `T.map (f i)` of `T` under a vertex embedding
 and together cover every edge of `K_{2n+1}` (`⨆ i, T.map (f i) = ⊤`).
 -/
 @[category research open, AMS 5]
-theorem ringel_conjecture {V : Type*} [Fintype V]
+theorem ringel_conjecture {V : Type*} [Finite V]
     (T : SimpleGraph V) (hT : T.IsTree)
     (n : ℕ) (hn : T.edgeSet.ncard = n) :
     ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),

--- a/FormalConjectures/Books/RingelConjecture.lean
+++ b/FormalConjectures/Books/RingelConjecture.lean
@@ -1,0 +1,50 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Ringel's Conjecture
+
+*Reference:* G. Ringel, *Problem 25*, in *Theory of Graphs and its Applications*
+(Proc. Sympos. Smolenice, 1963), Academia, Prague, 1964.
+
+Ringel's conjecture (1963): the complete graph `K_{2n+1}` decomposes into copies of any tree
+with `n` edges. It remains open; the case of all sufficiently large `n` is proved by
+Montgomery–Pokrovskiy–Sudakov, see `Arxiv/2001.02665/RingelConjecture.lean`.
+-/
+namespace RingelConjecture
+
+open SimpleGraph
+
+/--
+For any tree `T` with `n` edges, the complete graph on `2 * n + 1` vertices decomposes into
+`2 * n + 1` edge-disjoint copies of `T`.
+
+A "copy" of `T` is the image `T.map (f i)` of `T` under a vertex embedding
+`f i : V ↪ Fin (2 * n + 1)`; the copies are pairwise edge-disjoint (`Pairwise ... Disjoint`)
+and together cover every edge of `K_{2n+1}` (`⨆ i, T.map (f i) = ⊤`).
+-/
+@[category research open, AMS 5]
+theorem ringel_conjecture {V : Type*} [Fintype V]
+    (T : SimpleGraph V) (hT : T.IsTree)
+    (n : ℕ) (hn : T.edgeSet.ncard = n) :
+    ∃ f : Fin (2 * n + 1) → (V ↪ Fin (2 * n + 1)),
+      Pairwise (fun i j => Disjoint (T.map (f i)).edgeSet (T.map (f j)).edgeSet) ∧
+      ⨆ i, T.map (f i) = (⊤ : SimpleGraph (Fin (2 * n + 1))) := by
+  sorry
+
+end RingelConjecture

--- a/FormalConjectures/Wikipedia/GracefulLabeling.lean
+++ b/FormalConjectures/Wikipedia/GracefulLabeling.lean
@@ -1,0 +1,54 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Graceful Tree Conjecture (Ringel–Kotzig conjecture)
+
+*Reference:* [Wikipedia/Graceful_labeling](https://en.wikipedia.org/wiki/Graceful_labeling)
+
+A graceful labeling of a graph `G` with `m` edges is an injective vertex labeling
+`f : V → {0, …, m}` such that the induced edge labels `{|f(u) - f(v)| : {u,v} ∈ E(G)}`
+are exactly `{1, …, m}`. Conjectured by Ringel (1963) and Kotzig; formalized by Rosa (1967).
+-/
+
+namespace GracefulLabeling
+
+open SimpleGraph
+
+/--
+Every tree admits a graceful labeling.
+
+A graceful labeling of a tree `T` with `m` edges is an injective map `f : V → {0, …, m}`
+such that the multiset of absolute differences `|f(u) - f(v)|` over edges `{u,v}` of `T`
+equals `{1, …, m}`.
+-/
+@[category research open, AMS 5]
+theorem graceful_tree_conjecture {V : Type*} [Fintype V] [DecidableEq V]
+    (T : SimpleGraph V) [DecidableRel T.Adj] (hT : T.IsTree) :
+    let m := T.edgeFinset.card
+    ∃ f : V → ℕ,
+      Function.Injective f ∧
+      (∀ v, f v ≤ m) ∧
+      T.edgeFinset.image (fun e =>
+        e.lift ⟨fun u v => Int.natAbs ((f u : ℤ) - (f v : ℤ)),
+                fun u v => by
+                    show ((f u : ℤ) - f v).natAbs = ((f v : ℤ) - f u).natAbs
+                    rw [← Int.natAbs_neg, neg_sub]⟩) = Finset.Icc 1 m := by
+  sorry
+
+end GracefulLabeling


### PR DESCRIPTION
Adds the statement of the **graceful tree conjecture** (Ringel–Kotzig): every tree with `m` edges admits an injective vertex labeling into `{0, …, m}` whose induced edge labels are exactly `{1, …, m}`. Open for general trees.

File: `FormalConjectures/Wikipedia/GracefulLabeling.lean`, `@[category research open, AMS 5]`. Addresses the Ringel–Kotzig entry in #104.