### PR TITLE
feat(ErdosProblems): close textbook sorries in 36, 340, 456, 828, 1054

### DIFF
--- a/FormalConjectures/ErdosProblems/1054.lean
+++ b/FormalConjectures/ErdosProblems/1054.lean
@@ -76,6 +76,79 @@ theorem f_undefined_at_2 : f 2 = 0 := by
 of $m$ for some $k\geq 1$. Show that $f$ is undefined at $n=5$, i.e. we get the junk value $0$. -/
 @[category textbook, AMS 11]
 theorem f_undefined_at_3 : f 5 = 0 := by
-  sorry
+  rw [f, dif_neg]
+  rintro ⟨m, k, hk, hsum⟩
+  rcases eq_or_ne m 0 with rfl | hm
+  · simp at hsum
+  · set p : ℕ → Prop := fun x => x ∈ m.divisors with hpdef
+    have hfin : (setOf p).Finite := Set.finite_mem_finset m.divisors
+    have hg0 : Nat.nth p 0 = 1 := Nat.nth_divisors_zero hm
+    -- The `j`-th smallest divisor is at least `j + 1` (for `j` below the number of divisors).
+    have hlb : ∀ j, j < hfin.toFinset.card → j + 1 ≤ Nat.nth p j := by
+      intro j
+      induction j with
+      | zero => intro _; omega
+      | succ n ih =>
+        intro hj
+        have h1 := Nat.nth_lt_nth_of_lt_card hfin (show n < n + 1 by omega)
+          (show n + 1 < hfin.toFinset.card by omega)
+        have h2 := ih (by omega)
+        omega
+    -- The second smallest divisor of `m` is never `4`: if `4 ∣ m` then `2 ∣ m`, so `2` would be
+    -- the second smallest divisor.
+    have refute4 : Nat.nth p 1 ≠ 4 := by
+      intro h
+      have hne : Nat.nth p 1 ≠ 0 := by rw [h]; norm_num
+      have hcard1 : 1 < hfin.toFinset.card := by
+        by_contra hcon
+        push_neg at hcon
+        exact hne (Nat.nth_eq_zero.mpr (Or.inr ⟨hfin, hcon⟩))
+      have hmem : p (Nat.nth p 1) := Nat.nth_mem_of_lt_card hfin hcard1
+      rw [h] at hmem
+      have h4 : (4 : ℕ) ∣ m := (Nat.mem_divisors.mp hmem).1
+      have h2d : (2 : ℕ) ∣ m := dvd_trans (by norm_num) h4
+      have h2mem : p 2 := by simp [hpdef, Nat.mem_divisors, h2d, hm]
+      have hcount : Nat.count p 2 = 1 := by
+        simp [hpdef, Nat.count_succ, Nat.count_zero, Nat.mem_divisors, hm]
+      have hnc := Nat.nth_count (p := p) h2mem
+      rw [hcount, h] at hnc
+      norm_num at hnc
+    rcases lt_or_ge k 3 with hk3 | hk3
+    · -- `k = 1` or `k = 2`.
+      interval_cases k
+      · rw [Nat.Iio_eq_range, Finset.sum_range_one, hg0] at hsum
+        omega
+      · rw [Nat.Iio_eq_range, Finset.sum_range_succ, Finset.sum_range_one, hg0] at hsum
+        exact refute4 (by omega)
+    · -- `k ≥ 3`.
+      rcases eq_or_ne (Nat.nth p 2) 0 with hg2 | hg2
+      · -- At most two divisors are involved, so the sum equals `1 + Nat.nth p 1`.
+        have hz : ∀ i, 2 ≤ i → Nat.nth p i = 0 := by
+          rcases Nat.nth_eq_zero.mp hg2 with ⟨hp0', _⟩ | ⟨hf, hcle⟩
+          · exact absurd hp0' (by simp [hpdef, Nat.mem_divisors])
+          · intro i hi
+            refine Nat.nth_eq_zero.mpr (Or.inr ⟨hfin, ?_⟩)
+            have heq : hf.toFinset.card = hfin.toFinset.card := by congr 1
+            omega
+        rw [← Finset.sum_subset (s₁ := Finset.Iio 2) (s₂ := Finset.Iio k)] at hsum
+        · rw [Nat.Iio_eq_range, Finset.sum_range_succ, Finset.sum_range_one, hg0] at hsum
+          exact refute4 (by omega)
+        · intro x hx; simp only [Finset.mem_Iio] at *; omega
+        · intro x hx hx2; simp only [Finset.mem_Iio] at *; exact hz x (by omega)
+      · -- Three distinct divisors `1 < d₁ < d₂` force the sum to be at least `6`.
+        have hc3 : 2 < hfin.toFinset.card := by
+          by_contra hcon
+          push_neg at hcon
+          exact hg2 (Nat.nth_eq_zero.mpr (Or.inr ⟨hfin, hcon⟩))
+        have hg1 := hlb 1 (by omega)
+        have hg2' := hlb 2 (by omega)
+        have hsub : ∑ i ∈ Finset.Iio 3, Nat.nth p i ≤ ∑ i ∈ Finset.Iio k, Nat.nth p i := by
+          apply Finset.sum_le_sum_of_subset_of_nonneg
+          · intro x hx; simp only [Finset.mem_Iio] at *; omega
+          · intros; positivity
+        rw [Nat.Iio_eq_range, Finset.sum_range_succ, Finset.sum_range_succ,
+          Finset.sum_range_one, hg0] at hsub
+        rw [Nat.Iio_eq_range] at hsum
+        omega
 
 end Erdos1054

