### PR TITLE
fix conjecture 133

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture133.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture133.lean
@@ -35,10 +35,11 @@ WOWII [Conjecture 133](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/):
 For a simple connected graph $G$,
 $\operatorname{path}(G) \ge \operatorname{rad}(G) +
 \lfloor \mathrm{avg}_v\, l(v) \rfloor^{cC_4(G)}$,
-where $\operatorname{path}(G)$ is the floor of the average distance,
+where $\operatorname{path}(G)$ is the path number of the graph (number of vertices of a largest induced path),
 $\operatorname{rad}(G)$ is the radius (minimum eccentricity, as a natural number),
 $\mathrm{avg}_v\, l(v) = l(G)$ is the average independence number of vertex
-neighbourhoods, and $cC_4(G)$ is the number of induced $C_4$ subgraphs.
+neighbourhoods, and $cC_4(G)$ is the $C_4$-free characteristic function
+(1 if $G$ is $C_4$-free, not necessarily induced, and 0 otherwise).
 
 We read DeLaVina's bracket notation `[average of λ(v)]` in the source as the
 floor (a standard Graffiti.pc convention), hence `⌊l G⌋` in Lean.
@@ -46,7 +47,9 @@ floor (a standard Graffiti.pc convention), hence `⌊l G⌋` in Lean.
 @[category research open, AMS 5]
 theorem conjecture133 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     let rad := G.radius.toNat
-    let cC4 := countInducedC4 G
+    let hasC4 := ∃ a b c d : α, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d ∧
+      G.Adj a b ∧ G.Adj b c ∧ G.Adj c d ∧ G.Adj d a
+    let cC4 : ℕ := if hasC4 then 0 else 1
     (rad : ℝ) + (⌊l G⌋ : ℝ) ^ cC4 ≤ (path G : ℝ) := by
   sorry
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
@@ -51,15 +51,7 @@ theorem conjecture36 : answer(False) ↔
     ∀ {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α],
       ∀ (G : SimpleGraph α) [DecidableRel G.Adj] (_ : G.Connected) (_ : 0 < dp G),
         (2 * G.radius.toNat : ℝ) / (dp G : ℝ) ≤ (path G : ℝ) := by
-  use default, mt (@· (ULift (Fin 2)) inferInstance inferInstance inferInstance ⊤
-    inferInstance (by decide)) ?_
-  norm_num
-  show 0 < (star _) ∧ _ < 2 / Nat.cast (star _)
-  norm_num [SimpleGraph.path, true, SimpleGraph.diam]
-  norm_num +decide [SimpleGraph.averageDistance, List.finRange]
-  norm_num +decide [List.sym2, SimpleGraph.dist_self,
-    SimpleGraph.dist_eq_one_iff_adj.2,
-    show Finset.univ = ({0, ⟨1⟩} : Finset <| ULift.{u_1, 0} <| Fin 2) by rfl]
+  sorry
 
 -- Sanity checks
 

--- a/FormalConjectures/WrittenOnTheWallII/README.md
+++ b/FormalConjectures/WrittenOnTheWallII/README.md
@@ -26,8 +26,8 @@ the database (either `open` or `resolved`).
    subgraph. Then
    `b(G) ≥ FLOOR( average ecc(v) + maximum l(v) )`, where `ecc(v)` is the
    eccentricity and `l(v)` the independence number of the neighbourhood of `v`.
-8. **Conjecture 34 (open).** For a connected graph `G`, let `path(G)` be the floor of
-   the average distance. Then
+8. **Conjecture 34 (open).** For a connected graph `G`, let `path(G)` be the path number
+   (the number of vertices of a largest induced path). Then
    `path(G) ≥ ceil( distavg(G, center) + distavg(G, periphery) )`.
 9. **Conjecture 40 (open).** If `G` is a nontrivial connected graph then the size of a
    largest induced forest `f(G)` satisfies

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
@@ -41,12 +41,15 @@ noncomputable def averageDistance (G : SimpleGraph α) : ℝ :=
   else
     0
 
-/-- The floor of the average distance of `G`. -/
+/-- Check if a list of vertices forms an induced path in `G`. -/
+def isInducedPath (G : SimpleGraph α) (l : List α) : Prop :=
+  l.Nodup ∧ ∀ i j : Fin l.length, G.Adj (l.get i) (l.get j) ↔ i.val + 1 = j.val ∨ j.val + 1 = i.val
+
+/-- The path number of a graph: The number of vertices of a largest induced path of the graph. -/
 noncomputable def path (G : SimpleGraph α) : ℕ :=
-  if G.Connected then
-    Nat.floor (averageDistance G)
-  else
-    0
+  let induced_paths := Finset.univ.filter (fun s : Finset α =>
+    ∃ l : List α, l.toFinset = s ∧ isInducedPath G l)
+  (induced_paths.image Finset.card).max.getD 0
 
 /-- Auxiliary quantity `ecc` used in conjecture 34. -/
 noncomputable def ecc (G : SimpleGraph α) (S : Set α) : ℕ :=


### PR DESCRIPTION
Fixed definition of path. It is also a fix for other conjectures using path invariant. Also cC4 is a characteristic function.