### PR TITLE
Prove Written on the Wall II Conjecture 322

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
@@ -45,7 +45,8 @@ the neighborhood `N(v)` of `v` — is at most 1, then `G` is well totally domina
 Here `l(v) = α(Gᶜ[N(v)])` is the independence number of the subgraph induced by the
 open neighborhood of `v` in `Gᶜ`.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using formal_conjectures at
+  "https://github.com/SamuelSchlesinger/formal-conjectures/blob/78f39db3ea9f5a8b2e6841e7769f538ff263dbf2/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean#L50-L111"]
 theorem conjecture322 (G : SimpleGraph α) [DecidableRel G.Adj] (_hG : G.Connected)
     (hn : 5 ≤ Fintype.card α)
     (h : ∀ v : α, indepNeighborsCard Gᶜ v ≤ 1) :

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,12 @@ import FormalConjecturesUtil
 # Written on the Wall II - Conjecture 322
 
 *Reference:*
-[E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+[E. DeLaViña, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.uhd.edu/faculty/delavinae/research/wowII/)
+
+The source applies the local-independence hypothesis to the complement graph. Its conclusion
+also follows from the characterization of minimal total dominating sets of complete multipartite
+graphs in [M. Subramanian and A. Selvakumar, *Total Domination and Minimal Total Domination
+Polynomial of H-Join Graphs*](https://doi.org/10.2298/FIL2501267S).
 -/
 
 
@@ -31,21 +36,78 @@ open SimpleGraph
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
 /--
-WOWII [Conjecture 322](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+WOWII [Conjecture 322](http://cms.uhd.edu/faculty/delavinae/research/wowII/open.html)
 
 Let `G` be a simple connected graph on `n ≥ 5` vertices. If the maximum over all
-vertices `v` of `l(v)` — the independence number of the neighborhood `N(v)` of `v`
-— is at most 1, then `G` is well totally dominated.
+vertices `v` of `l(v)` in the complement graph `Gᶜ` — the independence number of
+the neighborhood `N(v)` of `v` — is at most 1, then `G` is well totally dominated.
 
-Here `l(v) = α(G[N(v)])` is the independence number of the subgraph induced by the
-open neighborhood of `v`.
+Here `l(v) = α(Gᶜ[N(v)])` is the independence number of the subgraph induced by the
+open neighborhood of `v` in `Gᶜ`.
 -/
-@[category research open, AMS 5]
-theorem conjecture322 (G : SimpleGraph α) [DecidableRel G.Adj] (hG : G.Connected)
+@[category research solved, AMS 5]
+theorem conjecture322 (G : SimpleGraph α) [DecidableRel G.Adj] (_hG : G.Connected)
     (hn : 5 ≤ Fintype.card α)
-    (h : ∀ v : α, indepNeighborsCard G v ≤ 1) :
+    (h : ∀ v : α, indepNeighborsCard Gᶜ v ≤ 1) :
     IsWellTotallyDominated G := by
-  sorry
+  have adj_of_local_independence_one (H : SimpleGraph α) {v x y : α}
+      (hv : indepNeighborsCard H v ≤ 1) (hx : H.Adj v x) (hy : H.Adj v y)
+      (hxy : x ≠ y) : H.Adj x y := by
+    by_contra hnxy
+    let x' : H.neighborSet v := ⟨x, hx⟩
+    let y' : H.neighborSet v := ⟨y, hy⟩
+    have hne : x' ≠ y' := by
+      intro heq
+      exact hxy (congrArg Subtype.val heq)
+    have hind : (H.induce (H.neighborSet v)).IsIndepSet ({x', y'} : Finset _) := by
+      rw [isIndepSet_iff]
+      intro a ha b hb hab
+      simp only [Finset.mem_coe, Finset.mem_insert, Finset.mem_singleton] at ha hb
+      rcases ha with (rfl | rfl) <;> rcases hb with (rfl | rfl)
+      · exact (hab rfl).elim
+      · exact hnxy
+      · exact fun hyx ↦ hnxy hyx.symm
+      · exact (hab rfl).elim
+    have hle := hind.card_le_indepNum
+    have hcard : ({x', y'} : Finset _).card = 2 := by simp [hne]
+    rw [hcard] at hle
+    exact (by omega : ¬(2 ≤ indepNeighborsCard H v)) hle
+  have edge_total {x y : α} (hxy : G.Adj x y) : IsTotalDominatingSet G {x, y} := by
+    intro v
+    by_cases hvx : G.Adj v x
+    · exact ⟨x, by simp, hvx⟩
+    by_cases hvy : G.Adj v y
+    · exact ⟨y, by simp, hvy⟩
+    exfalso
+    have hvx_ne : v ≠ x := by
+      rintro rfl
+      exact hvy hxy
+    have hvy_ne : v ≠ y := by
+      rintro rfl
+      exact hvx hxy.symm
+    have hvx_compl : Gᶜ.Adj v x := (G.compl_adj v x).2 ⟨hvx_ne, hvx⟩
+    have hvy_compl : Gᶜ.Adj v y := (G.compl_adj v y).2 ⟨hvy_ne, hvy⟩
+    have hxy_compl : Gᶜ.Adj x y :=
+      adj_of_local_independence_one Gᶜ (h v) hvx_compl hvy_compl hxy.ne
+    exact ((G.compl_adj x y).1 hxy_compl).2 hxy
+  have minimal_card_two {S : Finset α} (hS : IsMinimalTotalDominatingSet G S) :
+      S.card = 2 := by
+    have hcardpos : 0 < Fintype.card α := by omega
+    let v : α := Classical.choice (Fintype.card_pos_iff.mp hcardpos)
+    obtain ⟨w, hwS, _⟩ := hS.1 v
+    obtain ⟨x, hxS, hwx⟩ := hS.1 w
+    have hpair_subset : ({w, x} : Finset α) ⊆ S := by
+      simpa only [Finset.insert_subset_iff, Finset.singleton_subset_iff] using
+        (And.intro hwS hxS)
+    have hpair_not_ssubset : ¬({w, x} : Finset α) ⊂ S := by
+      intro hss
+      exact hS.2 {w, x} hss (edge_total hwx)
+    have hpair_eq : ({w, x} : Finset α) = S :=
+      hpair_subset.eq_of_not_ssubset hpair_not_ssubset
+    rw [← hpair_eq]
+    simp [hwx.ne]
+  intro S T hS hT
+  rw [minimal_card_two hS, minimal_card_two hT]
 
 -- Sanity checks
 


### PR DESCRIPTION
## What changed

- corrects the formal statement of Written on the Wall II Conjecture 322
- proves that every minimal total dominating set has cardinality two under the stated complement-local-independence hypothesis
- updates the source metadata and marks the conjecture as solved

## Proof idea

The hypothesis makes the endpoints of every edge a total dominating set. Conversely, every total dominating set contains an edge, so minimal total dominating sets are exactly the two-element edge sets.

## Validation

- `lake --wfail build` passed on the reviewed combined branch (8,869 jobs)
- the changed file compiles directly with `lake env lean`
- the theorem has no `sorry` or unproved theorem dependency
