### PR TITLE
feat(WrittenOnTheWallII): prove diameter, radius, girth, and matching invariants

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -143,7 +143,25 @@ theorem house_avg_deg : averageDegree HouseGraph = 12/5 := by
 
 @[category test, AMS 5]
 theorem house_matching : matchingNumber HouseGraph = 2 := by
-  sorry
+  have hbdd : BddAbove (Set.image (fun M : Subgraph HouseGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
+    refine ⟨(Fintype.card (Fin 5) : ℝ), ?_⟩
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ Fintype.card (Fin 5)
+    have hb := matching_card_bound HouseGraph M hM
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ Fintype.card (Fin 5))
+  unfold matchingNumber
+  apply le_antisymm
+  · apply csSup_le (Set.Nonempty.image _ ⟨⊥, by simp [Subgraph.IsMatching]⟩)
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ 2
+    have hb := matching_card_bound HouseGraph M hM
+    simp only [Fintype.card_fin] at hb
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ 2)
+  · apply le_csSup hbdd
+    refine ⟨HouseGraph.subgraphOfAdj (show HouseGraph.Adj 0 1 by decide) ⊔ HouseGraph.subgraphOfAdj (show HouseGraph.Adj 2 3 by decide), ?_, ?_⟩
+    · exact (Subgraph.IsMatching.subgraphOfAdj _).sup (Subgraph.IsMatching.subgraphOfAdj _)
+        (by rw [support_subgraphOfAdj, support_subgraphOfAdj]; simp [Set.disjoint_left])
+    · simp
 
 @[category test, AMS 5]
 theorem house_residue : residue HouseGraph = 2 := by
@@ -227,7 +245,25 @@ theorem K4_avg_deg : averageDegree K4 = 3 := by
 
 @[category test, AMS 5]
 theorem K4_matching : matchingNumber K4 = 2 := by
-  sorry
+  have hbdd : BddAbove (Set.image (fun M : Subgraph K4 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
+    refine ⟨(Fintype.card (Fin 4) : ℝ), ?_⟩
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ Fintype.card (Fin 4)
+    have hb := matching_card_bound K4 M hM
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ Fintype.card (Fin 4))
+  unfold matchingNumber
+  apply le_antisymm
+  · apply csSup_le (Set.Nonempty.image _ ⟨⊥, by simp [Subgraph.IsMatching]⟩)
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ 2
+    have hb := matching_card_bound K4 M hM
+    simp only [Fintype.card_fin] at hb
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ 2)
+  · apply le_csSup hbdd
+    refine ⟨K4.subgraphOfAdj (show K4.Adj 0 1 by decide) ⊔ K4.subgraphOfAdj (show K4.Adj 2 3 by decide), ?_, ?_⟩
+    · exact (Subgraph.IsMatching.subgraphOfAdj _).sup (Subgraph.IsMatching.subgraphOfAdj _)
+        (by rw [support_subgraphOfAdj, support_subgraphOfAdj]; simp [Set.disjoint_left])
+    · simp
 
 @[category test, AMS 5]
 theorem K4_residue : residue K4 = 1 := by
@@ -302,7 +338,37 @@ theorem petersen_avg_deg : averageDegree PetersenGraph = 3 := by
 
 @[category test, AMS 5]
 theorem petersen_matching : matchingNumber PetersenGraph = 5 := by
-  sorry
+  have hbdd : BddAbove (Set.image (fun M : Subgraph PetersenGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
+    refine ⟨(Fintype.card (Fin 10) : ℝ), ?_⟩
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ Fintype.card (Fin 10)
+    have hb := matching_card_bound PetersenGraph M hM
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ Fintype.card (Fin 10))
+  unfold matchingNumber
+  apply le_antisymm
+  · apply csSup_le (Set.Nonempty.image _ ⟨⊥, by simp [Subgraph.IsMatching]⟩)
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ 5
+    have hb := matching_card_bound PetersenGraph M hM
+    simp only [Fintype.card_fin] at hb
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ 5)
+  · apply le_csSup hbdd
+    refine ⟨PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 0 5 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 1 6 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 2 7 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 3 8 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 4 9 by decide), ?_, ?_⟩
+    · apply Subgraph.IsMatching.sup
+      · apply Subgraph.IsMatching.sup
+        · apply Subgraph.IsMatching.sup
+          · exact (Subgraph.IsMatching.subgraphOfAdj _).sup (Subgraph.IsMatching.subgraphOfAdj _)
+              (by rw [support_subgraphOfAdj, support_subgraphOfAdj]; simp [Set.disjoint_left])
+          · exact Subgraph.IsMatching.subgraphOfAdj _
+          · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
+            simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
+        · exact Subgraph.IsMatching.subgraphOfAdj _
+        · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
+          simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
+      · exact Subgraph.IsMatching.subgraphOfAdj _
+      · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
+        simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
+    · simp
 
 @[category test, AMS 5]
 theorem petersen_residue : residue PetersenGraph = 3 := by
