### PR TITLE
feat(Bugeaud): Problem 10.9

### DIFF
--- a/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
+++ b/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
@@ -34,9 +34,8 @@ See also FormalConjectures/Wikipedia/Mahler32.lean.
 namespace Bugeaud09
 
 /--
-Problem 10.9. There are no real numbers $\xi$ such that
-$0 \le \{\xi (3/2)^n\} < 1/2$ for every positive integer $n$,
-i.e. no Z-number exists. Posed by Mahler [Mah68].
+Problem 10.9. There are no real numbers $\xi$ such that $0 \le \{\xi (3/2)^n\} < 1/2$
+for every positive integer $n$, i.e. no Z-number exists. Posed by Mahler [Mah68].
 -/
 @[category research open, AMS 11]
 theorem problem_10_9 : type_of% Mahler32.mahler_conjecture := by

--- a/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
+++ b/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
@@ -1,0 +1,68 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+/-!
+# Bugeaud Collection of Conjectures and Open Questions: Mahler's Z-numbers
+
+See also FormalConjectures/Wikipedia/Mahler32.lean.
+
+*References:*
+  - [Bug12] Bugeaud, Yann. "Distribution modulo one and Diophantine approximation."
+    Vol. 193. Cambridge University Press, 2012. Chapter 10.
+  - [Mah68] Mahler, Kurt. "An unsolved problem on the powers of 3/2."
+    Journal of the Australian Mathematical Society 8.2 (1968): 313-321.
+  - [FLP95] Flatto, Leopold, Jeffrey C. Lagarias, and Andrew D. Pollington.
+    "On the range of fractional parts $\{\xi(p/q)^n\}$."
+    Acta Arithmetica 70.2 (1995): 125-147.
+-/
+
+namespace Bugeaud09
+
+/--
+A *Z-number* is a positive real number $\xi$ such that the fractional part of
+$\xi (3/2)^n$ lies in $[0, 1/2)$ for every positive integer $n$.
+-/
+def IsZNumber (ξ : ℝ) : Prop :=
+  0 < ξ ∧ ∀ n : ℕ, 1 ≤ n → Int.fract (ξ * (3 / 2 : ℝ) ^ n) < 1 / 2
+
+/--
+Problem 10.9. There are no real numbers $\xi$ such that
+$0 \le \{\xi (3/2)^n\} < 1/2$ for every positive integer $n$,
+i.e. no Z-number exists. Posed by Mahler [Mah68].
+-/
+@[category research open, AMS 11]
+theorem problem_10_9 : ¬ ∃ ξ : ℝ, IsZNumber ξ := by
+  sorry
+
+/--
+Mahler [Mah68] proved that the set of Z-numbers has Lebesgue measure zero.
+-/
+@[category research solved, AMS 11]
+theorem problem_10_9.variants.measure_zero :
+    MeasureTheory.volume {ξ : ℝ | IsZNumber ξ} = 0 := by
+  sorry
+
+/--
+Flatto, Lagarias, and Pollington [FLP95] proved that the set of Z-numbers has
+Hausdorff dimension strictly less than $1$.
+-/
+@[category research solved, AMS 11]
+theorem problem_10_9.variants.dimH_lt_one :
+    dimH {ξ : ℝ | IsZNumber ξ} < 1 := by
+  sorry
+
+end Bugeaud09

--- a/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
+++ b/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
+import FormalConjectures.Wikipedia.Mahler32
 /-!
 # Bugeaud Collection of Conjectures and Open Questions: Mahler's Z-numbers
 
@@ -33,20 +34,26 @@ See also FormalConjectures/Wikipedia/Mahler32.lean.
 namespace Bugeaud09
 
 /--
-A *Z-number* is a positive real number $\xi$ such that the fractional part of
-$\xi (3/2)^n$ lies in $[0, 1/2)$ for every positive integer $n$.
--/
-def IsZNumber (ξ : ℝ) : Prop :=
-  0 < ξ ∧ ∀ n : ℕ, 1 ≤ n → Int.fract (ξ * (3 / 2 : ℝ) ^ n) < 1 / 2
-
-/--
 Problem 10.9. There are no real numbers $\xi$ such that
 $0 \le \{\xi (3/2)^n\} < 1/2$ for every positive integer $n$,
 i.e. no Z-number exists. Posed by Mahler [Mah68].
 -/
 @[category research open, AMS 11]
-theorem problem_10_9 : ¬ ∃ ξ : ℝ, IsZNumber ξ := by
+theorem problem_10_9 : type_of% Mahler32.mahler_conjecture := by
   sorry
