### PR TITLE
feat(ErdosProblems/351): resolve via the polynomial Egyptian sums proof

### DIFF
--- a/FormalConjectures/ErdosProblems/351.lean
+++ b/FormalConjectures/ErdosProblems/351.lean
@@ -50,9 +50,9 @@ coefficient. Is it true that $$A=\{ p(n)+1/n : n \in \mathbb{N}\}$$ is strongly 
 in the sense that, for any finite set $B$,
 $$\left\{\sum_{a \in X} a : X \subseteq A \setminus B, X \textrm{ is finite}\right\}$$
 contains all sufficiently large integers? -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos351.lean"]
 theorem erdos_351 :
-    answer(sorry) ↔ ∀ P : ℚ[X], 0 < P.natDegree → 0 < P.leadingCoeff → HasCompleteImage P := by
+    answer(True) ↔ ∀ P : ℚ[X], 0 < P.natDegree → 0 < P.leadingCoeff → HasCompleteImage P := by
   sorry
 
 /--


### PR DESCRIPTION
fixes https://github.com/google-deepmind/formal-conjectures/issues/4048

## Summary

Resolves `erdos_351` (whether every non-constant rational polynomial with positive leading coefficient has a strongly-complete image set): flips it from `research open` to `research solved` with `answer(True)`, and links @plby's hosted Lean proof.

The statement itself is unchanged.

## Verification

The hosted theorem is `True ↔ ∀ P : ℚ[X], 0 < P.natDegree → 0 < P.leadingCoeff → HasCompleteImage P`, which matches this file's statement exactly. The proof goes through `PolynomialEgyptianSums.corollary_7_pos_leading`. The two supporting defs are the same as this file's local ones:
- `imageSet P = Set.range (fun n : ℕ ↦ P.eval n + 1 / n)`
- `IsStronglyComplete A = ∀ B : Finset ℚ, ∀ᶠ m in atTop, ↑m ∈ {∑ x ∈ X, x | ↑X ⊆ A \ ↑B}`

(this file's are stated over a typeclass-generalized carrier; on `ℚ` they are identical to the hosted ones).

## Attribution

The external proof is @plby's hosted Lean proof, linked via the canonical `plby/lean-proofs` index.