@@ -377,7 +443,29 @@ theorem C6_avg_deg : averageDegree C6 = 2 := by
 
 @[category test, AMS 5]
 theorem C6_matching : matchingNumber C6 = 3 := by
-  sorry
+  have hbdd : BddAbove (Set.image (fun M : Subgraph C6 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
+    refine ⟨(Fintype.card (Fin 6) : ℝ), ?_⟩
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ Fintype.card (Fin 6)
+    have hb := matching_card_bound C6 M hM
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ Fintype.card (Fin 6))
+  unfold matchingNumber
+  apply le_antisymm
+  · apply csSup_le (Set.Nonempty.image _ ⟨⊥, by simp [Subgraph.IsMatching]⟩)
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ 3
+    have hb := matching_card_bound C6 M hM
+    simp only [Fintype.card_fin] at hb
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ 3)
+  · apply le_csSup hbdd
+    refine ⟨C6.subgraphOfAdj (show C6.Adj 0 1 by decide) ⊔ C6.subgraphOfAdj (show C6.Adj 2 3 by decide) ⊔ C6.subgraphOfAdj (show C6.Adj 4 5 by decide), ?_, ?_⟩
+    · apply Subgraph.IsMatching.sup
+      · exact (Subgraph.IsMatching.subgraphOfAdj _).sup (Subgraph.IsMatching.subgraphOfAdj _)
+          (by rw [support_subgraphOfAdj, support_subgraphOfAdj]; simp [Set.disjoint_left])
+      · exact Subgraph.IsMatching.subgraphOfAdj _
+      · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
+        simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
+    · simp
 
 @[category test, AMS 5]
 theorem C6_residue : residue C6 = 2 := by
@@ -476,7 +564,40 @@ theorem Star5_avg_deg : averageDegree Star5 = 5/3 := by
 
 @[category test, AMS 5]
 theorem Star5_matching : matchingNumber Star5 = 1 := by
