### PR TITLE
feat(ErdosProblems/107): prove `f_three_eq`

### DIFF
--- a/FormalConjectures/ErdosProblems/107.lean
+++ b/FormalConjectures/ErdosProblems/107.lean
@@ -61,9 +61,61 @@ theorem f_zero_eq : f 0 = 0 := by
     intro; use ∅; simp [ConvexIndep]
   simp [f, cardSet, this]
 
+/-- Three distinct non-collinear points form a convex-independent set. -/
+@[category API, AMS 52]
+private lemma convexIndep_triple_of_not_collinear {a b c : ℝ²}
+    (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c)
+    (hcoll : ¬ Collinear ℝ ({a, b, c} : Set ℝ²)) :
+    ConvexIndep ({a, b, c} : Set ℝ²) := by
+  intro x hx hmem
+  -- The point `x` lies in the affine span of `{a, b, c} \ {x}` because it
+  -- lies in the convex hull of that two-element set.
+  apply hcoll
+  have hx_aff : x ∈ affineSpan ℝ (({a, b, c} : Set ℝ²) \ {x}) :=
+    convexHull_subset_affineSpan _ hmem
+  rw [show ({a, b, c} : Set ℝ²) = insert x (({a, b, c} : Set ℝ²) \ {x}) from
+        (Set.insert_diff_self_of_mem hx).symm,
+      collinear_insert_iff_of_mem_affineSpan hx_aff]
+  -- The two-element complement is collinear.
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+  rcases hx with rfl | rfl | rfl
+  · rw [show ({x, b, c} : Set ℝ²) \ {x} = ({b, c} : Set ℝ²) by ext; aesop]
+    exact collinear_pair ℝ b c
+  · rw [show ({a, x, c} : Set ℝ²) \ {x} = ({a, c} : Set ℝ²) by ext; aesop]
+    exact collinear_pair ℝ a c
+  · rw [show ({a, b, x} : Set ℝ²) \ {x} = ({a, b} : Set ℝ²) by ext; aesop]
+    exact collinear_pair ℝ a b
+
 @[category test, AMS 52]
 theorem f_three_eq : f 3 = 3 := by
-  sorry
+  -- The substantive bound: 3 ∈ cardSet 3.
+  have hmem3 : (3 : ℕ) ∈ cardSet 3 := by
+    intro pts hpts hnontri
+    obtain ⟨a, b, c, hab, hac, hbc, rfl⟩ := Finset.card_eq_three.mp hpts
+    refine ⟨{a, b, c}, by simp [hab, hac, hbc], subset_refl _, ?_⟩
+    have hcoerce : (({a, b, c} : Finset ℝ²) : Set ℝ²) = ({a, b, c} : Set ℝ²) := by simp
+    have hmem : ∀ {y : ℝ²}, y ∈ ({a, b, c} : Set ℝ²) →
+        y ∈ (({a, b, c} : Finset ℝ²) : Set ℝ²) := fun h => hcoerce ▸ h
+    have hnc : ¬ Collinear ℝ ({a, b, c} : Set ℝ²) :=
+      hnontri (hmem (by simp)) (hmem (by simp)) (hmem (by simp)) hab hbc hac
+    rw [hcoerce]
+    exact convexIndep_triple_of_not_collinear hab hac hbc hnc
+  refine le_antisymm (Nat.sInf_le hmem3) (le_csInf ⟨3, hmem3⟩ fun N hN => ?_)
+  -- A set with fewer than 3 points contains no 3-element subset.
+  by_contra! hlt
+  let f : ℕ → ℝ² := fun i => EuclideanSpace.single 0 (i : ℝ)
+  let pts : Finset ℝ² := (Finset.range N).image f
+  have hinj : Function.Injective f := fun i j hij => by
+    have := congrArg (fun v : ℝ² => v 0) hij; simpa [f] using this
+  have hpts_card : pts.card = N := by
+    simp [pts, Finset.card_image_of_injOn hinj.injOn]
+  have hnontri : NonTrilinear (pts : Set ℝ²) := by
+    apply Set.triplewise_of_encard_lt
+    rw [Set.encard_coe_eq_coe_finsetCard, hpts_card]
+    exact_mod_cast hlt
+  obtain ⟨S, hScard, hSsub, _⟩ := hN pts hpts_card hnontri
+  have : S.card ≤ pts.card := Finset.card_le_card (by exact_mod_cast hSsub)
+  omega
 
 namespace variants
 


### PR DESCRIPTION
Closes #4209

Base case of the Happy Ending problem: $f(3) = 3$.

**Helper** `convexIndep_triple_of_not_collinear` (private, 23 lines): three distinct non-collinear points form a convex-independent set. Proof: if a point $x \in \{a, b, c\}$ were in the convex hull of $\{a, b, c\} \setminus \{x\}$, it would lie in the affine span of that two-element set; by `collinear_insert_iff_of_mem_affineSpan` the triple is then collinear, contradicting the hypothesis.

**Main** `f_three_eq` (29 lines):
- Upper bound `f 3 ≤ 3`: any non-trilinear 3-point set is itself a convex 3-gon by the helper.
- Lower bound `3 ≤ f 3`: `le_csInf` + a concrete N-point witness on the x-axis for N < 3; a set of < 3 points contains no 3-element subset.

`#print axioms f_three_eq` → `[propext, Classical.choice, Quot.sound]`. Build clean (no warnings).