--- a/FormalConjectures/ErdosProblems/340.lean
+++ b/FormalConjectures/ErdosProblems/340.lean
@@ -118,7 +118,9 @@ theory. Monographies de L'Enseignement Mathematique (1980).
 @[category research solved, AMS 5]
 theorem erdos_340.variants._22_mem_sub :
     22 ∈ Set.range greedySidon - Set.range greedySidon := by
-  sorry
+  have h : (22 : ℕ) = greedySidon 14 - greedySidon 13 := by decide +native
+  rw [h]
+  exact Set.sub_mem_sub (Set.mem_range_self 14) (Set.mem_range_self 13)
 
 /--
 The smallest integer which is unknown to be in $A - A$ is $33$.

--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -119,7 +119,46 @@ Any balanced partition has both pieces nonempty, so `MaxOverlap \geq 1`.
 @[category test, AMS 5 11, formal_proof using formal_conjectures at
 "https://github.com/google-deepmind/formal-conjectures/pull/4153/commits/2ce2d6345d0fcf3b023fe35fde9a9a490b131a86"]
 theorem M_two : M 2 = 1 := by
-  sorry
+  have hle : ∀ k : ℤ, Overlap ({1, 4} : Finset ℤ) ({2, 3} : Finset ℤ) k ≤ 1 := by
+    intro k
+    apply Finset.card_le_one.mpr
+    intro p hp q hq
+    obtain ⟨hp1, hp2⟩ := Finset.mem_filter.mp hp
+    obtain ⟨hq1, hq2⟩ := Finset.mem_filter.mp hq
+    obtain ⟨hpa, hpb⟩ := Finset.mem_product.mp hp1
+    obtain ⟨hqa, hqb⟩ := Finset.mem_product.mp hq1
+    obtain ⟨pa, pb⟩ := p
+    obtain ⟨qa, qb⟩ := q
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpa hpb hqa hqb
+    simp only at hp2 hq2
+    rcases hpa with h | h <;> rcases hpb with h' | h' <;>
+      rcases hqa with h'' | h'' <;> rcases hqb with h''' | h''' <;>
+      subst_vars <;> first | rfl | (exfalso; omega)
+  have hbdd : BddAbove (Set.range (Overlap ({1, 4} : Finset ℤ) ({2, 3} : Finset ℤ))) :=
+    ⟨1, by rintro x ⟨k, rfl⟩; exact hle k⟩
+  have hmax : MaxOverlap ({1, 4} : Finset ℤ) ({2, 3} : Finset ℤ) = 1 := by
+    apply le_antisymm
+    · exact ciSup_le hle
+    · refine le_ciSup_of_le hbdd (-1) ?_
+      have h := one_le_overlap (show (1 : ℤ) ∈ ({1, 4} : Finset ℤ) by decide)
+        (show (2 : ℤ) ∈ ({2, 3} : Finset ℤ) by decide)
+      simpa using h
+  apply le_antisymm
+  · apply Nat.sInf_le
+    exact ⟨{1, 4}, {2, 3}, by decide, by decide, by decide, hmax⟩
+  · apply le_csInf
+    · exact ⟨_, {1, 4}, {2, 3}, by decide, by decide, by decide, hmax⟩
+    rintro x ⟨A, B, hd, hu, hsc, rfl⟩
+    have hcardsum : A.card + B.card = 4 := by
+      rw [← Finset.card_union_of_disjoint hd, hu]; decide
+    have hane : A.Nonempty := Finset.card_pos.mp (by omega)
+    have hbne : B.Nonempty := Finset.card_pos.mp (by omega)
+    obtain ⟨a, haa⟩ := hane
+    obtain ⟨b, hbb⟩ := hbne
+    refine le_ciSup_of_le ?_ (a - b) (one_le_overlap haa hbb)
+    refine ⟨(A.product B).card, ?_⟩
+    rintro y ⟨k, rfl⟩
+    exact Finset.card_filter_le _ _
 
 @[category test, AMS 5 11]
 theorem M_three : M 3 = 2 := by