-  sorry
+  have hle : ∀ M : Subgraph Star5, M.IsMatching → M.edgeSet.toFinset.card ≤ 1 := by
+    intro M hM
+    have hcenter : ∀ e ∈ M.edgeSet, (Sum.inl 0 : Fin 1 ⊕ Fin 5) ∈ e := by
+      intro e he
+      induction e using Sym2.inductionOn with | _ a b =>
+      rw [Subgraph.mem_edgeSet] at he
+      have hadj := he.adj_sub
+      simp only [Star5, completeBipartiteGraph] at hadj
+      rw [Sym2.mem_iff]
+      rcases hadj with ⟨ha, _⟩ | ⟨_, hb⟩
+      · left; obtain ⟨a', rfl⟩ := Sum.isLeft_iff.mp ha; exact congrArg Sum.inl (Subsingleton.elim 0 a')
+      · right; obtain ⟨b', rfl⟩ := Sum.isLeft_iff.mp hb; exact congrArg Sum.inl (Subsingleton.elim 0 b')
+    rw [Finset.card_le_one]
+    intro e he f hf
+    rw [Set.mem_toFinset] at he hf
+    obtain ⟨y, rfl⟩ := Sym2.mem_iff_exists.mp (hcenter e he)
+    obtain ⟨z, rfl⟩ := Sym2.mem_iff_exists.mp (hcenter f hf)
+    rw [Subgraph.mem_edgeSet] at he hf
+    rw [hM.eq_of_adj_left he hf]
+  have hbdd : BddAbove (Set.image (fun M : Subgraph Star5 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
+    refine ⟨1, ?_⟩
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ 1
+    exact_mod_cast hle M hM
+  unfold matchingNumber
+  apply le_antisymm
+  · apply csSup_le (Set.Nonempty.image _ ⟨⊥, by simp [Subgraph.IsMatching]⟩)
+    rintro x ⟨M, hM, rfl⟩
+    show (M.edgeSet.toFinset.card : ℝ) ≤ 1
+    exact_mod_cast hle M hM
+  · apply le_csSup hbdd
+    refine ⟨Star5.subgraphOfAdj (show Star5.Adj (Sum.inl 0) (Sum.inr 0) by simp [Star5, completeBipartiteGraph]), ?_, ?_⟩
+    · exact Subgraph.IsMatching.subgraphOfAdj _
+    · simp
 
 @[category test, AMS 5]
 theorem Star5_residue : residue Star5 = 5 := by

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -91,15 +91,26 @@ theorem house_avg_dist : averageDistance HouseGraph = 7/5 := by
 
 @[category test, AMS 5]
 theorem house_diameter : ediam HouseGraph = 2 := by
-  sorry
+  rw [ediam_eq_computable HouseGraph (by decide)]
+  exact_mod_cast (by decide +native : computable_ediam HouseGraph = 2)
 
 @[category test, AMS 5]
 theorem house_radius : radius HouseGraph = 2 := by
-  sorry
+  rw [radius_eq_computable HouseGraph (by decide)]
+  exact_mod_cast (by decide +native : computable_radius HouseGraph = 2)
 
 @[category test, AMS 5]
 theorem house_girth : HouseGraph.girth = 3 := by
-  sorry
+  have hcyc : (Walk.cons (show HouseGraph.Adj 2 3 by decide)
+      (Walk.cons (show HouseGraph.Adj 3 4 by decide)
+      (Walk.cons (show HouseGraph.Adj 4 2 by decide) Walk.nil))).IsCycle := by
+    rw [Walk.isCycle_def]
+    refine ⟨?_, ?_, ?_⟩
+    · rw [Walk.isTrail_def]; decide
+    · simp
+    · decide
+  refine le_antisymm ?_ (three_le_girth (fun hac => hac _ hcyc))
+  simpa using girth_le_length hcyc
 
 @[category test, AMS 5]
 theorem house_order : Fintype.card ↥(⊤ : Subgraph HouseGraph).verts = 5 := by
@@ -164,15 +175,26 @@ theorem K4_avg_dist : averageDistance K4 = 1 := by
 
 @[category test, AMS 5]
 theorem K4_diameter : ediam K4 = 1 := by
-  sorry
+  rw [ediam_eq_computable K4 (by decide)]
+  exact_mod_cast (by decide +native : computable_ediam K4 = 1)
 
 @[category test, AMS 5]
 theorem K4_radius : radius K4 = 1 := by
-  sorry
+  rw [radius_eq_computable K4 (by decide)]
+  exact_mod_cast (by decide +native : computable_radius K4 = 1)
 
 @[category test, AMS 5]
 theorem K4_girth : K4.girth = 3 := by
-  sorry
+  have hcyc : (Walk.cons (show K4.Adj 0 1 by decide)
+      (Walk.cons (show K4.Adj 1 2 by decide)
+      (Walk.cons (show K4.Adj 2 0 by decide) Walk.nil))).IsCycle := by
+    rw [Walk.isCycle_def]
+    refine ⟨?_, ?_, ?_⟩
+    · rw [Walk.isTrail_def]; decide
+    · simp
+    · decide
+  refine le_antisymm ?_ (three_le_girth (fun hac => hac _ hcyc))
+  simpa using girth_le_length hcyc
 
 @[category test, AMS 5]
 theorem K4_order : Fintype.card ↥(⊤ : Subgraph K4).verts = 4 := by
@@ -237,11 +259,13 @@ theorem petersen_avg_dist : averageDistance PetersenGraph = 5/3 := by
 
 @[category test, AMS 5]
 theorem petersen_diameter : ediam PetersenGraph = 2 := by
-  sorry
+  rw [ediam_eq_computable PetersenGraph (by decide)]
+  exact_mod_cast (by decide +native : computable_ediam PetersenGraph = 2)
 
 @[category test, AMS 5]
 theorem petersen_radius : radius PetersenGraph = 2 := by
-  sorry
+  rw [radius_eq_computable PetersenGraph (by decide)]
+  exact_mod_cast (by decide +native : computable_radius PetersenGraph = 2)
 
 @[category test, AMS 5]
 theorem petersen_girth : PetersenGraph.girth = 5 := by
@@ -310,11 +334,13 @@ theorem C6_avg_dist : averageDistance C6 = 9/5 := by
 
 @[category test, AMS 5]
 theorem C6_diameter : ediam C6 = 3 := by
-  sorry
+  rw [ediam_eq_computable C6 (by decide)]
+  exact_mod_cast (by decide +native : computable_ediam C6 = 3)
 
 @[category test, AMS 5]
 theorem C6_radius : radius C6 = 3 := by
-  sorry
+  rw [radius_eq_computable C6 (by decide)]
+  exact_mod_cast (by decide +native : computable_radius C6 = 3)
 
 @[category test, AMS 5]
 theorem C6_girth : C6.girth = 6 := by
@@ -382,15 +408,42 @@ theorem Star5_avg_dist : averageDistance Star5 = 5/3 := by
 
 @[category test, AMS 5]
 theorem Star5_diameter : ediam Star5 = 2 := by
-  sorry
+  rw [ediam_eq_computable Star5 (by decide)]
+  exact_mod_cast (by decide +native : computable_ediam Star5 = 2)
 
 @[category test, AMS 5]
 theorem Star5_radius : radius Star5 = 1 := by
-  sorry
+  rw [radius_eq_computable Star5 (by decide)]
+  exact_mod_cast (by decide +native : computable_radius Star5 = 1)
 
 @[category test, AMS 5]
 theorem Star5_girth : Star5.egirth = ⊤ := by
-  sorry
+  rw [egirth_eq_top]
+  have key : ∀ (b : Fin 5) (c : Star5.Walk (Sum.inr b) (Sum.inr b)), ¬ c.IsCycle := by
+    intro b c hc
+    have h1 := c.adj_snd hc.not_nil
+    have h2 := c.adj_penultimate hc.not_nil
+    have hs : c.snd.isLeft := by
+      simp only [Star5, completeBipartiteGraph, Sum.isRight_inr, Sum.isLeft_inr] at h1
+      tauto
+    have hp : c.penultimate.isLeft := by
+      simp only [Star5, completeBipartiteGraph, Sum.isRight_inr, Sum.isLeft_inr] at h2
+      tauto
+    apply hc.snd_ne_penultimate
+    obtain ⟨x, hx⟩ := Sum.isLeft_iff.mp hs
+    obtain ⟨y, hy⟩ := Sum.isLeft_iff.mp hp
+    rw [hx, hy, Subsingleton.elim x y]
+  intro v c hc
+  cases v with
+  | inr b => exact key b c hc
+  | inl a =>
+    have h1 := c.adj_snd hc.not_nil
+    obtain ⟨b, hb⟩ : ∃ b, c.snd = Sum.inr b := by
+      rcases hsnd : c.snd with x | y
+      · rw [hsnd] at h1; simp [Star5, completeBipartiteGraph] at h1
+      · exact ⟨y, rfl⟩
+    have hmem : Sum.inr b ∈ c.support := hb ▸ List.mem_of_mem_tail (c.snd_mem_tail_support hc.not_nil)
+    exact key b (c.rotate hmem) (hc.rotate hmem)
 
 @[category test, AMS 5]
 theorem Star5_order : Fintype.card ↥(⊤ : Subgraph Star5).verts = 6 := by

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Eccentricity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Eccentricity.lean
@@ -17,6 +17,7 @@ module
 
 public import Mathlib.Combinatorics.SimpleGraph.Diam
 public import Mathlib.Data.Real.Basic
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.VertexDistance
 
 @[expose] public section
 
@@ -33,5 +34,58 @@ noncomputable def maxEccentricityVertices (G : SimpleGraph α) : Set α :=
 converted to a real number. Returns 0 if the graph has no vertices. -/
 noncomputable def averageEccentricity (G : SimpleGraph α) : ℝ :=
   (∑ v : α, (G.eccent v).toNat) / (Fintype.card α : ℝ)
+
+/-- The diameter of a finite graph as a computable natural number: the maximum BFS distance
+(`computable_dist`) over all ordered pairs of vertices. -/
+def computable_ediam (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
+  Finset.univ.sup fun p : α × α => computable_dist G p.1 p.2
+
+/-- For a connected finite graph, the extended diameter `ediam` equals the computable diameter. -/
+theorem ediam_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] [Nonempty α]
+    (hc : G.Connected) : G.ediam = (computable_ediam G : ℕ∞) := by
+  apply le_antisymm
+  · rw [ediam_le_iff]; intro u v
+    rw [← (hc.preconnected u v).coe_dist_eq_edist, dist_eq_computable]
+    exact_mod_cast Finset.le_sup (f := fun p : α × α => computable_dist G p.1 p.2) (Finset.mem_univ (u, v))
+  · obtain ⟨p, -, hp⟩ := Finset.exists_mem_eq_sup (Finset.univ : Finset (α × α)) Finset.univ_nonempty
+      (fun p : α × α => computable_dist G p.1 p.2)
+    have hp' : computable_ediam G = computable_dist G p.1 p.2 := hp
+    rw [hp', ← dist_eq_computable, (hc.preconnected p.1 p.2).coe_dist_eq_edist]
+    exact edist_le_ediam
+
+/-- The eccentricity of a vertex `u` in a finite graph as a computable natural number:
+the maximum BFS distance (`computable_dist`) from `u` to any vertex. -/
+def computable_eccent (G : SimpleGraph α) [DecidableRel G.Adj] (u : α) : ℕ :=
+  Finset.univ.sup fun v => computable_dist G u v
+
+/-- The radius of a finite graph as a computable natural number: the minimum, over all vertices,
+of the computable eccentricity. -/
+def computable_radius (G : SimpleGraph α) [DecidableRel G.Adj] [Nonempty α] : ℕ :=
+  Finset.univ.inf' Finset.univ_nonempty (computable_eccent G)
+
+/-- For a connected finite graph, the eccentricity `eccent u` equals the computable eccentricity. -/
+theorem eccent_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] [Nonempty α]
+    (hc : G.Connected) (u : α) : G.eccent u = (computable_eccent G u : ℕ∞) := by
+  apply le_antisymm
+  · rw [eccent_le_iff]; intro v
+    rw [← (hc.preconnected u v).coe_dist_eq_edist, dist_eq_computable]
+    exact_mod_cast Finset.le_sup (f := fun v => computable_dist G u v) (Finset.mem_univ v)
+  · obtain ⟨v, -, hv⟩ := Finset.exists_mem_eq_sup (Finset.univ : Finset α) Finset.univ_nonempty
+      (fun v => computable_dist G u v)
+    have hv' : computable_eccent G u = computable_dist G u v := hv
+    rw [hv', ← dist_eq_computable, (hc.preconnected u v).coe_dist_eq_edist]
+    exact edist_le_eccent
+
+/-- For a connected finite graph, the radius `radius` equals the computable radius. -/
+theorem radius_eq_computable (G : SimpleGraph α) [DecidableRel G.Adj] [Nonempty α]
+    (hc : G.Connected) : G.radius = (computable_radius G : ℕ∞) := by
+  apply le_antisymm
+  · obtain ⟨u0, -, hu0⟩ := Finset.exists_mem_eq_inf' (Finset.univ_nonempty) (computable_eccent G)
+    have h0 : computable_radius G = computable_eccent G u0 := hu0
+    rw [h0, ← eccent_eq_computable G hc u0]
+    exact radius_le_eccent
+  · obtain ⟨u1, hu1⟩ := G.exists_eccent_eq_radius
+    rw [← hu1, eccent_eq_computable G hc u1]
+    exact_mod_cast Finset.inf'_le (computable_eccent G) (Finset.mem_univ u1)
 
 end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -31,4 +31,27 @@ noncomputable def matchingNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ
   sSup (Set.image (fun M => (M.edgeSet.toFinset.card : ℝ)) matchings)
 
 
+/-- In a finite graph, twice the number of edges of any matching is at most the number of
+vertices: each edge contributes two distinct vertices, and a matching's edges are vertex-disjoint. -/
+theorem matching_card_bound (G : SimpleGraph α) (M : Subgraph G) [Fintype ↥M.edgeSet]
+    (h : M.IsMatching) : 2 * M.edgeSet.toFinset.card ≤ Fintype.card α := by
+  have hdisj : ∀ e ∈ M.edgeSet.toFinset, ∀ f ∈ M.edgeSet.toFinset, e ≠ f →
+      Disjoint e.toFinset f.toFinset := by
+    intro e he f hf hef
+    rw [Set.mem_toFinset] at he hf
+    rw [Finset.disjoint_left]; intro x hxe hxf
+    rw [Sym2.mem_toFinset] at hxe hxf
+    obtain ⟨y, rfl⟩ := Sym2.mem_iff_exists.mp hxe
+    obtain ⟨z, rfl⟩ := Sym2.mem_iff_exists.mp hxf
+    rw [Subgraph.mem_edgeSet] at he hf
+    apply hef; rw [h.eq_of_adj_left he hf]
+  have hcard2 : ∀ e ∈ M.edgeSet.toFinset, e.toFinset.card = 2 := by
+    intro e he; rw [Set.mem_toFinset] at he
+    exact Sym2.card_toFinset_of_not_isDiag e (G.not_isDiag_of_mem_edgeSet (M.edgeSet_subset he))
+  calc 2 * M.edgeSet.toFinset.card
+      = ∑ e ∈ M.edgeSet.toFinset, e.toFinset.card := by
+        rw [Finset.sum_congr rfl hcard2, Finset.sum_const, smul_eq_mul]; omega
+    _ = (M.edgeSet.toFinset.biUnion Sym2.toFinset).card := (Finset.card_biUnion hdisj).symm
+    _ ≤ Fintype.card α := by rw [← Finset.card_univ]; exact Finset.card_le_card (Finset.subset_univ _)
+
 end SimpleGraph


### PR DESCRIPTION
## Summary

Closes **18 of the 27 `sorry`s** in `FormalConjectures/WrittenOnTheWallII/Test.lean` (the concrete graph-invariant test suite). Three reusable, Mathlib-quality lemmas are added to `FormalConjecturesForMathlib`. `lake --wfail build` passes.

| Invariant | Closed | Method |
|---|---|---|
| `ediam` (diameter) | **5/5** | `ediam_eq_computable` bridge + `decide +native` |
| `radius` | **5/5** | `radius_eq_computable` bridge + `decide +native` |
| `girth` | **3/5** (house, K4, Star5) | explicit cycle / acyclicity |
| `matchingNumber` | **5/5** | `matching_card_bound` + explicit witnesses |

## Reusable lemmas added (`FormalConjecturesForMathlib`)

- **`ediam_eq_computable` / `radius_eq_computable` / `eccent_eq_computable`** (`Combinatorics/SimpleGraph/Eccentricity.lean`) — express the `ℕ∞`-valued diameter / radius / eccentricity of a finite connected graph as a *decidable* max/min of BFS distances (`computable_dist`), so the invariants become `decide`-able.
- **`matching_card_bound`** (`Combinatorics/SimpleGraph/Matching.lean`) — `2 * M.edgeSet.toFinset.card ≤ Fintype.card V` for any matching `M` (i.e. a matching has at most `⌊|V|/2⌋` edges). Fully general and uses only existing Mathlib API — a plausible Mathlib upstream.

## Proof notes

- **Diameter / radius:** `ediam`/`radius` are `⨆`/`⨅` over `edist`, hence not directly `decide`-able; the bridges rewrite them to a `Finset` max/min of `computable_dist`, then each value is `decide +native`.
- **Girth:** `house`/`K4` girth `= 3` via an explicit triangle `Walk` + `IsCycle` + `three_le_girth` — note both `decide` and `native_decide` fail on `IsCycle` over `fromEdgeSet`, so the cycle is constructed by hand. `Star5` `egirth = ⊤` via acyclicity: rotate any cycle to a leaf, where `snd = penultimate = centre` contradicts `IsCycle.snd_ne_penultimate`.
- **Matching:** `matching_card_bound` is `Finset.card_biUnion` over each edge's 2-element vertex set (disjoint by the matching property). `house`/`K4`/`C6`/`Petersen` (`= 2/2/3/5`) use the bound for the upper bound plus an explicit `⊔`-union-of-`subgraphOfAdj` witness; `Star5` (`= 1`) uses that every K₁,₅ edge meets the centre.

## Out of scope (remaining `sorry`s)

`C6` / `PetersenGraph` girth (a girth **lower** bound requires cycle enumeration), `cvetkovic` (spectral — eigenvalues over `ℝ`), and `Star5` average-degree / residue.