+
+/--
+Sanity check: `1` is not a Z-number, since for `n = 1` we have
+$\{1 \cdot (3/2)^1\} = \{3/2\} = 1/2 \not< 1/2$.
+-/
+@[category test, AMS 11]
+theorem not_isZNumber_one : ¬ IsZNumber 1 := by
+  rintro ⟨-, h⟩
+  have h1 := h 1 le_rfl
+  rw [pow_one, one_mul] at h1
+  have hfr : Int.fract (3 / 2 : ℝ) = 1 / 2 := by rw [Int.fract]; norm_num [Int.floor_eq_iff]
+  rw [hfr] at h1
+  exact lt_irrefl _ h1
 
 /--
 Mahler [Mah68] proved that the set of Z-numbers has Lebesgue measure zero.

--- a/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
+++ b/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_9.lean
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
+import FormalConjecturesUtil
 import FormalConjectures.Wikipedia.Mahler32
 /-!
 # Bugeaud Collection of Conjectures and Open Questions: Mahler's Z-numbers

--- a/FormalConjectures/Wikipedia/Mahler32.lean
+++ b/FormalConjectures/Wikipedia/Mahler32.lean
@@ -34,14 +34,9 @@ noncomputable def Ω (α : ℝ) : ℝ :=
   sInf {Filter.atTop.limsup (fun n ↦ Int.fract (θ * α ^ n))
     - Filter.atTop.liminf (fun n ↦ Int.fract (θ * α ^ n)) | (θ : ℝ) (_ : 0 < θ)}
 
-/-- A Z-number is a real number `x` such that the fractional parts of `x(3/2)^n` are less than
-`1/2` for all positive integers `n`. -/
-def IsZNumber (x : ℝ) : Prop :=
-  ∀ n > 0, Int.fract (x * (3 / 2 : ℝ) ^ n) < 1 / 2
-
-/-- The **Mahler Conjecture** states that there are no non-zero Z-numbers. -/
+/-- The **Mahler Conjecture** states that there are no Z-numbers. -/
 @[category research open, AMS 11]
-theorem mahler_conjecture (x : ℝ) (h : x ≠ 0) (hx : IsZNumber x) : False := by
+theorem mahler_conjecture (x : ℝ) (hx : IsZNumber x) : False := by
   sorry
 
 /-- If Mahler's conjecture is true, i.e. there are no Z-numbers, then `Ω(3/2)` exceeds `1/2`. -/

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -114,6 +114,7 @@ public import FormalConjecturesForMathlib.NumberTheory.AdditivelyComplete
 public import FormalConjecturesForMathlib.NumberTheory.Amicable
 public import FormalConjecturesForMathlib.NumberTheory.BeurlingPrimes
 public import FormalConjecturesForMathlib.NumberTheory.CoveringSystem
+public import FormalConjecturesForMathlib.NumberTheory.DiophantineApproximation.ZNumber
 public import FormalConjecturesForMathlib.NumberTheory.DirichletCharacter.Basic
 public import FormalConjecturesForMathlib.NumberTheory.Divisors
 public import FormalConjecturesForMathlib.NumberTheory.Lacunary

--- a/FormalConjecturesForMathlib/NumberTheory/DiophantineApproximation/ZNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/DiophantineApproximation/ZNumber.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Order.Floor.Defs
+public import Mathlib.Data.Real.Archimedean
+
+@[expose] public section
+/-!
+# Mahler's Z-numbers
+
+A *Z-number* is a positive real number `ξ` such that the fractional part of
+`ξ (3/2)^n` lies in `[0, 1/2)` for every positive integer `n`. Mahler asked
+whether any Z-number exists; this is still open.
+
+*References*:
+- [Mah68] Mahler, Kurt. "An unsolved problem on the powers of 3/2."
+  Journal of the Australian Mathematical Society 8.2 (1968): 313-321.
+- [Wikipedia, Mahler's 3/2 problem](https://en.wikipedia.org/wiki/Mahler%27s_3/2_problem)
+
+## Main definitions
+
+* `IsZNumber`: a real number is a Z-number.
+-/
+
+/-- A **Z-number** is a positive real number `ξ` such that the fractional part of
+`ξ (3/2)^n` lies in `[0, 1/2)` for every positive integer `n`. -/
+def IsZNumber (ξ : ℝ) : Prop :=
+  0 < ξ ∧ ∀ n : ℕ, 1 ≤ n → Int.fract (ξ * (3 / 2 : ℝ) ^ n) < 1 / 2


### PR DESCRIPTION
This adds (different from `Wikipedia/Mahler32.lean`) formulations of Mahler's Z-number problem and two related solved theorems.

Note: I'm using Claude + Opus for supervised formalization tasks. Claude has no permission to use git on my machine.