### PR TITLE
feat(Paper/DegreeSequencesTriangleFree): prove `lemma2_b`

### DIFF
--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -77,6 +77,32 @@ lemma lemma1_b
     have h3 : d (k + 2 * r) ≤ d (k + 2 * r + 2) := h_mono (by omega)
     omega
 
+/-- Helper: additive form of Lemma 2(a)'s estimate, used by `lemma2_a`–`lemma2_d`.
+The upper sum (after reindexing) exceeds the lower sum by at least `2 * n * n`. -/
+@[category API, AMS 5]
+private lemma lemma2_helper_short
+    (h_mono : Monotone d)
+    (h_no_three : ∀ i, d (i + 2) ≠ d i) :
+    ∑ i ∈ Finset.Icc 1 (2 * n), d i + 2 * n * n ≤
+      ∑ i ∈ Finset.Icc (2 * n + 1) (4 * n), d i := by
+  -- Reindex `i ↦ i + 2 * n`.
+  have hreindex : ∑ i ∈ Finset.Icc (2 * n + 1) (4 * n), d i =
+      ∑ i ∈ Finset.Icc 1 (2 * n), d (i + 2 * n) := by
+    rw [show Finset.Icc (2 * n + 1) (4 * n) =
+        (Finset.Icc 1 (2 * n)).image (· + 2 * n) by
+      ext x; simp [Finset.mem_Icc]; omega]
+    rw [Finset.sum_image]; intro a _ b _ hab; exact Nat.add_right_cancel hab
+  rw [hreindex]
+  have hpt : ∀ i, d i + n ≤ d (i + 2 * n) := fun i => by
+    have h1 := lemma1_b d i n h_mono h_no_three
+    have h2 := h_mono (show i ≤ i + 2 * n by omega)
+    omega
+  have hcard : (Finset.Icc 1 (2 * n)).card = 2 * n := by simp [Nat.card_Icc]
+  have hsum_n : ∑ _ ∈ Finset.Icc 1 (2 * n), n = 2 * n * n := by
+    rw [Finset.sum_const, hcard, smul_eq_mul]
+  rw [← hsum_n, ← Finset.sum_add_distrib]
+  exact Finset.sum_le_sum fun i _ => hpt i
+
 /-- **Lemma 2 (a)**
 Inequality involving sums of terms of a nondecreasing sequence with no three terms equal. -/
 @[category API, AMS 5]
@@ -87,27 +113,7 @@ lemma lemma2_a
     2 * n * n ≤
       ∑ i ∈ .Icc (2 * n + 1) (4 * n), d i -
         ∑ i ∈ .Icc 1 (2 * n), d i := by
-  -- Reindex the upper sum via `i ↦ i + 2 * n`.
-  have hreindex : ∑ i ∈ Finset.Icc (2 * n + 1) (4 * n), d i =
-      ∑ i ∈ Finset.Icc 1 (2 * n), d (i + 2 * n) := by
-    rw [show Finset.Icc (2 * n + 1) (4 * n) =
-        (Finset.Icc 1 (2 * n)).image (· + 2 * n) by
-      ext x; simp [Finset.mem_Icc]; omega]
-    rw [Finset.sum_image]; intro a _ b _ hab; exact Nat.add_right_cancel hab
-  -- Pointwise from Lemma 1(b): `d i + n ≤ d (i + 2 * n)`.
-  have hpt : ∀ i, d i + n ≤ d (i + 2 * n) := fun i => by
-    have h1 := lemma1_b d i n h_mono h_no_three
-    have h2 := h_mono (show i ≤ i + 2 * n by omega)
-    omega
-  rw [hreindex]
-  -- Switch from truncated `Nat`-subtraction to additive form, then sum pointwise.
-  have hcard : (Finset.Icc 1 (2 * n)).card = 2 * n := by simp [Nat.card_Icc]
-  have hsum_n : ∑ _ ∈ Finset.Icc 1 (2 * n), n = 2 * n * n := by
-    rw [Finset.sum_const, hcard, smul_eq_mul]
-  have hle : ∑ i ∈ Finset.Icc 1 (2 * n), d i + 2 * n * n ≤
-      ∑ i ∈ Finset.Icc 1 (2 * n), d (i + 2 * n) := by
-    rw [← hsum_n, ← Finset.sum_add_distrib]
-    exact Finset.sum_le_sum fun i _ => hpt i
+  have := lemma2_helper_short d n h_mono h_no_three
   omega
 
 /-- **Lemma 2 (b)**
@@ -120,7 +126,27 @@ lemma lemma2_b
     2 * n * n + 2 * n + 1 ≤
       ∑ i ∈ .Icc (2 * n + 1) (4 * n + 1), d i -
         ∑ i ∈ .Icc 1 (2 * n), d i := by
-  sorry
+  -- Split the upper sum at `4 * n + 1`.
+  have hsplit : ∑ i ∈ Finset.Icc (2 * n + 1) (4 * n + 1), d i =
+      (∑ i ∈ Finset.Icc (2 * n + 1) (4 * n), d i) + d (4 * n + 1) := by
+    rw [show Finset.Icc (2 * n + 1) (4 * n + 1) =
+        insert (4 * n + 1) (Finset.Icc (2 * n + 1) (4 * n)) by
+      ext x; simp [Finset.mem_Icc, Finset.mem_insert]; omega]
+    rw [Finset.sum_insert (by simp [Finset.mem_Icc]), add_comm]
+  -- Bound `d (4 * n + 1) ≥ 2 * n + 1` via two applications of `lemma1_b` + `h_pos`.
+  have h_dbig : 2 * n + 1 ≤ d (4 * n + 1) := by
+    have h1 := lemma1_b d 1 n h_mono h_no_three
+    have h2 := lemma1_b d (2 * n + 1) n h_mono h_no_three
+    have hp := h_pos 1
+    have m1 : d 1 ≤ d (1 + 2 * n) := h_mono (by omega)
+    have m2 : d (2 * n + 1) ≤ d (2 * n + 1 + 2 * n) := h_mono (by omega)
+    have e1 : 1 + 2 * n = 2 * n + 1 := by ring
+    have e2 : 2 * n + 1 + 2 * n = 4 * n + 1 := by ring
+    rw [e1] at h1 m1; rw [e2] at h2 m2
+    omega
+  have h_add := lemma2_helper_short d n h_mono h_no_three
+  rw [hsplit]
+  omega
 
 /-- **Lemma 2 (c)**
 Inequality involving sums of terms of a nondecreasing sequence with no three terms equal. -/


### PR DESCRIPTION
Closes #4256

Second of four `lemma2_*` sorries. Statement: for a nondecreasing `d : ℕ → ℕ` with no three terms equal at distance 2 and `0 < d k`,
$$\sum_{i=2n+1}^{4n+1} d(i) - \sum_{i=1}^{2n} d(i) \ge 2n^2 + 2n + 1.$$

**Approach**:
1. **Extract `lemma2_helper_short` (private)**: the additive (non-truncated) form `∑ Icc 1 (2n) d + 2n² ≤ ∑ Icc (2n+1) (4n) d`. This is the substance shared with `lemma2_a`s old proof.
2. **`lemma2_a` becomes a 2-line wrapper** over the helper + `omega`.
3. **`lemma2_b` (16 lines)**: split the upper sum at `4n+1`; bound `d (4n+1) ≥ 2n + 1` via two `lemma1_b` applications chained through monotonicity (uses `h_pos 1`); combine with helper and close with `omega`.

- `#print axioms lemma2_b` → `[propext, Classical.choice, Quot.sound]`
- `lake build` clean, no warnings.