### PR TITLE
feat(ErdosProblems): mark 260 as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/260.lean
+++ b/FormalConjectures/ErdosProblems/260.lean
@@ -19,7 +19,10 @@ import FormalConjectures.Util.ProblemImports
 /-!
 # Erdős Problem 260
 
-*Reference:* [erdosproblems.com/260](https://www.erdosproblems.com/260)
+*References:*
+- [erdosproblems.com/260](https://www.erdosproblems.com/260)
+- [Wang--Grau Ribas, *Positive dyadic density for rational weighted binary expansions*]
+  (https://arxiv.org/abs/2606.24972)
 -/
 
 namespace Erdos260
@@ -30,8 +33,9 @@ open Filter
 Let $a_1 < a_2 < \cdots$ be an increasing sequence such that $\frac{a_n}{n} \to \infty$.
 Is the sum $\sum_{n}^{\infty} \frac{a_n}{2^{a_n}}$ irrational?
 -/
-@[category research open, AMS 11]
-theorem erdos_260 : answer(sorry) ↔
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/Hanziwww/erdos260/blob/1f2baf4547f2c2805cdd160611b0b983f43941aa/Erdos260/DeepMind.lean#L92-L132"]
+theorem erdos_260 : answer(True) ↔
                   ∀ a : ℕ → ℤ, ∀ s : ℝ,
                   StrictMono a →
                   Tendsto (fun n => (a n : ℝ ) / n ) atTop atTop →

--- a/FormalConjectures/Subsets/FC100OpenSet1.lean
+++ b/FormalConjectures/Subsets/FC100OpenSet1.lean
@@ -221,6 +221,6 @@ end Subsets.FC100OpenSet1
 
 open Lean Meta ProblemAttributes in
 #eval verifyCategoryCounts Subsets.FC100OpenSet1.problems [
-  ("research open", 94),
-  ("research solved", 6)
+  ("research open", 93),
+  ("research solved", 7)
 ]


### PR DESCRIPTION
## Summary

- mark Erdős Problem 260 as `research solved`;
- replace `answer(sorry)` with the affirmative answer `answer(True)`;
- attach a permanent `formal_proof using lean4` link to the complete external proof;
- add the associated arXiv reference; and
- update the fixed FC100 subset category counts affected by this status change.

## Formal proof

Permanent source:

https://github.com/Hanziwww/erdos260/blob/1f2baf4547f2c2805cdd160611b0b983f43941aa/Erdos260/DeepMind.lean#L92-L132

Proof repository:

https://github.com/Hanziwww/erdos260

Successful verification run:

https://github.com/Hanziwww/erdos260/actions/runs/29516048968

Associated paper:

https://arxiv.org/abs/2606.24972

The external theorem proves the exact RHS of the existing Formal Conjectures
statement. In particular, it preserves `a : ℕ → ℤ`, the original `n = 0`
division, integer exponentiation in `2 ^ a n`, `StrictMono`, `Tendsto`,
`HasSum`, and the conclusion `Irrational s`.

The pinned proof repository contains no `sorry`, project-specific axiom, or
`opaque` proof stand-in. Its CI verifies the Lean build and endpoint axiom
closure at trust level zero, replays the project with Leanchecker, and checks
the declarations with Nanoda's independent kernel.

## Validation

- `lake --wfail build` in this repository: passed (8,869 jobs)
- permanent proof and arXiv links: reachable
- external proof build and `--trust=0` declaration audit: passed
- external Leanchecker and Nanoda CI jobs: passed

## Scope

The long proof remains in its dedicated external repository, as recommended by
the contribution guidelines for proofs longer than approximately 25--50
lines. This PR only records the solved status and proof location. The FC100
count adjustment is the mechanical update required because
`Erdos260.erdos_260` is already a member of `FC100OpenSet1`.

Related to #457 and #1629.

Closes #4445.
