### PR TITLE
feat(ErdosProblems/1): link a complete formal proof of lb_strong

### DIFF
--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -89,7 +89,9 @@ theorem erdos_1.variants.lb : ∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ �
 A number of improvements of the constant $\frac{1}{4}$ have been given, with the current
 record $\sqrt{2 / \pi}$ first provied in unpublished work of Elkies and Gleason.
 -/
-@[category research solved, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using formal_conjectures at
+    "https://github.com/MyTH-zyxeon/formal-conjectures/blob/362eed1a8864d142ae65f51af7981a7c7530956e/FormalConjectures/Scratch/HarperCompression.lean#L2174"]
 theorem erdos_1.variants.lb_strong : ∃ (o : ℕ → ℝ) (_ : o =o[atTop] (1 : ℕ → ℝ)),
     ∀ (N : ℕ) (A : Finset ℕ) (h : IsSumDistinctSet A N),
       (√(2 / π) - o A.card) * 2 ^ A.card / (A.card : ℝ).sqrt ≤ N := by


### PR DESCRIPTION
Adds a formal_proof attribute to erdos_1.variants.lb_strong pointing to a complete, sorry-free Lean 4 proof hosted at a pinned commit of this fork (branch erdos1-lb-strong, commit 362eed1a).

## details

This PR adds a `formal_proof` attribute to `erdos_1.variants.lb_strong` — the √(2/π) asymptotic lower bound for the distinct subset sums problem (currently a `sorry` stub).

A complete, sorry-free Lean 4 proof of a statement verbatim-identical to `lb_strong` is hosted at a pinned commit of my fork, [`lb_strong_proved`](https://github.com/MyTH-zyxeon/formal-conjectures/blob/362eed1a8864d142ae65f51af7981a7c7530956e/FormalConjectures/Scratch/HarperCompression.lean#L2174). Following CONTRIBUTING's guidance that proofs longer than 25–50 lines should be hosted externally and linked via the `formal_proof` mechanism, this PR only adds the attribute.

About the proof (~2,700 lines across three files; `lake --wfail build` green on this repository's toolchain/Mathlib pin; no `sorry`/`admit`/`axiom`):
- **Stirling analysis** - central binomial asymptotics `C(2m,m) ~ 4^m/√(πm)` via a `stirlingSeq`-ratio argument, giving `C(n,⌊n/2⌋)·√n/2ⁿ → √(2/π)`.
- **The Dubroff–Fox–Xu reduction** (arXiv:2006.12988, second proof) - the exact bound `N ≥ C(n,⌊n/2⌋)` from the half-cube case of Harper's theorem.
- **A self-contained compression proof of Harper's vertex-isoperimetric theorem** (simplicial order, i-compressions, fixed-point dichotomy including the exceptional half-size family) — to my knowledge not currently available in Mathlib.

- **AI disclosure** - this proof was developed by multiple AI agents in an implement/review loop (every increment independently reviewed and rebuilt by two reviewer agents), under my supervision, following the guidelines in this repository's AGENTS.md. I reviewed this submission.