### PR TITLE
ErdosProblems 1052: add formal_proof (lean4) links for even/87360/Wall unitary perfect statements

### DIFF
--- a/FormalConjectures/ErdosProblems/1052.lean
+++ b/FormalConjectures/ErdosProblems/1052.lean
@@ -45,7 +45,9 @@ All unitary perfect numbers are even.
 
 Formal proof linked here provided by AlphaProof.
 -/
-@[category research solved, AMS 11, formal_proof using formal_conjectures at "https://github.com/mzhorvath1/formal-conjectures/blob/b70a2ddf5e55f743aac9d4f4a907786b39bc9807/FormalConjectures/ErdosProblems/1052.lean#L46"]
+@[category research solved, AMS 11,
+formal_proof using formal_conjectures at "https://github.com/mzhorvath1/formal-conjectures/blob/b70a2ddf5e55f743aac9d4f4a907786b39bc9807/FormalConjectures/ErdosProblems/1052.lean#L46",
+formal_proof using lean4 at "https://github.com/Mnehmos/llm-driven-proof-search/blob/5a70abe2ebad1438f328d3cd5201488c815d4c9f/lean-checker/LeanChecker/Erdos/Erdos1052.lean"]
 theorem even_of_isUnitaryPerfect (n : ℕ) (hn : IsUnitaryPerfect n) : Even n := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/1052.lean
+++ b/FormalConjectures/ErdosProblems/1052.lean
@@ -66,14 +66,17 @@ theorem isUnitaryPerfect_90 : IsUnitaryPerfect 90 := by
   norm_num [IsUnitaryPerfect, properUnitaryDivisors]
   decide +kernel
 
-@[category test, AMS 11]
+@[category test, AMS 11,
+formal_proof using lean4 at "https://github.com/Mnehmos/llm-driven-proof-search/blob/b03fb75a15519e5e886544e898afb4c7565054c7/lean-checker/LeanChecker/Erdos/Erdos1052.lean#L532"]
 theorem isUnitaryPerfect_87360 : IsUnitaryPerfect 87360 := by
   -- TODO: Find a quicker proof. This one is too slow.
+  -- A fast (multiplicative) Lean 4 proof of this exact statement is linked above.
   stop
   norm_num [IsUnitaryPerfect, properUnitaryDivisors]
   decide +kernel
 
-@[category test, AMS 11, formal_proof using formal_conjectures at "https://github.com/Sanexxxx777/formal-conjectures/blob/be8aed15e8888a08bbe723170698e26c046412a4/FormalConjectures/ErdosProblems/1052.lean#L346"]
+@[category test, AMS 11, formal_proof using formal_conjectures at "https://github.com/Sanexxxx777/formal-conjectures/blob/be8aed15e8888a08bbe723170698e26c046412a4/FormalConjectures/ErdosProblems/1052.lean#L346",
+formal_proof using lean4 at "https://github.com/Mnehmos/llm-driven-proof-search/blob/b03fb75a15519e5e886544e898afb4c7565054c7/lean-checker/LeanChecker/Erdos/Erdos1052.lean#L539"]
 theorem isUnitaryPerfect_146361946186458562560000 : IsUnitaryPerfect 146361946186458562560000 := by
   sorry
 


### PR DESCRIPTION
## Add `formal_proof` (lean4) links for three ErdosProblems/1052 statements

This adds independent, kernel-verified Lean 4 proofs (linked via `@[formal_proof using lean4 at "…"]`, following the repo's existing convention) for three statements in `FormalConjectures/ErdosProblems/1052.lean` (unitary perfect numbers) that currently have no replaying Lean proof:

| Statement | Current state in corpus | Added |
|---|---|---|
| `even_of_isUnitaryPerfect` (Subbarao–Warren 1966) | `sorry` + AlphaProof link that depends on this repo's custom tactic infra | independent plain-Mathlib proof |
| `isUnitaryPerfect_87360` | `stop`-disabled, TODO "too slow" (naive enumeration) | fast proof via σ* multiplicativity |
| `isUnitaryPerfect_146361946186458562560000` (Wall's 5th) | bare `sorry` + external link that does not replay against plain Mathlib | independent fast proof |

All three proofs live in [`Mnehmos/llm-driven-proof-search`](https://github.com/Mnehmos/llm-driven-proof-search), pinned to a commit permalink, in `lean-checker/LeanChecker/Erdos/Erdos1052.lean`. The `87360` / Wall statements there are byte-for-byte the unfolding of `IsUnitaryPerfect n` (`∑ over properUnitaryDivisors = n ∧ 0 < n`), i.e. definitionally the same statement.

**No in-file proof bodies change** — the `stop`/`sorry` bodies are left as-is, matching the existing `even_of_isUnitaryPerfect` precedent where the real proof is hosted externally and linked. So this PR is metadata-only (attribute additions); it does not affect `lake build`.

### Notes for reviewers
- **AI-assisted, kernel-verified.** These proofs were produced with LLM assistance and are verified solely by the Lean 4 kernel + Mathlib (no external trust). Disclosed per the repo's expectations.
- The σ* (unitary-divisor-sum) multiplicativity machinery the fast proofs rely on is not in Mathlib; it's built from scratch in the linked file. Happy to discuss upstreaming any of it to `FormalConjecturesForMathlib` / Mathlib if of interest.
- Happy to file a tracking issue first if that's the preferred process for `formal_proof`-link additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
