### PR TITLE
ErdosProblems: add 281, 419, 453, 476, 519, 540 (#3998 sync)

### DIFF
--- a/FormalConjectures/ErdosProblems/281.lean
+++ b/FormalConjectures/ErdosProblems/281.lean
@@ -41,16 +41,6 @@ def avoidAll (n : ℕ → ℕ) (a : ResidueChoice n) : Set ℤ :=
 def avoidPrefix (n : ℕ → ℕ) (a : ResidueChoice n) (k : ℕ) : Set ℤ :=
   {m | ∀ i : ℕ, i < k → (m : ZMod (n i)) ≠ a i}
 
-open Classical in
-/-- Two-sided natural density sequence for subsets of $\mathbb{Z}$. -/
-noncomputable def integerDensitySeq (S : Set ℤ) (N : ℕ) : ℝ :=
-  (((Finset.Icc (-(N : ℤ)) (N : ℤ)).filter (fun m => m ∈ S)).card : ℝ) /
-    (2 * (N : ℝ) + 1)
-
-/-- A subset of $\mathbb{Z}$ has two-sided natural density $d$. -/
-def HasIntegerDensity (S : Set ℤ) (d : ℝ) : Prop :=
-  Tendsto (integerDensitySeq S) atTop (nhds d)
-
 /--
 Let $n_1<n_2<\cdots$ be an infinite sequence such that, for any choice of congruence classes
 $a_i\pmod{n_i}$, the set of integers not satisfying any of the congruences $a_i\pmod{n_i}$ has
@@ -63,10 +53,10 @@ The answer is yes; the linked Lean proof formalizes Somani's argument.
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos281.lean"]
 theorem erdos_281 : answer(True) ↔
     ∀ (n : ℕ → ℕ), StrictMono n → (∀ i, 0 < n i) →
-      (∀ a : ResidueChoice n, HasIntegerDensity (avoidAll n a) 0) →
+      (∀ a : ResidueChoice n, Set.HasIntDensity (avoidAll n a) 0) →
         ∀ ε : ℝ, 0 < ε →
           ∃ k : ℕ, ∀ a : ResidueChoice n,
-            ∃ d : ℝ, HasIntegerDensity (avoidPrefix n a k) d ∧ d < ε := by
+            ∃ d : ℝ, Set.HasIntDensity (avoidPrefix n a k) d ∧ d < ε := by
   sorry
 
 end Erdos281

--- a/FormalConjectures/ErdosProblems/281.lean
+++ b/FormalConjectures/ErdosProblems/281.lean
@@ -1,0 +1,72 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 281
+
+*References:*
+- [erdosproblems.com/281](https://www.erdosproblems.com/281)
+- [DaEr36] Davenport, H. and Erdős, P., *On sequences of positive integers*. Acta
+  Arithmetica (1936), 147-151.
+- [HaRo66] Halberstam, H. and Roth, K. F., *Sequences. Vol. I*. (1966), xx+291.
+-/
+
+open Filter Topology
+
+namespace Erdos281
+
+/-- Choices of congruence classes $a_i \pmod{n_i}$. -/
+def ResidueChoice (n : ℕ → ℕ) := ∀ i : ℕ, ZMod (n i)
+
+/-- The integers avoiding all congruences $a_i \pmod{n_i}$. -/
+def avoidAll (n : ℕ → ℕ) (a : ResidueChoice n) : Set ℤ :=
+  {m | ∀ i : ℕ, (m : ZMod (n i)) ≠ a i}
+
+/-- The integers avoiding the first $k$ congruences $a_i \pmod{n_i}$. -/
+def avoidPrefix (n : ℕ → ℕ) (a : ResidueChoice n) (k : ℕ) : Set ℤ :=
+  {m | ∀ i : ℕ, i < k → (m : ZMod (n i)) ≠ a i}
+
+open Classical in
+/-- Two-sided natural density sequence for subsets of $\mathbb{Z}$. -/
+noncomputable def integerDensitySeq (S : Set ℤ) (N : ℕ) : ℝ :=
+  (((Finset.Icc (-(N : ℤ)) (N : ℤ)).filter (fun m => m ∈ S)).card : ℝ) /
+    (2 * (N : ℝ) + 1)
+
+/-- A subset of $\mathbb{Z}$ has two-sided natural density $d$. -/
+def HasIntegerDensity (S : Set ℤ) (d : ℝ) : Prop :=
+  Tendsto (integerDensitySeq S) atTop (nhds d)
+
+/--
+Let $n_1<n_2<\cdots$ be an infinite sequence such that, for any choice of congruence classes
+$a_i\pmod{n_i}$, the set of integers not satisfying any of the congruences $a_i\pmod{n_i}$ has
+density $0$. Is it true that for every $\epsilon>0$ there exists some $k$ such that, for every
+choice of congruence classes $a_i$, the density of integers not satisfying any of the congruences
+$a_i\pmod{n_i}$ for $1\leq i\leq k$ is less than $\epsilon$?
+
+The answer is yes; the linked Lean proof formalizes Somani's argument.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos281.lean"]
+theorem erdos_281 : answer(True) ↔
+    ∀ (n : ℕ → ℕ), StrictMono n → (∀ i, 0 < n i) →
+      (∀ a : ResidueChoice n, HasIntegerDensity (avoidAll n a) 0) →
+        ∀ ε : ℝ, 0 < ε →
+          ∃ k : ℕ, ∀ a : ResidueChoice n,
+            ∃ d : ℝ, HasIntegerDensity (avoidPrefix n a k) d ∧ d < ε := by
+  sorry
+
+end Erdos281

--- a/FormalConjectures/ErdosProblems/281.lean
+++ b/FormalConjectures/ErdosProblems/281.lean
@@ -21,6 +21,8 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/281](https://www.erdosproblems.com/281)
+- [ErGr80] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number
+  theory*. Monographies de L'Enseignement Mathematique (1980).
 - [DaEr36] Davenport, H. and Erdős, P., *On sequences of positive integers*. Acta
   Arithmetica (1936), 147-151.
 - [HaRo66] Halberstam, H. and Roth, K. F., *Sequences. Vol. I*. (1966), xx+291.

--- a/FormalConjectures/ErdosProblems/419.lean
+++ b/FormalConjectures/ErdosProblems/419.lean
@@ -1,0 +1,56 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 419
+
+*References:*
+- [erdosproblems.com/419](https://www.erdosproblems.com/419)
+- [EGIP96] Erdős, Paul and Graham, S. W. and Ivić, Aleksandar and Pomerance, Carl,
+  *On the number of divisors of $n!$*. (1996), 337--355.
+-/
+
+open Filter
+
+namespace Erdos419
+
+/-- The divisor-counting function $\tau(n)$. -/
+noncomputable def tau (n : ℕ) : ℕ := n.divisors.card
+
+/-- The ratio $\tau((n+1)!)/\tau(n!)$. -/
+noncomputable def factorialDivisorRatio (n : ℕ) : ℝ :=
+  (tau (n + 1).factorial : ℝ) / (tau n.factorial : ℝ)
+
+/-- The set $\{1\} \cup \{1+1/k : k \geq 1\}$. -/
+def limitPointSet : Set ℝ :=
+  {1} ∪ {x | ∃ k : ℕ, 1 ≤ k ∧ x = 1 + 1 / (k : ℝ)}
+
+/--
+If $\tau(n)$ counts the number of divisors of $n$, then what is the set of limit points of
+\[
+\frac{\tau((n+1)!)}{\tau(n!)}?
+\]
+
+The limit points are exactly $\{1\} \cup \{1+1/k : k \geq 1\}$.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos419.lean"]
+theorem erdos_419 :
+    {x : ℝ | MapClusterPt x atTop factorialDivisorRatio} = limitPointSet := by
+  sorry
+
+end Erdos419

--- a/FormalConjectures/ErdosProblems/419.lean
+++ b/FormalConjectures/ErdosProblems/419.lean
@@ -26,15 +26,13 @@ import FormalConjectures.Util.ProblemImports
 -/
 
 open Filter
+open scoped ArithmeticFunction.sigma
 
 namespace Erdos419
 
-/-- The divisor-counting function $\tau(n)$. -/
-noncomputable def tau (n : ℕ) : ℕ := n.divisors.card
-
-/-- The ratio $\tau((n+1)!)/\tau(n!)$. -/
+/-- The ratio $\sigma_0((n+1)!)/\sigma_0(n!)$, where $\sigma_0$ is the divisor-counting function. -/
 noncomputable def factorialDivisorRatio (n : ℕ) : ℝ :=
-  (tau (n + 1).factorial : ℝ) / (tau n.factorial : ℝ)
+  (σ 0 (n + 1).factorial : ℝ) / (σ 0 n.factorial : ℝ)
 
 /-- The set $\{1\} \cup \{1+1/k : k \geq 1\}$. -/
 def limitPointSet : Set ℝ :=

--- a/FormalConjectures/ErdosProblems/419.lean
+++ b/FormalConjectures/ErdosProblems/419.lean
@@ -21,6 +21,8 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/419](https://www.erdosproblems.com/419)
+- [ErGr80] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number
+  theory*. Monographies de L'Enseignement Mathematique (1980).
 - [EGIP96] Erdős, Paul and Graham, S. W. and Ivić, Aleksandar and Pomerance, Carl,
   *On the number of divisors of $n!$*. (1996), 337--355.
 -/

--- a/FormalConjectures/ErdosProblems/453.lean
+++ b/FormalConjectures/ErdosProblems/453.lean
@@ -1,0 +1,49 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 453
+
+*References:*
+- [erdosproblems.com/453](https://www.erdosproblems.com/453)
+- [Po79] Pomerance, Carl, *The prime number graph*. Math. Comp. (1979), 399-408.
+-/
+
+namespace Erdos453
+
+/-- The eventual prime inequality asked in Erdős Problem 453, using Mathlib's zero-based primes. -/
+def EventuallyHasPrimeWitness : Prop :=
+  ∃ N : ℕ, ∀ n : ℕ, N ≤ n →
+    ∃ i : ℕ, i < n ∧
+      (Nat.nth Nat.Prime n) ^ (2 : ℕ) <
+        Nat.nth Nat.Prime (n + i) * Nat.nth Nat.Prime (n - i)
+
+/--
+Is it true that, for all sufficiently large $n$, there exists some $i<n$ such that
+\[
+p_n^2 < p_{n+i}p_{n-i},
+\]
+where $p_k$ is the $k$th prime?
+
+Pomerance proved that the answer is no.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos453.lean"]
+theorem erdos_453 : answer(False) ↔ EventuallyHasPrimeWitness := by
+  sorry
+
+end Erdos453

--- a/FormalConjectures/ErdosProblems/453.lean
+++ b/FormalConjectures/ErdosProblems/453.lean
@@ -21,6 +21,17 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/453](https://www.erdosproblems.com/453)
+- [Er70b] Erdős, P., *Some applications of graph theory to number theory*. Proc. Second Chapel Hill
+  Conf. on Combinatorial Mathematics and its Applications (Univ. North Carolina, Chapel Hill, N.C.,
+  1970) (1970), 136-145.
+- [Er74b] Erdős, P., *Remarks on some problems in number theory*. Math. Balkanica (1974), 197-202.
+- [Er77c] Erdős, Paul, *Problems and results on combinatorial number theory. III*. Number theory day
+  (Proc. Conf., Rockefeller Univ., New York, 1976) (1977), 43-72.
+- [Er80] Erdős, Paul, *A survey of problems in combinatorial number theory*. Ann. Discrete Math.
+  (1980), 89-115.
+- [ErGr80] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number
+  theory*. Monographies de L'Enseignement Mathematique (1980).
+- [Gu04] Guy, Richard K., *Unsolved problems in number theory*. (2004), xviii+437.
 - [Po79] Pomerance, Carl, *The prime number graph*. Math. Comp. (1979), 399-408.
 -/
 

--- a/FormalConjectures/ErdosProblems/476.lean
+++ b/FormalConjectures/ErdosProblems/476.lean
@@ -21,6 +21,11 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/476](https://www.erdosproblems.com/476)
+- [Er65b] Erdős, Paul, *Some recent advances and current problems in number theory*. Lectures on
+  Modern Mathematics, Vol. III (1965), 196-244.
+- [ErGr80] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number
+  theory*. Monographies de L'Enseignement Mathematique (1980).
+- [Gu04] Guy, Richard K., *Unsolved problems in number theory*. (2004), xviii+437.
 - [dSHa94] Dias da Silva, J. A. and Hamidoune, Y. O., *Cyclic spaces for Grassmann
   derivatives and additive theory*. Bull. London Math. Soc. (1994), 140-146.
 -/

--- a/FormalConjectures/ErdosProblems/476.lean
+++ b/FormalConjectures/ErdosProblems/476.lean
@@ -1,0 +1,48 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 476
+
+*References:*
+- [erdosproblems.com/476](https://www.erdosproblems.com/476)
+- [dSHa94] Dias da Silva, J. A. and Hamidoune, Y. O., *Cyclic spaces for Grassmann
+  derivatives and additive theory*. Bull. London Math. Soc. (1994), 140-146.
+-/
+
+namespace Erdos476
+
+/--
+Let $A\subseteq \mathbb{F}_p$. Let
+\[
+A\hat{+}A = \{ a+b : a\neq b \in A\}.
+\]
+Is it true that
+\[
+\lvert A\hat{+}A\rvert \geq \min(2\lvert A\rvert-3,p)?
+\]
+
+This is the Erdős-Heilbronn inequality, proved by Dias da Silva and Hamidoune.
+-/
+@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos476.lean"]
+theorem erdos_476 : answer(True) ↔
+    ∀ p : ℕ, Fact p.Prime → ∀ A : Finset (ZMod p),
+      A.restrictedSumset.card ≥ min (2 * A.card - 3) p := by
+  sorry
+
+end Erdos476

--- a/FormalConjectures/ErdosProblems/519.lean
+++ b/FormalConjectures/ErdosProblems/519.lean
@@ -1,0 +1,53 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 519
+
+*References:*
+- [erdosproblems.com/519](https://www.erdosproblems.com/519)
+- [At61b] Atkinson, F. V., *On sums of powers of complex numbers*. Acta Math. Acad.
+  Sci. Hungar. (1961), 185-188.
+-/
+
+open scoped BigOperators
+
+namespace Erdos519
+
+/-- The $k$th power sum of a finite sequence of complex numbers. -/
+noncomputable def powerSum {n : ℕ} (z : Fin n → ℂ) (k : ℕ) : ℂ :=
+  ∑ i : Fin n, z i ^ k
+
+/--
+Let $z_1,\ldots,z_n\in \mathbb{C}$ with $z_1=1$. Must there exist an absolute constant $c>0$ such
+that
+\[
+\max_{1\leq k\leq n}\left\lvert \sum_{i}z_i^k\right\rvert>c?
+\]
+
+Atkinson proved that $c=1/6$ suffices.
+-/
+@[category research solved, AMS 30, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos519.lean"]
+theorem erdos_519 : answer(True) ↔
+    ∃ c : ℝ, 0 < c ∧
+      ∀ (n : ℕ) (hn : 0 < n) (z : Fin n → ℂ),
+        z ⟨0, hn⟩ = 1 →
+          ∃ k : Fin n, c < ‖powerSum z (k.val + 1)‖ := by
+  sorry
+
+end Erdos519

--- a/FormalConjectures/ErdosProblems/519.lean
+++ b/FormalConjectures/ErdosProblems/519.lean
@@ -21,6 +21,16 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/519](https://www.erdosproblems.com/519)
+- [Er61] Erdős, Paul, *Some unsolved problems*. Magyar Tud. Akad. Mat. Kutató Int. Közl. (1961),
+  221-254.
+- [Er65b] Erdős, Paul, *Some recent advances and current problems in number theory*. Lectures on
+  Modern Mathematics, Vol. III (1965), 196-244.
+- [Bi94] Biró, A., *On a problem of Turán concerning sums of powers of complex numbers*. Acta Math.
+  Hungar. (1994), 209-216.
+- [Bi00] Biró, András, *An improved estimate in a power sum problem of Turán*. Indag. Math. (N.S.)
+  (2000), 343-358.
+- [Bi00b] Biró, A., *An upper estimate in Turán's pure power sum problem*. Indag. Math. (N.S.)
+  (2000), 499--508.
 - [At61b] Atkinson, F. V., *On sums of powers of complex numbers*. Acta Math. Acad.
   Sci. Hungar. (1961), 185-188.
 -/

--- a/FormalConjectures/ErdosProblems/540.lean
+++ b/FormalConjectures/ErdosProblems/540.lean
@@ -1,0 +1,50 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 540
+
+*References:*
+- [erdosproblems.com/540](https://www.erdosproblems.com/540)
+- [ErHe64] Erdős, P. and Heilbronn, H., *On the addition of residue classes
+  mod $p$*. Acta Arith. (1964), 149--159.
+- [Sz70] Szemerédi, E., *On a conjecture of Erdős and Heilbronn*. Acta Arith.
+  (1970), 227-229.
+-/
+
+namespace Erdos540
+
+/-- A finite set has a non-empty subset whose sum is zero. -/
+def HasZeroSubsetSum {G : Type*} [AddCommMonoid G] (A : Finset G) : Prop :=
+  ∃ S : Finset G, S ⊆ A ∧ S.Nonempty ∧ S.sum id = 0
+
+/--
+Is it true that if $A\subseteq \mathbb{Z}/N\mathbb{Z}$ has size $\gg N^{1/2}$ then there exists
+some non-empty $S\subseteq A$ such that $\sum_{n\in S}n\equiv 0\pmod{N}$?
+
+Szemerédi proved the answer is yes, in fact for arbitrary finite abelian groups.
+-/
+@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos540.lean"]
+theorem erdos_540 : answer(True) ↔
+    ∃ C : ℝ, 0 < C ∧
+      ∀ (N : ℕ), 0 < N → ∀ A : Finset (ZMod N),
+        C * Real.sqrt N ≤ A.card →
+          HasZeroSubsetSum A := by
+  sorry
+
+end Erdos540

--- a/FormalConjectures/ErdosProblems/540.lean
+++ b/FormalConjectures/ErdosProblems/540.lean
@@ -21,6 +21,18 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/540](https://www.erdosproblems.com/540)
+- [Er65b] Erdős, Paul, *Some recent advances and current problems in number theory*. Lectures on
+  Modern Mathematics, Vol. III (1965), 196-244.
+- [Er73] Erdős, P., *Problems and results on combinatorial number theory*. A survey of combinatorial
+  theory (Proc. Internat. Sympos., Colorado State Univ., Fort Collins, Colo., 1971) (1973), 117-138.
+- [ErGr80] Erdős, P. and Graham, R., *Old and new problems and results in combinatorial number
+  theory*. Monographies de L'Enseignement Mathematique (1980).
+- [Ol68] Olson, John E., *An addition theorem modulo {$p$}*. J. Combinatorial Theory (1968), 45--52.
+- [Ba12] Balandraud, Éric, *An addition theorem and maximal zero-sum free sets in
+  $\mathbb{Z}/p\mathbb{Z}$*. Israel J. Math. (2012), 405-429.
+- [HaZe96] Hamidoune, Yahya Ould and Zémor, Gilles, *On zero-free subset sums*. Acta Arith. (1996),
+  143--152.
+- [Gu04] Guy, Richard K., *Unsolved problems in number theory*. (2004), xviii+437.
 - [ErHe64] Erdős, P. and Heilbronn, H., *On the addition of residue classes
   mod $p$*. Acta Arith. (1964), 149--159.
 - [Sz70] Szemerédi, E., *On a conjecture of Erdős and Heilbronn*. Acta Arith.

--- a/FormalConjecturesForMathlib/Data/Set/Density.lean
+++ b/FormalConjecturesForMathlib/Data/Set/Density.lean
@@ -101,6 +101,31 @@ def HasPosDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) : Prop :=
   ∃ α > 0, S.HasDensity α A
 
+open Classical in
+/--
+The two-sided partial natural density of a set of integers, counted inside the interval
+`[-N, N]`.
+-/
+noncomputable def intPartialDensity (S : Set ℤ) (N : ℕ) : ℝ :=
+  (((Finset.Icc (-(N : ℤ)) (N : ℤ)).filter (fun m => m ∈ S)).card : ℝ) /
+    (2 * (N : ℝ) + 1)
+
+/-- A set of integers has two-sided natural density `α`. -/
+def HasIntDensity (S : Set ℤ) (α : ℝ) : Prop :=
+  Tendsto (fun N : ℕ => S.intPartialDensity N) atTop (𝓝 α)
+
+@[simp]
+theorem intPartialDensity_empty (N : ℕ) : intPartialDensity (∅ : Set ℤ) N = 0 := by
+  simp [intPartialDensity]
+
+namespace HasIntDensity
+
+@[simp]
+theorem empty : HasIntDensity (∅ : Set ℤ) 0 := by
+  simp [HasIntDensity]
+
+end HasIntDensity
+
 namespace HasDensity
 
 -- TODO(mercuris): generalise these to non-univ `A`


### PR DESCRIPTION
fixes https://github.com/google-deepmind/formal-conjectures/issues/470

## Summary

Adds Formal Conjectures statement files for Erdős Problems 281, 419, 453, 476, 519, and 540: solved problems with a hosted Lean 4 proof but no FC statement yet. Each states the main `theorem erdos_n` from the boxed erdosproblems.com question and links the hosted proof.

Part of #3998.

## Verification

For each I confirmed the linked proof proves the stated theorem with the same quantifiers and no extra hypotheses:
- **281**: the `(∀ a, density 0) →` premise is the problem's own hypothesis and appears in the statement; the hosted proof discharges exactly `Hyp → Concl`.
- **419**: set equality `{x | MapClusterPt x atTop …} = …`, matching the hosted theorem directly.
- **453**: `answer(False)`, proven by the hosted negation.
- **476**: `∀ p prime, ∀ A, …`, matching the hosted `(p)[Fact p.Prime](A)` form.
- **519 / 540**: `∃ c > 0, ∀ …`, witnessed by the hosted constant.

`#print axioms` on each hosted proof reports only `[propext, Classical.choice, Quot.sound]`.

## Attribution

The external formal proofs are not mine; attribution follows the upstream proof headers, via @plby's hosted Lean proof index.
