### PR TITLE
Add survey-backed Erdős formalizations

### DIFF
--- a/FormalConjectures/ErdosProblems/105.lean
+++ b/FormalConjectures/ErdosProblems/105.lean
@@ -1,0 +1,51 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 105
+
+*References:*
+- [erdosproblems.com/105](https://www.erdosproblems.com/105)
+- [ErPu95] Erdős, P. and Purdy, G., Two combinatorial problems in the plane. Discrete Comput.
+  Geom. (1995), 441-443.
+-/
+
+open EuclideanGeometry
+
+namespace Erdos105
+
+/--
+Let $A,B\subset \mathbb{R}^2$ be disjoint sets of size $n$ and $n-3$ respectively,
+with not all of $A$ contained on a single line. Is there a line which contains at
+least two points from $A$ and no points from $B$?
+
+This has been disproved by an explicit counterexample.
+-/
+@[category research solved, AMS 51,
+formal_proof using lean4 at
+"https://github.com/plby/lean-proofs/blob/main/src/v4.30.0/ErdosProblems/Erdos105.lean#L287"]
+theorem erdos_105 : answer(False) ↔
+    ∀ (A B : Finset ℝ²) (n : ℕ),
+      Disjoint A B →
+      A.card = n →
+      B.card = n - 3 →
+      ¬ Collinear ℝ (A : Set ℝ²) →
+      ∃ p ∈ A, ∃ q ∈ A, p ≠ q ∧ ∀ b ∈ B, b ∉ affineSpan ℝ {p, q} := by
+  sorry
+
+end Erdos105

--- a/FormalConjectures/ErdosProblems/1108.lean
+++ b/FormalConjectures/ErdosProblems/1108.lean
@@ -34,11 +34,6 @@ def FactorialSums : Set ℕ :=
   {m : ℕ | ∃ S : Finset ℕ, m = ∑ n ∈ S, n.factorial}
 
 /--
-A number is powerful if each prime factor appears with exponent at least 2.
--/
-def IsPowerful (n : ℕ) : Prop :=
-  ∀ p : ℕ, p.Prime → p ∣ n → p ^ 2 ∣ n
-/--
 For each $k \geq 2$, does the set $A = \left\{ \sum_{n\in S}n! : S\subset \mathbb{N}\text{ finite}\right\}$ of all finite sums of distinct factorials contain only finitely many $k$-th powers?
 -/
 @[category research open, AMS 11]
@@ -48,10 +43,12 @@ theorem erdos_1108.parts.i : answer(sorry) ↔ ∀ k ≥ 2,
 
 /--
 Does the set $A = \left\{ \sum_{n\in S}n! : S\subset \mathbb{N}\text{ finite}\right\}$ of all finite sums of distinct factorials contain only finitely many powerful numbers?
+
+(A number $n$ is *powerful* if $p \mid n \to p^2 \mid n$; `Nat.Powerful`.)
 -/
 @[category research open, AMS 11]
 theorem erdos_1108.parts.ii :
-     answer(sorry) ↔ {a ∈ FactorialSums | IsPowerful a}.Finite := by
+     answer(sorry) ↔ {a ∈ FactorialSums | a.Powerful}.Finite := by
   sorry
 
 end Erdos1108

--- a/FormalConjectures/ErdosProblems/124.lean
+++ b/FormalConjectures/ErdosProblems/124.lean
@@ -40,8 +40,10 @@ where $c_i \in \{0, 1\}$ and $a_i$ has only the digits $0, 1$ when written in ba
 
 Conjectured by Erdős [Er97], solved by Boris Alexeev using Aristotle.
 -/
-@[category research solved, AMS 11]
-lemma erdos124.zero : answer(True) ↔
+@[category research solved, AMS 11,
+formal_proof using lean4 at
+"https://github.com/plby/lean-proofs/blob/main/src/v4.30.0/ErdosProblems/Erdos124b.lean#L616"]
+theorem erdos_124.parts.i : answer(True) ↔
     ∀ D : Finset ℕ, (∀ d ∈ D, 3 ≤ d) → 1 ≤ ∑ d ∈ D, (d - 1 : ℚ)⁻¹ →
       ∀ᶠ n in atTop, n ∈ ∑ d ∈ D, sumsOfDistinctPowers d 0 := sorry
 
@@ -55,7 +57,7 @@ written in base $d_i$?
 Conjectured by Burr, Erdős, Graham, and Li [BEGL96]
 -/
 @[category research open, AMS 11]
-lemma erdos124.ne_zero : answer(sorry) ↔
+theorem erdos_124.parts.ii : answer(sorry) ↔
     ∀ k ≠ 0, ∀ D : Finset ℕ, (∀ d ∈ D, 3 ≤ d) → 1 ≤ ∑ d ∈ D, (d - 1 : ℚ)⁻¹ → D.gcd id = 1 →
       ∀ᶠ n in atTop, n ∈ ∑ d ∈ D, sumsOfDistinctPowers d k := by
   sorry
@@ -64,10 +66,10 @@ lemma erdos124.ne_zero : answer(sorry) ↔
 All sufficiently large integers can be written as $a + b + c$ where $a$ has only the digits $0, 1$
 in base $3$, $b$ only the digits $0, 1$ in base $4$, $c$ only the digits $0, 1$ in base $7$.
 
-Provee by Burr, Erdős, Graham, and Li [BEGL96]
+Proved by Burr, Erdős, Graham, and Li [BEGL96]
 -/
 @[category research solved, AMS 11]
-lemma erdos124.ne_zero_three_four_seven {k : ℕ} (hk : k ≠ 0) :
+theorem erdos_124.variants.three_four_seven {k : ℕ} (hk : k ≠ 0) :
     ∀ᶠ n in atTop,
       n ∈ sumsOfDistinctPowers 3 k + sumsOfDistinctPowers 4 k + sumsOfDistinctPowers 7 k :=
   sorry
@@ -81,7 +83,7 @@ $$\sum_{1 \le i \le r}\frac 1{d_i - 1} \ge 1.$$
 Reported by Burr, Erdős, Graham, and Li [BEGL96] as an observation of Pomerance
 -/
 @[category research solved, AMS 11]
-lemma erdos124.converse {D : Finset ℕ} (hD₃ : ∀ d ∈ D, 3 ≤ d)
+theorem erdos_124.variants.converse {D : Finset ℕ} (hD₃ : ∀ d ∈ D, 3 ≤ d)
     (h : ∀ᶠ n in atTop, n ∈ ∑ d ∈ D, sumsOfDistinctPowers d 0) : 1 ≤ ∑ d ∈ D, (d - 1 : ℚ)⁻¹ :=
   sorry
 
@@ -94,7 +96,7 @@ but $\sum_{i \in I} \frac 1{d_i - 1} \le \varepsilon$.
 Proved by Melfi [Me04]
 -/
 @[category research solved, AMS 11]
-lemma erdos124.melfi_construction {ε : ℝ} (hε : 0 < ε) :
+theorem erdos_124.variants.melfi {ε : ℝ} (hε : 0 < ε) :
     ∃ d : ℕ → ℕ, StrictMono d ∧ ∑' i, (d i - 1 : ℝ)⁻¹ ≤ ε ∧ ∀ᶠ n in atTop,
       ∃ (I : Finset ℕ) (a : ℕ → ℕ), (∀ i ∈ I, a i ∈ sumsOfDistinctPowers (d i) 0) ∧
         ∑ i ∈ I, a i = n :=

--- a/FormalConjectures/ErdosProblems/367.lean
+++ b/FormalConjectures/ErdosProblems/367.lean
@@ -1,0 +1,64 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 367
+
+*References:*
+- [erdosproblems.com/367](https://www.erdosproblems.com/367)
+- [ErGr80] Erdős, P. and Graham, R. L., Old and new problems and results in combinatorial
+  number theory. (1980), p. 68.
+-/
+
+open Asymptotics Filter
+
+namespace Erdos367
+
+/-- The $2$-full part of `n`, i.e. $B_2(n) = n/n'$ where $n'$ is the product of all primes
+dividing `n` exactly once. Equivalently, $B_2(n) = \prod_{p^a \| n, a \geq 2} p^a$ is the
+largest powerful (`Nat.Powerful`) divisor of `n`. -/
+def twoFullPart (n : ℕ) : ℕ :=
+  n / ∏ p ∈ n.primeFactors with n.factorization p = 1, p
+
+/--
+Let $B_2(n)$ be the $2$-full part of $n$ (that is, $B_2(n)=n/n'$ where $n'$ is
+the product of all primes that divide $n$ exactly once). Is it true that, for every fixed
+$k\geq 1$,
+$$\prod_{n\leq m<n+k}B_2(m) \ll n^{2+o(1)}?$$
+-/
+@[category research open, AMS 11]
+theorem erdos_367 : answer(sorry) ↔
+    ∀ k ≥ 1, ∀ ε : ℝ, 0 < ε →
+      (fun n : ℕ => (∏ m ∈ Finset.Ico n (n + k), (twoFullPart m : ℝ))) =O[atTop]
+        fun n : ℕ => (n : ℝ) ^ (2 + ε) := by
+  sorry
+
+/--
+The stronger question asking whether
+$$\prod_{n\leq m<n+k}B_2(m) \ll_k n^2$$
+for every fixed $k$ is false. In fact, the bound already fails for $k=3$.
+-/
+@[category research solved, AMS 11,
+formal_proof using lean4 at
+"https://github.com/plby/lean-proofs/blob/main/src/v4.30.0/ErdosProblems/Erdos367b.lean#L677"]
+theorem erdos_367.variants.quadratic_bound : answer(False) ↔
+    ∀ k ≥ 1, ∃ C : ℝ, ∀ n : ℕ,
+      (∏ m ∈ Finset.Ico n (n + k), (twoFullPart m : ℝ)) ≤ C * (n : ℝ) * (n : ℝ) := by
+  sorry
+
+end Erdos367

--- a/FormalConjectures/ErdosProblems/47.lean
+++ b/FormalConjectures/ErdosProblems/47.lean
@@ -1,0 +1,46 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 47
+
+*References:*
+- [erdosproblems.com/47](https://www.erdosproblems.com/47)
+- [Bl21] Bloom, T. F., On a density conjecture about unit fractions. arXiv:2112.03726 (2021).
+-/
+
+namespace Erdos47
+
+/--
+If $\delta > 0$ and $N$ is sufficiently large in terms of $\delta$, and
+$A \subseteq \{1,\ldots,N\}$ is such that $\sum_{a\in A} 1/a > \delta \log N$,
+then there exists $S \subseteq A$ such that $\sum_{n\in S} 1/n = 1$.
+
+This was proved by Bloom [Bl21].
+-/
+@[category research solved, AMS 11,
+formal_proof using lean4 at
+"https://github.com/plby/lean-proofs/blob/main/src/v4.30.0/ErdosProblems/Erdos47.lean#L495"]
+theorem erdos_47 : answer(True) ↔
+    ∀ δ > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀, ∀ A : Finset ℕ,
+      A ⊆ Finset.Icc 1 N →
+      δ * Real.log (N : ℝ) < ∑ n ∈ A, (1 : ℝ) / n →
+      ∃ S ⊆ A, ∑ n ∈ S, (1 : ℝ) / n = 1 := by
+  sorry
+
+end Erdos47

--- a/FormalConjectures/ErdosProblems/481.lean
+++ b/FormalConjectures/ErdosProblems/481.lean
@@ -1,0 +1,63 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Erdős Problem 481
+
+*References:*
+- [erdosproblems.com/481](https://www.erdosproblems.com/481)
+- [ErGr80] Erdős, P. and Graham, R. L., Old and new problems and results in combinatorial
+  number theory. (1980), p. 96.
+- [Kl82] Klarner, D. A., A sufficient condition for certain semigroups to be free. J. Algebra
+  (1982), 140-148.
+-/
+
+namespace Erdos481
+
+/-- The constant $C = \sum_i 1/a_i$. -/
+noncomputable def C {r : ℕ} (a : Fin r → ℕ+) : ℝ :=
+  ∑ i : Fin r, (1 : ℝ) / (a i : ℝ)
+
+/-- The transformation `T` applied to a list of positive integers. -/
+def T {r : ℕ} (a b : Fin r → ℕ+) (L : List ℕ+) : List ℕ+ :=
+  L.flatMap fun x : ℕ+ => (List.finRange r).map fun i =>
+    ⟨a i * x + b i, Nat.add_pos_right _ (b i).2⟩
+
+/-- The sequence `A_k`, with `A_1 = [1]` and `A_{k+1} = T(A_k)`. -/
+def A {r : ℕ} (a b : Fin r → ℕ+) : ℕ → List ℕ+
+  | 0 => []
+  | 1 => [1]
+  | n + 2 => T a b (A a b (n + 1))
+
+/--
+Let $a_1,\ldots,a_r,b_1,\ldots,b_r\in \mathbb{N}$ such that
+$\sum_i 1/a_i > 1$. For any finite sequence of $n$ (not necessarily distinct) integers
+$A=(x_1,\ldots,x_n)$ let $T(A)$ denote the sequence of length $rn$ given by
+$(a_i x_j + b_i)_{1\leq j\leq n,1\leq i\leq r}$.
+
+If $A_1=(1)$ and $A_{i+1}=T(A_i)$, then there must be some $A_k$ with repeated elements.
+-/
+@[category research solved, AMS 11,
+formal_proof using lean4 at
+"https://github.com/plby/lean-proofs/blob/main/src/v4.30.0/ErdosProblems/Erdos481.lean#L382"]
+theorem erdos_481 : answer(True) ↔
+    ∀ {r : ℕ} (a b : Fin r → ℕ+), 0 < r → 1 < C a →
+      ∃ k, 1 ≤ k ∧ ¬ (A a b k).Nodup := by
+  sorry
+
+end Erdos481

--- a/FormalConjectures/ErdosProblems/613.lean
+++ b/FormalConjectures/ErdosProblems/613.lean
@@ -29,7 +29,9 @@ namespace Erdos613
 Let $n \geq 3$ and $G$ be a graph with $\binom{2n+1}{2} - \binom{n}{2} - 1$ edges.
 Must $G$ be the union of a bipartite graph and a graph with maximum degree less than $n$?
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5,
+formal_proof using lean4 at
+"https://github.com/plby/lean-proofs/blob/main/src/v4.30.0/ErdosProblems/Erdos613.lean#L1173"]
 theorem erdos_613 :
     answer(False) ↔
       ∀ n ≥ 3, ∀ (V : Type*) [Fintype V] (G : SimpleGraph V), [DecidableRel G.Adj] →


### PR DESCRIPTION
fixes https://github.com/google-deepmind/formal-conjectures/issues/336
fixes https://github.com/google-deepmind/formal-conjectures/issues/751 
fixes https://github.com/google-deepmind/formal-conjectures/issues/4049

## Summary
- Add Erdős problem statements with formal proof links for #47, #105, and #481.
- Add #367 with the open main asymptotic statement plus the formally disproved quadratic-bound variant.
- Add formal proof metadata for existing solved entries #124 and #613.
- Simplify #1108 to reuse `Nat.Powerful` instead of a local duplicate definition.

## Verification
- `lake --wfail build`
