### PR TITLE
Formalise Erdős Problem 1208 (distinct-distance subsets)

### DIFF
--- a/FormalConjectures/ErdosProblems/1208.lean
+++ b/FormalConjectures/ErdosProblems/1208.lean
@@ -1,0 +1,125 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 1208
+
+*References:*
+- [erdosproblems.com/1208](https://www.erdosproblems.com/1208)
+- [Er57b] Erdős, P., Néhány geometriai problémáról (On some geometrical problems, in Hungarian),
+  Mat. Lapok 8 (1957), 86-92.
+- [Er80] Erdős, P., A survey of problems in combinatorial number theory. Ann. Discrete Math.
+  (1980), 89-115, p.110.
+- [Th95] Thiele, T., Geometric selection problems and hypergraphs, PhD thesis, FU Berlin, 1995.
+- [Ch13] Charalambides, M., A note on distinct distance subsets, J. Geom. 104 (2013), 439-442.
+- [CFGHUZ15] Conlon, D., Fox, J., Gasarch, W., Harris, D. G., Ulrich, D. and Zbarsky, S.,
+  Distinct volume subsets, SIAM J. Discrete Math. 29 (2015), 472-480.
+- [CFR26] Clemen, F. C., Führer, J. and Roche-Newton, O., Geometric Sidon problems,
+  arXiv:2606.05841 (2026).
+
+For $d \geq 2$ let $F_d(n)$ be minimal such that every set of $n$ points in $\mathbb{R}^d$ contains
+a set of $F_d(n)$ points with distinct distances. Estimate $F_d(n)$ for fixed $d$ as $n \to \infty$.
+
+The example of the integer grid shows $F_d(n) \ll n^{1/d}$. Thiele [Th95] proved
+$F_d(n) \gg n^{1/(3d-2)}$ for $d \geq 3$, improved by Conlon, Fox, Gasarch, Harris, Ulrich and
+Zbarsky [CFGHUZ15] to $F_d(n) \gg_d n^{1/(3d-3)}(\log n)^{1/3 - 2/(3d-3)}$. In the plane the lower
+bound was proved by Charalambides [Ch13] (as $n^{1/3}/(\log n)^{1/3}$) and improved by Clemen,
+Führer and Roche-Newton [CFR26] to $F_2(n) \gg n^{1/3}$, so that
+$n^{1/3} \ll F_2(n) \ll n^{1/2}/(\log n)^{1/4}$. The order of magnitude is open for every $d \geq 2$;
+the conjecture is $F_d(n) = n^{1/d - o(1)}$.
+-/
+
+open Filter
+open scoped Asymptotics
+
+namespace Erdos1208
+
+/-- A finite set of points has *distinct distances* if all of its pairwise distances are distinct:
+whenever two pairs `{p, q}` and `{r, s}` of distinct points of `S` realise the same distance, the
+two pairs coincide. -/
+def HasDistinctDistances {d : ℕ} (S : Finset (EuclideanSpace ℝ (Fin d))) : Prop :=
+  ∀ p ∈ S, ∀ q ∈ S, ∀ r ∈ S, ∀ s ∈ S, p ≠ q → r ≠ s → dist p q = dist r s →
+    (p = r ∧ q = s) ∨ (p = s ∧ q = r)
+
+/-- The largest size of a distinct-distance subset of a finite point set `P` in `ℝ^d`. -/
+noncomputable def maxDistinctDistanceSubset {d : ℕ}
+    (P : Finset (EuclideanSpace ℝ (Fin d))) : ℕ :=
+  sSup {m | ∃ S ⊆ P, HasDistinctDistances S ∧ S.card = m}
+
+/-- `F d n` is the largest size of a distinct-distance subset that is *guaranteed* in every
+`n`-point set in `ℝ^d`: the minimum, over all `n`-point sets `P`, of `maxDistinctDistanceSubset P`.
+Equivalently, every `n`-point set contains `F d n` points with pairwise distinct distances, and
+some `n`-point set contains no larger such subset. -/
+noncomputable def F (d n : ℕ) : ℕ :=
+  sInf {m | ∃ P : Finset (EuclideanSpace ℝ (Fin d)), P.card = n ∧ maxDistinctDistanceSubset P = m}
+
+@[category test, AMS 52]
+theorem erdos_1208.test.empty {d : ℕ} :
+    HasDistinctDistances (∅ : Finset (EuclideanSpace ℝ (Fin d))) := by
+  intro p hp
+  simp at hp
+
+/--
+**Erdős Problem 1208.** For each fixed `d ≥ 2`, estimate `F d n` as `n → ∞`. The conjectured
+answer is `F_d(n) = n^{1/d - o(1)}`, i.e. the integer-grid upper bound is essentially tight. This
+is open for every `d ≥ 2`; in the plane it is the question whether `F_2(n) = n^{1/2 - o(1)}`.
+-/
+@[category research open, AMS 52]
+theorem erdos_1208 (d : ℕ) (hd : 2 ≤ d) :
+    ∃ o : ℕ → ℝ, o =o[atTop] (fun _ => (1 : ℝ)) ∧
+      (fun n => (F d n : ℝ)) =ᶠ[atTop] fun n => (n : ℝ) ^ ((1 : ℝ) / (d : ℝ) - o n) := by
+  sorry
+
+/--
+The integer grid `{1, …, n^{1/d}}^d` shows `F_d(n) ≪ n^{1/d}` for `d ≥ 2`.
+-/
+@[category research solved, AMS 52]
+theorem erdos_1208.upper_bound (d : ℕ) (hd : 2 ≤ d) :
+    (fun n => (F d n : ℝ)) =O[atTop] fun n => (n : ℝ) ^ ((1 : ℝ) / (d : ℝ)) := by
+  sorry
+
+/--
+Conlon, Fox, Gasarch, Harris, Ulrich and Zbarsky [CFGHUZ15] proved
+`F_d(n) ≫_d n^{1/(3d-3)}` for `d ≥ 2` (with an additional logarithmic factor), improving
+Thiele's `n^{1/(3d-2)}` for `d ≥ 3`.
+-/
+@[category research solved, AMS 52]
+theorem erdos_1208.lower_bound (d : ℕ) (hd : 2 ≤ d) :
+    (fun n : ℕ => (n : ℝ) ^ ((1 : ℝ) / (3 * (d : ℝ) - 3))) =O[atTop] fun n => (F d n : ℝ) := by
+  sorry
+
+/--
+In the plane, Clemen, Führer and Roche-Newton [CFR26] proved `F_2(n) ≫ n^{1/3}`, removing the
+`(log n)^{1/3}` factor from the earlier bound of Charalambides [Ch13].
+-/
+@[category research solved, AMS 52]
+theorem erdos_1208.lower_bound_plane :
+    (fun n : ℕ => (n : ℝ) ^ ((1 : ℝ) / 3)) =O[atTop] fun n => (F 2 n : ℝ) := by
+  sorry
+
+/--
+The upper bound for the plane: the `√n × √n` grid determines `≪ n / √(log n)` distinct distances,
+whence `F_2(n) ≪ n^{1/2} / (log n)^{1/4}`.
+-/
+@[category research solved, AMS 52]
+theorem erdos_1208.upper_bound_plane :
+    (fun n => (F 2 n : ℝ)) =O[atTop]
+      fun n => (n : ℝ) ^ ((1 : ℝ) / 2) / (Real.log (n : ℝ)) ^ ((1 : ℝ) / 4) := by
+  sorry
+
+end Erdos1208

--- a/FormalConjectures/ErdosProblems/1208.lean
+++ b/FormalConjectures/ErdosProblems/1208.lean
@@ -84,7 +84,7 @@ theorem erdos_1208.upper_bound (d : ℕ) (hd : 2 ≤ d) :
 
 /--
 Conlon, Fox, Gasarch, Harris, Ulrich and Zbarsky [CFGHUZ15] proved
-$F_d(n) \gg_d n^{1/(3d-3)}$ for $d \geq 2$, with an additional logarithmic factor.
+$F_d(n) \gg_d n^{1/(3d-3)}$ for $d \geq 2$.
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.lower_bound (d : ℕ) (hd : 2 ≤ d) :

--- a/FormalConjectures/ErdosProblems/1208.lean
+++ b/FormalConjectures/ErdosProblems/1208.lean
@@ -38,22 +38,18 @@ open scoped Asymptotics
 
 namespace Erdos1208
 
-/-- A finite set $S$ of points has *distinct distances* if all of its pairwise distances are
-distinct: whenever two pairs $\{p, q\}$ and $\{r, s\}$ of distinct points of $S$ realise the same
-distance, the two pairs coincide. -/
+/-- A finite set has distinct distances if equal distances between pairs of distinct points
+determine the same unordered pair. -/
 def HasDistinctDistances {d : ℕ} (S : Finset (EuclideanSpace ℝ (Fin d))) : Prop :=
   PairwiseDistinctDistances (S : Set (EuclideanSpace ℝ (Fin d)))
 
-/-- The largest size of a distinct-distance subset of a finite point set $P$ in
-$\mathbb{R}^d$. -/
+/-- Largest cardinality of a distinct-distance subset of $P$. -/
 noncomputable def maxDistinctDistanceSubset {d : ℕ}
     (P : Finset (EuclideanSpace ℝ (Fin d))) : ℕ :=
   sSup {m | ∃ S ⊆ P, HasDistinctDistances S ∧ S.card = m}
 
-/-- $F_d(n)$ is the largest size of a distinct-distance subset guaranteed in every $n$-point set
-in $\mathbb{R}^d$: the minimum, over all $n$-point sets $P$, of the largest distinct-distance
-subset of $P$. Equivalently, every $n$-point set contains $F_d(n)$ points with pairwise distinct
-distances, and some $n$-point set contains no larger such subset. -/
+/-- Minimum, over all $n$-point sets in $\mathbb{R}^d$, of the largest cardinality of a
+distinct-distance subset. -/
 noncomputable def F (d n : ℕ) : ℕ :=
   sInf {m | ∃ P : Finset (EuclideanSpace ℝ (Fin d)), P.card = n ∧ maxDistinctDistanceSubset P = m}
 
@@ -69,7 +65,7 @@ theorem erdos_1208.test.empty {d : ℕ} :
 For $d \geq 2$ let $F_d(n)$ be minimal such that every set of $n$ points in $\mathbb{R}^d$ contains
 a set of $F_d(n)$ points with distinct distances. Estimate $F_d(n)$ for fixed $d$ as $n \to \infty$.
 
-The conjectured estimate formalised here is $F_d(n) = n^{1/d - o(1)}$.
+Conjecturally, $F_d(n) = n^{1/d - o(1)}$.
 -/
 @[category research open, AMS 52]
 theorem erdos_1208 (d : ℕ) (hd : 2 ≤ d) :
@@ -78,8 +74,8 @@ theorem erdos_1208 (d : ℕ) (hd : 2 ≤ d) :
   sorry
 
 /--
-The integer grid $\{1, \ldots, n^{1/d}\}^d$ shows
-$F_d(n) \ll n^{1/d}$ for $d \geq 2$ [erdosproblems.com/1208].
+The integer grid gives $F_d(n) \ll n^{1/d}$ for $d \geq 2$
+[erdosproblems.com/1208].
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.upper_bound (d : ℕ) (hd : 2 ≤ d) :
@@ -88,8 +84,7 @@ theorem erdos_1208.upper_bound (d : ℕ) (hd : 2 ≤ d) :
 
 /--
 Conlon, Fox, Gasarch, Harris, Ulrich and Zbarsky [CFGHUZ15] proved
-$F_d(n) \gg_d n^{1/(3d-3)}$ for $d \geq 2$ (with an additional logarithmic factor), improving
-Thiele's $n^{1/(3d-2)}$ for $d \geq 3$.
+$F_d(n) \gg_d n^{1/(3d-3)}$ for $d \geq 2$, with an additional logarithmic factor.
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.lower_bound (d : ℕ) (hd : 2 ≤ d) :
@@ -97,9 +92,7 @@ theorem erdos_1208.lower_bound (d : ℕ) (hd : 2 ≤ d) :
   sorry
 
 /--
-In the plane, Clemen, Führer and Roche-Newton [CFR26] proved
-$F_2(n) \gg n^{1/3}$, removing the $(\log n)^{1/3}$ factor from the earlier bound of
-Charalambides [Ch13].
+Clemen, Führer and Roche-Newton [CFR26] proved $F_2(n) \gg n^{1/3}$.
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.lower_bound_plane :
@@ -107,9 +100,8 @@ theorem erdos_1208.lower_bound_plane :
   sorry
 
 /--
-The upper bound for the plane is
-$F_2(n) \ll n^{1/2} / (\log n)^{1/4}$: the $\sqrt{n} \times \sqrt{n}$ grid determines
-$\ll n / \sqrt{\log n}$ distinct distances [erdosproblems.com/1208].
+The planar grid construction gives
+$F_2(n) \ll n^{1/2} / (\log n)^{1/4}$ [erdosproblems.com/1208].
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.upper_bound_plane :

--- a/FormalConjectures/ErdosProblems/1208.lean
+++ b/FormalConjectures/ErdosProblems/1208.lean
@@ -31,17 +31,6 @@ import FormalConjectures.Util.ProblemImports
   Distinct volume subsets, SIAM J. Discrete Math. 29 (2015), 472-480.
 - [CFR26] Clemen, F. C., Führer, J. and Roche-Newton, O., Geometric Sidon problems,
   arXiv:2606.05841 (2026).
-
-For $d \geq 2$ let $F_d(n)$ be minimal such that every set of $n$ points in $\mathbb{R}^d$ contains
-a set of $F_d(n)$ points with distinct distances. Estimate $F_d(n)$ for fixed $d$ as $n \to \infty$.
-
-The example of the integer grid shows $F_d(n) \ll n^{1/d}$. Thiele [Th95] proved
-$F_d(n) \gg n^{1/(3d-2)}$ for $d \geq 3$, improved by Conlon, Fox, Gasarch, Harris, Ulrich and
-Zbarsky [CFGHUZ15] to $F_d(n) \gg_d n^{1/(3d-3)}(\log n)^{1/3 - 2/(3d-3)}$. In the plane the lower
-bound was proved by Charalambides [Ch13] (as $n^{1/3}/(\log n)^{1/3}$) and improved by Clemen,
-Führer and Roche-Newton [CFR26] to $F_2(n) \gg n^{1/3}$, so that
-$n^{1/3} \ll F_2(n) \ll n^{1/2}/(\log n)^{1/4}$. The order of magnitude is open for every $d \geq 2$;
-the conjecture is $F_d(n) = n^{1/d - o(1)}$.
 -/
 
 open Filter
@@ -49,22 +38,22 @@ open scoped Asymptotics
 
 namespace Erdos1208
 
-/-- A finite set of points has *distinct distances* if all of its pairwise distances are distinct:
-whenever two pairs `{p, q}` and `{r, s}` of distinct points of `S` realise the same distance, the
-two pairs coincide. -/
+/-- A finite set $S$ of points has *distinct distances* if all of its pairwise distances are
+distinct: whenever two pairs $\{p, q\}$ and $\{r, s\}$ of distinct points of $S$ realise the same
+distance, the two pairs coincide. -/
 def HasDistinctDistances {d : ℕ} (S : Finset (EuclideanSpace ℝ (Fin d))) : Prop :=
-  ∀ p ∈ S, ∀ q ∈ S, ∀ r ∈ S, ∀ s ∈ S, p ≠ q → r ≠ s → dist p q = dist r s →
-    (p = r ∧ q = s) ∨ (p = s ∧ q = r)
+  PairwiseDistinctDistances (S : Set (EuclideanSpace ℝ (Fin d)))
 
-/-- The largest size of a distinct-distance subset of a finite point set `P` in `ℝ^d`. -/
+/-- The largest size of a distinct-distance subset of a finite point set $P$ in
+$\mathbb{R}^d$. -/
 noncomputable def maxDistinctDistanceSubset {d : ℕ}
     (P : Finset (EuclideanSpace ℝ (Fin d))) : ℕ :=
   sSup {m | ∃ S ⊆ P, HasDistinctDistances S ∧ S.card = m}
 
-/-- `F d n` is the largest size of a distinct-distance subset that is *guaranteed* in every
-`n`-point set in `ℝ^d`: the minimum, over all `n`-point sets `P`, of `maxDistinctDistanceSubset P`.
-Equivalently, every `n`-point set contains `F d n` points with pairwise distinct distances, and
-some `n`-point set contains no larger such subset. -/
+/-- $F_d(n)$ is the largest size of a distinct-distance subset guaranteed in every $n$-point set
+in $\mathbb{R}^d$: the minimum, over all $n$-point sets $P$, of the largest distinct-distance
+subset of $P$. Equivalently, every $n$-point set contains $F_d(n)$ points with pairwise distinct
+distances, and some $n$-point set contains no larger such subset. -/
 noncomputable def F (d n : ℕ) : ℕ :=
   sInf {m | ∃ P : Finset (EuclideanSpace ℝ (Fin d)), P.card = n ∧ maxDistinctDistanceSubset P = m}
 
@@ -75,9 +64,12 @@ theorem erdos_1208.test.empty {d : ℕ} :
   simp at hp
 
 /--
-**Erdős Problem 1208.** For each fixed `d ≥ 2`, estimate `F d n` as `n → ∞`. The conjectured
-answer is `F_d(n) = n^{1/d - o(1)}`, i.e. the integer-grid upper bound is essentially tight. This
-is open for every `d ≥ 2`; in the plane it is the question whether `F_2(n) = n^{1/2 - o(1)}`.
+**Erdős Problem 1208.** [Er57b, Er80]
+
+For $d \geq 2$ let $F_d(n)$ be minimal such that every set of $n$ points in $\mathbb{R}^d$ contains
+a set of $F_d(n)$ points with distinct distances. Estimate $F_d(n)$ for fixed $d$ as $n \to \infty$.
+
+The conjectured estimate formalised here is $F_d(n) = n^{1/d - o(1)}$.
 -/
 @[category research open, AMS 52]
 theorem erdos_1208 (d : ℕ) (hd : 2 ≤ d) :
@@ -86,7 +78,8 @@ theorem erdos_1208 (d : ℕ) (hd : 2 ≤ d) :
   sorry
 
 /--
-The integer grid `{1, …, n^{1/d}}^d` shows `F_d(n) ≪ n^{1/d}` for `d ≥ 2`.
+The integer grid $\{1, \ldots, n^{1/d}\}^d$ shows
+$F_d(n) \ll n^{1/d}$ for $d \geq 2$ [erdosproblems.com/1208].
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.upper_bound (d : ℕ) (hd : 2 ≤ d) :
@@ -95,8 +88,8 @@ theorem erdos_1208.upper_bound (d : ℕ) (hd : 2 ≤ d) :
 
 /--
 Conlon, Fox, Gasarch, Harris, Ulrich and Zbarsky [CFGHUZ15] proved
-`F_d(n) ≫_d n^{1/(3d-3)}` for `d ≥ 2` (with an additional logarithmic factor), improving
-Thiele's `n^{1/(3d-2)}` for `d ≥ 3`.
+$F_d(n) \gg_d n^{1/(3d-3)}$ for $d \geq 2$ (with an additional logarithmic factor), improving
+Thiele's $n^{1/(3d-2)}$ for $d \geq 3$.
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.lower_bound (d : ℕ) (hd : 2 ≤ d) :
@@ -104,8 +97,9 @@ theorem erdos_1208.lower_bound (d : ℕ) (hd : 2 ≤ d) :
   sorry
 
 /--
-In the plane, Clemen, Führer and Roche-Newton [CFR26] proved `F_2(n) ≫ n^{1/3}`, removing the
-`(log n)^{1/3}` factor from the earlier bound of Charalambides [Ch13].
+In the plane, Clemen, Führer and Roche-Newton [CFR26] proved
+$F_2(n) \gg n^{1/3}$, removing the $(\log n)^{1/3}$ factor from the earlier bound of
+Charalambides [Ch13].
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.lower_bound_plane :
@@ -113,8 +107,9 @@ theorem erdos_1208.lower_bound_plane :
   sorry
 
 /--
-The upper bound for the plane: the `√n × √n` grid determines `≪ n / √(log n)` distinct distances,
-whence `F_2(n) ≪ n^{1/2} / (log n)^{1/4}`.
+The upper bound for the plane is
+$F_2(n) \ll n^{1/2} / (\log n)^{1/4}$: the $\sqrt{n} \times \sqrt{n}$ grid determines
+$\ll n / \sqrt{\log n}$ distinct distances [erdosproblems.com/1208].
 -/
 @[category research solved, AMS 52]
 theorem erdos_1208.upper_bound_plane :

--- a/FormalConjecturesForMathlib/Geometry/Metric.lean
+++ b/FormalConjecturesForMathlib/Geometry/Metric.lean
@@ -27,3 +27,10 @@ variable {X : Type*} [MetricSpace X]
 /-- The number of pairs of points of a finite set `s` in a metric space that are distance 1 apart.
 -/
 noncomputable def unitDistNum (s : Finset X) : ℕ := #{p ∈ s.sym2 | dist p.out.1 p.out.2 = 1}
+
+/-- A set `A` in a metric space has *pairwise distinct distances* if any two pairs of distinct
+points of `A` realising the same distance are equal as unordered pairs: whenever
+`x, y, z, w ∈ A` with `x ≠ y`, `z ≠ w` and `dist x y = dist z w`, then `{x, y} = {z, w}`. -/
+def PairwiseDistinctDistances (A : Set X) : Prop :=
+  ∀ x ∈ A, ∀ y ∈ A, ∀ z ∈ A, ∀ w ∈ A,
+    x ≠ y → z ≠ w → dist x y = dist z w → (x = z ∧ y = w) ∨ (x = w ∧ y = z)

--- a/FormalConjecturesForMathlib/Geometry/Metric.lean
+++ b/FormalConjecturesForMathlib/Geometry/Metric.lean
@@ -28,9 +28,8 @@ variable {X : Type*} [MetricSpace X]
 -/
 noncomputable def unitDistNum (s : Finset X) : ℕ := #{p ∈ s.sym2 | dist p.out.1 p.out.2 = 1}
 
-/-- A set `A` in a metric space has *pairwise distinct distances* if any two pairs of distinct
-points of `A` realising the same distance are equal as unordered pairs: whenever
-`x, y, z, w ∈ A` with `x ≠ y`, `z ≠ w` and `dist x y = dist z w`, then `{x, y} = {z, w}`. -/
+/-- A set has pairwise distinct distances if equal distances between pairs of distinct points
+determine the same unordered pair. -/
 def PairwiseDistinctDistances (A : Set X) : Prop :=
   ∀ x ∈ A, ∀ y ∈ A, ∀ z ∈ A, ∀ w ∈ A,
     x ≠ y → z ≠ w → dist x y = dist z w → (x = z ∧ y = w) ∨ (x = w ∧ y = z)


### PR DESCRIPTION
## Formalise Erdős Problem 1208 (distinct-distance subsets)

Adds `FormalConjectures/ErdosProblems/1208.lean`, the first formalisation of
[Erdős Problem #1208](https://www.erdosproblems.com/1208) (the problem page lists *"Formalised
statement? No"*).

**Statement.** For $d \ge 2$, $F_d(n)$ is minimal such that every $n$-point set in $\mathbb{R}^d$
contains $F_d(n)$ points with pairwise distinct distances; estimate $F_d(n)$ for fixed $d$.

**What the file contains:**
- `HasDistinctDistances`, `maxDistinctDistanceSubset`, and `F d n` (the min over all $n$-point
  configurations of the largest distinct-distance subset), modelled on the conventions in
  `ErdosProblems/755.lean`.
- a proven `@[category test]` sanity lemma (the empty set has distinct distances);
- `erdos_1208` — the open conjecture $F_d(n) = n^{1/d - o(1)}$, `@[category research open]`;
- `@[category research solved]` statements for the known bounds: the grid upper bound
  $F_d(n) \ll n^{1/d}$; the CFGHUZ lower bound $F_d(n) \gg n^{1/(3d-3)}$; the
  Clemen–Führer–Roche-Newton (2026) planar lower bound $F_2(n) \gg n^{1/3}$; and the planar upper
  bound $F_2(n) \ll n^{1/2}/(\log n)^{1/4}$.

**Verification.** Builds locally against the pinned toolchain (`leanprover/lean4:v4.27.0`) and the
Mathlib cache:
```
$ lake build FormalConjectures.ErdosProblems.«1208»
Build completed successfully.
```

**References** (verified against primary sources): Erdős [Er57b], [Er80, p.110]; Thiele [Th95];
Charalambides, *J. Geom.* 104 (2013); Conlon–Fox–Gasarch–Harris–Ulrich–Zbarsky, *SIAM J. Discrete
Math.* 29 (2015); Clemen–Führer–Roche-Newton, *Geometric Sidon problems*, arXiv:2606.05841 (2026).

*Disclosure: this formalisation was prepared with AI assistance; the Lean file was type-checked
locally as shown above, and the mathematical statements and citations were verified against the
primary sources.*
