### PR TITLE
chore: add proper reference for the Poincaré conjecture formalisation

### DIFF
--- a/FormalConjectures/Millenium/Poincare.lean
+++ b/FormalConjectures/Millenium/Poincare.lean
@@ -22,7 +22,9 @@ References:
 - [Miln2022](https://www.claymath.org/wp-content/uploads/2022/06/poincare.pdf)
 - [Wang2017](https://annals.math.princeton.edu/2017/186-2/p03).
 - [mo296171](https://mathoverflow.net/questions/296171/unique-smooth-structure-on-3-manifolds)
+- [mathlib4](https://github.com/leanprover-community/mathlib4)
 
+The formalisations in this file are based on the ones written by Junyan Xu in Mathlib4.
 -/
 
 namespace PoincareConjecture


### PR DESCRIPTION
I didn't add a link to the actual file in mathlib since there's a chance this file could move in the future.