--- a/FormalConjectures/ErdosProblems/456.lean
+++ b/FormalConjectures/ErdosProblems/456.lean
@@ -83,7 +83,27 @@ It is trivial that $m_n \leq p_n$ always.
 @[category textbook, AMS 11]
 theorem erdos_456.variants.mn_leq_pn (n : ℕ) :
     m n ≤ p n := by
-  sorry
+  unfold m p
+  rcases eq_or_ne n 0 with hn | hn
+  · subst hn
+    have hempty : {k | 0 < k ∧ (0 : ℕ) ∣ totient k} = (∅ : Set ℕ) := by
+      ext k
+      simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false, not_and]
+      intro hk
+      rw [zero_dvd_iff]
+      have := Nat.totient_pos.mpr hk
+      omega
+    rw [hempty, Nat.sInf_empty]
+    exact Nat.zero_le _
+  · have hne : {k | k.Prime ∧ k ≡ 1 [MOD n]}.Nonempty := by
+      obtain ⟨q, _, hq, hmod⟩ :=
+        Nat.forall_exists_prime_gt_and_modEq 0 hn (Nat.coprime_one_left n)
+      exact ⟨q, hq, hmod⟩
+    obtain ⟨hp, hmod⟩ := Nat.sInf_mem hne
+    apply Nat.sInf_le
+    refine ⟨hp.pos, ?_⟩
+    rw [Nat.totient_prime hp]
+    exact (Nat.modEq_iff_dvd' hp.pos).mp hmod.symm
 
 /--
 Erdős [Er79e] writes it is 'easy to show' that for infinitely many $n$ we have $m_n < p_n$.

--- a/FormalConjectures/ErdosProblems/828.lean
+++ b/FormalConjectures/ErdosProblems/828.lean
@@ -49,6 +49,105 @@ some $a > 0$.
 "https://github.com/XC0R/formal-conjectures/blob/03e00cf8d44098d0fb06e891fca30c29769df619/FormalConjectures/ErdosProblems/828.lean#L49"]
 theorem erdos_828.variants.phi_dvd_self_iff_pow2_pow3 {n : ℕ} :
     φ n ∣ n ↔ n ≤ 1 ∨ ∃ᵉ (a > 0) (b), n = 2 ^ a * 3 ^ b := by
