### PR TITLE
feat(ErdosProblems/90): link formal proof of unit distance disproof

### DIFF
--- a/FormalConjectures/ErdosProblems/90.lean
+++ b/FormalConjectures/ErdosProblems/90.lean
@@ -99,7 +99,8 @@ Tsimerman–Wang–Matchett Wood, [*Remarks on the disproof of the unit distance
 unit distance problem*](https://arxiv.org/abs/2605.20579) (2026); see
 `erdos_90.variants.sawin_explicit` below.
 -/
-@[category research solved, AMS 52]
+@[category research solved, AMS 52, formal_proof using lean4 at
+"https://github.com/plby/Erdos90"]
 theorem erdos_90.variants.polynomial_lower_bound :
     ∃ c > (0 : ℝ),
       {n : ℕ | (n : ℝ) ^ (1 + c) ≤ (maxUnitDistances n : ℝ)}.Infinite := by


### PR DESCRIPTION
erdosproblems.com/90 now marks the problem **DISPROVED (LEAN)** ("solved in the negative and the proof verified in Lean"). A complete, sorry-free Lean 4 formalisation of OpenAI's 2026 counterexample exists at [plby/Erdos90](https://github.com/plby/Erdos90) (Boris Alexeev); its main theorem matches `erdos_90.variants.polynomial_lower_bound`, so this adds the corresponding `formal_proof using lean4` annotation. No statements changed.

Closes #4229