### PR TITLE
ErdosProblems: formalise 11 solved problems, linking plby/lean-proofs

### DIFF
--- a/FormalConjectures/ErdosProblems/1090.lean
+++ b/FormalConjectures/ErdosProblems/1090.lean
@@ -19,13 +19,17 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 1090
 
-*Reference:* [erdosproblems.com/1090](https://www.erdosproblems.com/1090)
+*References:*
+- [erdosproblems.com/1090](https://www.erdosproblems.com/1090)
+- [Er75f] Erdős, Paul, *On some problems of elementary and combinatorial geometry*. Ann. Mat. Pura Appl. (4) (1975), 99-108.
 -/
 
 namespace Erdos1090
 
 /--
 Let $k\geq 3$. Does there exist a finite set $A\subset \mathbb{R}^2$ such that, in any $2$-colouring of $A$, there exists a line which contains at least $k$ points from $A$, and all the points of $A$ on the line have the same colour?
+
+Erdős [Er75f] says Graham and Selfridge proved the answer is yes when $k=3$. Hunter has observed that, for sufficiently large $n$, a generic projection of $[k]^n$ into $\mathbb{R}^2$ has this property, by the Hales-Jewett theorem.
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1090.lean"]
 theorem erdos_1090 : answer(True) ↔ ∀ (k : ℕ), ∀ (hk : 3 ≤ k),

--- a/FormalConjectures/ErdosProblems/1090.lean
+++ b/FormalConjectures/ErdosProblems/1090.lean
@@ -25,13 +25,10 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos1090
 
 /--
-For every $k \ge 3$ there is a finite set $A \subseteq \mathbb{R}^2$ such that in every
-2-colouring of $A$ there is a line $S$ containing at least $k$ points of $A$, such that
-every point of $A$ on that line lies in $S$ and all of them have the same colour.
-The answer is yes (Hunter), via the Hales–Jewett theorem.
+Let $k\geq 3$. Does there exist a finite set $A\subset \mathbb{R}^2$ such that, in any $2$-colouring of $A$, there exists a line which contains at least $k$ points from $A$, and all the points of $A$ on the line have the same colour?
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1090.lean"]
-theorem erdos_1090 (k : ℕ) (hk : 3 ≤ k) :
+theorem erdos_1090 : answer(True) ↔ ∀ (k : ℕ), ∀ (hk : 3 ≤ k),
     ∃ (A : Finset (Fin 2 → ℝ)), ∀ (C : A → Fin 2),
       ∃ (S : Finset (Fin 2 → ℝ)), ∃ (hSA : S ⊆ A),
         Collinear ℝ (S : Set (Fin 2 → ℝ)) ∧ S.card ≥ k ∧

--- a/FormalConjectures/ErdosProblems/1090.lean
+++ b/FormalConjectures/ErdosProblems/1090.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 1090
+
+*Reference:* [erdosproblems.com/1090](https://www.erdosproblems.com/1090)
+-/
+
+namespace Erdos1090
+
+/--
+For every $k \ge 3$ there is a finite set $A \subseteq \mathbb{R}^2$ such that in every
+2-colouring of $A$ there is a line $S$ containing at least $k$ points of $A$, such that
+every point of $A$ on that line lies in $S$ and all of them have the same colour.
+The answer is yes (Hunter), via the Hales–Jewett theorem.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1090.lean"]
+theorem erdos_1090 (k : ℕ) (hk : 3 ≤ k) :
+    ∃ (A : Finset (Fin 2 → ℝ)), ∀ (C : A → Fin 2),
+      ∃ (S : Finset (Fin 2 → ℝ)), ∃ (hSA : S ⊆ A),
+        Collinear ℝ (S : Set (Fin 2 → ℝ)) ∧ S.card ≥ k ∧
+          (∀ y ∈ A, y ∈ affineSpan ℝ (S : Set (Fin 2 → ℝ)) → y ∈ S) ∧
+          ∃ c, ∀ x (hx : x ∈ S), C ⟨x, hSA hx⟩ = c := by
+  sorry
+
+end Erdos1090

--- a/FormalConjectures/ErdosProblems/1125.lean
+++ b/FormalConjectures/ErdosProblems/1125.lean
@@ -25,12 +25,13 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos1125
 
 /--
-If $f : \mathbb{R} \to \mathbb{R}$ satisfies $2f(x) \le f(x+h) + f(x+2h)$ for all $x$ and all
-$h > 0$, then $f$ is monotone. The answer is yes (Laczkovich).
+Let $f:\mathbb{R}\to \mathbb{R}$ be such that
+\[2f(x) \leq f(x+h)+f(x+2h)\]
+for every $x\in \mathbb{R}$ and $h>0$. Must $f$ be monotonic?
 -/
 @[category research solved, AMS 26, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1125.lean"]
-theorem erdos_1125 {f : ℝ → ℝ}
-    (hf : ∀ x : ℝ, ∀ h : ℝ, h > 0 → 2 * f x ≤ f (x + h) + f (x + 2 * h)) :
+theorem erdos_1125 : answer(True) ↔ ∀ (f : ℝ → ℝ)
+    (hf : ∀ x : ℝ, ∀ h : ℝ, h > 0 → 2 * f x ≤ f (x + h) + f (x + 2 * h)),
     Monotone f := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/1125.lean
+++ b/FormalConjectures/ErdosProblems/1125.lean
@@ -1,0 +1,37 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 1125
+
+*Reference:* [erdosproblems.com/1125](https://www.erdosproblems.com/1125)
+-/
+
+namespace Erdos1125
+
+/--
+If $f : \mathbb{R} \to \mathbb{R}$ satisfies $2f(x) \le f(x+h) + f(x+2h)$ for all $x$ and all
+$h > 0$, then $f$ is monotone. The answer is yes (Laczkovich).
+-/
+@[category research solved, AMS 26, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1125.lean"]
+theorem erdos_1125 {f : ℝ → ℝ}
+    (hf : ∀ x : ℝ, ∀ h : ℝ, h > 0 → 2 * f x ≤ f (x + h) + f (x + 2 * h)) :
+    Monotone f := by
+  sorry
+
+end Erdos1125

--- a/FormalConjectures/ErdosProblems/1125.lean
+++ b/FormalConjectures/ErdosProblems/1125.lean
@@ -19,7 +19,11 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 1125
 
-*Reference:* [erdosproblems.com/1125](https://www.erdosproblems.com/1125)
+*References:*
+- [erdosproblems.com/1125](https://www.erdosproblems.com/1125)
+- [Er81b] Erdős, P., *My Scottish Book 'Problems'*. The Scottish Book (1981), 27-35.
+- [Ke69] Kemperman, J. H. B., *On the regularity of generalized convex functions*. Trans. Amer. Math. Soc. (1969), 69-93.
+- [La84] Laczkovich, M., *On Kemperman's inequality $2f(x)\leq f(x+h)+f(x+2h)$*. Colloq. Math. (1984), 109-115.
 -/
 
 namespace Erdos1125
@@ -28,6 +32,8 @@ namespace Erdos1125
 Let $f:\mathbb{R}\to \mathbb{R}$ be such that
 \[2f(x) \leq f(x+h)+f(x+2h)\]
 for every $x\in \mathbb{R}$ and $h>0$. Must $f$ be monotonic?
+
+A problem of Kemperman [Ke69], who proved it is true if $f$ is measurable. Erdős [Er81b] wrote 'if it were my problem I would offer \$500 for it'. This was solved by Laczkovich [La84].
 -/
 @[category research solved, AMS 26, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1125.lean"]
 theorem erdos_1125 : answer(True) ↔ ∀ (f : ℝ → ℝ)

--- a/FormalConjectures/ErdosProblems/1126.lean
+++ b/FormalConjectures/ErdosProblems/1126.lean
@@ -27,16 +27,18 @@ open MeasureTheory
 namespace Erdos1126
 
 /--
-If $f : \mathbb{R} \to \mathbb{R}$ satisfies the Cauchy functional equation
-$f(x+y) = f(x) + f(y)$ for almost every pair $(x, y)$, then there is an additive function
-$h : \mathbb{R} \to \mathbb{R}$ agreeing with $f$ almost everywhere. The answer is yes (de Bruijn).
+If
+\[f(x+y)=f(x)+f(y)\]
+for almost all $x,y\in \mathbb{R}$ then there exists a function $g$ such that
+\[g(x+y)=g(x)+g(y)\]
+for all $x,y\in\mathbb{R}$ such that $f(x)=g(x)$ for almost all $x$.
 -/
 @[category research solved, AMS 26 28, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1126.lean"]
-theorem erdos_1126
+theorem erdos_1126 : answer(True) ↔ ∀
     (f : ℝ → ℝ)
     (h :
       ∀ᵐ (p : ℝ × ℝ) ∂(volume.prod volume),
-        f (p.1 + p.2) = f p.1 + f p.2) :
+        f (p.1 + p.2) = f p.1 + f p.2),
     ∃ h : ℝ → ℝ,
       (∀ x y, h (x + y) = h x + h y) ∧ (∀ᵐ x ∂volume, f x = h x) := by
   sorry

--- a/FormalConjectures/ErdosProblems/1126.lean
+++ b/FormalConjectures/ErdosProblems/1126.lean
@@ -19,7 +19,11 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 1126
 
-*Reference:* [erdosproblems.com/1126](https://www.erdosproblems.com/1126)
+*References:*
+- [erdosproblems.com/1126](https://www.erdosproblems.com/1126)
+- [Er60c] Erdős, P., *Problem 310*. Colloq. Math., 311.
+- [dB66] de Bruijn, N. G., *On almost additive functions*. Colloq. Math. (1966), 59-63.
+- [Ju65] Jurkat, Wolfgang B., *On Cauchy's functional equation*. Proc. Amer. Math. Soc. (1965), 683-686.
 -/
 
 open MeasureTheory
@@ -32,6 +36,8 @@ If
 for almost all $x,y\in \mathbb{R}$ then there exists a function $g$ such that
 \[g(x+y)=g(x)+g(y)\]
 for all $x,y\in\mathbb{R}$ such that $f(x)=g(x)$ for almost all $x$.
+
+Proved independently by de Bruijn [dB66] and Jurkat [Ju65].
 -/
 @[category research solved, AMS 26 28, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1126.lean"]
 theorem erdos_1126 : answer(True) ↔ ∀

--- a/FormalConjectures/ErdosProblems/1126.lean
+++ b/FormalConjectures/ErdosProblems/1126.lean
@@ -1,0 +1,44 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 1126
+
+*Reference:* [erdosproblems.com/1126](https://www.erdosproblems.com/1126)
+-/
+
+open MeasureTheory
+
+namespace Erdos1126
+
+/--
+If $f : \mathbb{R} \to \mathbb{R}$ satisfies the Cauchy functional equation
+$f(x+y) = f(x) + f(y)$ for almost every pair $(x, y)$, then there is an additive function
+$h : \mathbb{R} \to \mathbb{R}$ agreeing with $f$ almost everywhere. The answer is yes (de Bruijn).
+-/
+@[category research solved, AMS 26 28, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1126.lean"]
+theorem erdos_1126
+    (f : ℝ → ℝ)
+    (h :
+      ∀ᵐ (p : ℝ × ℝ) ∂(volume.prod volume),
+        f (p.1 + p.2) = f p.1 + f p.2) :
+    ∃ h : ℝ → ℝ,
+      (∀ x y, h (x + y) = h x + h y) ∧ (∀ᵐ x ∂volume, f x = h x) := by
+  sorry
+
+end Erdos1126

--- a/FormalConjectures/ErdosProblems/134.lean
+++ b/FormalConjectures/ErdosProblems/134.lean
@@ -25,15 +25,13 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos134
 
 /--
-For every triangle-free graph $G$ on $n$ vertices with maximum degree $o(\sqrt{n})$
-(degree below $n^{1/2 - \varepsilon}$), one can add edges to obtain a triangle-free graph $H$
-of diameter $2$ (every two distinct vertices are adjacent or share a common neighbour) while
-adding at most $\delta \cdot n^2$ edges, for every $\delta > 0$ and all sufficiently large $n$.
-This is Theorem 1.2 of Alon's "Triangle-free graphs of diameter 2".
+Let $\epsilon,\delta>0$ and $n$ be sufficiently large in terms of $\epsilon$ and $\delta$.
+Let $G$ be a triangle-free graph on $n$ vertices with maximum degree $<n^{1/2-\epsilon}$.
+Can $G$ be made into a triangle-free graph with diameter $2$ by adding at most $\delta n^2$ edges?
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos134.lean"]
-theorem erdos_134
-    {ε δ : ℝ} (hε : 0 < ε) (hδ : 0 < δ) :
+theorem erdos_134 : answer(True) ↔
+    ∀ (ε δ : ℝ) (hε : 0 < ε) (hδ : 0 < δ),
     ∃ N : ℕ, ∀ n ≥ N, ∀ G : SimpleGraph (Fin n),
       G.CliqueFree 3 →
       (∀ v : Fin n, (G.degree v : ℝ) < Real.rpow (n : ℝ) ((1 : ℝ) / 2 - ε)) →

--- a/FormalConjectures/ErdosProblems/134.lean
+++ b/FormalConjectures/ErdosProblems/134.lean
@@ -19,7 +19,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 134
 
-*Reference:* [erdosproblems.com/134](https://www.erdosproblems.com/134)
+*References:*
+- [erdosproblems.com/134](https://www.erdosproblems.com/134)
+- [Er97b] Erdős, Paul, *Some old and new problems in various branches of combinatorics*. Discrete Math. (1997), 227-231.
 -/
 
 namespace Erdos134
@@ -28,6 +30,8 @@ namespace Erdos134
 Let $\epsilon,\delta>0$ and $n$ be sufficiently large in terms of $\epsilon$ and $\delta$.
 Let $G$ be a triangle-free graph on $n$ vertices with maximum degree $<n^{1/2-\epsilon}$.
 Can $G$ be made into a triangle-free graph with diameter $2$ by adding at most $\delta n^2$ edges?
+
+Asked by Erdős and Gyárfás, who proved that this is the case when $G$ has maximum degree $\ll \log n/\log\log n$. A construction of Simonovits shows that this conjecture is false if we just have maximum degree $\leq Cn^{1/2}$, for some large enough $C$. In this note Alon solves this problem in a strong form, in particular proving that a triangle-free graph on $n$ vertices with maximum degree $<n^{1/2-\epsilon}$ can be made into a triangle-free graph with diameter $2$ by adding at most $O(n^{2-\epsilon})$ edges.
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos134.lean"]
 theorem erdos_134 : answer(True) ↔

--- a/FormalConjectures/ErdosProblems/134.lean
+++ b/FormalConjectures/ErdosProblems/134.lean
@@ -1,0 +1,47 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 134
+
+*Reference:* [erdosproblems.com/134](https://www.erdosproblems.com/134)
+-/
+
+namespace Erdos134
+
+/--
+For every triangle-free graph $G$ on $n$ vertices with maximum degree $o(\sqrt{n})$
+(degree below $n^{1/2 - \varepsilon}$), one can add edges to obtain a triangle-free graph $H$
+of diameter $2$ (every two distinct vertices are adjacent or share a common neighbour) while
+adding at most $\delta \cdot n^2$ edges, for every $\delta > 0$ and all sufficiently large $n$.
+This is Theorem 1.2 of Alon's "Triangle-free graphs of diameter 2".
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos134.lean"]
+theorem erdos_134
+    {ε δ : ℝ} (hε : 0 < ε) (hδ : 0 < δ) :
+    ∃ N : ℕ, ∀ n ≥ N, ∀ G : SimpleGraph (Fin n),
+      G.CliqueFree 3 →
+      (∀ v : Fin n, (G.degree v : ℝ) < Real.rpow (n : ℝ) ((1 : ℝ) / 2 - ε)) →
+      ∃ H : SimpleGraph (Fin n),
+        G ≤ H ∧
+        H.CliqueFree 3 ∧
+        (∀ x y : Fin n, x ≠ y → H.Adj x y ∨ ∃ z, H.Adj x z ∧ H.Adj z y) ∧
+        ((H.edgeFinset \ G.edgeFinset).card : ℝ) ≤ δ * (n : ℝ) ^ 2 := by
+  sorry
+
+end Erdos134

--- a/FormalConjectures/ErdosProblems/178.lean
+++ b/FormalConjectures/ErdosProblems/178.lean
@@ -27,17 +27,14 @@ namespace Erdos178
 open Finset BigOperators
 
 /--
-Given any infinite collection of infinite strictly increasing sequences of natural
-numbers $a_i : \mathbb{N} \to \mathbb{N}$, is there a colouring $f : \mathbb{N} \to \{-1, 1\}$
-such that for each $d$ the partial sums $\left|\sum_{j < m} f(a_i\,j)\right|$ are uniformly
-bounded over all $m$ and all $i < d$?
-
-The answer is yes (J. Beck, "Balancing Families of Integer Sequences",
-Combinatorica, 1981).
+Let $A_1,A_2,\ldots$ be an infinite collection of infinite sets of integers, say
+$A_i=\{a_{i1}<a_{i2}<\cdots\}$. Does there exist some $f:\mathbb{N}\to\{-1,1\}$ such that
+\[\max_{m, 1\leq i\leq d} \left\lvert \sum_{1\leq j\leq m} f(a_{ij})\right\rvert \ll_d 1\]
+for all $d\geq 1$?
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos178.lean"]
-theorem erdos_178 (a : ℕ → ℕ → ℕ)
-    (ha : ∀ i, StrictMono (a i)) :
+theorem erdos_178 : answer(True) ↔
+    ∀ (a : ℕ → ℕ → ℕ) (ha : ∀ i, StrictMono (a i)),
     ∃ f : ℕ → ℤ, (∀ n, f n = 1 ∨ f n = -1) ∧
       ∀ d : ℕ, ∃ C : ℕ, ∀ m i : ℕ, i < d →
         |∑ j ∈ range m, f (a i j)| ≤ ↑C := by

--- a/FormalConjectures/ErdosProblems/178.lean
+++ b/FormalConjectures/ErdosProblems/178.lean
@@ -1,0 +1,46 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 178
+
+*Reference:* [erdosproblems.com/178](https://www.erdosproblems.com/178)
+-/
+
+namespace Erdos178
+
+open Finset BigOperators
+
+/--
+Given any infinite collection of infinite strictly increasing sequences of natural
+numbers $a_i : \mathbb{N} \to \mathbb{N}$, is there a colouring $f : \mathbb{N} \to \{-1, 1\}$
+such that for each $d$ the partial sums $\left|\sum_{j < m} f(a_i\,j)\right|$ are uniformly
+bounded over all $m$ and all $i < d$?
+
+The answer is yes (J. Beck, "Balancing Families of Integer Sequences",
+Combinatorica, 1981).
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos178.lean"]
+theorem erdos_178 (a : ℕ → ℕ → ℕ)
+    (ha : ∀ i, StrictMono (a i)) :
+    ∃ f : ℕ → ℤ, (∀ n, f n = 1 ∨ f n = -1) ∧
+      ∀ d : ℕ, ∃ C : ℕ, ∀ m i : ℕ, i < d →
+        |∑ j ∈ range m, f (a i j)| ≤ ↑C := by
+  sorry
+
+end Erdos178

--- a/FormalConjectures/ErdosProblems/178.lean
+++ b/FormalConjectures/ErdosProblems/178.lean
@@ -19,7 +19,12 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 178
 
-*Reference:* [erdosproblems.com/178](https://www.erdosproblems.com/178)
+*References:*
+- [erdosproblems.com/178](https://www.erdosproblems.com/178)
+- [ErGr79] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number theory: van der Waerden's theorem and related topics*. Enseign. Math. (1979), 325-344.
+- [ErGr80] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number theory*. Monographies de L'Enseignement Mathématique (1980).
+- [Be81] Beck, József, *Balancing families of integer sequences*. Combinatorica (1981), 209-216.
+- [Be17] Beck, József, *A discrepancy problem: balancing infinite dimensional vectors*. Number theory—Diophantine problems, uniform distribution and applications (2017), 61-82.
 -/
 
 namespace Erdos178
@@ -31,6 +36,8 @@ Let $A_1,A_2,\ldots$ be an infinite collection of infinite sets of integers, say
 $A_i=\{a_{i1}<a_{i2}<\cdots\}$. Does there exist some $f:\mathbb{N}\to\{-1,1\}$ such that
 \[\max_{m, 1\leq i\leq d} \left\lvert \sum_{1\leq j\leq m} f(a_{ij})\right\rvert \ll_d 1\]
 for all $d\geq 1$?
+
+Erdős remarks 'it seems certain that the answer is affirmative'. This was solved by Beck [Be81]. Recently Beck [Be17] proved that one can replace $\ll_d 1$ with $\ll d^{4+\epsilon}$ for any $\epsilon>0$.
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos178.lean"]
 theorem erdos_178 : answer(True) ↔

--- a/FormalConjectures/ErdosProblems/493.lean
+++ b/FormalConjectures/ErdosProblems/493.lean
@@ -25,13 +25,12 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos493
 
 /--
-Is there some $k$ such that every sufficiently large integer $n$ can be written as
-$\prod a_i - \sum a_i$ for integers $a_1, \ldots, a_k$ all at least $2$?
-
-The answer is yes: already $k = 2$ suffices, since $n = (n + 2) \cdot 2 - ((n + 2) + 2)$.
+Does there exist a $k$ such that every sufficiently large integer can be written in the form
+\[\prod_{i=1}^k a_i - \sum_{i=1}^k a_i\]
+for some integers $a_i\geq 2$?
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos493.lean"]
-theorem erdos_493 :
+theorem erdos_493 : answer(True) ↔
     ∃ k : ℕ, ∃ N : ℤ, ∀ n : ℤ, N ≤ n →
       ∃ a : Fin k → ℤ,
         (∀ i : Fin k, (2 : ℤ) ≤ a i) ∧

--- a/FormalConjectures/ErdosProblems/493.lean
+++ b/FormalConjectures/ErdosProblems/493.lean
@@ -19,7 +19,9 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 493
 
-*Reference:* [erdosproblems.com/493](https://www.erdosproblems.com/493)
+*References:*
+- [erdosproblems.com/493](https://www.erdosproblems.com/493)
+- [Er61] Erdős, Paul, *Some unsolved problems*. Magyar Tud. Akad. Mat. Kutató Int. Közl. (1961), 221-254.
 -/
 
 namespace Erdos493
@@ -28,6 +30,8 @@ namespace Erdos493
 Does there exist a $k$ such that every sufficiently large integer can be written in the form
 \[\prod_{i=1}^k a_i - \sum_{i=1}^k a_i\]
 for some integers $a_i\geq 2$?
+
+Erdős attributes this question to Schinzel. Eli Seamans has observed that the answer is yes (with $k=2$) for a very simple reason: $n = 2(n+2)-(2+(n+2))$. There may well have been some additional constraint in the problem as Schinzel posed it, but [Er61] does not record what this is.
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos493.lean"]
 theorem erdos_493 : answer(True) ↔

--- a/FormalConjectures/ErdosProblems/493.lean
+++ b/FormalConjectures/ErdosProblems/493.lean
@@ -1,0 +1,41 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 493
+
+*Reference:* [erdosproblems.com/493](https://www.erdosproblems.com/493)
+-/
+
+namespace Erdos493
+
+/--
+Is there some $k$ such that every sufficiently large integer $n$ can be written as
+$\prod a_i - \sum a_i$ for integers $a_1, \ldots, a_k$ all at least $2$?
+
+The answer is yes: already $k = 2$ suffices, since $n = (n + 2) \cdot 2 - ((n + 2) + 2)$.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos493.lean"]
+theorem erdos_493 :
+    ∃ k : ℕ, ∃ N : ℤ, ∀ n : ℤ, N ≤ n →
+      ∃ a : Fin k → ℤ,
+        (∀ i : Fin k, (2 : ℤ) ≤ a i) ∧
+        (∏ i : Fin k, a i) - (∑ i : Fin k, a i) = n := by
+  sorry
+
+end Erdos493

--- a/FormalConjectures/ErdosProblems/532.lean
+++ b/FormalConjectures/ErdosProblems/532.lean
@@ -25,16 +25,17 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos532
 
 /--
-If the natural numbers are $2$-coloured, then there is an infinite set $A \subseteq \mathbb{N}$
-whose nonempty finite subset sums are all the same colour. The answer is yes, a consequence of
-Hindman's theorem.
+If $\mathbb{N}$ is 2-coloured then is there some infinite set $A\subseteq \mathbb{N}$ such that
+all finite subset sums\[ \sum_{n\in S}n\](as $S$ ranges over all non-empty finite subsets of $A$)
+are monochromatic?
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos532.lean"]
-theorem erdos_532 (c : ℕ → Fin 2) :
-    ∃ A : Set ℕ, A.Infinite ∧
-      ∃ color : Fin 2,
-        ∀ S : Finset ℕ, S.Nonempty → ↑S ⊆ A →
-          c (∑ n ∈ S, n) = color := by
+theorem erdos_532 :
+    answer(True) ↔ ∀ (c : ℕ → Fin 2),
+      ∃ A : Set ℕ, A.Infinite ∧
+        ∃ color : Fin 2,
+          ∀ S : Finset ℕ, S.Nonempty → ↑S ⊆ A →
+            c (∑ n ∈ S, n) = color := by
   sorry
 
 end Erdos532

--- a/FormalConjectures/ErdosProblems/532.lean
+++ b/FormalConjectures/ErdosProblems/532.lean
@@ -1,0 +1,40 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 532
+
+*Reference:* [erdosproblems.com/532](https://www.erdosproblems.com/532)
+-/
+
+namespace Erdos532
+
+/--
+If the natural numbers are $2$-coloured, then there is an infinite set $A \subseteq \mathbb{N}$
+whose nonempty finite subset sums are all the same colour. The answer is yes, a consequence of
+Hindman's theorem.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos532.lean"]
+theorem erdos_532 (c : ℕ → Fin 2) :
+    ∃ A : Set ℕ, A.Infinite ∧
+      ∃ color : Fin 2,
+        ∀ S : Finset ℕ, S.Nonempty → ↑S ⊆ A →
+          c (∑ n ∈ S, n) = color := by
+  sorry
+
+end Erdos532

--- a/FormalConjectures/ErdosProblems/532.lean
+++ b/FormalConjectures/ErdosProblems/532.lean
@@ -19,7 +19,12 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 532
 
-*Reference:* [erdosproblems.com/532](https://www.erdosproblems.com/532)
+*References:*
+- [erdosproblems.com/532](https://www.erdosproblems.com/532)
+- [Er73] Erdős, P., *Problems and results on combinatorial number theory*. A survey of combinatorial theory (1973), 117-138.
+- [Er75b] Erdős, Paul, *Problems and results in combinatorial number theory*. Journées Arithmétiques de Bordeaux (1975), 295-310.
+- [Er77c] Erdős, Paul, *Problems and results on combinatorial number theory. III*. Number theory day (1977), 43-72.
+- [Hi74] Hindman, Neil, *Finite sums from sequences within cells of a partition of $\mathbb{N}$*. J. Combinatorial Theory Ser. A (1974), 1-11.
 -/
 
 namespace Erdos532
@@ -28,6 +33,8 @@ namespace Erdos532
 If $\mathbb{N}$ is 2-coloured then is there some infinite set $A\subseteq \mathbb{N}$ such that
 all finite subset sums\[ \sum_{n\in S}n\](as $S$ ranges over all non-empty finite subsets of $A$)
 are monochromatic?
+
+Asked by Graham and Rothschild. Proved by Hindman [Hi74] (for any number of colours).
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos532.lean"]
 theorem erdos_532 :

--- a/FormalConjectures/ErdosProblems/729.lean
+++ b/FormalConjectures/ErdosProblems/729.lean
@@ -25,18 +25,18 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos729
 
 /--
-For any $C > 0$, there exists a constant $K \geq 3$ such that there are infinitely many triples
-$(a, b, n)$ with $a + b > n + C \log n$ and the denominator of $n!/(a!\, b!)$ being $K$-smooth (no
-prime factor exceeding $K$). This answers the Erdős–Graham–Ruzsa–Straus problem affirmatively.
+Let $C>0$ be a constant. Are there infinitely many integers $a,b,n$ with $a+b> n+C\log n$ such
+that the denominator of\[\frac{n!}{a!b!}\]contains only primes $\ll_C 1$?
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos729.lean"]
-theorem erdos_729 (C : ℝ) (hC : C > 0) :
-    ∃ K ≥ 3, Set.Infinite { T : ℕ × ℕ × ℕ |
-      let (a, b, n) := T
-      a > 0 ∧ b > 0 ∧ n > 0 ∧
-      (a : ℝ) + b > n + C * Real.log n ∧
-      ∀ p, p.Prime → p > K →
-        padicValNat p ((n.factorial / (a.factorial * b.factorial) : ℚ).den) = 0 } := by
+theorem erdos_729 :
+    answer(True) ↔ ∀ (C : ℝ) (hC : C > 0),
+      ∃ K ≥ 3, Set.Infinite { T : ℕ × ℕ × ℕ |
+        let (a, b, n) := T
+        a > 0 ∧ b > 0 ∧ n > 0 ∧
+        (a : ℝ) + b > n + C * Real.log n ∧
+        ∀ p, p.Prime → p > K →
+          padicValNat p ((n.factorial / (a.factorial * b.factorial) : ℚ).den) = 0 } := by
   sorry
 
 end Erdos729

--- a/FormalConjectures/ErdosProblems/729.lean
+++ b/FormalConjectures/ErdosProblems/729.lean
@@ -19,7 +19,10 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 729
 
-*Reference:* [erdosproblems.com/729](https://www.erdosproblems.com/729)
+*References:*
+- [erdosproblems.com/729](https://www.erdosproblems.com/729)
+- [EGRS75] Erdős, P. and Graham, R. L. and Ruzsa, I. Z. and Straus, E. G., *On the prime factors of $\binom{2n}{n}$*. Math. Comp. (1975), 83-92.
+- [Er68c] Erdős, P., *Aufgabe 557*. Elemente Math. (1968), 111-113.
 -/
 
 namespace Erdos729
@@ -27,6 +30,8 @@ namespace Erdos729
 /--
 Let $C>0$ be a constant. Are there infinitely many integers $a,b,n$ with $a+b> n+C\log n$ such
 that the denominator of\[\frac{n!}{a!b!}\]contains only primes $\ll_C 1$?
+
+Erdős [Er68c] proved that if $a!b!\mid n!$ then $a+b\leq n+O(\log n)$. This has been proved in the affirmative by Barreto and Leeham, using ChatGPT and Aristotle, with a modification of the argument used for [728].
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos729.lean"]
 theorem erdos_729 :

--- a/FormalConjectures/ErdosProblems/729.lean
+++ b/FormalConjectures/ErdosProblems/729.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 729
+
+*Reference:* [erdosproblems.com/729](https://www.erdosproblems.com/729)
+-/
+
+namespace Erdos729
+
+/--
+For any $C > 0$, there exists a constant $K \geq 3$ such that there are infinitely many triples
+$(a, b, n)$ with $a + b > n + C \log n$ and the denominator of $n!/(a!\, b!)$ being $K$-smooth (no
+prime factor exceeding $K$). This answers the Erdős–Graham–Ruzsa–Straus problem affirmatively.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos729.lean"]
+theorem erdos_729 (C : ℝ) (hC : C > 0) :
+    ∃ K ≥ 3, Set.Infinite { T : ℕ × ℕ × ℕ |
+      let (a, b, n) := T
+      a > 0 ∧ b > 0 ∧ n > 0 ∧
+      (a : ℝ) + b > n + C * Real.log n ∧
+      ∀ p, p.Prime → p > K →
+        padicValNat p ((n.factorial / (a.factorial * b.factorial) : ℚ).den) = 0 } := by
+  sorry
+
+end Erdos729

--- a/FormalConjectures/ErdosProblems/871.lean
+++ b/FormalConjectures/ErdosProblems/871.lean
@@ -19,13 +19,18 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 871
 
-*Reference:* [erdosproblems.com/871](https://www.erdosproblems.com/871)
+*References:*
+- [erdosproblems.com/871](https://www.erdosproblems.com/871)
+- [ErNa88] Erdős, Paul and Nathanson, Melvyn B., *Partitions of bases into disjoint unions of bases*. J. Number Theory (1988), 1-9.
+- [ErNa89] Erdős, Paul and Nathanson, Melvyn B., *Additive bases with many representations*. Acta Arith. (1989), 399-406.
 -/
 
 namespace Erdos871
 
 /--
 Let $A$ be an additive basis of order $2$, and suppose $1_A\ast 1_A(n)\to \infty$ as $n\to \infty$. Can $A$ be partitioned into two disjoint additive bases of order $2$?
+
+A question of Erdős and Nathanson [ErNa88], who proved this is true if $1_A\ast 1_A(n) > c\log n$ (for all large $n$) for some constant $c>(\log\frac{4}{3})^{-1}$. Erdős and Nathanson [ErNa89] also proved that for every $t$ there exists a basis $A$ of order $2$ such that $1_A\ast 1_A(n)\geq t$ for all large $n$ and yet $A$ cannot be partitioned into two disjoint additive bases. This has been disproved by Larsen using Claude Opus 4.5 - in fact only a small modification of the argument of [ErNa89] is required.
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos871.lean"]
 theorem erdos_871 :

--- a/FormalConjectures/ErdosProblems/871.lean
+++ b/FormalConjectures/ErdosProblems/871.lean
@@ -1,0 +1,47 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 871
+
+*Reference:* [erdosproblems.com/871](https://www.erdosproblems.com/871)
+-/
+
+namespace Erdos871
+
+/--
+A set $A \subseteq \mathbb{N}$ is an (asymptotic) additive basis of order $2$ if every sufficiently
+large $n$ can be written as $a + b$ with $a, b \in A$. There exists an additive basis of order $2$
+(in fact with unboundedly many such representations as $n$ grows) that cannot be written as the
+disjoint union of two additive bases of order $2$. This answers Erdős' question in the negative.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos871.lean"]
+theorem erdos_871 :
+    ∃ (A : Set ℕ),
+      (∀ᶠ n in Filter.atTop, ∃ a ∈ A, ∃ b ∈ A, a + b = n) ∧
+      (∀ t, ∀ᶠ n in Filter.atTop, ∃ pairs : Finset (ℕ × ℕ),
+        pairs.card ≥ t ∧
+          ∀ p ∈ pairs, p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 + p.2 = n ∧ p.1 ≤ p.2) ∧
+      ¬∃ (B C : Set ℕ),
+        (∀ x, x ∈ A ↔ x ∈ B ∨ x ∈ C) ∧
+        Disjoint B C ∧
+        (∀ᶠ n in Filter.atTop, ∃ a ∈ B, ∃ b ∈ B, a + b = n) ∧
+        (∀ᶠ n in Filter.atTop, ∃ a ∈ C, ∃ b ∈ C, a + b = n) := by
+  sorry
+
+end Erdos871

--- a/FormalConjectures/ErdosProblems/871.lean
+++ b/FormalConjectures/ErdosProblems/871.lean
@@ -25,23 +25,21 @@ import FormalConjectures.Util.ProblemImports
 namespace Erdos871
 
 /--
-A set $A \subseteq \mathbb{N}$ is an (asymptotic) additive basis of order $2$ if every sufficiently
-large $n$ can be written as $a + b$ with $a, b \in A$. There exists an additive basis of order $2$
-(in fact with unboundedly many such representations as $n$ grows) that cannot be written as the
-disjoint union of two additive bases of order $2$. This answers Erdős' question in the negative.
+Let $A$ be an additive basis of order $2$, and suppose $1_A\ast 1_A(n)\to \infty$ as $n\to \infty$. Can $A$ be partitioned into two disjoint additive bases of order $2$?
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos871.lean"]
 theorem erdos_871 :
-    ∃ (A : Set ℕ),
-      (∀ᶠ n in Filter.atTop, ∃ a ∈ A, ∃ b ∈ A, a + b = n) ∧
-      (∀ t, ∀ᶠ n in Filter.atTop, ∃ pairs : Finset (ℕ × ℕ),
-        pairs.card ≥ t ∧
-          ∀ p ∈ pairs, p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 + p.2 = n ∧ p.1 ≤ p.2) ∧
-      ¬∃ (B C : Set ℕ),
-        (∀ x, x ∈ A ↔ x ∈ B ∨ x ∈ C) ∧
-        Disjoint B C ∧
-        (∀ᶠ n in Filter.atTop, ∃ a ∈ B, ∃ b ∈ B, a + b = n) ∧
-        (∀ᶠ n in Filter.atTop, ∃ a ∈ C, ∃ b ∈ C, a + b = n) := by
+    answer(False) ↔
+      ∀ (A : Set ℕ),
+        (∀ᶠ n in Filter.atTop, ∃ a ∈ A, ∃ b ∈ A, a + b = n) ∧
+        (∀ t, ∀ᶠ n in Filter.atTop, ∃ pairs : Finset (ℕ × ℕ),
+          pairs.card ≥ t ∧
+            ∀ p ∈ pairs, p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 + p.2 = n ∧ p.1 ≤ p.2) →
+        ∃ (B C : Set ℕ),
+          (∀ x, x ∈ A ↔ x ∈ B ∨ x ∈ C) ∧
+          Disjoint B C ∧
+          (∀ᶠ n in Filter.atTop, ∃ a ∈ B, ∃ b ∈ B, a + b = n) ∧
+          (∀ᶠ n in Filter.atTop, ∃ a ∈ C, ∃ b ∈ C, a + b = n) := by
   sorry
 
 end Erdos871

--- a/FormalConjectures/ErdosProblems/904.lean
+++ b/FormalConjectures/ErdosProblems/904.lean
@@ -19,7 +19,13 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 904
 
-*Reference:* [erdosproblems.com/904](https://www.erdosproblems.com/904)
+*References:*
+- [erdosproblems.com/904](https://www.erdosproblems.com/904)
+- [BoEr75] Bollobás, B. and Erdős, P., *Unsolved Problems*. Proc. Fifth British Combinatorial Conf. (1975), 678-680.
+- [Er75] Erdős, P., *Some recent progress on extremal problems in graph theory*. Congr. Numer. (1975), 3-14.
+- [Ed78] Edwards, C. S., *Complete subgraphs with largest sum of vertex degrees*. (1978), 293-306.
+- [Fa92] Faudree, Ralph J., *Complete subgraphs with large degree sums*. J. Graph Theory (1992), 327-334.
+- [BoNi05] Bollobás, Béla and Nikiforov, Vladimir, *The sum of degrees in cliques*. Electron. J. Combin. (2005), Note 21, 10.
 -/
 
 namespace Erdos904
@@ -38,6 +44,8 @@ vertices with no $K_{r+1}$).
 
 If $G$ is a graph with $n$ vertices and $m\geq t_r(n)$ edges there exists a clique on $r$ vertices,
 say $x_1,\ldots,x_r$, such that\[d(x_1)+\cdots+d(x_r)\geq \frac{2rm}{n}.\]
+
+A conjecture of Bollobás and Erdős. This was conjectured in [Er75] only in the special case $r=3$. Edwards [Ed78] proved the conjecture for $2\leq r\leq 8$ (under the additional assumption that $n\geq r^2$). Faudree [Fa92] proved the conjecture for all $r\geq 2$ provided $n>\frac{r-1}{4}r^2$. The full conjecture was proved by Bollobás and Nikiforov [BoNi05].
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos904.lean"]
 theorem erdos_904 :

--- a/FormalConjectures/ErdosProblems/904.lean
+++ b/FormalConjectures/ErdosProblems/904.lean
@@ -26,8 +26,6 @@ namespace Erdos904
 
 open Finset
 
-variable {V : Type*} [Fintype V]
-
 /-- An abbreviation for the fixed number of vertices $n$ in the graph. -/
 abbrev n (V : Type*) [Fintype V] : ℕ := Fintype.card V
 

--- a/FormalConjectures/ErdosProblems/904.lean
+++ b/FormalConjectures/ErdosProblems/904.lean
@@ -35,15 +35,17 @@ abbrev n (V : Type*) [Fintype V] : ℕ := Fintype.card V
 abbrev turanNumber (n r : ℕ) : ℕ := #(SimpleGraph.turanGraph n r).edgeFinset
 
 /--
-A conjecture of Bollobás and Nikiforov on cliques and degrees: every graph $G$ with at least
-$\mathrm{turanNumber}(n, r)$ edges (the Turán bound forcing a $K_r$, for $1 \le r \le n$) contains
-an $r$-clique $s$ whose vertices have large total degree, namely
-$2r \cdot e(G) \le n \cdot \sum_{v \in s} \deg(v)$. This is true: such a clique always exists.
+Let $r\geq 2$ and let $t_r(n)$ be the Turán number (the maximal number of edges in a graph on $n$
+vertices with no $K_{r+1}$).
+
+If $G$ is a graph with $n$ vertices and $m\geq t_r(n)$ edges there exists a clique on $r$ vertices,
+say $x_1,\ldots,x_r$, such that\[d(x_1)+\cdots+d(x_r)\geq \frac{2rm}{n}.\]
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos904.lean"]
-theorem erdos_904 (G : SimpleGraph V) [DecidableRel G.Adj]
-    {r : ℕ} (hr : r ∈ Set.Icc 1 (n V)) (hm : turanNumber (n V) r ≤ #G.edgeFinset) :
-    ∃ s, G.IsNClique r s ∧ 2 * r * #G.edgeFinset ≤ n V * ∑ v ∈ s, G.degree v := by
+theorem erdos_904 :
+    answer(True) ↔ ∀ (V : Type*) [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+      (r : ℕ) (hr : r ∈ Set.Icc 1 (n V)) (hm : turanNumber (n V) r ≤ #G.edgeFinset),
+      ∃ s, G.IsNClique r s ∧ 2 * r * #G.edgeFinset ≤ n V * ∑ v ∈ s, G.degree v := by
   sorry
 
 end Erdos904

--- a/FormalConjectures/ErdosProblems/904.lean
+++ b/FormalConjectures/ErdosProblems/904.lean
@@ -1,0 +1,49 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 904
+
+*Reference:* [erdosproblems.com/904](https://www.erdosproblems.com/904)
+-/
+
+namespace Erdos904
+
+open Finset
+
+variable {V : Type*} [Fintype V]
+
+/-- An abbreviation for the fixed number of vertices $n$ in the graph. -/
+abbrev n (V : Type*) [Fintype V] : ℕ := Fintype.card V
+
+/-- The number of edges of the Turán graph $T(n, r)$, i.e. the Turán number. -/
+abbrev turanNumber (n r : ℕ) : ℕ := #(SimpleGraph.turanGraph n r).edgeFinset
+
+/--
+A conjecture of Bollobás and Nikiforov on cliques and degrees: every graph $G$ with at least
+$\mathrm{turanNumber}(n, r)$ edges (the Turán bound forcing a $K_r$, for $1 \le r \le n$) contains
+an $r$-clique $s$ whose vertices have large total degree, namely
+$2r \cdot e(G) \le n \cdot \sum_{v \in s} \deg(v)$. This is true: such a clique always exists.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos904.lean"]
+theorem erdos_904 (G : SimpleGraph V) [DecidableRel G.Adj]
+    {r : ℕ} (hr : r ∈ Set.Icc 1 (n V)) (hm : turanNumber (n V) r ≤ #G.edgeFinset) :
+    ∃ s, G.IsNClique r s ∧ 2 * r * #G.edgeFinset ≤ n V * ∑ v ∈ s, G.degree v := by
+  sorry
+
+end Erdos904

--- a/FormalConjectures/ErdosProblems/923.lean
+++ b/FormalConjectures/ErdosProblems/923.lean
@@ -19,7 +19,10 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 923
 
-*Reference:* [erdosproblems.com/923](https://www.erdosproblems.com/923)
+*References:*
+- [erdosproblems.com/923](https://www.erdosproblems.com/923)
+- [Er69b] Erdős, P., *Problems and results in chromatic graph theory*. Proof Techniques in Graph Theory (1969), 27-35.
+- [Ro77] Rödl, V., *On the chromatic number of subgraphs of a given graph*. Proc. Amer. Math. Soc. (1977), 370-371.
 -/
 
 namespace Erdos923
@@ -29,6 +32,8 @@ open SimpleGraph
 /--
 Is it true that, for every $k$, there is some $f(k)$ such that if $G$ has chromatic number
 $\geq f(k)$ then $G$ contains a triangle-free subgraph with chromatic number $\geq k$?
+
+This is true, as shown by Rödl [Ro77].
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos923.lean"]
 theorem erdos_923 : answer(True) ↔ ∀ (V : Type*) (n : ℕ),

--- a/FormalConjectures/ErdosProblems/923.lean
+++ b/FormalConjectures/ErdosProblems/923.lean
@@ -1,0 +1,39 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 923
+
+*Reference:* [erdosproblems.com/923](https://www.erdosproblems.com/923)
+-/
+
+namespace Erdos923
+
+open SimpleGraph
+
+/--
+For every $n$ there exists $f(n)$ such that any graph $G$ with $\chi(G) \ge f(n)$ has a
+triangle-free subgraph $H$ with $\chi(H) \ge n$. This is a theorem of Rödl.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos923.lean"]
+theorem erdos_923 {V : Type*} (n : ℕ) :
+    ∃ k : ℕ, ∀ G : SimpleGraph V, k ≤ G.chromaticNumber →
+    ∃ H ≤ G, n ≤ H.chromaticNumber ∧ H.CliqueFree 3 := by
+  sorry
+
+end Erdos923

--- a/FormalConjectures/ErdosProblems/923.lean
+++ b/FormalConjectures/ErdosProblems/923.lean
@@ -27,11 +27,11 @@ namespace Erdos923
 open SimpleGraph
 
 /--
-For every $n$ there exists $f(n)$ such that any graph $G$ with $\chi(G) \ge f(n)$ has a
-triangle-free subgraph $H$ with $\chi(H) \ge n$. This is a theorem of Rödl.
+Is it true that, for every $k$, there is some $f(k)$ such that if $G$ has chromatic number
+$\geq f(k)$ then $G$ contains a triangle-free subgraph with chromatic number $\geq k$?
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos923.lean"]
-theorem erdos_923 {V : Type*} (n : ℕ) :
+theorem erdos_923 : answer(True) ↔ ∀ (V : Type*) (n : ℕ),
     ∃ k : ℕ, ∀ G : SimpleGraph V, k ≤ G.chromaticNumber →
     ∃ H ≤ G, n ≤ H.chromaticNumber ∧ H.CliqueFree 3 := by
   sorry


### PR DESCRIPTION
Part of #3998. Closes #919 (Erdős 729) and #993 (Erdős 871).

Adds statements for 11 solved Erdős problems FC doesn't have yet, each linking plby's proof in `src/v4.29.1` via `formal_proof using lean4`. Statement-only; the proofs stay in plby's repo. All files are ports of @plby's hosted formalizations.

A small first batch. I have ~100 more done locally and would rather you sign off on the conventions before I send the rest. I checked each statement against its erdosproblems.com page, not only that it compiles. One caveat: in 178 the sequences range over ℕ where the source says ℤ (non-weakening, but the one spot that isn't a literal transcription).

Who formalized each (from plby's `sources.yaml`):

```
134: "This was formalized in Lean by Boris Alexeev using Aristotle."
178: "This was formalized in Lean by Matteo Del Vecchio using Aristotle."
493: "This was formalized in Lean by Zheng Yuan using Seed-Prover 1.5, Aristotle, and ChatGPT."
532: "This was formalized in Lean by David Wärn."
729: "This was formalized in Lean by Kevin Barreto using Aristotle."
871: "This was formalized in Lean by Daniel Larsen using Claude Opus 4.5 and Gemini 3 Pro."
904: "This was formalized in Lean by Parcly Taxel using Aristotle."
923: "This was formalized in Lean by Parcly Taxel using Aristotle."
1090: "This was formalized in Lean by JoshuaB using Aristotle and Gemini 3.0 Flash."
1125: "This was formalized in Lean by Stefano Rocca using Aristotle."
1126: "This was formalized in Lean by JoshuaB using Aristotle."
```

The conditional-on-axiom problems will come separately, with a docstring note rather than `formal_proof`, per the discussion above.
