### PR TITLE
feat(GreensOpenProblems/40): link formal proof of f_tilde_le_f

### DIFF
--- a/FormalConjectures/GreensOpenProblems/40.lean
+++ b/FormalConjectures/GreensOpenProblems/40.lean
@@ -115,7 +115,8 @@ theorem green_40.variants.arbitrary_subsets_sanity_f_tilde_two : f_tilde 2 = 1 :
   sorry
 
 /-- We evidently have $\tilde{f}(r) \le f(r)$ [Gr24]. -/
-@[category research solved, AMS 5 94]
+@[category research solved, AMS 5 94, formal_proof using formal_conjectures at
+  "https://github.com/Solarys431/formal-conjectures/blob/36457e70a378d8adfe37e99f9aa7885edc03150d/FormalConjectures/GreensOpenProblems/40.lean#L119"]
 theorem green_40.f_tilde_le_f (r : ℕ) : f_tilde r ≤ f r := by
   sorry
 

--- a/FormalConjectures/GreensOpenProblems/40.lean
+++ b/FormalConjectures/GreensOpenProblems/40.lean
@@ -115,10 +115,31 @@ theorem green_40.variants.arbitrary_subsets_sanity_f_tilde_two : f_tilde 2 = 1 :
   sorry
 
 /-- We evidently have $\tilde{f}(r) \le f(r)$ [Gr24]. -/
-@[category research solved, AMS 5 94, formal_proof using formal_conjectures at
-  "https://github.com/Solarys431/formal-conjectures/blob/36457e70a378d8adfe37e99f9aa7885edc03150d/FormalConjectures/GreensOpenProblems/40.lean#L119"]
+@[category research solved, AMS 5 94]
 theorem green_40.f_tilde_le_f (r : ℕ) : f_tilde r ≤ f r := by
-  sorry
+  refine Filter.liminf_le_liminf (Filter.Eventually.of_forall fun n => ?_)
+  refine le_iInf₂ fun V hV => ?_
+  have hfin : (V : Set (𝔽₂ n)).Finite := Set.toFinite _
+  have hcov : IsCoveringFinset n r hfin.toFinset := by
+    unfold IsCoveringFinset
+    ext x
+    simp only [Finset.mem_univ, iff_true]
+    have hx : x ∈ (V : Set (𝔽₂ n)) + hammingBall n r := hV ▸ Set.mem_univ x
+    obtain ⟨a, ha, b, hb, hab⟩ := hx
+    exact Finset.mem_add.mpr
+      ⟨a, hfin.mem_toFinset.mpr ha, b, by simpa [hammingBallFinset, hammingBall] using hb, hab⟩
+  have hcard : (hfin.toFinset.card : ℝ≥0∞) = (Nat.card V : ℝ≥0∞) := by
+    have h : Nat.card V = hfin.toFinset.card := by
+      rw [show Nat.card V = Nat.card (V : Set (𝔽₂ n)) from rfl, Nat.card_coe_set_eq,
+        Set.ncard_eq_toFinset_card _ hfin]
+    exact_mod_cast congrArg Nat.cast h.symm
+  calc minDensityFinset n r
+      ≤ (hfin.toFinset.card : ℝ≥0∞) * (Nat.card (hammingBall n r) : ℝ≥0∞) /
+          (2 ^ n : ℝ≥0∞) :=
+        iInf₂_le hfin.toFinset hcov
+    _ = (Nat.card V : ℝ≥0∞) * (Nat.card (hammingBall n r) : ℝ≥0∞) /
+          (2 ^ n : ℝ≥0∞) := by
+        rw [hcard]
 
 -- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 -- Variant for all n


### PR DESCRIPTION
This PR links a formal proof for `green_40.f_tilde_le_f` ($\tilde{f}(r) \le f(r)$, Ben Green's Open Problem 40 on covering codes), following the convention of #4245: the statement keeps its `sorry` here, and the `formal_proof` attribute points to the proof at a pinned commit in my fork.

**Proof sketch.** Every covering subspace $V$, viewed as a finite set, is an admissible covering finset with the same cardinality (`Nat.card V = hfin.toFinset.card`), so `minDensityFinset n r ≤ minDensity n r` pointwise for every $n$; the inequality between the liminfs follows from monotonicity of `liminf` in `ℝ≥0∞`.

**Verification.** The fork branch compiles with the repository's toolchain (lean4 v4.27.0): `green_40.f_tilde_le_f` has no `sorry` and introduces no new axioms. Prior-art check before submission: no existing formal proof of this statement was found on GitHub, the Lean Zulip, or arXiv.

**AI disclosure** (per the contribution guidelines): the proof was written with AI assistance — drafted and iterated by Claude (Anthropic) against the Lean compiler within a human-orchestrated pipeline — and should be considered LLM-generated. I understand and can justify each step of the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
