### PR TITLE
feat(ErdosProblems/499): link the Marcus–Minc doubly-stochastic proof

### DIFF
--- a/FormalConjectures/ErdosProblems/499.lean
+++ b/FormalConjectures/ErdosProblems/499.lean
@@ -34,7 +34,7 @@ This is true, and was proved by Marcus and Minc [MaMi62]
 
 [MaMi62] Marcus, Marvin and Minc, Henryk, Some results on doubly stochastic matrices. Proc. Amer. Math. Soc. (1962), 571-579.
 -/
-@[category research solved, AMS 15]
+@[category research solved, AMS 15, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos499.lean"]
 lemma erdos_499 :
     answer(True) ↔ (∀ n, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ : Equiv.Perm (Fin n),
       n ^ (- n : ℤ) ≤ ∏ i, M i (σ i)) := by


### PR DESCRIPTION
## Summary

`erdos_499` is already `research solved` with `answer(True)`; this just adds the missing `formal_proof` link to @plby's hosted Lean proof of the Marcus–Minc result.

The hosted theorem's statement is an exact match for the FC statement (same `∀ n, ∀ M ∈ doublyStochastic ℝ (Fin n), ∃ σ, n ^ (-n) ≤ ∏ i, M i (σ i)`, using Mathlib's `doublyStochastic`/`Equiv.Perm` — no vendored defs), and `#print axioms` on it is clean (`[propext, Classical.choice, Quot.sound]`).

## Attribution

The external proof is not mine; it is @plby's hosted Lean proof, linked via the canonical `plby/lean-proofs` index.