### PR TITLE
feat(ErdosProblems/1084): prove upper_d1

### DIFF
--- a/FormalConjectures/ErdosProblems/1084.lean
+++ b/FormalConjectures/ErdosProblems/1084.lean
@@ -44,7 +44,7 @@ noncomputable def f (d n : ℕ) : ℕ :=
 -- TODO: Add erdos_1084.
 
 /-- It is easy to check that $f_1(n) = n - 1$. -/
-@[category research solved, AMS 52]
+@[category research solved, AMS 52, formal_proof using formal_conjectures at "https://github.com/Sanexxxx777/formal-conjectures/blob/9e4f3845be122a8fa3190d38543ebdd0a6f25605/FormalConjectures/ErdosProblems/1084.lean#L232"]
 theorem erdos_1084.variants.upper_d1 : f 1 n = n - 1 := by
   sorry
 


### PR DESCRIPTION
`f 1 n = n - 1` is formally proved: among `n` points on the line with pairwise distance ≥ 1, the maximum number of pairs at distance exactly 1 is `n - 1`.

Following the repository convention for longer proofs (and @mo271's suggestion), the proof is **linked via the `formal_proof` mechanism** rather than inlined — this PR only adds the `formal_proof using formal_conjectures at …` attribute to the existing statement. The full Lean development (statement + 12 supporting lemmas) lives on the linked fork branch and builds cleanly.

**Proof outline:** upper bound via an injection of unit-distance pairs into `s.erase m` (`m` = coordinate-minimal point); lower bound via the witness `{0,1,…,n-1}`; the `iSup` over separated finsets is handled with `ciSup_le'` / `le_ciSup_of_le` and an explicit `BddAbove` bound.

Verification of the linked proof: `lake build` clean, `#print axioms` shows only `[propext, Classical.choice, Quot.sound]`.
