### PR TITLE
fix(GreensOpenProblems/72): add `2 < k`

### DIFF
--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -55,8 +55,8 @@ def NoKInLineFor (k : ℕ) (N : ℕ) : Prop :=
   AllowedSetSize k N = (k - 1) * N
 
 /-- The **no-k-in-line problem**:
-For $N \geq k$ and $k > 2$, the AllowedSetSize is $(k - 1) * N$, i. e. on an $N \times N$ subset,
-there is a set of $(k - 1) * N$ points for which no $k$ lie on a line (and not such a set of bigger size).
+For $N \geq k$ and $k > 2$, the AllowedSetSize is $(k - 1) N$, i. e. on an $N \times N$ subset,
+there is a set of $(k - 1) N$ points for which no $k$ lie on a line (and not such a set of bigger size).
 -/
 @[category research open, AMS 5 52]
 theorem NoKInLine {k : ℕ} {N : ℕ} (hk : 2 < k) (h : k ≤ N) : NoKInLineFor k N := by

--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -55,11 +55,11 @@ def NoKInLineFor (k : ℕ) (N : ℕ) : Prop :=
   AllowedSetSize k N = (k - 1) * N
 
 /-- The **no-k-in-line problem**:
-For $N \geq k$ and $k > 1$, the AllowedSetSize in $(k - 1) * N$, i. e. on an $N \times N$ subset,
-there is a set of $k * N$ points for which no $k$ lie on a line (and not such a set of bigger size).
+For $N \geq k$ and $k > 2$, the AllowedSetSize is $(k - 1) * N$, i. e. on an $N \times N$ subset,
+there is a set of $(k - 1) * N$ points for which no $k$ lie on a line (and not such a set of bigger size).
 -/
 @[category research open, AMS 5 52]
-theorem NoKInLine {k : ℕ} {N : ℕ} (hk : 1 < k) (h : k ≤ N) : NoKInLineFor k N := by
+theorem NoKInLine {k : ℕ} {N : ℕ} (hk : 2 < k) (h : k ≤ N) : NoKInLineFor k N := by
   sorry
 
 /-- **Green's Open Problem 72 / No-three-in-line problem**:


### PR DESCRIPTION
Otherwise we can disprove `NoKInLine` for k=2

Drive-by: also fix docstring, should read  $(k - 1)N$ instead of  $k * N$