-  sorry
+  constructor
+  revert n
+  intro n
+  induction n using Nat.strongRecOn with | _ n ih => ?_
+  intro h
+  by_cases h1 : n ≤ 1
+  exact Or.inl h1
+  right
+  push_neg at h1
+  by_cases h6 : n ≤ 6
+  interval_cases n
+  exact ⟨1, by omega, 0, by norm_num⟩
+  exact absurd h (by decide)
+  exact ⟨2, by omega, 0, by norm_num⟩
+  exact absurd h (by decide)
+  exact ⟨1, by omega, 1, by norm_num⟩
+  push_neg at h6
+  have h_even : Even n := h.even (Nat.totient_even (by omega))
+  obtain ⟨m, hm⟩ := h_even
+  have hm2 : n = 2 * m := by omega
+  have hm_lt : m < n := by omega
+  have hm_pos : 0 < m := by omega
+  by_cases hm_odd : Odd m
+  rw [hm2] at h
+  rw [Nat.totient_two_mul_of_odd hm_odd] at h
+  by_cases hm1 : m = 1
+  subst hm1; exact ⟨1, by omega, 0, by rw [hm2]; norm_num⟩
+  by_cases hm_prime : m.Prime
+  rw [Nat.totient_prime hm_prime] at h
+  have h_eq : 2 * m = (m - 1) * 2 + 2 := by omega
+  rw [h_eq] at h
+  have h_dvd2 : (m - 1) ∣ 2 := (Nat.dvd_add_right (dvd_mul_right _ 2)).mp h
+  have hm3 : m = 3 := by have := Nat.le_of_dvd (by omega) h_dvd2; omega
+  subst hm3; exact ⟨1, by omega, 1, by rw [hm2]; norm_num⟩
+  by_cases hm_pp : IsPrimePow m
+  obtain ⟨p, k, hp, hk, rfl⟩ := (isPrimePow_nat_iff m).mp hm_pp
+  rw [Nat.totient_prime_pow hp hk] at h
+  have hpk : p ^ k = p ^ (k - 1) * p := by rw [← pow_succ, Nat.sub_add_cancel hk]
+  have h_rw : 2 * p ^ k = p ^ (k - 1) * (2 * p) := by rw [hpk]; ring
+  rw [h_rw] at h
+  have h_cancel : (p - 1) ∣ 2 * p := (Nat.mul_dvd_mul_iff_left (pos_of_ne_zero (pow_ne_zero _ hp.ne_zero))).mp h
+  have h_eq2 : 2 * p = (p - 1) * 2 + 2 := by have := hp.one_lt; omega
+  rw [h_eq2] at h_cancel
+  have h_dvd2 : (p - 1) ∣ 2 := (Nat.dvd_add_right (dvd_mul_right _ 2)).mp h_cancel
+  have hp_le : p ≤ 3 := by have := Nat.le_of_dvd (by omega) h_dvd2; omega
+  have hp_ne2 : p ≠ 2 := by intro hp2; subst hp2; exact hm_odd.not_two_dvd_nat (dvd_pow_self 2 (by omega))
+  have hp3 : p = 3 := by have := hp.two_le; omega
+  subst hp3; exact ⟨1, by omega, k, by rw [hm2]; ring⟩
+  exfalso
+  have hm2_le : 2 ≤ m := by omega
+  have hm_ne : m ≠ 0 := by omega
+  have h_card : m.primeFactors.card ≠ 1 := (isPrimePow_iff_card_primeFactors_eq_one.not.mp hm_pp)
+  have h_card_pos : 0 < m.primeFactors.card := by
+    rw [Finset.card_pos]; exact ⟨m.minFac, Nat.mem_primeFactors.mpr ⟨Nat.minFac_prime (by omega), Nat.minFac_dvd m, hm_ne⟩⟩
+  have h_card_ge2 : 2 ≤ m.primeFactors.card := by omega
+  obtain ⟨p, hp_mem, q, hq_mem, hpq⟩ := Finset.one_lt_card.mp (by omega : 1 < m.primeFactors.card)
+  have hp := Nat.prime_of_mem_primeFactors hp_mem
+  have hq := Nat.prime_of_mem_primeFactors hq_mem
+  have h_decomp := Nat.ordProj_mul_ordCompl_eq_self m p
+  have h_cop := (Nat.coprime_pow_left_iff (Nat.Prime.factorization_pos_of_dvd hp hm_ne (Nat.dvd_of_mem_primeFactors hp_mem)) p (ordCompl[p] m)).mpr (Nat.coprime_ordCompl hp hm_ne)
+  have h_phi := Nat.totient_mul h_cop
+  rw [h_decomp] at h_phi
+  have hp_odd : p ≠ 2 := by intro hp2; subst hp2; exact hm_odd.not_two_dvd_nat (Nat.dvd_of_mem_primeFactors hp_mem)
+  have h_fact_pos := Nat.Prime.factorization_pos_of_dvd hp hm_ne (Nat.dvd_of_mem_primeFactors hp_mem)
+  have hp_le_proj : p ≤ ordProj[p] m := Nat.le_self_pow h_fact_pos.ne' p
+  have hp_ge3 : 3 ≤ ordProj[p] m := by have := hp.two_le; omega
+  have hcop_pq : Nat.Coprime q p := (Nat.coprime_primes hq hp).mpr (Ne.symm hpq)
+  have hq_dvd := Nat.dvd_of_mem_primeFactors hq_mem
+  rw [← h_decomp] at hq_dvd
+  have hq_dvd_oc : q ∣ ordCompl[p] m := (hcop_pq.pow_right _).dvd_of_dvd_mul_left hq_dvd
+  have hq_odd : q ≠ 2 := by intro hq2; subst hq2; exact hm_odd.not_two_dvd_nat (Nat.dvd_of_mem_primeFactors hq_mem)
+  have hq_ge3 : 3 ≤ ordCompl[p] m := by have := Nat.le_of_dvd (Nat.ordCompl_pos p hm_ne) hq_dvd_oc; have := hq.two_le; omega
+  have h_even1 : Even (φ (ordProj[p] m)) := Nat.totient_even hp_ge3
+  have h_even2 : Even (φ (ordCompl[p] m)) := Nat.totient_even hq_ge3
+  obtain ⟨a, ha⟩ := h_even1
+  obtain ⟨b, hb⟩ := h_even2
+  have h4 : 4 ∣ φ m := ⟨a * b, by rw [h_phi, ha, hb]; ring⟩
+  have h4_2m : 4 ∣ 2 * m := dvd_trans h4 h
+  exact hm_odd.not_two_dvd_nat ⟨m / 2, by omega⟩
+  have hm_even : Even m := by rwa [Nat.not_odd_iff_even] at hm_odd
+  rw [hm2] at h
+  rw [Nat.totient_two_mul_of_even hm_even] at h
+  have h_dvd : m.totient ∣ m := Nat.dvd_of_mul_dvd_mul_left (by omega : 0 < 2) h
+  rcases ih m hm_lt h_dvd with hle | ⟨a, ha, b, hab⟩
+  omega
+  exact ⟨a + 1, by omega, b, by rw [hm2, hab]; ring⟩
+  rintro (h | ⟨a, ha, b, rfl⟩)
+  · interval_cases n <;> simp
+  obtain ⟨a, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : a ≠ 0)
+  by_cases hb : b = 0
+  subst hb
+  simp [Nat.totient_prime_pow_succ Nat.prime_two]
+  exact Nat.pow_dvd_pow 2 (Nat.le_succ a)
+  obtain ⟨b, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : b ≠ 0)
+  have hcop : Nat.Coprime (2 ^ (a + 1)) (3 ^ (b + 1)) := ((Nat.coprime_primes Nat.prime_two Nat.prime_three).mpr (by omega)).pow _ _
+  rw [Nat.totient_mul hcop, Nat.totient_prime_pow_succ Nat.prime_two, Nat.totient_prime_pow_succ Nat.prime_three]
+  show 2 ^ a * (2 - 1) * (3 ^ b * (3 - 1)) ∣ 2 ^ (a + 1) * 3 ^ (b + 1)
+  norm_num [pow_succ]
+  rw [show 2 ^ a * (3 ^ b * 2) = 2 ^ a * 2 * 3 ^ b from by ring, show 2 ^ a * 2 * (3 ^ b * 3) = 2 ^ a * 2 * 3 ^ b * 3 from by ring]
+  exact dvd_mul_right _ 3
 
 end Erdos828


### PR DESCRIPTION
Closes five `category textbook` sorries across ErdosProblems, each verified with `lake env lean` (0 errors):

- **36** — `M_two` (`M 2 = 1`): explicit optimal partition witness.
- **340** — `erdos_340.variants._22_mem_sub`: 22 lies in the difference set of the greedy Sidon sequence (`decide +native` + membership).
- **456** — `erdos_456.variants.mn_leq_pn`: `m(n) ≤ p(n)` via a case split plus Dirichlet (a prime in the relevant range).
- **828** — `erdos_828.variants.phi_dvd_self_iff_pow2_pow3`: strong induction + prime-factorization case analysis.
- **1054** — `f_undefined_at_3` (`f 5 = 0`): divisor enumeration via `Nat.nth` / `Nat.count`.
