### PR TITLE
feat(WrittenOnTheWallII): prove Star5 average-degree and residue

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -560,7 +560,7 @@ theorem Star5_max_deg : Star5.maxDegree = 5 := by
 
 @[category test, AMS 5]
 theorem Star5_avg_deg : averageDegree Star5 = 5/3 := by
-  sorry
+  unfold averageDegree; simp [Fintype.card_sum, Fintype.card_fin]; decide +native
 
 @[category test, AMS 5]
 theorem Star5_matching : matchingNumber Star5 = 1 := by
@@ -601,7 +601,7 @@ theorem Star5_matching : matchingNumber Star5 = 1 := by
 
 @[category test, AMS 5]
 theorem Star5_residue : residue Star5 = 5 := by
-  sorry
+  unfold residue; decide +native
 
 @[category test, AMS 5]
 theorem Star5_annihilation : annihilationNumber Star5 = 5 := by


### PR DESCRIPTION
Follow-up to #4304. Closes two more `sorry`s in `FormalConjectures/WrittenOnTheWallII/Test.lean`:

- `Star5_avg_deg` — `averageDegree Star5 = 5/3`
- `Star5_residue` — `residue Star5 = 5`

Both by `decide +native`, matching the other graphs' `avg_deg`/`residue` proofs; the `Fin 1 ⊕ Fin 5` sum type is handled via `Fintype.card_sum`. `lake --wfail build` is clean.

Remaining in the file (genuinely harder, left as `sorry`): the five `cvetkovic` (spectral) and `C6`/`PetersenGraph` girth (girth lower bound).
