### PR TITLE
ErdosProblems/17: prove isClusterPrime_97_isLeast_non_cluster

### DIFF
--- a/FormalConjectures/ErdosProblems/17.lean
+++ b/FormalConjectures/ErdosProblems/17.lean
@@ -72,6 +72,49 @@ theorem erdos_17.variants.upper_Elsholtz :
 /-- $97$ is the smallest prime that is not a cluster prime. -/
 @[category test, AMS 11]
 theorem isClusterPrime_97_isLeast_non_cluster : IsLeast {p : ℕ | p.Prime ∧ ¬ IsClusterPrime p} 97 := by
-  sorry
+  -- For a prime `p`, being a cluster prime is equivalent to a fully bounded
+  -- (hence decidable) statement over `ℕ`: every even `n ≤ p - 3` is `q₁ - q₂`
+  -- for primes `q₁, q₂ ≤ p`, which (since `n ≥ 0`) amounts to a prime `q₂ ≤ p`
+  -- with `q₂ + n` again prime and `≤ p`.
+  have cluster_iff : ∀ p : ℕ, p.Prime →
+      (IsClusterPrime p ↔
+        (∀ n ∈ Finset.range (p - 2), Even n →
+          ∃ q₂ ∈ Finset.range (p + 1), (Nat.Prime q₂) ∧ Nat.Prime (q₂ + n) ∧ q₂ + n ≤ p)) := by
+    intro p hp
+    constructor
+    · rintro ⟨-, h⟩ n hn hev
+      simp only [Finset.mem_range] at hn
+      have hn3 : (n : ℤ) ≤ (p - 3 : ℤ) := by omega
+      obtain ⟨q₁, q₂, hq1p, hq2p, hq1le, hq2le, heq⟩ := h hev hn3
+      refine ⟨q₂, ?_, hq2p, ?_, ?_⟩
+      · simp only [Finset.mem_range]; omega
+      · have hq2n : q₂ + n = q₁ := by omega
+        rw [hq2n]; exact hq1p
+      · omega
+    · intro h
+      refine ⟨hp, ?_⟩
+      intro n hev hn3
+      have hnp : n ≤ p - 3 := by omega
+      have hnrange : n ∈ Finset.range (p - 2) := by
+        simp only [Finset.mem_range]; omega
+      obtain ⟨q₂, hq2r, hq2p, hq1p, hle⟩ := h n hnrange hev
+      refine ⟨q₂ + n, q₂, hq1p, hq2p, hle, ?_, ?_⟩
+      · simp only [Finset.mem_range] at hq2r; omega
+      · push_cast; ring
+  constructor
+  · -- `97` is prime but not a cluster prime: the even number `88 ≤ 94` is not a
+    -- difference of two primes `≤ 97`.
+    refine ⟨by norm_num, ?_⟩
+    rw [cluster_iff 97 (by norm_num)]
+    set_option maxRecDepth 8000 in decide
+  · -- `97` is a lower bound: every prime `< 97` is a cluster prime, so cannot lie
+    -- in the set of non-cluster primes.
+    rintro b ⟨hbp, hbnc⟩
+    by_contra hlt
+    push_neg at hlt
+    interval_cases b <;>
+      first
+        | exact absurd hbp (by decide)
+        | exact hbnc ((cluster_iff _ (by norm_num)).mpr (by set_option maxRecDepth 8000 in decide))
 
 end Erdos17


### PR DESCRIPTION
Closes the `sorry` on `isClusterPrime_97_isLeast_non_cluster` (97 is the least prime that is not a cluster prime).

### Approach

For a prime `p`, `IsClusterPrime p` is reformulated as a fully bounded, decidable statement (`cluster_iff`): every even `n ∈ Finset.range (p - 2)` admits a prime `q₂ ≤ p` with `q₂ + n` prime and `≤ p`.

- **Membership** (`97 ∈ S`): `97` is prime and not a cluster prime. The even number `88 ≤ 94` is not a difference of two primes `≤ 97`, discharged by `decide` through `cluster_iff`.
- **Lower bound** (`97` is a lower bound of `S`): `interval_cases` over `b < 97`; each case is either non-prime (`decide`) or a cluster prime (`cluster_iff` + `decide`).

### Verification

Kernel-clean: `#print axioms isClusterPrime_97_isLeast_non_cluster` reports `[propext, Classical.choice, Quot.sound]` — no `sorryAx`. No `native_decide` (plain `decide` with a raised `maxRecDepth`). Built against this repo's pinned toolchain (`leanprover/lean4:v4.27.0`) and Mathlib rev.

The proof was drafted with AI assistance and machine-checked by the Lean kernel.
