### PR TITLE
Mark WOWII Graph Conjecture 65 solved

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/65.lean
+++ b/FormalConjectures/WrittenOnTheWallII/65.lean
@@ -50,7 +50,7 @@ argument and Lean formalization; all formal claims were checked by the pinned
 Lean compiler.
 -/
 @[category research solved, AMS 5,
-  formal_proof using formal_conjectures at "https://github.com/DomTheDeveloper/formal-conjectures/blob/cf59008ef1cd432bf9803275dcf5d62ab1f094a3/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean"]
+  formal_proof using formal_conjectures at "https://github.com/DomTheDeveloper/formal-conjectures/blob/93900e4d3378a799ab41b9192050a41820de1b6f/FormalConjectures/WrittenOnTheWallII/65.lean"]
 theorem conjecture65 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     let A : Set α := {v | G.degree v = G.minDegree}
     let M : Set α := {v | G.degree v = G.maxDegree}

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
@@ -42,6 +42,10 @@ vertex set has an edge crossing to its complement, so both distance-minimum
 terms are at most one. Hence the left-hand side is at most two. A nontrivial
 connected graph contains an edge, and its two endpoints induce a forest, so the
 largest induced forest has at least two vertices.
+
+**Provenance.** Solved by Dominic Dabish. ProofOrchestrator, using OpenAI GPT-5.6
+Thinking, assisted with the mathematical argument and Lean formalization; all
+formal claims were checked by the pinned Lean compiler.
 -/
 @[category research solved, AMS 5,
   formal_proof using formal_conjectures at "https://github.com/DomTheDeveloper/formal-conjectures/blob/cf59008ef1cd432bf9803275dcf5d62ab1f094a3/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean"]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
@@ -43,9 +43,11 @@ terms are at most one. Hence the left-hand side is at most two. A nontrivial
 connected graph contains an edge, and its two endpoints induce a forest, so the
 largest induced forest has at least two vertices.
 
-**Provenance.** Solved by Dominic Dabish. ProofOrchestrator, using OpenAI GPT-5.6
-Thinking, assisted with the mathematical argument and Lean formalization; all
-formal claims were checked by the pinned Lean compiler.
+**Provenance.** Solved by Dominic Dabish.
+
+ProofOrchestrator, using OpenAI GPT-5.6 Thinking, assisted with the mathematical
+argument and Lean formalization; all formal claims were checked by the pinned
+Lean compiler.
 -/
 @[category research solved, AMS 5,
   formal_proof using formal_conjectures at "https://github.com/DomTheDeveloper/formal-conjectures/blob/cf59008ef1cd432bf9803275dcf5d62ab1f094a3/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean"]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
@@ -36,8 +36,15 @@ For a simple connected graph $G$, the size $f(G)$ of a largest induced forest sa
 $f(G) \ge \operatorname{dist\_min}(A) + \lceil \operatorname{dist\_min}(M) / 3 \rceil$,
 where $A$ is the set of minimum-degree vertices, $M$ is the set of maximum-degree vertices,
 and $\operatorname{dist\_min}(S) = \min_{v \notin S} \operatorname{dist}(v, S)$ (see `distMin`).
+
+The proof uses two universal bounds. In a connected graph, every nonempty proper
+vertex set has an edge crossing to its complement, so both distance-minimum
+terms are at most one. Hence the left-hand side is at most two. A nontrivial
+connected graph contains an edge, and its two endpoints induce a forest, so the
+largest induced forest has at least two vertices.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using formal_conjectures at "https://github.com/DomTheDeveloper/formal-conjectures/blob/cf59008ef1cd432bf9803275dcf5d62ab1f094a3/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean"]
 theorem conjecture65 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     let A : Set α := {v | G.degree v = G.minDegree}
     let M : Set α := {v | G.degree v = G.maxDegree}


### PR DESCRIPTION
Marks WOWII Graph Conjecture 65 as `research solved` and links the complete external Lean 4 proof.

CRL-hosted proof archive:
- Project page: https://domthedeveloper.github.io/crl/math/wowii/65/
- Exact Lean proof: https://domthedeveloper.github.io/crl/math/wowii/65/proof/GraphConjecture65Proof.lean
- Submitted statement snapshot: https://domthedeveloper.github.io/crl/math/wowii/65/statement/GraphConjecture65.lean

The proof is sorry-free and proves the exact current Formal Conjectures theorem. The submission branch is one commit and one changed file over upstream.

AI assistance disclosure: the proof and submission preparation used OpenAI GPT-5.6 Thinking; the mathematical argument and Lean artifact should receive normal maintainer review.