### PR TITLE
chore: update status of erdos-888

### DIFF
--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -40,7 +40,7 @@ def p (n : ℕ) (k : ℕ) : Prop := ∃ A : Finset ℕ, RequiredCondition A n �
 
 /-- What is the size of the largest subset `A` of `{1,...,n}` such that if
 `a ≤ b ≤ c ≤ d ∈ A` and `abcd` square then `ad=bc` -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11]
 theorem erdos_888 : ∀ n, Nat.findGreatest (p n) n = (answer(sorry) : ℕ → ℕ) n := by
   sorry
 


### PR DESCRIPTION
Closes #4099.

This updates the category annotation on the exact main theorem `erdos_888` from `research open` to `research solved`, matching the status reported by `scripts/check_erdos_status.py`.

Validation:
- `python3 scripts/check_erdos_status.py | python3 -c 'import json,sys; xs=json.load(sys.stdin); assert not any(x["number"]=="888" for x in xs), xs'`
- `lake --wfail build 'FormalConjectures.ErdosProblems.«888»'`

No broader status-sync or linter changes are included.