### PR TITLE
feat(ErdosProblems/884): link formal proof of Larsen's unconditional disproof

### DIFF
--- a/FormalConjectures/ErdosProblems/884.lean
+++ b/FormalConjectures/ErdosProblems/884.lean
@@ -24,8 +24,6 @@ import FormalConjectures.Wikipedia.HardyLittlewood
 - [erdosproblems.com/884](https://www.erdosproblems.com/884)
 - [Tao25](https://terrytao.wordpress.com/wp-content/uploads/2025/09/erdos-884.pdf)
 - [Larsen](https://github.com/Larsen-Daniel/Erdos-884/blob/main/884.pdf)
-- [CF26] Claude Fable 5 (with minor guidance from R. J. Honicky),
-  [Lean formalisation of Erdős problem 884](https://github.com/honicky/erdos884) (2026)
 -/
 
 namespace Erdos884
@@ -80,14 +78,12 @@ This conjecture has been **disproved**:
 - Daniel Larsen subsequently gave an
   [unconditional disproof](https://github.com/Larsen-Daniel/Erdos-884/blob/main/884.pdf).
 
-Larsen's unconditional disproof has been formalised in Lean 4 (over Mathlib) by Claude Fable 5,
-with minor guidance from R. J. Honicky [CF26]; the linked development proves `¬ Erdos884Prop`, in
-the exact `answer(False) ↔ Erdos884Prop` shape of this statement (see `erdos_884_iff_false` there).
+This was formalized in lean by Honicky using Claude Fable 5.
 
 *Reference:* [erdosproblems.com/884](https://www.erdosproblems.com/884)
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at
-  "https://github.com/honicky/erdos884"]
+  "https://github.com/honicky/erdos884/blob/main/Erdos884.lean"]
 theorem erdos_884 :
     answer(False) ↔ Erdos884Prop := by
   sorry

--- a/FormalConjectures/ErdosProblems/884.lean
+++ b/FormalConjectures/ErdosProblems/884.lean
@@ -24,6 +24,8 @@ import FormalConjectures.Wikipedia.HardyLittlewood
 - [erdosproblems.com/884](https://www.erdosproblems.com/884)
 - [Tao25](https://terrytao.wordpress.com/wp-content/uploads/2025/09/erdos-884.pdf)
 - [Larsen](https://github.com/Larsen-Daniel/Erdos-884/blob/main/884.pdf)
+- [CF26] Claude Fable 5 (with minor guidance from R. J. Honicky),
+  [Lean formalisation of Erdős problem 884](https://github.com/honicky/erdos884) (2026)
 -/
 
 namespace Erdos884
@@ -78,9 +80,14 @@ This conjecture has been **disproved**:
 - Daniel Larsen subsequently gave an
   [unconditional disproof](https://github.com/Larsen-Daniel/Erdos-884/blob/main/884.pdf).
 
+Larsen's unconditional disproof has been formalised in Lean 4 (over Mathlib) by Claude Fable 5,
+with minor guidance from R. J. Honicky [CF26]; the linked development proves `¬ Erdos884Prop`, in
+the exact `answer(False) ↔ Erdos884Prop` shape of this statement (see `erdos_884_iff_false` there).
+
 *Reference:* [erdosproblems.com/884](https://www.erdosproblems.com/884)
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/honicky/erdos884"]
 theorem erdos_884 :
     answer(False) ↔ Erdos884Prop := by
   sorry


### PR DESCRIPTION
[erdosproblems.com/884](https://www.erdosproblems.com/884) is **disproved**: Tao gave a conditional disproof (assuming the prime tuples conjecture), and Daniel Larsen subsequently gave an [unconditional disproof](https://github.com/Larsen-Daniel/Erdos-884/blob/main/884.pdf). This PR links a Lean 4 / Mathlib formalisation of Larsen's unconditional disproof.

The formalisation lives at [honicky/erdos884](https://github.com/honicky/erdos884). Its `erdos_884_iff_false` proves `False ↔ (sumDivisorInvPairwiseDifference =O[Filter.atTop] (1 + sumDivisorInvConsecutiveDifference))` — i.e. exactly the `answer(False) ↔ Erdos884Prop` statement of `erdos_884` with `answer(False)` reduced to `False` and `≪` unfolded to `Asymptotics.IsBigO Filter.atTop`. The `sumDivisorInvPairwiseDifference` / `sumDivisorInvConsecutiveDifference` definitions in the linked development are token-identical to those in this file.

Verification:
- **Offline** `lake build` against Mathlib `v4.31.0`: 0 errors, 0 `sorry`.
- **Independently** via the [Axle](https://axle.axiommath.ai) hosted engine.
- Both report `#print axioms erdos_884_disproof = [propext, Classical.choice, Quot.sound]` (the three standard Mathlib axioms only).

This follows the convention used for `erdos_258`: the `sorry` in this repo's file is retained and a `@[formal_proof using lean4 at "…"]` attribute is added, since per CONTRIBUTING longer proofs are hosted externally and linked rather than inlined. **No statements changed.**

Notes for reviewers:
- The proof formalises Larsen's construction (multiscale product of near-consecutive primes), building on a vendored copy of the Selberg-sieve fundamental theorem from [PrimeNumberTheoremAnd](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd) (Apache-2.0). The linked repo has a README describing structure and both verification paths.
- Context: #3954 (status-sync) previously flagged 884 as solved; this PR adds the formal-proof link.
