### PR TITLE
feat(Wikipedia): add Scholz conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -33,7 +33,7 @@ $$\ell(2^n - 1) \le n - 1 + \ell(n).$$
 - [MathWorld](https://mathworld.wolfram.com/ScholzConjecture.html)
 -/
 
-namespace Scholz
+namespace ScholzConjecture
 
 /-- `IsAdditionChain c` asserts that the list `c` is an addition chain: it starts at
 `1`, is strictly increasing, and every entry after the first is the sum of two (not

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -1,0 +1,68 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Scholz conjecture on addition chains
+
+An *addition chain* for a positive integer `n` is a strictly increasing sequence
+`1 = a₀ < a₁ < ⋯ < a_r = n` in which every entry after the first is the sum of two
+(not necessarily distinct) earlier entries. The *length* `ℓ(n)` is the minimal number
+of addition steps `r` over all such chains.
+
+The **Scholz conjecture** (also known as the Scholz–Brauer or Brauer–Scholz conjecture)
+asserts that for every positive integer `n`,
+$$\ell(2^n - 1) \le n - 1 + \ell(n).$$
+
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Scholz_conjecture)
+- [MathWorld](https://mathworld.wolfram.com/ScholzConjecture.html)
+-/
+
+namespace Scholz
+
+/-- `IsAdditionChain c` asserts that the list `c` is an addition chain: it starts at
+`1`, is strictly increasing, and every entry after the first is the sum of two (not
+necessarily distinct) earlier entries. The step condition is phrased with the safe
+`getElem?` accessor: for each valid index `i ≠ 0` there are earlier indices `j, k` with
+`c[i]? = c[j]? + c[k]?` (as `Option`-valued sums). -/
+def IsAdditionChain (c : List ℕ) : Prop :=
+  c.head? = some 1 ∧
+  c.Pairwise (· < ·) ∧
+  ∀ i, i ≠ 0 → i < c.length →
+    ∃ j k, j < i ∧ k < i ∧ getElem? c i = (· + ·) <$> getElem? c j <*> getElem? c k
+
+/-- The length `ℓ(n)` of `n`: the minimal number of addition steps (number of entries
+minus one) over all addition chains ending at `n`. -/
+noncomputable def additionChainLength (n : ℕ) : ℕ :=
+  sInf { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
+
+local notation "ℓ(" n ")" => additionChainLength n
+
+/--
+The Scholz conjecture, also known as the Scholz-Brauer conjecture, asserts that
+for every positive integer $n$, the addition-chain length of $2^n - 1$ is at most
+$n - 1 + \ell(n)$.
+
+References: Wikipedia and MathWorld.
+-/
+@[category research open, AMS 11 68]
+theorem scholz_conjecture (n : ℕ) (hn : 0 < n) :
+    ℓ(2 ^ n - 1) ≤ n - 1 + ℓ(n) := by
+  sorry
+
+end Scholz

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -19,34 +19,29 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Scholz conjecture on addition chains
 
-An *addition chain* for a positive integer `n` is a strictly increasing sequence
-`1 = a₀ < a₁ < ⋯ < a_r = n` in which every entry after the first is the sum of two
-(not necessarily distinct) earlier entries. The *length* `ℓ(n)` is the minimal number
-of addition steps `r` over all such chains.
-
-The **Scholz conjecture** (also known as the Scholz–Brauer or Brauer–Scholz conjecture)
-asserts that for every positive integer `n`,
-$$\ell(2^n - 1) \le n - 1 + \ell(n).$$
-
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Scholz_conjecture)
 - [MathWorld](https://mathworld.wolfram.com/ScholzConjecture.html)
+- [Tall22](https://arxiv.org/abs/2210.13812) Amadou Tall. "The Scholz conjecture on addition
+  chain is true for infinitely many integers with $\ell(2n) = \ell(n)$." _arXiv:2210.13812_ (2022).
+  Also available as [ePrint 2023/020](https://eprint.iacr.org/2023/020).
 -/
 
 namespace ScholzConjecture
 
-/-- `IsAdditionChain c` asserts that the list `c` is an addition chain: it starts at
-`1`, is strictly increasing, and every entry after the first is the sum of two (not
-necessarily distinct) earlier entries. The step condition is phrased with the safe
-`getElem?` accessor: for each valid index `i ≠ 0` there are earlier indices `j, k` with
-`c[i]? = c[j]? + c[k]?` (as `Option`-valued sums). -/
+/-- An *addition chain* is a strictly increasing sequence
+$1 = a_0 < a_1 < \cdots < a_r$ in which every entry after the first is the sum of two
+(not necessarily distinct) earlier entries.
+
+`IsAdditionChain c` asserts that the list $c$ is such a chain: it starts at $1$, is
+strictly increasing, and every entry other than $1$ is a sum of two entries of $c$. -/
 def IsAdditionChain (c : List ℕ) : Prop :=
   c.head? = some 1 ∧
   c.Pairwise (· < ·) ∧
   ∀ x ∈ c, x ≠ 1 → ∃ y ∈ c, ∃ z ∈ c, x = y + z
 
-/-- The length `ℓ(n)` of `n`: the minimal number of addition steps (number of entries
-minus one) over all addition chains ending at `n`. -/
+/-- The *length* $\ell(n)$ of $n$: the minimal number of addition steps (the number of
+entries minus one) over all addition chains ending at $n$. -/
 noncomputable def additionChainLength (n : ℕ) : ℕ :=
   sInf { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
 

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -64,4 +64,4 @@ theorem scholz_conjecture (n : ℕ) (hn : 0 < n) :
     ℓ(2 ^ n - 1) ≤ n - 1 + ℓ(n) := by
   sorry
 
-end Scholz
+end ScholzConjecture

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -59,4 +59,11 @@ theorem scholz_conjecture :
 
 -- TODO(eyang07): add solved variants. See Wikipedia reference.
 
+/-- The first few values of $\ell(n)$. See [OEIS A003313](https://oeis.org/A003313). -/
+@[category test, AMS 11]
+theorem additionChainLength_first_values :
+    [ℓ(1), ℓ(2), ℓ(3), ℓ(4), ℓ(5), ℓ(6), ℓ(7), ℓ(8), ℓ(9), ℓ(10)] =
+    [0, 1, 2, 2, 3, 3, 4, 3, 4, 4] := by
+  sorry
+  
 end ScholzConjecture

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -43,8 +43,7 @@ necessarily distinct) earlier entries. The step condition is phrased with the sa
 def IsAdditionChain (c : List ℕ) : Prop :=
   c.head? = some 1 ∧
   c.Pairwise (· < ·) ∧
-  ∀ i, i ≠ 0 → i < c.length →
-    ∃ j k, j < i ∧ k < i ∧ getElem? c i = (· + ·) <$> getElem? c j <*> getElem? c k
+  ∀ x ∈ c, x ≠ 1 → ∃ y ∈ c, ∃ z ∈ c, x = y + z
 
 /-- The length `ℓ(n)` of `n`: the minimal number of addition steps (number of entries
 minus one) over all addition chains ending at `n`. -/

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -57,4 +57,6 @@ theorem scholz_conjecture :
     answer(sorry) ↔ ∀ (n : ℕ), 0 < n → ℓ(2 ^ n - 1) ≤ n - 1 + ℓ(n) := by
   sorry
 
+-- TODO(eyang07): add solved variants. See Wikipedia reference.
+
 end ScholzConjecture

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -56,8 +56,6 @@ local notation "ℓ(" n ")" => additionChainLength n
 The Scholz conjecture, also known as the Scholz-Brauer conjecture, asserts that
 for every positive integer $n$, the addition-chain length of $2^n - 1$ is at most
 $n - 1 + \ell(n)$.
-
-References: Wikipedia and MathWorld.
 -/
 @[category research open, AMS 11 68]
 theorem scholz_conjecture (n : ℕ) (hn : 0 < n) :

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -25,6 +25,7 @@ import FormalConjectures.Util.ProblemImports
 - [Tall22](https://arxiv.org/abs/2210.13812) Amadou Tall. "The Scholz conjecture on addition
   chain is true for infinitely many integers with $\ell(2n) = \ell(n)$." _arXiv:2210.13812_ (2022).
   Also available as [ePrint 2023/020](https://eprint.iacr.org/2023/020).
+- [OEIS A003313](https://oeis.org/A003313)
 -/
 
 namespace ScholzConjecture

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -53,8 +53,8 @@ for every positive integer $n$, the addition-chain length of $2^n - 1$ is at mos
 $n - 1 + \ell(n)$.
 -/
 @[category research open, AMS 11 68]
-theorem scholz_conjecture (n : ℕ) (hn : 0 < n) :
-    ℓ(2 ^ n - 1) ≤ n - 1 + ℓ(n) := by
+theorem scholz_conjecture :
+    answer(sorry) ↔ ∀ (n : ℕ), 0 < n → ℓ(2 ^ n - 1) ≤ n - 1 + ℓ(n) := by
   sorry
 
 end ScholzConjecture

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Util.ProblemImports
+import FormalConjecturesUtil
 
 /-!
 # Scholz conjecture on addition chains


### PR DESCRIPTION
Closes #2217.

Tested with: `lake --wfail build FormalConjectures.Wikipedia.ScholzConjecture`.