### PR TITLE
feat(ErdosProblems/686): prove variants.nine via explicit witness

### DIFF
--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -97,7 +97,10 @@ for some $k≥2$ and $m≥n+k$?
 theorem erdos_686.variants.nine :
     answer(True) ↔ ∃ᵉ (k ≥ 2) (n : ℕ) (m ≥ n + k),
       (9 : ℚ) = (∏ i ∈ Finset.Icc 1 k, (m + i)) / (∏ i ∈ Finset.Icc 1 k, (n + i)) := by
-  sorry
+  -- Witness: k = 3, n = 11, m = 25, since (26·27·28)/(12·13·14) = 19656/2184 = 9.
+  simp only [true_iff]
+  refine ⟨3, by norm_num, 11, 25, by norm_num, ?_⟩
+  norm_num [Finset.prod_Icc_succ_top, Finset.Icc_self, Finset.prod_singleton]
 
 /--
 Can $25$ be written as


### PR DESCRIPTION
Closes the `erdos_686.variants.nine` sorry with an explicit witness.

Taking `k = 3`, `n = 11`, `m = 25` gives

```
(26·27·28) / (12·13·14) = 19656 / 2184 = 9,
```

with `m = 25 ≥ n + k = 14`. The proof supplies that witness, then `norm_num` discharges the rational identity after `Finset.prod_Icc_succ_top` unfolds the interval products.

The `@[category research solved, AMS 11]` attribute and the docstring stay as they were; only the proof body changes.

Verified against the pinned Mathlib: the file compiles, and `#print axioms erdos_686.variants.nine` returns `[propext, Classical.choice, Quot.sound]`. No `sorryAx`, no `native_decide`.

I used AI assistance (Claude) to draft the proof and verified it myself.
