### PR TITLE
ErdosProblems/499,613: link Jayyhk formal proofs (#4184)

### DIFF
--- a/FormalConjectures/ErdosProblems/499.lean
+++ b/FormalConjectures/ErdosProblems/499.lean
@@ -34,7 +34,7 @@ This is true, and was proved by Marcus and Minc [MaMi62]
 
 [MaMi62] Marcus, Marvin and Minc, Henryk, Some results on doubly stochastic matrices. Proc. Amer. Math. Soc. (1962), 571-579.
 -/
-@[category research solved, AMS 15]
+@[category research solved, AMS 15, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/main/problems/499/Erdos499.lean"]
 lemma erdos_499 :
     answer(True) ↔ (∀ n, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ : Equiv.Perm (Fin n),
       n ^ (- n : ℤ) ≤ ∏ i, M i (σ i)) := by

--- a/FormalConjectures/ErdosProblems/613.lean
+++ b/FormalConjectures/ErdosProblems/613.lean
@@ -29,7 +29,7 @@ namespace Erdos613
 Let $n \geq 3$ and $G$ be a graph with $\binom{2n+1}{2} - \binom{n}{2} - 1$ edges.
 Must $G$ be the union of a bipartite graph and a graph with maximum degree less than $n$?
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/main/problems/613/Erdos613.lean"]
 theorem erdos_613 :
     answer(False) ↔
       ∀ n ≥ 3, ∀ (V : Type*) [Fintype V] (G : SimpleGraph V), [DecidableRel G.Adj] →


### PR DESCRIPTION
Resolves part of #4184: links `Jayyhk/erdos-lean`'s complete Lean proofs into FC's `formal_proof` tags for **Erdős 499 and 613**.

I diffed `Jayyhk/erdos-lean` (199 formalizations) against FC's `conjectures.json`, and verified each candidate by its **axiom footprint**, not just `sorry`-count. Of the 9 problems where FC has the (research-solved) statement with no link, only these two are complete, axiom-clean, and statement-matched:
- **499** (`erdos_499`) — doubly-stochastic permanent bound; RHS character-identical to Jayyhk's theorem.
- **613** (`erdos_613`) — the explicit 44-edge Pikhurko counterexample establishing `answer(False)`.

The other 7 I checked but did **not** tag, for the reasons #4184 cares about:
- **90, 659, 694, 1148** — the Lean file hides the hard input behind a custom `axiom` (Golod–Shafarevich, Bernays, Linnik, an assumed lemma), so it isn't a self-contained proof.
- **330, 351** — incomplete (`sorry`s).
- **678** — Jayyhk proves the *negation* of FC's `lcmInterval`-based RHS; that formalization looks **incorrect**. Flagging separately as a statement-fidelity issue, not a tag.

Tags use `formal_proof using lean4` (external proofs). The diff is reproducible against any fork.
