### PR TITLE
feat(website/stats): growth plot

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -215,6 +215,9 @@ jobs:
           mkdir -p site/data _literate_html docbuild/out
           echo "Downloading conjectures data from $LIVE_URL ..."
           curl -sfL "$LIVE_URL/data/conjectures.json" -o /tmp/live_conjectures.json
+          echo "Downloading growth plots from $LIVE_URL ..."
+          curl -sfL "$LIVE_URL/doc/file_counts_white.html" -o docbuild/out/file_counts_white.html || true
+          curl -sfL "$LIVE_URL/doc/file_counts_dark.html" -o docbuild/out/file_counts_dark.html || true
           node -e "
             const fs = require('fs');
             const data = JSON.parse(fs.readFileSync('/tmp/live_conjectures.json', 'utf8'));

--- a/site/build.js
+++ b/site/build.js
@@ -714,9 +714,32 @@ async function main() {
   copyStaticTemplate('about.html', 'site/about/index.html');
 
   // ---- Stats page ----
+  let growthPlot = '';
+  const whitePlotPath = path.join('..', 'docbuild', 'out', 'file_counts_white.html');
+  const darkPlotPath = path.join('..', 'docbuild', 'out', 'file_counts_dark.html');
+  if (fs.existsSync(whitePlotPath) && fs.existsSync(darkPlotPath)) {
+    const graphHtmlLight = fs.readFileSync(whitePlotPath, 'utf8');
+    const graphHtmlDark = fs.readFileSync(darkPlotPath, 'utf8');
+    growthPlot = `
+      <style>
+        .theme-dark { display: none; }
+        @media (prefers-color-scheme: dark) {
+          .theme-light { display: none; }
+          .theme-dark { display: block; }
+        }
+      </style>
+      <div class="theme-light">${graphHtmlLight}</div>
+      <div class="theme-dark">${graphHtmlDark}</div>
+    `;
+    console.log('  Loaded repository growth plots.');
+  } else {
+    console.log('  Repository growth plots not found (skipping growth plot).');
+  }
+
   const statsHtml = readTemplate('stats.html');
   writePage('site/stats/index.html', applyBasePath(fill(statsHtml, {
     totalCount:           stats.total,
+    growthPlot:           growthPlot,
     subjectStatusTable:   subjectStatusTableHTML(advancedStats.subjectByCategory),
   })));
 

--- a/site/src/templates/stats.html
+++ b/site/src/templates/stats.html
@@ -37,6 +37,16 @@
 <main>
   <section class="section">
     <div class="container">
+      <h2 class="section__title">Repository growth</h2>
+      <p class="section__lede">
+        The number of Lean files in Formal Conjectures over time.
+      </p>
+      {{growthPlot}}
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
       <h2 class="section__title">Subject &times; status</h2>
       <p class="section__lede">
         Each row is an AMS MSC2020 subject; each column is a problem


### PR DESCRIPTION
This adds the growth plot to the stats page, preparing the removal of docgen, where we currently inject this plot.