### PR TITLE
feat(Arxiv/2507.17780): refute TxGraffiti Conjecture 4

### DIFF
--- a/FormalConjectures/Arxiv/2507.17780/IndepDominationSaturation.lean
+++ b/FormalConjectures/Arxiv/2507.17780/IndepDominationSaturation.lean
@@ -1,0 +1,51 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# TxGraffiti Conjecture 3: independent domination versus saturation (regular)
+
+*Reference:* [arxiv/2507.17780](https://arxiv.org/abs/2507.17780)
+**In Reverie Together: Ten Years of Mathematical Discovery with a Machine
+Collaborator** by *Randy Davila, Boris Brimkov, Ryan Pepper*
+
+Conjecture 3 (open since 2020) asserts that for every $r$-regular graph $G$
+(every vertex has degree $r$),
+$$i(G) \le \mu^*(G),$$
+where $i(G)$ is the independent domination number and $\mu^*(G)$ the saturation
+number (minimum size of a maximal matching).
+-/
+
+open SimpleGraph
+
+namespace Arxiv.«2507.17780»
+
+/--
+TxGraffiti [Conjecture 3](https://arxiv.org/abs/2507.17780):
+for every $r$-regular graph $G$ ($r \ge 1$),
+$$i(G) \le \mu^*(G).$$
+
+This conjecture is **open**.
+-/
+@[category research open, AMS 5]
+theorem tx_graffiti_conjecture_3 (V : Type) [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (r : ℕ) (_hReg : ∀ v, G.degree v = r) (_hr : 1 ≤ r) :
+    G.indepDominationNumber ≤ G.saturationNumber := by
+  sorry
+
+end Arxiv.«2507.17780»

--- a/FormalConjectures/Arxiv/2507.17780/IndependenceAnnihilationResidue.lean
+++ b/FormalConjectures/Arxiv/2507.17780/IndependenceAnnihilationResidue.lean
@@ -1,0 +1,65 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# TxGraffiti Conjecture 1: independence, annihilation, and residue
+
+*Reference:* [arxiv/2507.17780](https://arxiv.org/abs/2507.17780)
+**In Reverie Together: Ten Years of Mathematical Discovery with a Machine
+Collaborator** by *Randy Davila, Boris Brimkov, Ryan Pepper*
+
+Conjecture 1, the oldest of the four TxGraffiti conjectures in the cited
+collection (open since 2016), asserts that every nontrivial connected graph $G$
+with maximum degree $\Delta \ge 2$ satisfies
+$$\alpha(G) \ge \frac{a(G) + R(G)}{\Delta(G)},$$
+where $\alpha$ is the independence number, $a$ the annihilation number, $R$ the
+Havel–Hakimi residue, and $\Delta$ the maximum degree.
+
+This conjecture is **true**, proved in
+[arXiv:2606.29553](https://arxiv.org/abs/2606.29553) (C. Gupta).
+-/
+
+open SimpleGraph
+
+namespace Arxiv.«2507.17780»
+
+/--
+TxGraffiti [Conjecture 1](https://arxiv.org/abs/2507.17780):
+for every nontrivial connected graph $G$ with $\Delta(G) \ge 2$,
+$$\alpha(G) \ge \frac{a(G) + R(G)}{\Delta(G)}.$$
+
+This conjecture is **true**.
+
+**Proof sketch.** Substitute the Caro–Wei lower bound $\alpha \ge W$ for $\alpha$
+and reduce to $a \le (\Delta - 1) \alpha$. The case $\Delta = 2$ is trivial
+($a = \alpha$). For $\Delta \ge 4$ an AM–HM argument with $m \le (n - a)\Delta$
+yields a quadratic whose discriminant is negative. For $\Delta = 3$ the
+annihilation number has a closed form in the degree counts $(n_1, n_2, n_3)$ and
+$a \le 2W$ is verified in three regimes. See
+[arXiv:2606.29553](https://arxiv.org/abs/2606.29553).
+-/
+@[category research solved, AMS 5,
+  formal_proof using lean4 at
+    "https://github.com/ChakshuGupta13/lab/tree/main/math/gupta2026annihilation"]
+theorem tx_graffiti_conjecture_1 (V : Type) [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] (_hConn : G.Connected)
+    (_hDeg : 2 ≤ G.maxDegree) :
+    (G.annihilationNumber + residue G : ℝ) / G.maxDegree ≤ G.indepNum := by
+  sorry
+
+end Arxiv.«2507.17780»

--- a/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
+++ b/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
@@ -86,13 +86,13 @@ large; the windmill generalisation and its exact limit appear in
 [arXiv:2606.15761](https://arxiv.org/abs/2606.15761).
 -/
 @[category research solved, AMS 5]
-theorem txGraffitiConjecture4 : answer(False) ↔
+theorem tx_graffiti_conjecture_4 : answer(False) ↔
     ∀ (V : Type) [Fintype V] [DecidableEq V] [Nontrivial V] (G : SimpleGraph V)
       [DecidableRel G.Adj] (_hConn : G.Connected),
       (G.saturationNumber : ℚ) ≤ G.harmonicIndex := by
   refine iff_of_false (by simp) (fun h => ?_)
   have key := h (Fin 9) friendshipF4 (by native_decide)
-  rw [friendshipF4.sat_num_eq_computable] at key
+  rw [friendshipF4.saturationNumber_eq_computable] at key
   revert key
   native_decide
 

--- a/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
+++ b/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
@@ -1,0 +1,98 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# TxGraffiti Conjecture 4: the saturation number versus the harmonic index
+
+*Reference:* [arxiv/2507.17780](https://arxiv.org/abs/2507.17780)
+**In Reverie Together: Ten Years of Mathematical Discovery with a Machine
+Collaborator** by *Randy Davila, Boris Brimkov, Ryan Pepper*
+
+TxGraffiti is an automated conjecturing program, a successor of Fajtlowicz's
+*Graffiti* and DeLaViña's *Graffiti.pc*. Conjecture 4 in the cited collection
+asserts a bound between two graph invariants:
+
+* the *saturation number* `μ*(G)` (`SimpleGraph.saturationNumber`), the minimum
+  number of edges in a maximal matching of `G`;
+* the *harmonic index* `H(G)` (`SimpleGraph.harmonicIndex`),
+  `∑_{uv ∈ E(G)} 2 / (deg u + deg v)`.
+
+The conjecture is **false**. It was first refuted by Bıyıkoğlu, who exhibited a
+family of counterexamples — a disjoint union of edges joined to an independent
+set — with unbounded ratio `μ*/H`. That the smallest counterexample has order
+`9`, namely the friendship graph `F₄` formalised below, and that the windmill
+family has an exact limiting ratio, are established in Gupta.
+
+*References:*
+- [A Note on the TxGraffiti Conjecture about Harmonic Index and Minimum Maximal
+  Matching Number](https://doi.org/10.46793/match.96-3.28425), Türker Bıyıkoğlu,
+  *MATCH Commun. Math. Comput. Chem.* **96** (2026), no. 3, 1097–1099 — the
+  first refutation.
+- [The saturation number is not bounded by the harmonic
+  index](https://arxiv.org/abs/2606.15761), C. Gupta — the order-`9` minimality
+  of `F₄` (formalised below) and the exact windmill limit.
+-/
+
+open SimpleGraph
+
+namespace Arxiv.«2507.17780»
+
+/-- The friendship graph `F₄`: a hub vertex `0` joined to four triangles, whose
+rims are the pairs `(1, 2)`, `(3, 4)`, `(5, 6)`, `(7, 8)`. It has `12` edges on
+`9` vertices (`8` spokes and `4` rim edges). -/
+def friendshipF4 : SimpleGraph (Fin 9) := fromEdgeSet {
+  s(0, 1), s(0, 2), s(0, 3), s(0, 4), s(0, 5), s(0, 6), s(0, 7), s(0, 8),
+  s(1, 2), s(3, 4), s(5, 6), s(7, 8) }
+
+instance : DecidableRel friendshipF4.Adj := by unfold friendshipF4; infer_instance
+
+/--
+TxGraffiti [Conjecture 4](https://arxiv.org/abs/2507.17780):
+for every nontrivial connected graph `G`, the saturation number is at most the
+harmonic index, `μ*(G) ≤ H(G)`.
+
+This conjecture is **FALSE**.
+
+**Counterexample.**
+The friendship graph `F₄` (`friendshipF4`) is connected and nontrivial, with
+`μ*(F₄) = 4` and `H(F₄) = 18/5`. Indeed the four rim edges
+`{1,2}, {3,4}, {5,6}, {7,8}` form a maximal matching of size `4`, and no maximal
+matching is smaller, so `μ*(F₄) = 4`; the eight spokes contribute
+`2/(8 + 2) = 1/5` each and the four rim edges contribute `2/(2 + 2) = 1/2` each,
+giving `H(F₄) = 8 · 1/5 + 4 · 1/2 = 18/5`. Since `4 > 18/5`, the bound fails.
+
+More generally the friendship graphs `F_k` satisfy `μ*(F_k) = k` and
+`H(F_k) = 2k/(k + 1) + k/2`, so the conjecture fails for every `k ≥ 4`. An
+exhaustive search confirms that `F₄` is the smallest counterexample (order `9`).
+The unbounded separation was first shown by Bıyıkoğlu, whose family of edges
+joined to an independent set makes `μ*/H` arbitrarily large; the windmill
+generalisation and its exact limit appear in
+[arXiv:2606.15761](https://arxiv.org/abs/2606.15761).
+-/
+@[category research solved, AMS 5]
+theorem txGraffitiConjecture4 : answer(False) ↔
+    ∀ (V : Type) [Fintype V] [DecidableEq V] [Nontrivial V] (G : SimpleGraph V)
+      [DecidableRel G.Adj] (_hConn : G.Connected),
+      (G.saturationNumber : ℚ) ≤ G.harmonicIndex := by
+  refine iff_of_false (by simp) (fun h => ?_)
+  have key := h (Fin 9) friendshipF4 (by native_decide)
+  rw [friendshipF4.sat_num_eq_computable] at key
+  revert key
+  native_decide
+
+end Arxiv.«2507.17780»

--- a/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
+++ b/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
@@ -27,16 +27,16 @@ TxGraffiti is an automated conjecturing program, a successor of Fajtlowicz's
 *Graffiti* and DeLaViña's *Graffiti.pc*. Conjecture 4 in the cited collection
 asserts a bound between two graph invariants:
 
-* the *saturation number* `μ*(G)` (`SimpleGraph.saturationNumber`), the minimum
-  number of edges in a maximal matching of `G`;
-* the *harmonic index* `H(G)` (`SimpleGraph.harmonicIndex`),
-  `∑_{uv ∈ E(G)} 2 / (deg u + deg v)`.
+* the *saturation number* $\mu^*(G)$ (`SimpleGraph.saturationNumber`), the
+  minimum number of edges in a maximal matching of $G$;
+* the *harmonic index* $H(G)$ (`SimpleGraph.harmonicIndex`),
+  $\sum_{uv \in E(G)} 2 / (\deg u + \deg v)$.
 
 The conjecture is **false**. It was first refuted by Bıyıkoğlu, who exhibited a
 family of counterexamples — a disjoint union of edges joined to an independent
-set — with unbounded ratio `μ*/H`. That the smallest counterexample has order
-`9`, namely the friendship graph `F₄` formalised below, and that the windmill
-family has an exact limiting ratio, are established in Gupta.
+set — with unbounded ratio $\mu^*/H$. That the smallest counterexample has
+order $9$, namely the friendship graph $F_4$ formalised below, and that the
+windmill family has an exact limiting ratio, are established in Gupta.
 
 *References:*
 - [A Note on the TxGraffiti Conjecture about Harmonic Index and Minimum Maximal
@@ -44,17 +44,17 @@ family has an exact limiting ratio, are established in Gupta.
   *MATCH Commun. Math. Comput. Chem.* **96** (2026), no. 3, 1097–1099 — the
   first refutation.
 - [The saturation number is not bounded by the harmonic
-  index](https://arxiv.org/abs/2606.15761), C. Gupta — the order-`9` minimality
-  of `F₄` (formalised below) and the exact windmill limit.
+  index](https://arxiv.org/abs/2606.15761), C. Gupta — the order-$9$
+  minimality of $F_4$ (formalised below) and the exact windmill limit.
 -/
 
 open SimpleGraph
 
 namespace Arxiv.«2507.17780»
 
-/-- The friendship graph `F₄`: a hub vertex `0` joined to four triangles, whose
-rims are the pairs `(1, 2)`, `(3, 4)`, `(5, 6)`, `(7, 8)`. It has `12` edges on
-`9` vertices (`8` spokes and `4` rim edges). -/
+/-- The friendship graph $F_4$: a hub vertex $0$ joined to four triangles, whose
+rims are the pairs $\{1,2\}, \{3,4\}, \{5,6\}, \{7,8\}$. It has $12$ edges on
+$9$ vertices ($8$ spokes and $4$ rim edges). -/
 def friendshipF4 : SimpleGraph (Fin 9) := fromEdgeSet {
   s(0, 1), s(0, 2), s(0, 3), s(0, 4), s(0, 5), s(0, 6), s(0, 7), s(0, 8),
   s(1, 2), s(3, 4), s(5, 6), s(7, 8) }
@@ -63,25 +63,26 @@ instance : DecidableRel friendshipF4.Adj := by unfold friendshipF4; infer_instan
 
 /--
 TxGraffiti [Conjecture 4](https://arxiv.org/abs/2507.17780):
-for every nontrivial connected graph `G`, the saturation number is at most the
-harmonic index, `μ*(G) ≤ H(G)`.
+for every nontrivial connected graph $G$, the saturation number is at most
+the harmonic index, $\mu^*(G) \le H(G)$.
 
 This conjecture is **FALSE**.
 
 **Counterexample.**
-The friendship graph `F₄` (`friendshipF4`) is connected and nontrivial, with
-`μ*(F₄) = 4` and `H(F₄) = 18/5`. Indeed the four rim edges
-`{1,2}, {3,4}, {5,6}, {7,8}` form a maximal matching of size `4`, and no maximal
-matching is smaller, so `μ*(F₄) = 4`; the eight spokes contribute
-`2/(8 + 2) = 1/5` each and the four rim edges contribute `2/(2 + 2) = 1/2` each,
-giving `H(F₄) = 8 · 1/5 + 4 · 1/2 = 18/5`. Since `4 > 18/5`, the bound fails.
+The friendship graph $F_4$ (`friendshipF4`) is connected and nontrivial, with
+$\mu^*(F_4) = 4$ and $H(F_4) = 18/5$. Indeed the four rim edges
+$\{1,2\}, \{3,4\}, \{5,6\}, \{7,8\}$ form a maximal matching of size $4$, and
+no maximal matching is smaller, so $\mu^*(F_4) = 4$; the eight spokes
+contribute $2/(8+2) = 1/5$ each and the four rim edges contribute
+$2/(2+2) = 1/2$ each, giving $H(F_4) = 8 \cdot 1/5 + 4 \cdot 1/2 = 18/5$.
+Since $4 > 18/5$, the bound fails.
 
-More generally the friendship graphs `F_k` satisfy `μ*(F_k) = k` and
-`H(F_k) = 2k/(k + 1) + k/2`, so the conjecture fails for every `k ≥ 4`. An
-exhaustive search confirms that `F₄` is the smallest counterexample (order `9`).
-The unbounded separation was first shown by Bıyıkoğlu, whose family of edges
-joined to an independent set makes `μ*/H` arbitrarily large; the windmill
-generalisation and its exact limit appear in
+More generally the friendship graphs $F_k$ satisfy $\mu^*(F_k) = k$ and
+$H(F_k) = 2k/(k+1) + k/2$, so the conjecture fails for every $k \ge 4$. An
+exhaustive search confirms that $F_4$ is the smallest counterexample
+(order $9$). The unbounded separation was first shown by Bıyıkoğlu, whose
+family of edges joined to an independent set makes $\mu^*/H$ arbitrarily
+large; the windmill generalisation and its exact limit appear in
 [arXiv:2606.15761](https://arxiv.org/abs/2606.15761).
 -/
 @[category research solved, AMS 5]

--- a/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
+++ b/FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean
@@ -1,0 +1,99 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# TxGraffiti Conjecture 4: the saturation number versus the harmonic index
+
+*Reference:* [arxiv/2507.17780](https://arxiv.org/abs/2507.17780)
+**In Reverie Together: Ten Years of Mathematical Discovery with a Machine
+Collaborator** by *Randy Davila, Boris Brimkov, Ryan Pepper*
+
+TxGraffiti is an automated conjecturing program, a successor of Fajtlowicz's
+*Graffiti* and DeLaViña's *Graffiti.pc*. Conjecture 4 in the cited collection
+asserts a bound between two graph invariants:
+
+* the *saturation number* $\mu^*(G)$ (`SimpleGraph.saturationNumber`), the
+  minimum number of edges in a maximal matching of $G$;
+* the *harmonic index* $H(G)$ (`SimpleGraph.harmonicIndex`),
+  $\sum_{uv \in E(G)} 2 / (\deg u + \deg v)$.
+
+The conjecture is **false**. It was first refuted by Bıyıkoğlu, who exhibited a
+family of counterexamples — a disjoint union of edges joined to an independent
+set — with unbounded ratio $\mu^*/H$. That the smallest counterexample has
+order $9$, namely the friendship graph $F_4$ formalised below, and that the
+windmill family has an exact limiting ratio, are established in Gupta.
+
+*References:*
+- [A Note on the TxGraffiti Conjecture about Harmonic Index and Minimum Maximal
+  Matching Number](https://doi.org/10.46793/match.96-3.28425), Türker Bıyıkoğlu,
+  *MATCH Commun. Math. Comput. Chem.* **96** (2026), no. 3, 1097–1099 — the
+  first refutation.
+- [The saturation number is not bounded by the harmonic
+  index](https://arxiv.org/abs/2606.15761), C. Gupta — the order-$9$
+  minimality of $F_4$ (formalised below) and the exact windmill limit.
+-/
+
+open SimpleGraph
+
+namespace Arxiv.«2507.17780»
+
+/-- The friendship graph $F_4$: a hub vertex $0$ joined to four triangles, whose
+rims are the pairs $\{1,2\}, \{3,4\}, \{5,6\}, \{7,8\}$. It has $12$ edges on
+$9$ vertices ($8$ spokes and $4$ rim edges). -/
+def friendshipF4 : SimpleGraph (Fin 9) := fromEdgeSet {
+  s(0, 1), s(0, 2), s(0, 3), s(0, 4), s(0, 5), s(0, 6), s(0, 7), s(0, 8),
+  s(1, 2), s(3, 4), s(5, 6), s(7, 8) }
+
+instance : DecidableRel friendshipF4.Adj := by unfold friendshipF4; infer_instance
+
+/--
+TxGraffiti [Conjecture 4](https://arxiv.org/abs/2507.17780):
+for every nontrivial connected graph $G$, the saturation number is at most
+the harmonic index, $\mu^*(G) \le H(G)$.
+
+This conjecture is **FALSE**.
+
+**Counterexample.**
+The friendship graph $F_4$ (`friendshipF4`) is connected and nontrivial, with
+$\mu^*(F_4) = 4$ and $H(F_4) = 18/5$. Indeed the four rim edges
+$\{1,2\}, \{3,4\}, \{5,6\}, \{7,8\}$ form a maximal matching of size $4$, and
+no maximal matching is smaller, so $\mu^*(F_4) = 4$; the eight spokes
+contribute $2/(8+2) = 1/5$ each and the four rim edges contribute
+$2/(2+2) = 1/2$ each, giving $H(F_4) = 8 \cdot 1/5 + 4 \cdot 1/2 = 18/5$.
+Since $4 > 18/5$, the bound fails.
+
+More generally the friendship graphs $F_k$ satisfy $\mu^*(F_k) = k$ and
+$H(F_k) = 2k/(k+1) + k/2$, so the conjecture fails for every $k \ge 4$. An
+exhaustive search confirms that $F_4$ is the smallest counterexample
+(order $9$). The unbounded separation was first shown by Bıyıkoğlu, whose
+family of edges joined to an independent set makes $\mu^*/H$ arbitrarily
+large; the windmill generalisation and its exact limit appear in
+[arXiv:2606.15761](https://arxiv.org/abs/2606.15761).
+-/
+@[category research solved, AMS 5]
+theorem tx_graffiti_conjecture_4 : answer(False) ↔
+    ∀ (V : Type) [Fintype V] [DecidableEq V] [Nontrivial V] (G : SimpleGraph V)
+      [DecidableRel G.Adj] (_hConn : G.Connected),
+      (G.saturationNumber : ℚ) ≤ G.harmonicIndex := by
+  refine iff_of_false (by simp) (fun h => ?_)
+  have key := h (Fin 9) friendshipF4 (by native_decide)
+  rw [friendshipF4.saturationNumber_eq_computable] at key
+  revert key
+  native_decide
+
+end Arxiv.«2507.17780»

--- a/FormalConjectures/Arxiv/2507.17780/ZeroForcingIndependence.lean
+++ b/FormalConjectures/Arxiv/2507.17780/ZeroForcingIndependence.lean
@@ -1,0 +1,74 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# TxGraffiti Conjecture 2: zero forcing versus independence (cubic graphs)
+
+*Reference:* [arxiv/2507.17780](https://arxiv.org/abs/2507.17780)
+**In Reverie Together: Ten Years of Mathematical Discovery with a Machine
+Collaborator** by *Randy Davila, Boris Brimkov, Ryan Pepper*
+
+Conjecture 2 (open since 2017) asserts that for every connected graph $G$ with
+maximum degree at most $3$ and $G \ne K_4$,
+$$Z(G) \le \alpha(G) + 1,$$
+where $Z(G)$ is the zero forcing number and $\alpha(G)$ the independence number.
+-/
+
+open SimpleGraph
+
+namespace Arxiv.«2507.17780»
+
+/-- One step of the zero forcing colour-change rule: add to $S$ every vertex $w$
+that is the unique neighbour of some $v \in S$ outside $S$. -/
+noncomputable def zeroForcingStep {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] (S : Finset V) : Finset V :=
+  S ∪ Finset.univ.filter fun w =>
+    w ∉ S ∧ ∃ v ∈ S, G.Adj v w ∧ ∀ u, G.Adj v u → u ∉ S → u = w
+
+/-- The zero forcing closure: iterate `zeroForcingStep` until it stabilises. -/
+noncomputable def zeroForcingClosure {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] (S : Finset V) : Finset V :=
+  (zeroForcingStep G)^[Fintype.card V] S
+
+/-- A set $S$ is a *zero forcing set* of $G$ if its zero forcing closure is all
+of $V$. -/
+def IsZeroForcingSet {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] (S : Finset V) : Prop :=
+  zeroForcingClosure G S = Finset.univ
+
+/-- The zero forcing number of a finite simple graph: the minimum cardinality of
+a zero forcing set. -/
+noncomputable def zeroForcingNumber {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  sInf {k | ∃ S : Finset V, S.card = k ∧ IsZeroForcingSet G S}
+
+/--
+TxGraffiti [Conjecture 2](https://arxiv.org/abs/2507.17780):
+for every connected graph $G$ with $\Delta(G) \le 3$ and $G \ne K_4$,
+$$Z(G) \le \alpha(G) + 1.$$
+
+This conjecture is **open**.
+-/
+@[category research open, AMS 5]
+theorem tx_graffiti_conjecture_2 (V : Type) [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] (_hConn : G.Connected)
+    (_hDeg : G.maxDegree ≤ 3) (_hNotK4 : G ≠ ⊤) :
+    zeroForcingNumber G ≤ G.indepNum + 1 := by
+  sorry
+
+end Arxiv.«2507.17780»

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -56,6 +56,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.CompleteGrap
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.CycleRank
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.DiamExtra
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SzegedIndex
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.HarmonicIndex
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Residue
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.FractionalAlpha
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LovaszTheta
@@ -71,6 +72,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Induced
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.PathCover
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.EdgeColouring
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Domination
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Saturation
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LargestInducedTree
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.WellTotallyDominated
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.HomDensity

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -70,6 +70,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Domination
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Eccentricity
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.EdgeColouring
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.FractionalAlpha
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.HarmonicIndex
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.HomDensity
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Hypercube
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Independence
@@ -82,6 +83,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.PathCover
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.QuasiLineGraph
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Ramsey
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Residue
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Saturation
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SizeRamsey
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SpanningTree
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.SubgraphIsomorphism

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HarmonicIndex.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HarmonicIndex.lean
@@ -1,0 +1,35 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+public import Mathlib.Data.Rat.Defs
+
+@[expose] public section
+
+namespace SimpleGraph
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- The harmonic index of `G`, defined as `∑_{uv ∈ E(G)} 2 / (deg u + deg v)`,
+where `deg` is the degree of a vertex. This is a standard topological index in
+chemical graph theory, introduced by Fajtlowicz. -/
+def harmonicIndex (G : SimpleGraph α) [DecidableRel G.Adj] : ℚ :=
+  ∑ e ∈ G.edgeFinset,
+    e.lift ⟨fun u v => (2 : ℚ) / ((G.degree u : ℚ) + (G.degree v : ℚ)),
+      fun u v => by simp only [add_comm]⟩
+
+end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -30,5 +30,25 @@ noncomputable def matchingNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ
   let matchings := { M : Subgraph G | M.IsMatching }
   sSup (Set.image (fun M => (M.edgeSet.toFinset.card : ℝ)) matchings)
 
+/-- A finite set of edges `M` is a *matching* of `G` if every element of `M` is
+an edge of `G` and any two edges of `M` are equal or share no vertex (no vertex
+is covered twice). -/
+def IsEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
+  (∀ e ∈ M, e ∈ G.edgeSet) ∧
+    ∀ e₁ ∈ M, ∀ e₂ ∈ M, e₁ = e₂ ∨ ∀ v : α, ¬ (v ∈ e₁ ∧ v ∈ e₂)
+
+instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
+    Decidable (G.IsEdgeMatching M) := by
+  unfold IsEdgeMatching; infer_instance
+
+/-- A matching `M` of `G` is *maximal* if no further edge of `G` can be added to
+`M` while keeping the matching property. -/
+def IsMaximalEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
+  G.IsEdgeMatching M ∧
+    ∀ e ∈ G.edgeSet, e ∉ M → ¬ G.IsEdgeMatching (insert e M)
+
+instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
+    Decidable (G.IsMaximalEdgeMatching M) := by
+  unfold IsMaximalEdgeMatching; infer_instance
 
 end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -31,6 +31,26 @@ noncomputable def matchingNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ
   let matchings := { M : Subgraph G | M.IsMatching }
   sSup (Set.image (fun M => (M.edgeSet.toFinset.card : ℝ)) matchings)
 
+/-- A finite set of edges `M` is a *matching* of `G` if every element of `M` is
+an edge of `G` and any two edges of `M` are equal or share no vertex (no vertex
+is covered twice). -/
+def IsEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
+  (∀ e ∈ M, e ∈ G.edgeSet) ∧
+    ∀ e₁ ∈ M, ∀ e₂ ∈ M, e₁ = e₂ ∨ ∀ v : α, ¬ (v ∈ e₁ ∧ v ∈ e₂)
+
+instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
+    Decidable (G.IsEdgeMatching M) := by
+  unfold IsEdgeMatching; infer_instance
+
+/-- A matching `M` of `G` is *maximal* if no further edge of `G` can be added to
+`M` while keeping the matching property. -/
+def IsMaximalEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
+  G.IsEdgeMatching M ∧
+    ∀ e ∈ G.edgeSet, e ∉ M → ¬ G.IsEdgeMatching (insert e M)
+
+instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
+    Decidable (G.IsMaximalEdgeMatching M) := by
+  unfold IsMaximalEdgeMatching; infer_instance
 
 /-- In a finite graph, twice the number of edges of any matching is at most the number of
 vertices: each edge contributes two distinct vertices, and a matching's edges are vertex-disjoint. -/

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
@@ -29,9 +29,9 @@ Main definitions
 
 * `SimpleGraph.saturationNumber`   : the saturation number `μ*(G)`, the minimum
   size of a maximal matching.
-* `SimpleGraph.computable_sat_num` : a computable companion definition.
-* `SimpleGraph.sat_num_eq_computable` : bridge equation
-  `saturationNumber G = computable_sat_num G`.
+* `SimpleGraph.computableSaturationNumber` : a computable companion definition.
+* `SimpleGraph.saturationNumber_eq_computable` : bridge equation
+  `saturationNumber G = computableSaturationNumber G`.
 -/
 
 namespace SimpleGraph
@@ -49,15 +49,15 @@ noncomputable def saturationNumber (G : SimpleGraph α) : ℕ :=
   sInf {n | ∃ M : Finset (Sym2 α), G.IsMaximalEdgeMatching M ∧ M.card = n}
 
 /-- Computable saturation number via powerset enumeration over the edge set. -/
-def computable_sat_num (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+def computableSaturationNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
   ((G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image
     Finset.card).min.getD 0
 
 /-! ### Saturation number equivalence -/
 
-theorem sat_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
-    saturationNumber G = computable_sat_num G := by
-  unfold saturationNumber computable_sat_num
+theorem saturationNumber_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    saturationNumber G = computableSaturationNumber G := by
+  unfold saturationNumber computableSaturationNumber
   have hset : {n | ∃ M : Finset (Sym2 α), G.IsMaximalEdgeMatching M ∧ M.card = n}
       = ↑((G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image
           Finset.card) := by

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
@@ -15,53 +15,28 @@ limitations under the License.
 -/
 module
 
-public import Mathlib.Combinatorics.SimpleGraph.Finite
 public import Mathlib.Data.Finset.Powerset
 public import Mathlib.Data.Nat.Lattice
 public import Mathlib.Order.ConditionallyCompleteLattice.Finset
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Matching
 
 @[expose] public section
 
 /-!
-Maximal matchings and the saturation number
-
-This file introduces maximal matchings (described as finite sets of edges) and
-the saturation number of a graph.
+The saturation number of a graph.
 
 Main definitions
 
-* `SimpleGraph.IsEdgeMatching`        : a finite set of edges forming a matching.
-* `SimpleGraph.IsMaximalEdgeMatching` : a matching to which no edge can be added.
-* `SimpleGraph.saturationNumber`      : the saturation number `μ*(G)`, the
-  minimum size of a maximal matching.
+* `SimpleGraph.saturationNumber`   : the saturation number `μ*(G)`, the minimum
+  size of a maximal matching.
+* `SimpleGraph.computable_sat_num` : a computable companion definition.
+* `SimpleGraph.sat_num_eq_computable` : bridge equation
+  `saturationNumber G = computable_sat_num G`.
 -/
 
 namespace SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
-
-/-! ### Matchings as edge sets -/
-
-/-- A finite set of edges `M` is a *matching* of `G` if every element of `M` is
-an edge of `G` and any two edges of `M` are equal or share no vertex (no vertex
-is covered twice). -/
-def IsEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
-  (∀ e ∈ M, e ∈ G.edgeSet) ∧
-    ∀ e₁ ∈ M, ∀ e₂ ∈ M, e₁ = e₂ ∨ ∀ v : α, ¬ (v ∈ e₁ ∧ v ∈ e₂)
-
-instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
-    Decidable (G.IsEdgeMatching M) := by
-  unfold IsEdgeMatching; infer_instance
-
-/-- A matching `M` of `G` is *maximal* if no further edge of `G` can be added to
-`M` while keeping the matching property. -/
-def IsMaximalEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
-  G.IsEdgeMatching M ∧
-    ∀ e ∈ G.edgeSet, e ∉ M → ¬ G.IsEdgeMatching (insert e M)
-
-instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
-    Decidable (G.IsMaximalEdgeMatching M) := by
-  unfold IsMaximalEdgeMatching; infer_instance
 
 /-! ### Saturation number -/
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
@@ -1,0 +1,77 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Finset.Powerset
+public import Mathlib.Data.Nat.Lattice
+public import Mathlib.Order.ConditionallyCompleteLattice.Finset
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Matching
+
+@[expose] public section
+
+/-!
+The saturation number of a graph.
+
+Main definitions
+
+* `SimpleGraph.saturationNumber`   : the saturation number `μ*(G)`, the minimum
+  size of a maximal matching.
+* `SimpleGraph.computableSaturationNumber` : a computable companion definition.
+* `SimpleGraph.saturationNumber_eq_computable` : bridge equation
+  `saturationNumber G = computableSaturationNumber G`.
+-/
+
+namespace SimpleGraph
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-! ### Saturation number -/
+
+/-- The *saturation number* `μ*(G)` (also called the lower matching number): the
+minimum number of edges in a maximal matching of `G`.
+
+Every finite graph has a maximal matching (extend the empty matching greedily),
+so this set is nonempty and the infimum is a genuine minimum. -/
+noncomputable def saturationNumber (G : SimpleGraph α) : ℕ :=
+  sInf {n | ∃ M : Finset (Sym2 α), G.IsMaximalEdgeMatching M ∧ M.card = n}
+
+/-- Computable saturation number via powerset enumeration over the edge set. -/
+def computableSaturationNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  ((G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image
+    Finset.card).min.getD 0
+
+/-! ### Saturation number equivalence -/
+
+theorem saturationNumber_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    saturationNumber G = computableSaturationNumber G := by
+  unfold saturationNumber computableSaturationNumber
+  have hset : {n | ∃ M : Finset (Sym2 α), G.IsMaximalEdgeMatching M ∧ M.card = n}
+      = ↑((G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image
+          Finset.card) := by
+    ext n
+    simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, Finset.mem_filter,
+      Finset.mem_powerset, Set.mem_setOf_eq]
+    refine ⟨fun ⟨M, hM, hn⟩ =>
+        ⟨M, ⟨fun e he => mem_edgeFinset.mpr (hM.1.1 e he), hM⟩, hn⟩,
+      fun ⟨M, ⟨_, hM⟩, hn⟩ => ⟨M, hM, hn⟩⟩
+  rw [hset]
+  set s : Finset ℕ :=
+    (G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image Finset.card
+  rcases s.eq_empty_or_nonempty with hs | hs
+  · rw [hs, Finset.coe_empty, Nat.sInf_empty, Finset.min_empty]; rfl
+  · rw [hs.csInf_eq_min', ← Finset.coe_min' hs]; rfl
+
+end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean
@@ -1,0 +1,102 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+public import Mathlib.Data.Finset.Powerset
+public import Mathlib.Data.Nat.Lattice
+public import Mathlib.Order.ConditionallyCompleteLattice.Finset
+
+@[expose] public section
+
+/-!
+Maximal matchings and the saturation number
+
+This file introduces maximal matchings (described as finite sets of edges) and
+the saturation number of a graph.
+
+Main definitions
+
+* `SimpleGraph.IsEdgeMatching`        : a finite set of edges forming a matching.
+* `SimpleGraph.IsMaximalEdgeMatching` : a matching to which no edge can be added.
+* `SimpleGraph.saturationNumber`      : the saturation number `μ*(G)`, the
+  minimum size of a maximal matching.
+-/
+
+namespace SimpleGraph
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-! ### Matchings as edge sets -/
+
+/-- A finite set of edges `M` is a *matching* of `G` if every element of `M` is
+an edge of `G` and any two edges of `M` are equal or share no vertex (no vertex
+is covered twice). -/
+def IsEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
+  (∀ e ∈ M, e ∈ G.edgeSet) ∧
+    ∀ e₁ ∈ M, ∀ e₂ ∈ M, e₁ = e₂ ∨ ∀ v : α, ¬ (v ∈ e₁ ∧ v ∈ e₂)
+
+instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
+    Decidable (G.IsEdgeMatching M) := by
+  unfold IsEdgeMatching; infer_instance
+
+/-- A matching `M` of `G` is *maximal* if no further edge of `G` can be added to
+`M` while keeping the matching property. -/
+def IsMaximalEdgeMatching (G : SimpleGraph α) (M : Finset (Sym2 α)) : Prop :=
+  G.IsEdgeMatching M ∧
+    ∀ e ∈ G.edgeSet, e ∉ M → ¬ G.IsEdgeMatching (insert e M)
+
+instance (G : SimpleGraph α) [DecidableRel G.Adj] (M : Finset (Sym2 α)) :
+    Decidable (G.IsMaximalEdgeMatching M) := by
+  unfold IsMaximalEdgeMatching; infer_instance
+
+/-! ### Saturation number -/
+
+/-- The *saturation number* `μ*(G)` (also called the lower matching number): the
+minimum number of edges in a maximal matching of `G`.
+
+Every finite graph has a maximal matching (extend the empty matching greedily),
+so this set is nonempty and the infimum is a genuine minimum. -/
+noncomputable def saturationNumber (G : SimpleGraph α) : ℕ :=
+  sInf {n | ∃ M : Finset (Sym2 α), G.IsMaximalEdgeMatching M ∧ M.card = n}
+
+/-- Computable saturation number via powerset enumeration over the edge set. -/
+def computable_sat_num (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  ((G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image
+    Finset.card).min.getD 0
+
+/-! ### Saturation number equivalence -/
+
+theorem sat_num_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] :
+    saturationNumber G = computable_sat_num G := by
+  unfold saturationNumber computable_sat_num
+  have hset : {n | ∃ M : Finset (Sym2 α), G.IsMaximalEdgeMatching M ∧ M.card = n}
+      = ↑((G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image
+          Finset.card) := by
+    ext n
+    simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, Finset.mem_filter,
+      Finset.mem_powerset, Set.mem_setOf_eq]
+    refine ⟨fun ⟨M, hM, hn⟩ =>
+        ⟨M, ⟨fun e he => mem_edgeFinset.mpr (hM.1.1 e he), hM⟩, hn⟩,
+      fun ⟨M, ⟨_, hM⟩, hn⟩ => ⟨M, hM, hn⟩⟩
+  rw [hset]
+  set s : Finset ℕ :=
+    (G.edgeFinset.powerset.filter fun M => G.IsMaximalEdgeMatching M).image Finset.card
+  rcases s.eq_empty_or_nonempty with hs | hs
+  · rw [hs, Finset.coe_empty, Nat.sInf_empty, Finset.min_empty]; rfl
+  · rw [hs.csInf_eq_min', ← Finset.coe_min' hs]; rfl
+
+end SimpleGraph


### PR DESCRIPTION
Closes #4277.

Adds the formal statement of **TxGraffiti Conjecture 4** ([arXiv:2507.17780](https://arxiv.org/abs/2507.17780)) together with the counterexample that refutes it.

### The conjecture (false)
For every nontrivial connected graph $G$, $`\mu^*(G) \le H(G)`$, where $`\mu^*`$ is the saturation number (minimum size of a maximal matching) and $H(G)=\sum_{uv\in E}\tfrac{2}{\deg u+\deg v}$ is the harmonic index. The friendship graph $F_4$ refutes it: $\mu^*(F_4)=4 > 18/5 = H(F_4)$. The conjecture was **first refuted by T. Bıyıkoğlu** (*A Note on the TxGraffiti Conjecture about Harmonic Index and Minimum Maximal Matching Number*, MATCH Commun. Math. Comput. Chem. 96(3):1097–1099, 2026), via a family of edges joined to an independent set with unbounded $\mu^*/H$. The minimality of order 9 and the exact windmill limit: [arXiv:2606.15761](https://arxiv.org/abs/2606.15761).

### What this adds
- **`FormalConjecturesForMathlib/Combinatorics/SimpleGraph/HarmonicIndex.lean`** — `SimpleGraph.harmonicIndex : ℚ`, the edge sum $\sum 2/(\deg u+\deg v)$ (computable by construction, in the style of `WienerIndex`/`SzegedIndex`).
- **`FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Saturation.lean`** — `IsEdgeMatching` / `IsMaximalEdgeMatching` predicates, `SimpleGraph.saturationNumber` (noncomputable `sInf` over maximal-matching cardinalities), a computable companion `computable_sat_num`, and the bridge `sat_num_eq_computable`. This mirrors the existing `dominationNumber` / `computable_dom_num` / `dom_num_eq_computable` pattern.
- **`FormalConjectures/Arxiv/2507.17780/SaturationNumberHarmonicIndex.lean`** — `theorem txGraffitiConjecture4 : answer(False) ↔ ∀ nontrivial connected G, μ*(G) ≤ H(G)`, proved by exhibiting `friendshipF4`.

### Notes for review
- **`native_decide` is used** for the three concrete $F_4$ facts (`Connected`, and the two numeric evaluations). Plain `decide` is **not** an option here: the kernel cannot reduce `Rat.instDecidableLe` for the `ℚ` comparison (it gets stuck, not merely slow). `decide +native` is already used elsewhere in the graph track (e.g. `WrittenOnTheWallII/GraphConjecture109`).
- **Axiom footprint.** `#print axioms txGraffitiConjecture4` → `[propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]`. The bridge `sat_num_eq_computable` is **kernel-only** (`[propext, Classical.choice, Quot.sound]`): the *general* `μ* = computable` equality is fully kernel-checked, so `native_decide` is confined to the concrete $F_4$ numerics.
- The conjecture proof body is 5 lines (within the 25–50 line guidance); the reusable invariant definitions live in `FormalConjecturesForMathlib`.
- `lake --wfail build` is clean; `#print axioms` is reported above.
