### PR TITLE
chore(Wikipedia/EllipticCurveRank): don't assume `AddCommMonoid E⟮K⟯`

### DIFF
--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -49,9 +49,8 @@ open Module (finrank)
 Consequently, the rank is always finite, so `finrank ℤ E⟮K⟯ = 0` really means that the group of
 rational points is torsion, not that it is of infinite rank. -/
 @[category research solved, AMS 11 14]
-instance {K} [Field K] [NumberField K] (E : WeierstrassCurve K) [E.IsElliptic]
-    [AddCommMonoid E⟮K⟯] [Module ℤ E⟮K⟯] :
-      Module.Finite ℤ E⟮K⟯ := by
+instance {K} [Field K] [NumberField K] [DecidableEq K] (E : WeierstrassCurve K) [E.IsElliptic] :
+    Module.Finite ℤ E⟮K⟯ := by
   sorry
 
 namespace RatEllipticCurve


### PR DESCRIPTION
Assuming this is nonsense. One should instead use the existing typeclass provided by mathlib.