### PR TITLE
fix(ErdosProblems): 522 — make h_unif satisfiable (counting-measure reference for the discrete coefficient sets)

### DIFF
--- a/FormalConjectures/ErdosProblems/522.lean
+++ b/FormalConjectures/ErdosProblems/522.lean
@@ -33,6 +33,14 @@ of independent random variables, each uniformly distributed over `S`.
 
 Such a sequence determines a *Kac polynomial* of degree `n` for each `n`, which is the random
 polynomial given by `KacCoefficients.polynomial`.
+
+Note: the uniformity hypothesis `h_unif` is relative to the reference measure `μ`. For the
+discrete coefficient sets used in this file (`{-1, 1}`, `{0, 1}`), the statements below
+instantiate `μ := Measure.count`, so that `h_unif` states that the law of each coefficient is
+`ProbabilityTheory.uniformOn S`. The `volume` default would be degenerate here: a finite `S` is
+`volume`-null, conditioning `volume` on it yields the zero measure, and no a.e.-measurable
+coefficient has the zero measure as its law. See the regression witness
+`coinKacCoefficients` below.
 -/
 @[ext]
 structure KacCoefficients
@@ -77,6 +85,86 @@ noncomputable def numRootsInUnitDisk [PseudoMetricSpace k] (c : KacCoefficients 
 
 end KacCoefficients
 
+/-!
+### Regression witness
+
+An honest Rademacher coefficient sequence — coordinate signs on the Bernoulli space
+`ℕ → Bool` carrying the infinite product of fair coins — inhabits
+`KacCoefficients ({-1, 1} : Set ℂ) (ℕ → Bool) Measure.count`, so the statements below
+quantify over the intended instances. (With the previously elided `volume` default the
+structure admitted no a.e.-measurable coefficients at all.)
+-/
+
+section RegressionWitness
+
+/-- The fair coin measure on `Bool`: `½ (δ_false + δ_true)`. -/
+noncomputable def fairCoin : Measure Bool :=
+  (2 : ENNReal)⁻¹ • (Measure.dirac false + Measure.dirac true)
+
+instance : IsProbabilityMeasure fairCoin := by
+  refine ⟨?_⟩
+  rw [fairCoin, Measure.smul_apply, Measure.add_apply, measure_univ, measure_univ,
+    smul_eq_mul, one_add_one_eq_two, ENNReal.inv_mul_cancel two_ne_zero ENNReal.ofNat_ne_top]
+
+/-- The Bernoulli sequence space: `ℕ → Bool` carrying the infinite product of fair-coin
+measures (Ionescu-Tulcea). Local instance — scoped to this section. -/
+@[reducible] noncomputable def coinSpace : MeasureSpace (ℕ → Bool) :=
+  ⟨Measure.infinitePi fun _ => fairCoin⟩
+
+attribute [local instance] coinSpace
+
+/-- The coin-to-sign map: `true ↦ 1`, `false ↦ -1`. -/
+def boolSign (b : Bool) : ℂ := if b then 1 else -1
+
+lemma measurable_boolSign : Measurable boolSign := Measurable.of_discrete
+
+/-- `uniformOn` of a two-point set is the average of the two Dirac masses. -/
+lemma uniformOn_pair {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α]
+    {a b : α} (hab : a ≠ b) :
+    ProbabilityTheory.uniformOn ({a, b} : Set α) =
+      (2 : ENNReal)⁻¹ • (Measure.dirac a + Measure.dirac b) := by
+  have hd : Disjoint ({a} : Set α) ({b} : Set α) := Set.disjoint_singleton.mpr hab
+  have hcount : Measure.count ({a, b} : Set α) = 2 := by
+    rw [Set.insert_eq, measure_union hd (measurableSet_singleton b),
+      Measure.count_singleton, Measure.count_singleton, one_add_one_eq_two]
+  unfold ProbabilityTheory.uniformOn ProbabilityTheory.cond
+  rw [hcount, Set.insert_eq, Measure.restrict_union hd (measurableSet_singleton b),
+    Measure.restrict_singleton, Measure.restrict_singleton,
+    Measure.count_singleton, Measure.count_singleton, one_smul, one_smul]
+
+/-- The law of the coin sign is uniform on `{-1, 1}` w.r.t. counting measure. -/
+lemma map_boolSign_fairCoin :
+    Measure.map boolSign fairCoin = ProbabilityTheory.uniformOn ({-1, 1} : Set ℂ) := by
+  rw [uniformOn_pair (by norm_num : (-1 : ℂ) ≠ 1), fairCoin,
+    Measure.map_smul, Measure.map_add _ _ measurable_boolSign,
+    Measure.map_dirac measurable_boolSign false, Measure.map_dirac measurable_boolSign true]
+  rfl
+
+/-- An honest Rademacher coefficient sequence inhabits the counting-measure structure. -/
+noncomputable def coinKacCoefficients :
+    KacCoefficients ({-1, 1} : Set ℂ) (ℕ → Bool) Measure.count where
+  toFun i ω := boolSign (ω i)
+  h_indep :=
+    ProbabilityTheory.iIndepFun_infinitePi (P := fun _ => fairCoin)
+      (X := fun _ : ℕ => boolSign) (fun _ => measurable_boolSign)
+  h_unif i := by
+    show Measure.map (fun ω : ℕ → Bool => boolSign (ω i)) ℙ =
+      ProbabilityTheory.cond Measure.count ({-1, 1} : Set ℂ)
+    have h1 : (fun ω : ℕ → Bool => boolSign (ω i)) =
+        boolSign ∘ (fun ω : ℕ → Bool => ω i) := rfl
+    have h2 : Measure.map (fun ω : ℕ → Bool => ω i) ℙ = fairCoin :=
+      Measure.infinitePi_map_eval (fun _ => fairCoin) i
+    rw [h1, ← Measure.map_map measurable_boolSign (measurable_pi_apply i), h2,
+      map_boolSign_fairCoin]
+    rfl
+
+/-- The structure with `μ := Measure.count` is non-vacuous. -/
+theorem kacCoefficients_count_nonempty :
+    Nonempty (KacCoefficients ({-1, 1} : Set ℂ) (ℕ → Bool) Measure.count) :=
+  ⟨coinKacCoefficients⟩
+
+end RegressionWitness
+
 /--
 Let $f(z)=\sum_{0\leq k\leq n} \epsilon_k z^k$ be a random polynomial, where
 $\epsilon_k\in \{-1,1\}$ independently uniformly at random for $0\leq k\leq n$.
@@ -94,7 +182,7 @@ see `erdos_522.variants.zero_one` for the alternate version.
 @[category research open, AMS 12 60]
 theorem erdos_522 :
     answer(sorry) ↔ ∀ {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-      (c : KacCoefficients ({-1, 1} : Set ℂ) Ω),
+      (c : KacCoefficients ({-1, 1} : Set ℂ) Ω Measure.count),
       ℙ {ω | atTop.Tendsto (fun n : ℕ ↦ (2 * c.numRootsInUnitDisk n ω : ℝ) / n) (𝓝 1)} = 1 := by
   sorry
 
@@ -112,7 +200,7 @@ almost surely?
 @[category research open, AMS 12 60]
 theorem erdos_522.variants.zero_one :
     answer(sorry) ↔ ∀ {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-      {n : ℕ} (hn : 1 ≤ n) (f : KacCoefficients ({0, 1} : Set ℂ) Ω),
+      {n : ℕ} (hn : 1 ≤ n) (f : KacCoefficients ({0, 1} : Set ℂ) Ω Measure.count),
       ℙ {ω | atTop.Tendsto (fun n : ℕ ↦ (2 * f.numRootsInUnitDisk n ω : ℝ) / n) (𝓝 1)} = 1 := by
   sorry
 
@@ -124,7 +212,7 @@ coefficients is `(2/π+o(1))log n`.
 theorem erdos_522.variants.number_real_roots : ∃ p o : ℕ → ℝ,
     atTop.Tendsto o (𝓝 0) ∧ atTop.Tendsto p (𝓝 0) ∧
     ∀ (Ω : Type*) [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-      (n : ℕ) (hn : 2 ≤ n) (f : KacCoefficients ({-1, 1} : Set ℝ) Ω),
+      (n : ℕ) (hn : 2 ≤ n) (f : KacCoefficients ({-1, 1} : Set ℝ) Ω Measure.count),
       (ℙ {ω | |(f.roots n ω).card / (n : ℝ).log - 2 / π| ≥ o n}).toReal ≤ p n := by
   sorry
 
@@ -135,7 +223,7 @@ Yakir proved that almost all Kac polynomials have `n/2+O(n^(9/10))` many roots i
 theorem erdos_522.variants.yakir_solution :
     ∃ p : ℕ → ℝ, atTop.Tendsto p (𝓝 0) ∧
     ∀ (Ω : Type*) [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
-      (n : ℕ) (hn : 2 ≤ n) (f : KacCoefficients ({-1, 1} : Set ℂ) Ω),
+      (n : ℕ) (hn : 2 ≤ n) (f : KacCoefficients ({-1, 1} : Set ℂ) Ω Measure.count),
        (ℙ {ω | |(f.roots n ω).countP
          (· ∈ Metric.closedBall 0 1) - (n / 2 : ℝ)| ≥ n^(9/10 : ℝ) }).toReal ≤ p n := by
   sorry


### PR DESCRIPTION
Fixes #4386.

`KacCoefficients` requires `h_unif : ∀ i, pdf.IsUniform (toFun i) S ℙ μ` with the
reference measure `μ` defaulting to `volume` via `volume_tac`, and all four statements
in `522.lean` elided `μ`, so the default fired. The coefficient sets here are finite,
hence `volume`-null, so `ProbabilityTheory.cond volume S` is the zero measure and
`h_unif` demanded `Measure.map (toFun i) ℙ = 0` — impossible for any a.e.-measurable
coefficient (the map of a probability measure under an a.e.-measurable function is a
probability measure). The statements therefore quantified over no intended instance.
See #4386 for the machine-checked exclusion.

Changes (Option A from the issue — no structure change):

- Instantiate `μ := Measure.count` at the four statement sites (`erdos_522`,
  `erdos_522.variants.zero_one`, `erdos_522.variants.number_real_roots`,
  `erdos_522.variants.yakir_solution`). With the counting measure, `h_unif` unfolds
  definitionally to `Measure.map (toFun i) ℙ = ProbabilityTheory.uniformOn S` — each
  coefficient's law is the uniform distribution on the (two-point) coefficient set, as
  intended. Since `Measure.map` junk-defaults to `0` for non-a.e.-measurable functions
  and `uniformOn S ≠ 0`, this also forces each coefficient to be a.e.-measurable — no
  extra measurability field needed.
- Add a note to the `KacCoefficients` docstring explaining the reference-measure choice.
- Add a regression witness (`RegressionWitness` section): an honest Rademacher
  coefficient sequence — coordinate signs on `ℕ → Bool` with the infinite product of
  fair coins (`Measure.infinitePi`) — inhabiting
  `KacCoefficients ({-1, 1} : Set ℂ) (ℕ → Bool) Measure.count`
  (`coinKacCoefficients`, with `kacCoefficients_count_nonempty`), so the statements are
  known to quantify over at least the intended objects. Independence is
  `iIndepFun_infinitePi`; the marginal law is `infinitePi_map_eval` pushed through the
  sign map; the supporting `uniformOn_pair` lemma computes `uniformOn {a, b}` as the
  average of two Dirac masses.

The four theorem statements' mathematical content is otherwise unchanged (same
convergence mode, same sets, same bounds); the two open problems keep
`answer(sorry)` and everything keeps its `sorry` proof.

Verified downstream against Mathlib v4.31.0 (statements elaborate; the witness and
supporting lemmas depend on exactly `[propext, Classical.choice, Quot.sound]`); all
Mathlib names used were checked present at this repo's v4.27.0 pin. Happy to iterate on
any CI/linter feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Hhp9yDLeqxGUEGDkXT5Mh
