### PR TITLE
Add Komlós conjecture (vector balancing / discrepancy)

### DIFF
--- a/FormalConjectures/Wikipedia/KomlosConjecture.lean
+++ b/FormalConjectures/Wikipedia/KomlosConjecture.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjectures/Wikipedia/KomlosConjecture.lean
+++ b/FormalConjectures/Wikipedia/KomlosConjecture.lean
@@ -1,0 +1,91 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Komlós conjecture
+
+The Komlós conjecture in discrepancy theory: there is a universal constant $K$ such
+that for all $n, m$ and all vectors $v_1, \dots, v_n \in \mathbb{R}^m$ with
+$\|v_i\|_2 \le 1$, there exist signs $\varepsilon_i \in \{-1, +1\}$ such that
+$$\left\|\sum_{i=1}^n \varepsilon_i v_i\right\|_\infty \le K.$$
+
+The best known bound is due to Banaszczyk, who proved that one can always achieve
+$O(\sqrt{\log n})$. The Beck–Fiala theorem on the discrepancy of sparse set systems
+is a special case (up to scaling), and the conjecture would imply the Beck–Fiala
+conjecture that set systems of degree $t$ have discrepancy $O(\sqrt{t})$.
+
+*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Discrepancy_theory#Major_open_problems)
+
+*References:*
+- [W. Banaszczyk, *Balancing vectors and Gaussian measures of n-dimensional convex bodies*,
+  Random Structures & Algorithms **12** (1998), 351–360](https://doi.org/10.1002/(SICI)1098-2418(199807)12:4%3C351::AID-RSA3%3E3.0.CO;2-S)
+- [J. Spencer, *Six standard deviations suffice*,
+  Trans. Amer. Math. Soc. **289** (1985), 679–706](https://doi.org/10.1090/S0002-9947-1985-0784009-0)
+-/
+
+namespace KomlosConjecture
+
+/--
+**The Komlós conjecture**
+
+There exists a universal constant $K > 0$ such that for all $n, m \in \mathbb{N}$ and
+all vectors $v_1, \dots, v_n \in \mathbb{R}^m$ with $\|v_i\|_2 \le 1$ (encoded here as
+$\sum_j v_{ij}^2 \le 1$), there exist signs $\varepsilon_i \in \{-1, +1\}$ such that
+$\left\|\sum_i \varepsilon_i v_i\right\|_\infty \le K$, i.e.
+$\left|\sum_i \varepsilon_i v_{ij}\right| \le K$ for every coordinate $j$.
+-/
+@[category research open, AMS 5]
+theorem komlos_conjecture :
+    ∃ K : ℝ, 0 < K ∧ ∀ (n m : ℕ) (v : Fin n → Fin m → ℝ),
+      (∀ i, ∑ j, (v i j) ^ 2 ≤ 1) →
+      ∃ ε : Fin n → ℝ, (∀ i, ε i = 1 ∨ ε i = -1) ∧
+        ∀ j, |∑ i, ε i * v i j| ≤ K := by
+  sorry
+
+/--
+**Banaszczyk's theorem**
+
+There exists a constant $C > 0$ such that for all $n, m \in \mathbb{N}$ and all vectors
+$v_1, \dots, v_n \in \mathbb{R}^m$ with $\|v_i\|_2 \le 1$, there exist signs
+$\varepsilon_i \in \{-1, +1\}$ such that
+$\left\|\sum_i \varepsilon_i v_i\right\|_\infty \le C \sqrt{\log(n + 2)}$.
+This is the best known bound towards the Komlós conjecture. (The shift $n + 2$ inside
+the logarithm is a harmless normalization keeping it positive for $n \in \{0, 1\}$.)
+
+[W. Banaszczyk, *Balancing vectors and Gaussian measures of n-dimensional convex bodies*,
+Random Structures & Algorithms **12** (1998), 351–360.]
+-/
+@[category research solved, AMS 5]
+theorem komlos_conjecture.variants.banaszczyk :
+    ∃ C : ℝ, 0 < C ∧ ∀ (n m : ℕ) (v : Fin n → Fin m → ℝ),
+      (∀ i, ∑ j, (v i j) ^ 2 ≤ 1) →
+      ∃ ε : Fin n → ℝ, (∀ i, ε i = 1 ∨ ε i = -1) ∧
+        ∀ j, |∑ i, ε i * v i j| ≤ C * Real.sqrt (Real.log (n + 2)) := by
+  sorry
+
+/--
+Sanity check: with no vectors at all ($n = 0$), the empty signed sum is $0$ in every
+coordinate, so any constant bound holds.
+-/
+@[category test, AMS 5]
+theorem komlos_conjecture.variants.zero_vectors (m : ℕ) (v : Fin 0 → Fin m → ℝ) :
+    ∃ ε : Fin 0 → ℝ, (∀ i, ε i = 1 ∨ ε i = -1) ∧
+      ∀ j, |∑ i, ε i * v i j| ≤ 1 :=
+  ⟨Fin.elim0, fun i => i.elim0, by simp⟩
+
+end KomlosConjecture

--- a/FormalConjectures/Wikipedia/KomlosConjecture.lean
+++ b/FormalConjectures/Wikipedia/KomlosConjecture.lean
@@ -29,9 +29,8 @@ $O(\sqrt{\log n})$. The Beck–Fiala theorem on the discrepancy of sparse set sy
 is a special case (up to scaling), and the conjecture would imply the Beck–Fiala
 conjecture that set systems of degree $t$ have discrepancy $O(\sqrt{t})$.
 
-*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Discrepancy_theory#Major_open_problems)
-
 *References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Discrepancy_theory#Major_open_problems)
 - [W. Banaszczyk, *Balancing vectors and Gaussian measures of n-dimensional convex bodies*,
   Random Structures & Algorithms **12** (1998), 351–360](https://doi.org/10.1002/(SICI)1098-2418(199807)12:4%3C351::AID-RSA3%3E3.0.CO;2-S)
 - [J. Spencer, *Six standard deviations suffice*,


### PR DESCRIPTION
This PR adds the **Komlós conjecture** from discrepancy theory, in `FormalConjectures/Wikipedia/KomlosConjecture.lean`.

**Statement.** There is a universal constant $K$ such that for all $n, m$ and all vectors $v_1, \dots, v_n \in \mathbb{R}^m$ with $\|v_i\|_2 \le 1$, there exist signs $\varepsilon_i \in \{-1, +1\}$ with $\left\|\sum_i \varepsilon_i v_i\right\|_\infty \le K$.

Vectors are encoded elementarily as `v : Fin n → Fin m → ℝ` with the hypothesis `∀ i, ∑ j, (v i j) ^ 2 ≤ 1` (the ℓ² unit ball) and the conclusion `∀ j, |∑ i, ε i * v i j| ≤ K` (the ℓ∞ bound), avoiding `PiLp` friction.

**Status.** The conjecture is open (`@[category research open, AMS 5]`). The best known bound is Banaszczyk's $O(\sqrt{\log n})$ (Random Structures & Algorithms 12 (1998), 351–360), included as the variant `komlos_conjecture.variants.banaszczyk` (`@[category research solved]`, statement left as `sorry`). The Beck–Fiala theorem is the special case for sparse set systems.

**Contents:**
- `komlos_conjecture` — the headline open conjecture (`sorry`)
- `komlos_conjecture.variants.banaszczyk` — Banaszczyk's $C\sqrt{\log(n+2)}$ bound, the best known (`sorry`; the $+2$ shift is a harmless normalization keeping the logarithm positive for $n \in \{0,1\}$)
- `komlos_conjecture.variants.zero_vectors` — sanity check for $n = 0$, proved without `sorry`

Sorry count: 2 (both research statements). `lake build FormalConjectures.Wikipedia.KomlosConjecture` passes with the project linters; the only warnings are `declaration uses 'sorry'`.

*Reference:* [Wikipedia: Discrepancy theory § Major open problems](https://en.wikipedia.org/wiki/Discrepancy_theory#Major_open_problems) (the Komlós conjecture has no dedicated article; it is listed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)