### PR TITLE
feat(ErdosProblems/1052): link the fast proof of isUnitaryPerfect_87360

### DIFF
--- a/FormalConjectures/ErdosProblems/1052.lean
+++ b/FormalConjectures/ErdosProblems/1052.lean
@@ -64,12 +64,9 @@ theorem isUnitaryPerfect_90 : IsUnitaryPerfect 90 := by
   norm_num [IsUnitaryPerfect, properUnitaryDivisors]
   decide +kernel
 
-@[category test, AMS 11]
+@[category test, AMS 11, formal_proof using formal_conjectures at "https://github.com/Sanexxxx777/formal-conjectures/blob/be8aed15e8888a08bbe723170698e26c046412a4/FormalConjectures/ErdosProblems/1052.lean#L328"]
 theorem isUnitaryPerfect_87360 : IsUnitaryPerfect 87360 := by
-  -- TODO: Find a quicker proof. This one is too slow.
-  stop
-  norm_num [IsUnitaryPerfect, properUnitaryDivisors]
-  decide +kernel
+  sorry
 
 @[category test, AMS 11, formal_proof using formal_conjectures at "https://github.com/Sanexxxx777/formal-conjectures/blob/be8aed15e8888a08bbe723170698e26c046412a4/FormalConjectures/ErdosProblems/1052.lean#L346"]
 theorem isUnitaryPerfect_146361946186458562560000 : IsUnitaryPerfect 146361946186458562560000 := by


### PR DESCRIPTION
## Summary

`isUnitaryPerfect_87360` was left as a `stop`-ped slow `decide +kernel` with a `-- TODO: Find a quicker proof. This one is too slow.` marker. This PR replaces it with a `formal_proof` link to a fast proof, removing the last unproved test case in `ErdosProblems/1052.lean`.

The fast proof goes via multiplicativity of the sum-of-unitary-divisors function σ\*: from the factorisation `87360 = 2^6 · 3 · 5 · 7 · 13`, `sigmaStar` factors as a product of `(1 + p^a)`, and the goal reduces to `norm_num`. This is exactly the same technique (and same linked file/commit) as the already-merged link for the fifth, 24-digit unitary perfect number `isUnitaryPerfect_146361946186458562560000` (#4244) — this PR simply completes the pair.

## Linked proof

`formal_proof` points at the frozen commit on the fork where the full σ\* API lives and builds:
`Sanexxxx777/formal-conjectures@be8aed1 · FormalConjectures/ErdosProblems/1052.lean#L328`

## Verification

Built locally on the pinned toolchain (`leanprover/lean4:v4.27.0`):

```
'Erdos1052.isUnitaryPerfect_87360' depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorryAx`. The updated `1052.lean` in this repo compiles cleanly (the only remaining `sorry`s are the `research open`/`research solved` statements and the two `formal_proof`-linked test cases, as expected).