### PR TITLE
refactor(SimpleGraph/Residue): make residueAux well-founded to enable induction

### DIFF
--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean
@@ -58,9 +58,7 @@ is dropped. This is the termination measure for the well-founded `residueAux` be
 -/
 theorem havelHakimiStep_length_cons (d : ℕ) (rest : List ℕ) :
     (havelHakimiStep (d :: rest)).length = rest.length := by
-  simp only [havelHakimiStep, List.splitAt_eq, List.length_mergeSort,
-    List.length_append, List.length_map, List.length_take, List.length_drop]
-  omega
+  grind [havelHakimiStep, List.length_mergeSort]
 
 /--
 Auxiliary function to calculate the residue recursively.

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean
@@ -51,17 +51,36 @@ def havelHakimiStep (s : List ℕ) : List ℕ :=
     (decremented ++ remaining).mergeSort (· ≥ ·)
 
 /--
-Auxiliary function to calculate the residue recursively.
-Applies Havel-Hakimi steps until the sequence consists only of zeros or is empty.
+`havelHakimiStep` drops the list length by exactly one on a nonempty list:
+`(havelHakimiStep (d :: rest)).length = rest.length`. `splitAt` partitions `rest`,
+and `map`, `++`, and `mergeSort` all preserve the total length while the head `d`
+is dropped. This is the termination measure for the well-founded `residueAux` below.
 -/
-partial def residueAux : List ℕ → ℕ
-  | [] => 0        -- Empty sequence, residue is 0.
-  | 0 :: s => 1 + s.length -- If the largest degree is 0 (and the list is sorted), all are 0.
-  | s => residueAux (havelHakimiStep s) -- Apply one reduction step and recurse.
+theorem havelHakimiStep_length_cons (d : ℕ) (rest : List ℕ) :
+    (havelHakimiStep (d :: rest)).length = rest.length := by
+  simp only [havelHakimiStep, List.splitAt_eq, List.length_mergeSort,
+    List.length_append, List.length_map, List.length_take, List.length_drop]
+  omega
 
 /--
-Computes the residue of a graph G, ,i.e. the number of zeros remaining after iteratively applying the Havel-Hakimi
-algorithm to the degree sequence until all remaining degrees are zero.
+Auxiliary function to calculate the residue recursively.
+Applies Havel-Hakimi steps until the sequence consists only of zeros or is empty.
+Defined by well-founded recursion on the list length (via `havelHakimiStep_length_cons`),
+so that it admits equational and inductive reasoning.
+-/
+def residueAux : List ℕ → ℕ
+  | [] => 0        -- Empty sequence, residue is 0.
+  | 0 :: s => 1 + s.length -- If the largest degree is 0 (and the list is sorted), all are 0.
+  | d :: rest => residueAux (havelHakimiStep (d :: rest)) -- Apply one reduction step and recurse.
+termination_by l => l.length
+decreasing_by
+  simp_wf
+  rw [havelHakimiStep_length_cons]
+  omega
+
+/--
+Computes the residue of a graph `G`, i.e. the number of zeros remaining after iteratively
+applying the Havel-Hakimi algorithm to the degree sequence until all remaining degrees are zero.
 Starts with the descending degree sequence and applies the Havel-Hakimi process.
 -/
 noncomputable def residue (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=


### PR DESCRIPTION
Closes #4413

## What

Replaces `partial def residueAux` in
`FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean` with a
well-founded `def` (terminating on the list length), via a new helper lemma
`havelHakimiStep_length_cons` (`(havelHakimiStep (d :: rest)).length = rest.length`).
The third match arm `| s =>` becomes `| d :: rest =>` so the recursive argument is
provably shorter. **The computed function is unchanged** (both `[]` and `0 :: _` are
caught by earlier arms, so the third arm fires only on `d :: rest`).

Also fixes a small docstring typo in `residue` ("G, ,i.e." → "G, i.e.").

## Why

A `partial def` generates no equation lemmas, so no property of `residue` can be
proved by induction. The well-founded definition auto-generates `residueAux.induct`
and `residueAux.eq_def`, which are prerequisites for proving anything about the
Havel–Hakimi residue — e.g. any `residue` conjecture, or classical bounds such as
Favaron's `R ≤ α`.

## Verification

- `lake build FormalConjecturesForMathlib` builds green and lint-clean.
- `#print axioms residueAux` = `[propext, Quot.sound]` (no `sorryAx`).
- `residueAux.induct` and `residueAux.eq_def` are now available.
