### PR TITLE
feat(ErdosProblems/409): prove the totient-plus-one iteration reaches a prime

### DIFF
--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -43,7 +43,25 @@ reaches a prime. -/
 @[category test, AMS 11]
 theorem erdos_409.variants.termination (n : ℕ) (hn : 0 < n) :
     ∃ i, (φ · + 1)^[i] n |>.Prime := by
-  sorry
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    by_cases hp : n.Prime
+    · exact ⟨0, by simpa using hp⟩
+    · have h1 : n = 1 ∨ 1 < n := by omega
+      rcases h1 with h1 | h1
+      · subst h1
+        refine ⟨1, ?_⟩
+        norm_num [Function.iterate_one, Nat.totient_one]
+      · have hlt : φ n < n := Nat.totient_lt n h1
+        have hne : φ n ≠ n - 1 := by
+          intro h
+          exact hp ((Nat.totient_eq_iff_prime hn).1 h)
+        have hdec : φ n + 1 < n := by omega
+        have hpos : 0 < φ n + 1 := by positivity
+        obtain ⟨i, hi⟩ := ih (φ n + 1) hdec hpos
+        refine ⟨i + 1, ?_⟩
+        rw [Function.iterate_succ_apply]
+        exact hi
 
 -- Formalisation note: it's possible that solution to `erdos_409.parts.i` needs to be
 -- expressed asymptotically. To handle this we include `IsTheta`, `IsBigO`


### PR DESCRIPTION
Closes `erdos_409.variants.termination`: for every n > 0, iterating n ↦ φ(n)+1 eventually reaches a prime. Proof by strong induction using `Nat.totient_lt` and `Nat.totient_eq_iff_prime`.