### PR TITLE
feat(Arxiv/2508.09246): Strings from Almost Nothing — Veneziano uniqueness

### DIFF
--- a/FormalConjectures/Arxiv/2502.20372/VenezianoPositivity.lean
+++ b/FormalConjectures/Arxiv/2502.20372/VenezianoPositivity.lean
@@ -1,0 +1,344 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Positivity of the Veneziano amplitude in ten dimensions
+
+*Reference:* [arxiv/2502.20372](https://arxiv.org/abs/2502.20372)
+**Positivity of the Veneziano Amplitude in Ten Dimensions** by *Gareth Mansfield*
+
+The (type-I, `α₀ = 0`) Veneziano amplitude is the Euler beta function
+$$A(s,t) = \frac{\Gamma(-s)\,\Gamma(-t)}{\Gamma(1-s-t)}.$$
+It is meromorphic with simple poles at non-negative integers `s = n`, and its residue there is
+the polynomial in `t`
+$$\operatorname{Res}_{s=n} A(s,t) = \frac{(t+1)_{(n-1)}}{n!}
+  = \frac{(t+1)(t+2)\cdots(t+n-1)}{n!},$$
+where `(a)_{(m)}` is the rising factorial.
+
+Unitarity in `D` spacetime dimensions requires that, when this residue is written in the angular
+variable `x = 1 + 2t/n` and expanded in the basis of Gegenbauer polynomials `C_j^{(λ)}` with
+`λ = (D-3)/2` (the partial-wave / spin-`j` basis for the little group `O(D-1)`),
+$$\operatorname{Res}_{s=n} A = \sum_j B_{n,j}^{D}\, C_j^{(λ)}(x),$$
+all the partial-wave coefficients `B_{n,j}^D` are non-negative.
+
+Mansfield proves this **positivity** holds for all `n, j` precisely when `D ≤ 10`, giving the first
+direct, amplitude-level proof above `D ≤ 6`. Sharpness is visible already at level `n = 3`, spin
+`0`, where (eq. 1.3)
+$$B_{3,0}^{D} = \frac{10 - D}{24\,(D-1)},$$
+which is negative as soon as `D > 10`.
+-/
+
+namespace Arxiv.«2502.20372»
+
+open Polynomial
+
+/--
+The residue `Res_{s=n} A(s,t)` of the type-I Veneziano amplitude at the pole `s = n`, written as
+a polynomial in the angular variable `x` via `t = n (x - 1) / 2`. Explicitly it is
+`((t+1)(t+2)⋯(t+n-1)) / n!` with `t = n (x - 1) / 2`, a polynomial of degree `n - 1`.
+-/
+noncomputable def residueX (n : ℕ) : ℚ[X] :=
+  C ((n.factorial : ℚ)⁻¹) *
+    ∏ i ∈ Finset.range (n - 1), (C ((n : ℚ) / 2) * (X - 1) + C ((i : ℚ) + 1))
+
+/-- The Gegenbauer parameter `λ = (D - 3) / 2` attached to spacetime dimension `D`. -/
+noncomputable def lam (D : ℕ) : ℚ := ((D : ℚ) - 3) / 2
+
+@[category test, AMS 81]
+theorem residueX_one : residueX 1 = 1 := by
+  simp [residueX]
+
+/-- The level-3 residue in the angular variable: `Res_{s=3} = (9x² - 1)/24`. Validates `residueX`. -/
+@[category test, AMS 81]
+theorem residueX_three : residueX 3 = C (9 / 24 : ℚ) * X ^ 2 - C (1 / 24) := by
+  apply Polynomial.funext
+  intro x
+  simp only [residueX, Finset.prod_range_succ, Finset.prod_range_zero, one_mul,
+    Nat.factorial, eval_mul, eval_add, eval_sub, eval_C, eval_X, eval_pow, eval_one]
+  push_cast
+  ring
+
+/--
+**Main theorem (Mansfield, 2025).** Partial-wave positivity of the type-I Veneziano amplitude in
+`D ≤ 10`: at every massive level `n ≥ 1` the residue expands in the Gegenbauer (spin) basis
+`C_j^{(λ)}`, `λ = (D-3)/2`, with non-negative coefficients. Equivalently, there is a non-negative
+sequence of partial-wave coefficients realising the expansion.
+-/
+@[category research solved, AMS 33 81]
+theorem partial_wave_positivity {D : ℕ} (hD : 3 ≤ D) (hD10 : D ≤ 10) {n : ℕ} (hn : 1 ≤ n) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      residueX n = ∑ j ∈ Finset.range n, C (B j) * gegenbauer (lam D) j := by
+  sorry
+
+/-- The Gegenbauer parameter `λ = (D-3)/2` is positive for `D ≥ 4`. -/
+@[category API, AMS 33]
+theorem lam_pos {D : ℕ} (hD : 4 ≤ D) : 0 < lam D := by
+  have : (4 : ℚ) ≤ (D : ℚ) := by exact_mod_cast hD
+  rw [lam]; linarith
+
+/-- `partial_wave_positivity` at level `n = 1`: the residue is the positive scalar `B₁,₀ = 1`
+(holds in every dimension). -/
+@[category test, AMS 33 81]
+theorem partial_wave_positivity_one (D : ℕ) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      residueX 1 = ∑ j ∈ Finset.range 1, C (B j) * gegenbauer (lam D) j := by
+  refine ⟨fun j => if j = 0 then 1 else 0, fun j => by dsimp only; split <;> norm_num, ?_⟩
+  rw [residueX_one, Finset.sum_range_one, gegenbauer_zero]
+  norm_num
+
+/-- `partial_wave_positivity` at level `n = 2`: only spin 1 contributes, coefficient `1/(4λ) > 0`
+(holds for `D ≥ 4`). -/
+@[category test, AMS 33 81]
+theorem partial_wave_positivity_two {D : ℕ} (hD : 4 ≤ D) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      residueX 2 = ∑ j ∈ Finset.range 2, C (B j) * gegenbauer (lam D) j := by
+  have hl := lam_pos hD
+  refine ⟨fun j => if j = 1 then 1 / (4 * lam D) else 0, fun j => by
+    dsimp only; split
+    · positivity
+    · norm_num, ?_⟩
+  apply Polynomial.funext
+  intro x
+  rw [eval_finset_sum]
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add, gegenbauer_zero,
+    gegenbauer_one, residueX, Finset.prod_range_succ, Finset.prod_range_zero, one_mul,
+    Nat.factorial, eval_mul, eval_add, eval_sub, eval_C, eval_X, eval_one, reduceIte]
+  field_simp
+  rw [if_neg (by decide : ¬ (0 : ℕ) = 1)]
+  ring
+
+/-- `partial_wave_positivity` at the critical level `n = 3`: spins 0 and 2 contribute, with
+`B₃,₀ = (10-D)/(24(D-1)) ≥ 0` (needs `D ≤ 10`) and `B₃,₂ = 3/(4(D-3)(D-1)) > 0` (needs `D ≥ 4`).
+This is exactly where the dimension bound becomes sharp. -/
+@[category test, AMS 33 81]
+theorem partial_wave_positivity_three {D : ℕ} (hD : 4 ≤ D) (hD10 : D ≤ 10) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      residueX 3 = ∑ j ∈ Finset.range 3, C (B j) * gegenbauer (lam D) j := by
+  have hDQ : (4 : ℚ) ≤ (D : ℚ) := by exact_mod_cast hD
+  have hD10Q : (D : ℚ) ≤ 10 := by exact_mod_cast hD10
+  have h3 : (0 : ℚ) < (D : ℚ) - 3 := by linarith
+  have h1 : (0 : ℚ) < (D : ℚ) - 1 := by linarith
+  refine ⟨fun j => if j = 0 then (10 - (D : ℚ)) / (24 * ((D : ℚ) - 1))
+                   else if j = 2 then 3 / (4 * ((D : ℚ) - 3) * ((D : ℚ) - 1)) else 0, ?_, ?_⟩
+  · intro j
+    dsimp only
+    split
+    · exact div_nonneg (by linarith) (by linarith)
+    · split
+      · exact div_nonneg (by norm_num) (by positivity)
+      · norm_num
+  · apply Polynomial.funext
+    intro x
+    rw [eval_finset_sum, residueX_three]
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add, gegenbauer_zero,
+      gegenbauer_one, gegenbauer_two, eval_mul, eval_sub, eval_C, eval_X, eval_one,
+      eval_pow, reduceIte, lam]
+    rw [if_neg (by decide : ¬ (1 : ℕ) = 0), if_neg (by decide : ¬ (1 : ℕ) = 2),
+      if_neg (by decide : ¬ (2 : ℕ) = 0)]
+    field_simp
+    ring
+
+/--
+Gegenbauer linear independence (the engine behind uniqueness): for `0 < a`, the only way a
+combination `∑_{j < n} B_j C_j^{(a)}` of the first `n` Gegenbauer polynomials can vanish is if
+every coefficient is zero. Proved by reading off the top (degree `n-1`) coefficient and inducting.
+-/
+@[category API, AMS 33]
+theorem gegenbauer_sum_eq_zero {a : ℚ} (ha : 0 < a) :
+    ∀ (n : ℕ) (c : ℕ → ℚ),
+      (∑ j ∈ Finset.range n, C (c j) * gegenbauer a j = 0) → ∀ j, j < n → c j = 0
+  | 0 => fun _ _ j hj => absurd hj (Nat.not_lt_zero j)
+  | (n + 1) => fun c h => by
+    have hcoeff := congrArg (fun p : ℚ[X] => p.coeff n) h
+    simp only [finset_sum_coeff, coeff_C_mul, coeff_zero] at hcoeff
+    have hlow : ∀ j ∈ Finset.range n, c j * (gegenbauer a j).coeff n = 0 := fun j hj => by
+      have hjn : (gegenbauer a j).natDegree < n :=
+        lt_of_eq_of_lt (gegenbauer_natDegree_leadingCoeff ha j).1 (Finset.mem_range.mp hj)
+      exact mul_eq_zero_of_right _ (coeff_eq_zero_of_natDegree_lt hjn)
+    rw [Finset.sum_range_succ, Finset.sum_eq_zero hlow, zero_add] at hcoeff
+    have hgn : (gegenbauer a n).coeff n = (gegenbauer a n).leadingCoeff := by
+      unfold Polynomial.leadingCoeff; rw [(gegenbauer_natDegree_leadingCoeff ha n).1]
+    rw [hgn] at hcoeff
+    have hcn : c n = 0 :=
+      (mul_eq_zero.mp hcoeff).resolve_right (gegenbauer_natDegree_leadingCoeff ha n).2.ne'
+    have hsum_n : ∑ j ∈ Finset.range n, C (c j) * gegenbauer a j = 0 := by
+      rw [Finset.sum_range_succ, hcn, map_zero, zero_mul, add_zero] at h; exact h
+    intro j hj
+    rcases Nat.lt_succ_iff_lt_or_eq.mp hj with hjn | rfl
+    · exact gegenbauer_sum_eq_zero ha n c hsum_n j hjn
+    · exact hcn
+
+/--
+**Uniqueness of the partial-wave coefficients.** For `0 < a`, the Gegenbauer expansion of a
+polynomial of degree `< n` is unique: this makes the partial-wave coefficients `B_{n,j}` (with
+`a = (D-3)/2`, `D ≥ 4`) genuinely well-defined, not merely existent.
+-/
+@[category API, AMS 33]
+theorem gegenbauer_expansion_unique {a : ℚ} (ha : 0 < a) (n : ℕ) (B B' : ℕ → ℚ)
+    (h : ∑ j ∈ Finset.range n, C (B j) * gegenbauer a j
+       = ∑ j ∈ Finset.range n, C (B' j) * gegenbauer a j) :
+    ∀ j, j < n → B j = B' j := by
+  intro j hj
+  have hz : ∑ k ∈ Finset.range n, C (B k - B' k) * gegenbauer a k = 0 := by
+    simp only [C_sub, sub_mul]
+    rw [Finset.sum_sub_distrib, h, sub_self]
+  exact sub_eq_zero.mp (gegenbauer_sum_eq_zero ha n (fun k => B k - B' k) hz j hj)
+
+/--
+The spin-`0` partial-wave coefficient at level `n = 3` is `B_{3,0}^D = (10 - D) / (24 (D-1))`
+(eq. 1.3). Combined with uniqueness of the Gegenbauer expansion, this pins down the boundary
+dimension: it is non-negative iff `D ≤ 10`.
+-/
+@[category research solved, AMS 81]
+theorem B_three_zero {D : ℕ} (hD : 4 ≤ D) (B : ℕ → ℚ)
+    (hB : residueX 3 = ∑ j ∈ Finset.range 3, C (B j) * gegenbauer (lam D) j) :
+    B 0 = (10 - (D : ℚ)) / (24 * ((D : ℚ) - 1)) := by
+  rw [residueX_three, Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ,
+    Finset.sum_range_zero, gegenbauer_zero, gegenbauer_one, gegenbauer_two] at hB
+  have e0 := congrArg (Polynomial.eval (0 : ℚ)) hB
+  have e1 := congrArg (Polynomial.eval (1 : ℚ)) hB
+  have em := congrArg (Polynomial.eval (-1 : ℚ)) hB
+  simp only [eval_add, eval_sub, eval_mul, eval_C, eval_X, eval_pow, eval_one, eval_zero] at e0 e1 em
+  -- Eliminating the spin-1 term: `(2λ+1)·e0 + (e1+e₋₁)/2` gives `(2λ+2)·B 0 = (7-2λ)/24`.
+  have key : (2 * lam D + 2) * B 0 = (7 - 2 * lam D) / 24 := by
+    linear_combination -(2 * lam D + 1) * e0 - e1 / 2 - em / 2
+  have hDQ : (4 : ℚ) ≤ (D : ℚ) := by exact_mod_cast hD
+  have hD1 : (D : ℚ) - 1 ≠ 0 := by intro h; nlinarith
+  have key2 : ((D : ℚ) - 1) * B 0 = (10 - (D : ℚ)) / 24 := by
+    rw [lam] at key; linear_combination key
+  rw [eq_div_iff (mul_ne_zero (by norm_num) hD1)]
+  linear_combination 24 * key2
+
+/--
+**Sharpness.** In `D = 11` the spin-`0` coefficient at level `3` is already negative
+(`= -1/240`), so partial-wave positivity fails — consistency forces `D ≤ 10`.
+-/
+@[category test, AMS 81]
+theorem partial_wave_negative_of_dim_eleven (B : ℕ → ℚ)
+    (hB : residueX 3 = ∑ j ∈ Finset.range 3, C (B j) * gegenbauer (lam 11) j) :
+    B 0 < 0 := by
+  rw [B_three_zero (D := 11) (by norm_num) B hB]
+  norm_num
+
+/- ## Section 2 — the partial-wave projection by integration
+
+Section 2 *defines* the partial-wave coefficients analytically (eq. 2.5): integrate the residue
+polynomial against the Gegenbauer polynomials with respect to the weight `(1 - x²)^{(D-4)/2}` on
+`[-1, 1]`, using Gegenbauer orthogonality to isolate each spin `j`. It then recasts this as the
+double-contour integral (eq. 2.11) on which the positivity proof operates.
+
+We formalise the integral side faithfully; the analytic identities are stated as benchmark
+`sorry`s. (The contour form (2.11) is omitted pending complex-contour integration API.) -/
+
+section Section2
+
+open MeasureTheory
+
+/-- The Gegenbauer weight `w_D(x) = (1 - x²)^{(D-4)/2}` on `[-1, 1]`. -/
+noncomputable def weight (D : ℕ) (x : ℝ) : ℝ := (1 - x ^ 2) ^ (((D : ℝ) - 4) / 2)
+
+/-- The real Gegenbauer parameter `λ = (D - 3) / 2`. -/
+noncomputable def lamR (D : ℕ) : ℝ := ((D : ℝ) - 3) / 2
+
+/--
+The partial-wave coefficient `B_{n,j}^D` defined analytically as in eq. (2.5): the integral over
+`[-1, 1]` of the level-`n` residue against the spin-`j` Gegenbauer polynomial, against the weight
+`(1 - x²)^{(D-4)/2}`.
+-/
+noncomputable def Bintegral (D n j : ℕ) : ℝ :=
+  ∫ x in (-1 : ℝ)..1, weight D x * (gegenbauer (lamR D) j).eval x * aeval x (residueX n)
+
+/-- The squared Gegenbauer norm `‖C_j^{(λ)}‖²` appearing in the projection (eq. 2.5). -/
+noncomputable def gegenbauerNormSq (D j : ℕ) : ℝ :=
+  ∫ x in (-1 : ℝ)..1, weight D x * (gegenbauer (lamR D) j).eval x ^ 2
+
+/-- **Gegenbauer orthogonality.** Distinct spins are orthogonal for the weight `(1 - x²)^{(D-4)/2}`. -/
+@[category research solved, AMS 33]
+theorem gegenbauer_orthogonal {D : ℕ} (hD : 3 ≤ D) {i j : ℕ} (hij : i ≠ j) :
+    ∫ x in (-1 : ℝ)..1,
+        weight D x * (gegenbauer (lamR D) i).eval x * (gegenbauer (lamR D) j).eval x = 0 := by
+  sorry
+
+/--
+The Gegenbauer norm is strictly positive for `D ≥ 4`: the weight is positive on the open
+interval and the polynomial is non-zero, so the squared integrand has positive support.
+(`D = 3` must be excluded: there `λ = 0` and `C_1^{(0)} = 0`, so the norm vanishes.)
+-/
+@[category API, AMS 33]
+theorem gegenbauerNormSq_pos {D : ℕ} (hD : 4 ≤ D) (j : ℕ) : 0 < gegenbauerNormSq D j := by
+  have hDR : (4 : ℝ) ≤ (D : ℝ) := by exact_mod_cast hD
+  have he : 0 ≤ ((D : ℝ) - 4) / 2 := by linarith
+  have hl : 0 < lamR D := by rw [lamR]; linarith
+  set g : Polynomial ℝ := gegenbauer (lamR D) j with hg
+  have hgne : g ≠ 0 :=
+    Polynomial.leadingCoeff_ne_zero.mp (gegenbauer_natDegree_leadingCoeff hl j).2.ne'
+  set f : ℝ → ℝ := fun x => weight D x * g.eval x ^ 2 with hf
+  have hwcont : Continuous (weight D) := by
+    have h1 : Continuous fun x : ℝ => 1 - x ^ 2 := by continuity
+    exact h1.rpow_const fun x => Or.inr he
+  have hfc : Continuous f := hwcont.mul (g.continuous.pow 2)
+  have hfi : IntervalIntegrable f MeasureTheory.volume (-1 : ℝ) 1 :=
+    hfc.intervalIntegrable _ _
+  have hnonneg : 0 ≤ᵐ[MeasureTheory.volume.restrict (Set.uIoc (-1 : ℝ) 1)] f := by
+    rw [Set.uIoc_of_le (by norm_num : (-1 : ℝ) ≤ 1)]
+    filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_Ioc] with x hx
+    have hw : (0 : ℝ) ≤ weight D x :=
+      Real.rpow_nonneg (by nlinarith [hx.1, hx.2] : (0 : ℝ) ≤ 1 - x ^ 2) _
+    exact mul_nonneg hw (sq_nonneg _)
+  have hroots : {x : ℝ | g.IsRoot x}.Finite := Polynomial.finite_setOf_isRoot hgne
+  have hsubset : Set.Ioo (-1 : ℝ) 1 \ {x | g.IsRoot x}
+      ⊆ Function.support f ∩ Set.Ioc (-1 : ℝ) 1 := by
+    rintro x ⟨hx, hroot⟩
+    have h1x : (0 : ℝ) < 1 - x ^ 2 := by nlinarith [hx.1, hx.2]
+    have hw : 0 < weight D x := Real.rpow_pos_of_pos h1x _
+    have hgx : g.eval x ≠ 0 := fun h => hroot h
+    have hfx : 0 < f x :=
+      mul_pos hw (lt_of_le_of_ne (sq_nonneg _) (Ne.symm (pow_ne_zero 2 hgx)))
+    exact ⟨hfx.ne', hx.1, hx.2.le⟩
+  have hmeas : 0 < MeasureTheory.volume (Function.support f ∩ Set.Ioc (-1 : ℝ) 1) := by
+    refine lt_of_lt_of_le ?_ (MeasureTheory.measure_mono hsubset)
+    rw [MeasureTheory.measure_diff_null (hroots.measure_zero MeasureTheory.volume),
+      Real.volume_Ioo]
+    exact ENNReal.ofReal_pos.mpr (by norm_num)
+  show 0 < ∫ x in (-1 : ℝ)..1, f x
+  exact (intervalIntegral.integral_pos_iff_support_of_nonneg_ae' hnonneg hfi).mpr
+    ⟨by norm_num, hmeas⟩
+
+/--
+**Projection (eq. 2.5).** When the residue is written in the Gegenbauer basis with rational
+coefficients `b`, the analytic coefficient `B_{n,j}^D` recovers `b_j` times the squared norm.
+This is what makes `Bintegral` the partial-wave coefficient, and ties Section 2 to the algebraic
+expansion used in `partial_wave_positivity`.
+-/
+@[category research solved, AMS 33 81]
+theorem Bintegral_eq_coeff_mul_normSq {D n : ℕ} (hD : 3 ≤ D) (b : ℕ → ℚ)
+    (hb : residueX n = ∑ k ∈ Finset.range n, C (b k) * gegenbauer (lam D) k) (j : ℕ) :
+    Bintegral D n j = (b j : ℝ) * gegenbauerNormSq D j := by
+  sorry
+
+/--
+**Positivity, integral form (Mansfield, 2025).** The analytically-defined partial-wave
+coefficients are non-negative for `D ≤ 10` — the Section-2 statement of the main theorem.
+-/
+@[category research solved, AMS 33 81]
+theorem Bintegral_nonneg {D : ℕ} (hD : 3 ≤ D) (hD10 : D ≤ 10) {n : ℕ} (hn : 1 ≤ n) (j : ℕ) :
+    0 ≤ Bintegral D n j := by
+  sorry
+
+end Section2
+
+end Arxiv.«2502.20372»

--- a/FormalConjectures/Arxiv/2502.20372/VirasoroShapiro.lean
+++ b/FormalConjectures/Arxiv/2502.20372/VirasoroShapiro.lean
@@ -1,0 +1,209 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjectures.Arxiv.«2502.20372».VenezianoPositivity
+
+/-!
+# Positivity of the Virasoro–Shapiro amplitude (Section 3.1)
+
+*Reference:* [arxiv/2502.20372](https://arxiv.org/abs/2502.20372)
+**Positivity of the Veneziano Amplitude in Ten Dimensions** by *Gareth Mansfield*, §3.1
+
+The closed-string analogues of the Veneziano amplitude follow from KLT/double copy. The
+type-II Virasoro–Shapiro amplitude (eq. 3.5)
+$$A^{\mathrm{II}}(s,t) = \frac{\sin(\pi s)\sin(\pi t)}{\pi \sin(\pi(s+t))}\,A^0(s,t)^2
+  = \frac{\Gamma(-s)\Gamma(-t)\Gamma(-u)}{\Gamma(1+s)\Gamma(1+t)\Gamma(1+u)}, \quad u = -s-t,$$
+has residues (eq. 3.7) that are the *squares* of the open-string residues,
+$$\operatorname{Res}_{s=n} A^{\mathrm{II}} = \Big(\frac{(t+1)_{(n-1)}}{n!}\Big)^{\!2},$$
+while the heterotic amplitude (eq. 3.6) has
+$$\operatorname{Res}_{s=n} A^{\mathrm{Het}}
+  = \frac{(t+1)_{(n-1)}\,(t+2)_{(n+1)}}{n!\,(n+1)!}.$$
+Mansfield deduces partial-wave positivity of both in `D ≤ 10` from the open-string result,
+since products of positive Gegenbauer expansions are positive.
+
+This is the shared statement for the uniqueness paper
+`FormalConjectures/Arxiv/2508.09246/StringsFromAlmostNothing.lean`, whose nonplanar
+bootstrap lands precisely on the Virasoro–Shapiro amplitude.
+-/
+
+namespace Arxiv.«2502.20372»
+
+open Polynomial
+
+/--
+The type-II Virasoro–Shapiro residue at level `n` in the angular variable `x = 1 + 2t/n`:
+the square of the open-string residue (eq. 3.7).
+-/
+noncomputable def vsResidueX (n : ℕ) : ℚ[X] := residueX n ^ 2
+
+/--
+The heterotic residue at level `n` in the angular variable `x = 1 + 2t/n` (eq. 3.7):
+$(t+1)_{(n-1)} (t+2)_{(n+1)} / (n!\,(n+1)!)$ with `t = n (x - 1) / 2`.
+-/
+noncomputable def hetResidueX (n : ℕ) : ℚ[X] :=
+  C (((n.factorial : ℚ) * (n + 1).factorial)⁻¹) *
+    (∏ i ∈ Finset.range (n - 1), (C ((n : ℚ) / 2) * (X - 1) + C ((i : ℚ) + 1))) *
+    (∏ i ∈ Finset.range (n + 1), (C ((n : ℚ) / 2) * (X - 1) + C ((i : ℚ) + 2)))
+
+@[category test, AMS 81]
+theorem vsResidueX_one : vsResidueX 1 = 1 := by
+  simp [vsResidueX, residueX_one]
+
+/--
+**Type-II Virasoro–Shapiro positivity (§3.1).** In `D ≤ 10` the closed-string residues —
+squares of the open-string residues — expand in the Gegenbauer spin basis with non-negative
+coefficients. Follows from the Veneziano result via the double copy, since the Gegenbauer
+linearization of a product of non-negative expansions is non-negative.
+-/
+@[category research solved, AMS 33 81]
+theorem virasoro_shapiro_positivity {D : ℕ} (hD : 3 ≤ D) (hD10 : D ≤ 10) {n : ℕ}
+    (hn : 1 ≤ n) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      vsResidueX n = ∑ j ∈ Finset.range (2 * n - 1), C (B j) * gegenbauer (lam D) j := by
+  sorry
+
+/--
+**Heterotic positivity (§3.1).** The heterotic residues likewise have non-negative
+partial-wave coefficients in `D ≤ 10`.
+-/
+@[category research solved, AMS 33 81]
+theorem heterotic_positivity {D : ℕ} (hD : 3 ≤ D) (hD10 : D ≤ 10) {n : ℕ} (hn : 1 ≤ n) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      hetResidueX n = ∑ j ∈ Finset.range (2 * n + 1), C (B j) * gegenbauer (lam D) j := by
+  sorry
+
+/--
+Heterotic positivity at level `n = 1` across `4 ≤ D ≤ 10`: the residue
+`(t+2)(t+3)/2 = (x+3)(x+5)/8` decomposes into spins 0, 1, 2 with coefficients
+`15/8 + 1/(16(λ+1))`, `1/(2λ)`, `1/(16λ(λ+1))`, all positive. A concrete verification of
+`heterotic_positivity` (and of the `hetResidueX` definition) at the first level.
+-/
+@[category test, AMS 33 81]
+theorem heterotic_positivity_one {D : ℕ} (hD : 4 ≤ D) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      hetResidueX 1 = ∑ j ∈ Finset.range 3, C (B j) * gegenbauer (lam D) j := by
+  have hl := lam_pos hD
+  refine ⟨fun j => if j = 0 then 15 / 8 + 1 / (16 * (lam D + 1))
+                   else if j = 1 then 1 / (2 * lam D)
+                   else if j = 2 then 1 / (16 * lam D * (lam D + 1)) else 0, ?_, ?_⟩
+  · intro j
+    dsimp only
+    split
+    · positivity
+    · split
+      · positivity
+      · split
+        · positivity
+        · norm_num
+  · apply Polynomial.funext
+    intro x
+    rw [eval_finset_sum]
+    simp only [hetResidueX, Nat.sub_self, Finset.sum_range_succ, Finset.sum_range_zero,
+      zero_add, gegenbauer_zero, gegenbauer_one, gegenbauer_two, Finset.prod_range_succ,
+      Finset.prod_range_zero, one_mul, Nat.factorial, eval_mul, eval_add, eval_sub, eval_C,
+      eval_X, eval_one, eval_pow, reduceIte, Nat.one_ne_zero, Nat.reduceEqDiff,
+      OfNat.ofNat_ne_zero, OfNat.ofNat_ne_one, if_false]
+    have h0 : lam D ≠ 0 := hl.ne'
+    have h1 : lam D + 1 ≠ 0 := by positivity
+    field_simp
+    ring
+
+/--
+Type-II positivity at level `n = 2` across `4 ≤ D ≤ 10`: the squared residue `(x/2)² = x²/4`
+decomposes into spins 0 and 2 with coefficients `1/(8(λ+1))` and `1/(8λ(λ+1))`, both positive.
+A concrete verification of `virasoro_shapiro_positivity` at the first non-trivial level.
+-/
+@[category test, AMS 33 81]
+theorem virasoro_shapiro_positivity_two {D : ℕ} (hD : 4 ≤ D) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      vsResidueX 2 = ∑ j ∈ Finset.range 3, C (B j) * gegenbauer (lam D) j := by
+  have hl := lam_pos hD
+  refine ⟨fun j => if j = 0 then 1 / (8 * (lam D + 1))
+                   else if j = 2 then 1 / (8 * lam D * (lam D + 1)) else 0, ?_, ?_⟩
+  · intro j
+    dsimp only
+    split
+    · positivity
+    · split
+      · positivity
+      · norm_num
+  · apply Polynomial.funext
+    intro x
+    rw [eval_finset_sum]
+    simp only [vsResidueX, Finset.sum_range_succ, Finset.sum_range_zero, zero_add,
+      gegenbauer_zero, gegenbauer_one, gegenbauer_two, residueX, Finset.prod_range_succ,
+      Finset.prod_range_zero, one_mul, Nat.factorial, eval_mul, eval_add, eval_sub, eval_C,
+      eval_X, eval_one, eval_pow, reduceIte]
+    rw [if_neg (by decide : ¬ (1 : ℕ) = 0), if_neg (by decide : ¬ (1 : ℕ) = 2),
+      if_neg (by decide : ¬ (2 : ℕ) = 0)]
+    have h0 : lam D ≠ 0 := hl.ne'
+    have h1 : lam D + 1 ≠ 0 := by positivity
+    field_simp
+    ring
+
+/--
+Type-II positivity at the critical level `n = 3` across `4 ≤ D ≤ 10`: the squared residue
+`((9x²-1)/24)²` decomposes into spins 0, 2, 4 with explicit coefficients
+`B₄ = 27/(128λ(λ+1)(λ+2)(λ+3))`, `B₂ = (21-2λ)/(128λ(λ+1)(λ+3))`,
+`B₀ = (4λ³-12λ²+107λ+537)/(2304(λ+1)(λ+2)(λ+3))`, all non-negative for `λ ≤ 21/2`
+(i.e. `D ≤ 24` — comfortably covering `D ≤ 10`).
+-/
+@[category test, AMS 33 81]
+theorem virasoro_shapiro_positivity_three {D : ℕ} (hD : 4 ≤ D) (hD10 : D ≤ 10) :
+    ∃ B : ℕ → ℚ, (∀ j, 0 ≤ B j) ∧
+      vsResidueX 3 = ∑ j ∈ Finset.range 5, C (B j) * gegenbauer (lam D) j := by
+  have hl := lam_pos hD
+  have hDQ : (4 : ℚ) ≤ (D : ℚ) := by exact_mod_cast hD
+  have hD10Q : (D : ℚ) ≤ 10 := by exact_mod_cast hD10
+  have h21 : 0 < 21 - 2 * lam D := by rw [lam]; linarith
+  set a := lam D with ha
+  have h0 : a ≠ 0 := hl.ne'
+  have h1 : a + 1 ≠ 0 := by positivity
+  have h2 : a + 2 ≠ 0 := by positivity
+  have h3 : a + 3 ≠ 0 := by positivity
+  refine ⟨fun j => if j = 0 then (4*a^3 - 12*a^2 + 107*a + 537) / (2304*(a+1)*(a+2)*(a+3))
+                   else if j = 2 then (21 - 2*a) / (128*a*(a+1)*(a+3))
+                   else if j = 4 then 27 / (128*a*(a+1)*(a+2)*(a+3)) else 0, ?_, ?_⟩
+  · intro j
+    dsimp only
+    split
+    · have hnum : 0 < 4*a^3 - 12*a^2 + 107*a + 537 := by
+        nlinarith [mul_nonneg hl.le (sq_nonneg (a - 3/2))]
+      exact (div_pos hnum (by positivity)).le
+    · split
+      · exact (div_pos h21 (by positivity)).le
+      · split
+        · positivity
+        · norm_num
+  · apply Polynomial.funext
+    intro x
+    rw [eval_finset_sum]
+    simp only [vsResidueX, residueX_three, Finset.sum_range_succ, Finset.sum_range_zero,
+      zero_add, gegenbauer_zero, gegenbauer_one, gegenbauer_two, eval_mul, eval_sub,
+      eval_C, eval_X, eval_one, eval_pow, reduceIte]
+    rw [if_neg (by decide : ¬ (1 : ℕ) = 0), if_neg (by decide : ¬ (1 : ℕ) = 2),
+      if_neg (by decide : ¬ (1 : ℕ) = 4), if_neg (by decide : ¬ (2 : ℕ) = 0),
+      if_neg (by decide : ¬ (3 : ℕ) = 0), if_neg (by decide : ¬ (3 : ℕ) = 2),
+      if_neg (by decide : ¬ (3 : ℕ) = 4), if_neg (by decide : ¬ (4 : ℕ) = 0),
+      if_neg (by decide : ¬ (4 : ℕ) = 2)]
+    have e3 := congrArg (eval x) (gegenbauer_add_two a 1)
+    have e4 := congrArg (eval x) (gegenbauer_add_two a 2)
+    norm_num [eval_mul, eval_sub, eval_add, eval_C, eval_X, eval_pow, eval_one,
+      gegenbauer_two, gegenbauer_one, gegenbauer_zero] at e3 e4
+    rw [e4, e3]
+    field_simp
+    ring
+
+end Arxiv.«2502.20372»

--- a/FormalConjectures/Arxiv/2508.09246/StringsFromAlmostNothing.lean
+++ b/FormalConjectures/Arxiv/2508.09246/StringsFromAlmostNothing.lean
@@ -1,0 +1,150 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjectures.Arxiv.«2502.20372».VirasoroShapiro
+
+/-!
+# Strings from Almost Nothing
+
+*Reference:* [arxiv/2508.09246](https://arxiv.org/abs/2508.09246)
+**Strings from Almost Nothing**
+by *Clifford Cheung, Grant N. Remmen, Francesco Sciotti, Michele Tarquini*
+
+Any tree-level, crossing-symmetric, unitary four-point amplitude with poles at masses
+`μ(n)` and maximal spin `J(n)` at level `n`, and Regge behavior `A(s,t) ~ f(t) s^{α(t)}`,
+is forced by consistency to have residues vanishing on the "Regge zeros" `α(t) + r = 0`
+(eq. 6). The paper's uniqueness argument: assuming
+(i) *ultrasoftness* — the Regge trajectory `α` is bijective for `t < 0` with
+    `α(t) → -∞` as `t → -∞`, and
+(ii) *minimal zeros* — the residues consist of Regge zeros and nothing more, i.e.
+    `R(n,t) = c(n) ∏_{r=1}^{N(n)} (α(t) + r)^h` (eq. 12),
+the spectrum and trajectory are forced to be linear, `μ(n) ~ J(n) ~ n`, `α(t) ~ t`
+(eq. 13), and the amplitude is *uniquely* the Veneziano amplitude
+`Γ(-s)Γ(-t)/Γ(-s-t)`; the nonplanar analogue lands on Virasoro–Shapiro.
+
+The string residues themselves (eq. 7) are `R_str(n,t) = (1/n!) ∏_{r=1}^{n} (t+r)`,
+with Regge zeros at `t = -1, …, -n`; these we formalise concretely. See
+`FormalConjectures/Arxiv/2502.20372/VenezianoPositivity.lean` for the companion
+positivity benchmark for the same amplitude.
+-/
+
+namespace Arxiv.«2508.09246»
+
+open Polynomial
+
+/--
+Eq. (7): the level-`n` residue of the (bosonic-convention) string amplitude,
+$$R_{\mathrm{str}}(n,t) = \frac{1}{n!} \prod_{r=1}^{n} (t+r).$$
+-/
+noncomputable def stringResidue (n : ℕ) : ℝ[X] :=
+  C ((n.factorial : ℝ)⁻¹) * ∏ r ∈ Finset.range n, (X + C ((r : ℝ) + 1))
+
+/-- The string residue at level `n` has its Regge zeros at `t = -1, …, -n` (eq. 6/7). -/
+@[category test, AMS 81]
+theorem stringResidue_regge_zero {n r : ℕ} (h1 : 1 ≤ r) (hn : r ≤ n) :
+    (stringResidue n).eval (-(r : ℝ)) = 0 := by
+  have hmem : r - 1 ∈ Finset.range n := Finset.mem_range.mpr (by omega)
+  have hzero : (-(r : ℝ)) + (((r - 1 : ℕ) : ℝ) + 1) = 0 := by
+    have : ((r - 1 : ℕ) : ℝ) = (r : ℝ) - 1 := by
+      push_cast [Nat.cast_sub h1]; ring
+    rw [this]; ring
+  simp only [stringResidue, eval_mul, eval_prod, eval_add, eval_C, eval_X]
+  rw [Finset.prod_eq_zero hmem hzero, mul_zero]
+
+/-- The Regge zeros of the string residue are *exactly* `t = -1, …, -n`: assumption (ii)
+("minimal zeros") holds for the string — the residues contain the consistency-mandated zeros
+and nothing more. Strengthens `stringResidue_regge_zero` to a characterization. -/
+@[category test, AMS 81]
+theorem stringResidue_eval_eq_zero_iff {n : ℕ} {t : ℝ} :
+    (stringResidue n).eval t = 0 ↔ ∃ r : ℕ, 1 ≤ r ∧ r ≤ n ∧ t = -(r : ℝ) := by
+  simp only [stringResidue, eval_mul, eval_prod, eval_add, eval_C, eval_X]
+  rw [mul_eq_zero]
+  constructor
+  · rintro (hfac | hprod)
+    · exact absurd hfac (by positivity)
+    · obtain ⟨i, hi, hzero⟩ := Finset.prod_eq_zero_iff.mp hprod
+      refine ⟨i + 1, by omega, by have := Finset.mem_range.mp hi; omega, ?_⟩
+      push_cast
+      linarith
+  · rintro ⟨r, h1, hn, rfl⟩
+    right
+    apply Finset.prod_eq_zero (Finset.mem_range.mpr (show r - 1 < n by omega))
+    have : ((r - 1 : ℕ) : ℝ) = (r : ℝ) - 1 := by push_cast [Nat.cast_sub h1]; ring
+    rw [this]
+    ring
+
+/-- For `t > 0` the string residue is strictly positive — there are no residue zeros in the
+physical region (as noted below eq. 6). -/
+@[category test, AMS 81]
+theorem stringResidue_pos {n : ℕ} {t : ℝ} (ht : 0 < t) : 0 < (stringResidue n).eval t := by
+  simp only [stringResidue, eval_mul, eval_prod, eval_add, eval_C, eval_X]
+  have hfac : (0 : ℝ) < ((n.factorial : ℝ))⁻¹ := by positivity
+  refine mul_pos hfac (Finset.prod_pos fun r _ => ?_)
+  positivity
+
+/--
+**Main theorem, algebraic core (eq. 12 ⟹ eq. 13).** Suppose every level-`n` residue is
+built entirely out of Regge zeros of a polynomial trajectory `α` with constant multiplicity
+`h ≥ 1` (the minimal-zero ansatz, eq. 12), the maximal spin at level `n` equals the residue's
+degree and matches the trajectory at the pole (`α(μ n) = J n`, eq. 2), with infinitely many
+levels. Then ultrasoftness forces a *linear* Regge trajectory: `h = 1` and `deg α = 1`.
+-/
+@[category research solved, AMS 81]
+theorem trajectory_linear (α : ℝ[X]) (hα : 1 ≤ α.natDegree)
+    (μ : ℕ → ℝ) (hμ : StrictMono μ) (hμtop : Filter.Tendsto μ Filter.atTop Filter.atTop)
+    (J N : ℕ → ℕ) (c : ℕ → ℝ) (h : ℕ)
+    (hh : 1 ≤ h) (hc : ∀ n, c n ≠ 0) (hN : Filter.Tendsto N Filter.atTop Filter.atTop)
+    (R : ℕ → ℝ[X])
+    (hR : ∀ n, R n = C (c n) * ∏ r ∈ Finset.range (N n), (α + C ((r : ℝ) + 1)) ^ h)
+    (hdeg : ∀ n, (R n).natDegree = J n)
+    (hspin : ∀ n, α.eval (μ n) = J n)
+    -- Regge scaling (eq. 5): in the Regge region the residues scale as `μ(n)^{α(t)}`, i.e.
+    -- `log |R(n,t)| / log μ(n) → α(t)`. Without this hypothesis the statement is false
+    -- (e.g. `α = X²`, `h = 2` satisfies all the algebraic conditions).
+    (hRegge : ∀ t : ℝ, t < 0 → (∀ n, (R n).eval t ≠ 0) →
+      Filter.Tendsto (fun n => Real.log |(R n).eval t| / Real.log (μ n))
+        Filter.atTop (nhds (α.eval t))) :
+    h = 1 ∧ α.natDegree = 1 := by
+  sorry
+
+/--
+**Uniqueness of the Veneziano amplitude (four-point planar), residue form.** Under the
+minimal-zero ansatz and ultrasoftness, the residues are — up to an overall normalization and
+the linear reparametrization `α(t) = t` fixed by eq. 13 — precisely the string residues of
+eq. 7: bootstrapping zeros alone lands on the Veneziano amplitude.
+-/
+@[category research solved, AMS 81]
+theorem veneziano_uniqueness (α : ℝ[X]) (hα : α = X)
+    (μ : ℕ → ℝ) (hμ : ∀ n, μ n = n) (N : ℕ → ℕ) (hN : ∀ n, N n = n) (c : ℕ → ℝ)
+    (hc : ∀ n, 0 < c n)
+    (R : ℕ → ℝ[X])
+    (hR : ∀ n, R n = C (c n) * ∏ r ∈ Finset.range (N n), (α + C ((r : ℝ) + 1)))
+    -- normalization: unit residue at the first pole, as for `Γ(-s)Γ(-t)/Γ(-s-t)`
+    (hnorm : ∀ n, (R n).leadingCoeff = (n.factorial : ℝ)⁻¹) :
+    ∀ n, R n = stringResidue n := by
+  sorry
+
+/--
+**Nonplanar endpoint: Virasoro–Shapiro.** The nonplanar bootstrap of this paper (eqs. 14–18)
+lands on the Virasoro–Shapiro amplitude, whose partial-wave positivity in `D ≤ 10` is the
+shared statement formalised with the companion paper arXiv:2502.20372 (§3.1). Pointer per
+repository convention.
+-/
+@[category research solved, AMS 33 81]
+theorem virasoro_shapiro_positivity :
+    type_of% @Arxiv.«2502.20372».virasoro_shapiro_positivity := by
+  sorry
+
+end Arxiv.«2508.09246»

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -33,6 +33,7 @@ public import FormalConjecturesForMathlib.Analysis.Equidistribution.ModOne
 public import FormalConjecturesForMathlib.Analysis.Fourier.SpectralSets
 public import FormalConjecturesForMathlib.Analysis.HasGaps
 public import FormalConjecturesForMathlib.Analysis.Real.Cardinality
+public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Gegenbauer
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Log.Basic
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.NthRoot
 public import FormalConjecturesForMathlib.Combinatorics.AP.Basic

--- a/FormalConjecturesForMathlib/Analysis/SpecialFunctions/Gegenbauer.lean
+++ b/FormalConjecturesForMathlib/Analysis/SpecialFunctions/Gegenbauer.lean
@@ -1,0 +1,128 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.Basic
+public import Mathlib.Algebra.Polynomial.Eval.Defs
+public import Mathlib.Algebra.Polynomial.Monic
+public import Mathlib.Algebra.Polynomial.Degree.Lemmas
+public import Mathlib.Algebra.Order.Field.Basic
+public import Mathlib.Tactic.FieldSimp
+public import Mathlib.Tactic.Ring
+public import Mathlib.Tactic.NormNum
+public import Mathlib.Tactic.Positivity
+
+@[expose] public section
+
+/-!
+# Gegenbauer (ultraspherical) polynomials
+
+The Gegenbauer (or ultraspherical) polynomials `C_n^{(a)}` are the family of orthogonal
+polynomials with respect to the weight `(1 - x²)^{a - 1/2}` on `[-1, 1]`. They generalise
+both the Legendre polynomials (`a = 1/2`) and the Chebyshev polynomials of the second kind
+(`a = 1`), and arise as the partial-wave / angular basis for scattering in `D` spacetime
+dimensions, with parameter `a = (D - 3) / 2`.
+
+We define them over an arbitrary field by the standard three-term recurrence
+$$ C_0^{(a)} = 1, \qquad C_1^{(a)} = 2 a X, $$
+$$ n\, C_n^{(a)} = 2 (n + a - 1)\, X\, C_{n-1}^{(a)} - (n + 2a - 2)\, C_{n-2}^{(a)} \quad (n \ge 2). $$
+-/
+
+open Polynomial
+
+namespace Polynomial
+
+variable {K : Type*} [Field K]
+
+/--
+The Gegenbauer (ultraspherical) polynomial `C_n^{(a)} : K[X]` with parameter `a : K`,
+defined by the three-term recurrence
+`C_0 = 1`, `C_1 = 2 a X`, and
+`(n + 2) C_{n+2} = 2 (n + 1 + a) X C_{n+1} - (n + 2 a) C_n`.
+-/
+noncomputable def gegenbauer (a : K) : ℕ → K[X]
+  | 0 => 1
+  | 1 => C (2 * a) * X
+  | (n + 2) => C ((n : K) + 2)⁻¹ *
+      (C (2 * ((n : K) + 1 + a)) * X * gegenbauer a (n + 1)
+        - C ((n : K) + 2 * a) * gegenbauer a n)
+
+@[simp]
+theorem gegenbauer_zero (a : K) : gegenbauer a 0 = 1 := rfl
+
+@[simp]
+theorem gegenbauer_one (a : K) : gegenbauer a 1 = C (2 * a) * X := rfl
+
+/-- The defining three-term recurrence, valid for all `n`. -/
+theorem gegenbauer_add_two (a : K) (n : ℕ) :
+    gegenbauer a (n + 2) = C ((n : K) + 2)⁻¹ *
+      (C (2 * ((n : K) + 1 + a)) * X * gegenbauer a (n + 1)
+        - C ((n : K) + 2 * a) * gegenbauer a n) := rfl
+
+/-- Closed form `C_2^{(a)} = 2 a (a + 1) X² - a`. -/
+theorem gegenbauer_two [CharZero K] (a : K) :
+    gegenbauer a 2 = C (2 * a * (a + 1)) * X ^ 2 - C a := by
+  have h2 : (2 : K) ≠ 0 := by norm_num
+  rw [gegenbauer_add_two, gegenbauer_one, gegenbauer_zero]
+  simp only [Nat.cast_zero, zero_add, mul_one]
+  rw [mul_sub,
+    show C (2 * (1 + a)) * X * (C (2 * a) * X) = C (2 * (1 + a) * (2 * a)) * X ^ 2 by
+      simp only [C_mul]; ring,
+    ← mul_assoc, ← C_mul, ← C_mul,
+    show (2 : K)⁻¹ * (2 * (1 + a) * (2 * a)) = 2 * a * (a + 1) by field_simp; ring,
+    show (2 : K)⁻¹ * (2 * a) = a by field_simp]
+
+/--
+For `0 < a`, the Gegenbauer polynomial `C_n^{(a)}` has degree exactly `n` and positive leading
+coefficient. Consequently `{C_0^{(a)}, …, C_{m-1}^{(a)}}` is a basis of the polynomials of degree
+`< m`, so the Gegenbauer expansion of any such polynomial is unique.
+-/
+theorem gegenbauer_natDegree_leadingCoeff {K : Type*} [Field K] [LinearOrder K]
+    [IsStrictOrderedRing K] {a : K} (ha : 0 < a) :
+    ∀ n, (gegenbauer a n).natDegree = n ∧ 0 < (gegenbauer a n).leadingCoeff
+  | 0 => by constructor <;> simp [gegenbauer_zero]
+  | 1 => by
+    rw [gegenbauer_one]
+    exact ⟨natDegree_C_mul_X _ (by positivity), by rw [leadingCoeff_C_mul_X]; positivity⟩
+  | (n + 2) => by
+    obtain ⟨hd1, hl1⟩ := gegenbauer_natDegree_leadingCoeff ha (n + 1)
+    obtain ⟨hd0, hl0⟩ := gegenbauer_natDegree_leadingCoeff ha n
+    have hd : (2 : K) * ((n : K) + 1 + a) ≠ 0 := by positivity
+    set t1 : K[X] := C (2 * ((n : K) + 1 + a)) * X * gegenbauer a (n + 1) with ht1
+    set t2 : K[X] := C ((n : K) + 2 * a) * gegenbauer a n with ht2
+    have hlcprod : (C (2 * ((n : K) + 1 + a)) * X).leadingCoeff *
+        (gegenbauer a (n + 1)).leadingCoeff ≠ 0 := by
+      rw [leadingCoeff_C_mul_X]; exact mul_ne_zero hd hl1.ne'
+    have ht1deg : t1.natDegree = n + 2 := by
+      rw [ht1, natDegree_mul' hlcprod, natDegree_C_mul_X _ hd, hd1]; omega
+    have ht1lc : t1.leadingCoeff = 2 * ((n : K) + 1 + a) * (gegenbauer a (n + 1)).leadingCoeff := by
+      rw [ht1, leadingCoeff_mul' hlcprod, leadingCoeff_C_mul_X]
+    have ht2deg : t2.natDegree ≤ n := (natDegree_C_mul_le _ _).trans hd0.le
+    have hlt : t2.natDegree < t1.natDegree := by rw [ht1deg]; omega
+    have hbdeg : (t1 - t2).natDegree = n + 2 :=
+      (natDegree_sub_eq_left_of_natDegree_lt hlt).trans ht1deg
+    have hlt2 : t2.natDegree < n + 2 := lt_of_le_of_lt ht2deg (by omega)
+    have hblc : (t1 - t2).leadingCoeff = t1.leadingCoeff := by
+      unfold leadingCoeff
+      rw [hbdeg, ht1deg, coeff_sub, coeff_eq_zero_of_natDegree_lt hlt2, sub_zero]
+    have hc : ((n : K) + 2)⁻¹ ≠ 0 := by positivity
+    rw [gegenbauer_add_two]
+    refine ⟨by rw [natDegree_C_mul hc, hbdeg], ?_⟩
+    rw [leadingCoeff_mul' (by rw [hblc, ht1lc, leadingCoeff_C]; positivity),
+      leadingCoeff_C, hblc, ht1lc]
+    positivity
+
+end Polynomial


### PR DESCRIPTION
Formalises **Cheung–Remmen–Sciotti–Tarquini, _Strings from Almost Nothing_** (arXiv:2508.09246): uniqueness of the Veneziano amplitude from Regge zeros + ultrasoft high-energy behavior.

- **Proven**: the string residues `(1/n!)∏(t+r)` have Regge zeros *exactly* at `t = −1, …, −n` (the paper's 'minimal zeros' assumption holds for the string), and are strictly positive in the physical region.
- **Benchmarks** (`research solved`, sorry): the algebraic core — minimal-zero ansatz + Regge scaling ⟹ linear Regge trajectory (eq. 12 ⟹ 13) — and residue-form Veneziano uniqueness.
- Pointer (via `type_of%`) to the shared Virasoro–Shapiro positivity statement of arXiv:2502.20372 §3.1, where the paper's nonplanar bootstrap lands.

**Top of the stack** (depends on the three previous PRs). `lake --wfail build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)