### PR TITLE
feat(GreensOpenProblems): 64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Daniel Chin
 Eric Wieser
 Franz Huschenbeth
 Hansle Cho
+Himanshu Gupta
 James Jordan
 Jean-Guillaume Durand
 Jofre Costa

--- a/FormalConjectures/GreensOpenProblems/64.lean
+++ b/FormalConjectures/GreensOpenProblems/64.lean
@@ -1,0 +1,52 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Util.ProblemImports
+
+/-!
+# Ben Green's Open Problem 64
+
+Do there exist infinitely many primes for which $p - 2$ has an odd number of prime factors?
+
+With $p - 2$ the question is a weak form of the twin prime conjecture: the set of integers
+with an odd number of prime factors (counted with multiplicity) has density $1/2$, so one is
+"only" asking for infinitely many primes in a set of density $1/2$.
+
+*Reference:* [Ben Green's Open Problem 64](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.64)
+-/
+
+open ArithmeticFunction
+open scoped ArithmeticFunction.Omega
+
+namespace Green64
+
+/--
+Do there exist infinitely many primes for which $p - 2$ has an odd number of prime factors?
+-/
+@[category research open, AMS 11]
+theorem green_64 :
+    answer(sorry) ↔ {p : ℕ | p.Prime ∧ Odd (Ω (p - 2))}.Infinite := by
+  sorry
+
+/--
+The same question may be asked with $p - 1$ (and this is probably more natural).
+-/
+@[category research open, AMS 11]
+theorem green_64.variants.sub_one :
+    answer(sorry) ↔ {p : ℕ | p.Prime ∧ Odd (Ω (p - 1))}.Infinite := by
+  sorry
+
+end Green64


### PR DESCRIPTION
Closes #1684

Formalizes [Ben Green's Open Problem 64](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.64): do there exist infinitely many primes for which $p - 2$ has an odd number of prime factors?

- `green_64`: the main question, stated as `answer(sorry) ↔ {p : ℕ | p.Prime ∧ Odd (Ω (p - 2))}.Infinite`, using Mathlib's `ArithmeticFunction.cardFactors` (`Ω`, prime factors counted with multiplicity).
- `green_64.variants.sub_one`: the $p - 1$ variant mentioned in Green's comments ("probably more natural").

Notes:
- `p = 2` is correctly excluded by the statement since `Ω 0 = 0` is even.
- Sanity-checked the predicate by evaluation: primes $\le 60$ satisfying it are $\{5, 7, 13, 19, 29, 31, 43, 47\}$, matching hand computation.
- Also adds myself to `AUTHORS`.