### PR TITLE
feat(ErdosProblems/888): record 2026 order-of-growth solution

### DIFF
--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -20,6 +20,14 @@ import FormalConjectures.Util.ProblemImports
 # Erdős Problem 888
 
 *Reference:* [erdosproblems.com/888](https://www.erdosproblems.com/888)
+
+Let $f(n)$ be the size of the largest $A \subseteq \{1,\dots,n\}$ with $ad = bc$ whenever
+$a \le b \le c \le d \in A$ and $abcd$ is a perfect square. The order of growth was determined
+in 2026: the semiprimes (noted by Cambie and Weisenberg) give
+$f(n) \ge (1 + o(1)) \frac{n \log\log n}{\log n}$, and a matching upper bound
+$f(n) \ll \frac{n \log\log n}{\log n}$ was proved by GPT-5.5 Pro (prompted by Chojecki),
+so $f(n) = \Theta\!\left(\frac{n \log\log n}{\log n}\right)$. The exact value of $f(n)$
+remains open.
 -/
 
 open Classical Filter
@@ -52,4 +60,20 @@ theorem erdos_888.variants.sarkozy : (fun n ↦ (Nat.findGreatest (p n) n : ℝ)
 /-- The primes show that `|A| ≫ n/log n` is possible. -/
 @[category research solved, AMS 11]
 theorem erdos_888.variants.primes : (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ )) ≫ (fun n : ℕ ↦ n / (n : ℝ).log) := by
+  sorry
+
+/-- The **semiprimes** $\le n$ satisfy the condition, and there are
+$(1 + o(1)) \frac{n \log\log n}{\log n}$ of them, giving the sharp lower bound.
+Noted by Cambie and Weisenberg. -/
+@[category research solved, AMS 11]
+theorem erdos_888.variants.semiprimes :
+    (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ)) ≫ (fun n : ℕ ↦ n * (n : ℝ).log.log / (n : ℝ).log) := by
+  sorry
+
+/-- **Matching upper bound** (proved by GPT-5.5 Pro, prompted by Chojecki, 2026):
+$f(n) \ll \frac{n \log\log n}{\log n}$. Together with `semiprimes` this determines
+the order of growth of $f(n)$. -/
+@[category research solved, AMS 11]
+theorem erdos_888.variants.upper_bound :
+    (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ)) ≪ (fun n : ℕ ↦ n * (n : ℝ).log.log / (n : ℝ).log) := by
   sorry


### PR DESCRIPTION
erdosproblems.com/888 now marks the problem **SOLVED**: the order of growth of the extremal set is $\Theta(n \log\log n / \log n)$ — the semiprimes (noted by Cambie and Weisenberg) give the sharp lower bound, and a matching upper bound $f(n) \ll n \log\log n/\log n$ was proved by GPT-5.5 Pro (prompted by Chojecki). This records both sharp bounds as `research solved` variants and updates the module docstring.

The main theorem `erdos_888` asks for the exact value of `Nat.findGreatest`, which is only known up to constants, so it stays `research open` — happy to adjust if the maintainers prefer a different treatment.

Closes #4099