### PR TITLE
feat(GreensOpenProblems): 55

### DIFF
--- a/FormalConjectures/GreensOpenProblems/55.lean
+++ b/FormalConjectures/GreensOpenProblems/55.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
-import FormalConjecturesForMathlib.Combinatorics.Additive.GowersNorm
 
 /-!
 # Ben Green's Open Problem 55

--- a/FormalConjectures/GreensOpenProblems/55.lean
+++ b/FormalConjectures/GreensOpenProblems/55.lean
@@ -1,0 +1,93 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Ben Green's Open Problem 55
+
+*Reference:*
+- [Gr24] [Green, Ben. "100 open problems." (2024).](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.55)
+- [Au14] T. Austin, Partial difference equations over compact Abelian groups, I: modules of solutions,
+  https://arxiv.org/abs/1305.7269.
+- [GrTa10] Green, Benjamin, and Terence Tao. "Linear equations in primes."
+  Annals of mathematics (2010): 1753-1850.
+- [GTZ12] Green, Ben, Terence Tao, and Tamar Ziegler. "An inverse theorem for the Gowers $U^{s+1}[N]$-norm."
+  Annals of Mathematics (2012): 1231-1372.
+-/
+
+namespace Green55
+
+open scoped BigOperators
+open Complex
+
+/-- Shorthand notation for `𝔽 p n` over `p, n` as variables. -/
+local macro "𝔽ₚⁿ" : term => `(𝔽 $(Lean.mkIdent `p) $(Lean.mkIdent `n))
+
+/--
+The fourth power of the box norm of a function $g : G \times G \to \mathbb{C}$ on a finite type $G$,
+see [GrTa10, Appendix B.1].
+-/
+noncomputable def boxNorm4 {G : Type*} [Fintype G] (g : G × G → ℂ) : ℝ :=
+  (1 / (Nat.card G : ℝ)^4) * (∑ x₁ : G, ∑ x₂ : G, ∑ y₁ : G, ∑ y₂ : G,
+    g (x₁, y₁) * star (g (x₁, y₂)) * star (g (x₂, y₁)) * g (x₂, y₂)).re
+
+/--
+The multiplicative derivative $\Delta_{(h,h)} f (x, y) = f(x, y) \overline{f(x+h, y+h)}$.
+[Au14, Section 1.3 p.15]
+
+NOTE: the original problem statement from [Gr24] has a typo and conjugates the whole product.
+-/
+noncomputable def delta {G : Type*} [AddGroup G] (h : G) (f : G × G → ℂ) : G × G → ℂ :=
+  fun (x, y) ↦ f (x, y) * star (f (x + h, y + h))
+
+/--
+Let $p$ be an odd prime and suppose that $f : \mathbb{F}_p^n \times \mathbb{F}_p^n \to \mathbb{C}$
+is a function bounded pointwise by 1. Suppose that
+$\mathbb{E}_h \lVert \Delta_{(h,h)} f \rVert_{\square}^4 \geq \delta$.
+
+Does $f$ correlate with a function of the form $a(x)b(y)c(x+y)(-1)^{q(x,y)}$?
+
+NOTE: here "correlate" means that the inner product is at least $C(\delta) > 0$, see [GTZ12, Conjecture 1.2].
+-/
+@[category research open, AMS 5 11]
+theorem green_55 :
+    answer(sorry) ↔ ∀ (p : ℕ) [Fact p.Prime] (hp : p ≠ 2), ∃ C : ℝ → ℝ, (∀ δ > 0, 0 < C δ) ∧
+      ∀ (δ : ℝ) (hδ : 0 < δ) (n : ℕ)
+
+      -- Edge case: avoid the trivial truth  $|f(0,0)| \leq 1$ if n = 0 (single point domain)
+      (hn : 1 ≤ n)
+
+      (f : 𝔽ₚⁿ × 𝔽ₚⁿ → ℂ)
+      (hf : ∀ x, ‖f x‖ ≤ 1)
+
+      -- Since f is 1-bounded, and since the box norm counts bounded configurations, the expectation
+      -- of the box norm will never exceed 1. If $\delta > 1$, `h_bound` is vacuously false,
+      -- rendering the entire implication trivially true.
+      (hδ_le : δ ≤ 1)
+
+      (h_bound : (1 / (p^n : ℝ)) * ∑ h : 𝔽ₚⁿ, boxNorm4 (delta h f) ≥ δ),
+      ∃ (a b c : 𝔽ₚⁿ → ℂ) (q : 𝔽ₚⁿ × 𝔽ₚⁿ → ℤ),
+
+        -- Common assumption for inverse Gowers norm theorems, prevents trivial solutions by
+        -- arbitrarily scaling one of the functions (and thus the correlation).
+        (∀ x, ‖a x‖ ≤ 1) ∧ (∀ x, ‖b x‖ ≤ 1) ∧ (∀ x, ‖c x‖ ≤ 1) ∧
+
+        ‖(1 / (p^(2*n) : ℝ)) * ∑ x : 𝔽ₚⁿ, ∑ y : 𝔽ₚⁿ,
+          f (x, y) * star (a x * b y * c (x + y) * (-1 : ℂ) ^ q (x, y))‖ ≥ C δ := by
+  sorry
+
+end Green55

--- a/FormalConjectures/GreensOpenProblems/55.lean
+++ b/FormalConjectures/GreensOpenProblems/55.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjectures.Util.ProblemImports
+import FormalConjecturesForMathlib.Combinatorics.Additive.GowersNorm
 
 /-!
 # Ben Green's Open Problem 55
@@ -38,21 +39,12 @@ open Complex
 local macro "𝔽ₚⁿ" : term => `(𝔽 $(Lean.mkIdent `p) $(Lean.mkIdent `n))
 
 /--
-The fourth power of the box norm of a function $g : G \times G \to \mathbb{C}$ on a finite type $G$,
-see [GrTa10, Appendix B.1].
+The fourth power of the box norm of a function $g : G \times G \to \mathbb{C}$ on a finite type $G$.
+See [GrTa10, Appendix B.1].
 -/
 noncomputable def boxNorm4 {G : Type*} [Fintype G] (g : G × G → ℂ) : ℝ :=
   (1 / (Nat.card G : ℝ)^4) * (∑ x₁ : G, ∑ x₂ : G, ∑ y₁ : G, ∑ y₂ : G,
     g (x₁, y₁) * star (g (x₁, y₂)) * star (g (x₂, y₁)) * g (x₂, y₂)).re
-
-/--
-The multiplicative derivative $\Delta_{(h,h)} f (x, y) = f(x, y) \overline{f(x+h, y+h)}$.
-[Au14, Section 1.3 p.15]
-
-NOTE: the original problem statement from [Gr24] has a typo and conjugates the whole product.
--/
-noncomputable def delta {G : Type*} [AddGroup G] (h : G) (f : G × G → ℂ) : G × G → ℂ :=
-  fun (x, y) ↦ f (x, y) * star (f (x + h, y + h))
 
 /--
 Let $p$ be an odd prime and suppose that $f : \mathbb{F}_p^n \times \mathbb{F}_p^n \to \mathbb{C}$
@@ -79,7 +71,7 @@ theorem green_55 :
       -- rendering the entire implication trivially true.
       (hδ_le : δ ≤ 1)
 
-      (h_bound : (1 / (p^n : ℝ)) * ∑ h : 𝔽ₚⁿ, boxNorm4 (delta h f) ≥ δ),
+      (h_bound : (1 / (p^n : ℝ)) * ∑ h : 𝔽ₚⁿ, boxNorm4 (multiplicativeDerivative (h, h) f) ≥ δ),
       ∃ (a b c : 𝔽ₚⁿ → ℂ) (q : 𝔽ₚⁿ × 𝔽ₚⁿ → ℤ),
 
         -- Common assumption for inverse Gowers norm theorems, prevents trivial solutions by

--- a/FormalConjectures/Util/ProblemImports.lean
+++ b/FormalConjectures/Util/ProblemImports.lean
@@ -17,6 +17,7 @@ module
 
 public import Mathlib
 public import FormalConjecturesForMathlib
+public import FormalConjecturesForMathlib.Combinatorics.Additive.GowersNorm
 public import FormalConjectures.Util.Answer
 public import FormalConjectures.Util.Linters.AMSLinter
 public import FormalConjectures.Util.Linters.AnswerLinter

--- a/FormalConjecturesForMathlib/Combinatorics/Additive/GowersNorm.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Additive/GowersNorm.lean
@@ -1,0 +1,35 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Fintype.Card
+
+open scoped BigOperators
+open Complex
+
+/-!
+# Gowers Norms and Multiplicative Derivatives
+
+This file provides common definitions for the multiplicative derivative and Gowers norms
+over finite groups, which are frequently used in additive combinatorics.
+-/
+
+/--
+The multiplicative derivative $\Delta_h f(x) = f(x) \overline{f(x+h)}$.
+-/
+noncomputable def multiplicativeDerivative {G : Type*} [AddGroup G] (h : G) (f : G → ℂ) : G → ℂ :=
+  fun x ↦ f x * star (f (x + h))

--- a/FormalConjecturesTest/ForMathlib/Combinatorics/Additive/GowersNormTest.lean
+++ b/FormalConjecturesTest/ForMathlib/Combinatorics/Additive/GowersNormTest.lean
@@ -60,3 +60,18 @@ lemma multiplicativeDerivative_comm (h1 h2 : G) (f : G → ℂ) :
   ext x
   simp [multiplicativeDerivative, add_right_comm]
   ring
+
+/--
+The multiplicative derivative of a linear phase (a unitary character) is a constant function.
+This captures the property that taking the derivative of a phase annihilates the variable x.
+-/
+lemma multiplicativeDerivative_phase (h : G) (f : G → ℂ)
+    (h_add : ∀ a b, f (a + b) = f a * f b)
+    (h_unit : ∀ a, f a * star (f a) = 1) :
+    multiplicativeDerivative h f = fun _ ↦ star (f h) := by
+  ext x
+  simp only [multiplicativeDerivative, h_add, star_mul]
+  calc
+    f x * (star (f h) * star (f x)) = (f x * star (f x)) * star (f h) := by ring
+    _ = 1 * star (f h) := by rw [h_unit x]
+    _ = star (f h) := by ring

--- a/FormalConjecturesTest/ForMathlib/Combinatorics/Additive/GowersNormTest.lean
+++ b/FormalConjecturesTest/ForMathlib/Combinatorics/Additive/GowersNormTest.lean
@@ -1,0 +1,62 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesForMathlib.Combinatorics.Additive.GowersNorm
+
+open Complex
+
+variable {G : Type*} [AddCommGroup G]
+
+/-- The multiplicative derivative with step 0 evaluates to the function multiplied by its conjugate. -/
+lemma multiplicativeDerivative_zero (f : G → ℂ) (x : G) :
+    multiplicativeDerivative 0 f x = f x * star (f x) := by
+  simp [multiplicativeDerivative]
+
+/-- The multiplicative derivative of a constant function is constant. -/
+lemma multiplicativeDerivative_const (h : G) (c : ℂ) (x : G) :
+    multiplicativeDerivative h (fun _ ↦ c) x = c * star c := by
+  rfl
+
+/-- The multiplicative derivative is invariant under translation of the input function. -/
+lemma multiplicativeDerivative_add_right (h : G) (f : G → ℂ) (x y : G) :
+    multiplicativeDerivative h (fun z ↦ f (z + y)) x = multiplicativeDerivative h f (x + y) := by
+  simp [multiplicativeDerivative, add_right_comm]
+
+/-- The multiplicative derivative distributes over the product of two functions. -/
+lemma multiplicativeDerivative_mul (h : G) (f g : G → ℂ) :
+    multiplicativeDerivative h (f * g) = multiplicativeDerivative h f * multiplicativeDerivative h g := by
+  ext x
+  simp only [multiplicativeDerivative, Pi.mul_apply, star_mul]
+  ring
+
+/-- The multiplicative derivative of a conjugated function. -/
+lemma multiplicativeDerivative_star (h : G) (f : G → ℂ) (x : G) :
+    multiplicativeDerivative h (star f) x = star (f x) * f (x + h) := by
+  simp [multiplicativeDerivative]
+
+/-- Taking the derivative with a negative step is equivalent to conjugating and shifting the positive derivative. -/
+lemma multiplicativeDerivative_neg_add (h : G) (f : G → ℂ) (x : G) :
+    multiplicativeDerivative (-h) f (x + h) = star (multiplicativeDerivative h f x) := by
+  simp [multiplicativeDerivative, add_assoc, add_neg_cancel]
+  ring
+
+/-- Iterated multiplicative derivatives commute. -/
+lemma multiplicativeDerivative_comm (h1 h2 : G) (f : G → ℂ) :
+    multiplicativeDerivative h1 (multiplicativeDerivative h2 f) =
+    multiplicativeDerivative h2 (multiplicativeDerivative h1 f) := by
+  ext x
+  simp [multiplicativeDerivative, add_right_comm]
+  ring


### PR DESCRIPTION
# Description
> Let $p$ be an odd prime and suppose that $f : 𝔽_p^n \times 𝔽_p^n \to ℂ$ is a function bounded pointwise by 1. Suppose that $𝔼_h \lVert \Delta\_{(h,h)} f \rVert\_{\square}^4 \geq \delta$. Does $f$ correlate with a function of the form $a(x)b(y)c(x+y)(-1)^{q(x,y)}$?

**Link:** https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.55

- Closes #1660
- Introduces the `GowersNorm.lean` module (and tests!) for generalization. For now it contains only the multiplicative derivative, and will eventually include the Gowers norms definition for #1661.
- :robot: Initial draft working with **Gemini 3.1 Pro**, then reworked for lighter notation, syntax, and addressing edge cases (see inline comments).

# Testing
:white_check_mark: Builds successfully
```shell
$ lake build FormalConjectures/GreensOpenProblems/55.lean 
Build completed successfully (8037 jobs).
```