### PR TITLE
Add OEIS A397433 reference to Erdős problem 448

### DIFF
--- a/FormalConjectures/ErdosProblems/448.lean
+++ b/FormalConjectures/ErdosProblems/448.lean
@@ -21,6 +21,8 @@ import FormalConjectures.Util.ProblemImports
 
 *References:*
 - [erdosproblems.com/448](https://www.erdosproblems.com/448)
+- [OEIS A397433](https://oeis.org/A397433): the integer sequence $\tau^+(n)$
+  (the constant $\alpha$ in Ford's asymptotic is [OEIS A074738](https://oeis.org/A074738)).
 - [Er79] Erdős, Paul, Some unconventional problems in number theory. Math. Mag. (1979), 67-70.
 - [Er79e] Erdős, Paul, Some unconventional problems in number theory. Astérisque (1979), 73-82.
 - [HaTe88] Hall, Richard R. and Tenenbaum, Gérald, Divisors. (1988), xvi+167.


### PR DESCRIPTION
Adds a reference to the OEIS entry for this problem's sequence: tau^+(n) is now published as A397433 (https://oeis.org/A397433), and the Ford constant alpha is A074738. Docstring-only change (no code changes).

I used Claude Code with the Claude Fable 5 model to add the two docstring lines to `448.lean`, linking to A397433 and A074738. No code or proofs were changed, and I personally reviewed and verified both links; A397433 is my own OEIS submission.
