### PR TITLE
Mark WOWII graph conjecture 142 solved

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
@@ -38,6 +38,41 @@ where $\mathrm{tree}(G)$ is the largest induced tree size, $\mathrm{girth}(G)$
 is the length of the shortest cycle ($0$ if acyclic), $B$ is the set of
 boundary vertices (those of maximum eccentricity), and $\mathrm{ecc}(B)$ is
 the eccentricity of the set $B$.
+
+**Proof sketch.** The proof first strengthens the real-valued target to the
+integral bound
+$$
+\mathrm{ecc}(B) + \mathrm{girth}(G)
+  - \lfloor \mathrm{girth}(G) / 3 \rfloor \leq \mathrm{tree}(G).
+$$
+For a cyclic graph, start with a shortest cycle $K$. It is chordless, so
+removing one vertex leaves an induced path on $\mathrm{girth}(G)-1$ vertices.
+Shortest paths from selected vertices to $K$ are called *descents*. Pairwise
+noninteracting descents attach to the retained cycle path as disjoint branches.
+If two descents interact, the proof cuts at the first interaction encountered
+from the outer endpoint toward the cycle and splices the paths there.
+Minimality of that interaction makes the retained prefix disjoint and
+nonadjacent to the first descent; geodesicity excludes chords, while girth at
+least five rules out extra cross-edges and cycle attachments.
+
+Choose a vertex realizing $\mathrm{ecc}(B)$ and two endpoints of a diametral
+geodesic. Either two of their descents interact, directly giving a sufficiently
+long spliced tree, or all three are separate, in which case a three-point
+distance inequality forces their total length to be large enough. This proves
+the integral bound in the main range. Girths three and four, small
+$\mathrm{ecc}(B)$, and the two remaining congruence cases are handled by
+separate geodesic/cycle certificates with one or two descents; the acyclic case
+follows from a diametral path. Finally,
+$$
+\mathrm{girth}(G)-\lfloor\mathrm{girth}(G)/3\rfloor
+  = \lceil 2\,\mathrm{girth}(G)/3\rceil
+  \geq 2\,\mathrm{girth}(G)/3,
+$$
+which gives the stated real-valued inequality.
+
+The argument was developed with assistance from ChatGPT Pro. The linked Lean 4
+formalization was produced with assistance from OpenAI Codex and checked by
+Lean.
 -/
 @[category research solved, AMS 5,
   formal_proof using formal_conjectures at "https://github.com/AlperTheKing/formal-conjectures/blob/46bf39015f5c3c3ba3bfcf9f752b4b1e49b584ac/FormalConjecturesForMathlib/WrittenOnTheWallII/GraphConjecture142Proof.lean#L3927-L3932"]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
@@ -40,7 +40,7 @@ boundary vertices (those of maximum eccentricity), and $\mathrm{ecc}(B)$ is
 the eccentricity of the set $B$.
 -/
 @[category research solved, AMS 5,
-  formal_proof using formal_conjectures at "https://github.com/AlperTheKing/formal-conjectures/blob/46bf39015f5c3c3ba3bfcf9f752b4b1e49b584ac/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean#L44"]
+  formal_proof using formal_conjectures at "https://github.com/AlperTheKing/formal-conjectures/blob/46bf39015f5c3c3ba3bfcf9f752b4b1e49b584ac/FormalConjecturesForMathlib/WrittenOnTheWallII/GraphConjecture142Proof.lean#L3927-L3932"]
 theorem conjecture142 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     let B : Set α := (maxEccentricityVertices G : Set α)
     (2 : ℝ) / 3 * (G.girth : ℝ) + (eccSet G B : ℝ) ≤ (largestInducedTreeSize G : ℝ) := by

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
@@ -39,7 +39,8 @@ is the length of the shortest cycle ($0$ if acyclic), $B$ is the set of
 boundary vertices (those of maximum eccentricity), and $\mathrm{ecc}(B)$ is
 the eccentricity of the set $B$.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using formal_conjectures at "https://github.com/AlperTheKing/formal-conjectures/blob/46bf39015f5c3c3ba3bfcf9f752b4b1e49b584ac/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean#L44"]
 theorem conjecture142 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     let B : Set α := (maxEccentricityVertices G : Set α)
     (2 : ℝ) / 3 * (G.girth : ℝ) + (eccSet G B : ℝ) ≤ (largestInducedTreeSize G : ℝ) := by


### PR DESCRIPTION
## Summary

- mark WOWII / Graffiti.pc Conjecture 142 as solved
- link the immutable Lean proof commit in the formal proof annotation
- prove the stronger integral inequality `ecc(B) + girth - girth / 3 ≤ tree`, then derive the stated real-valued bound

## Verification

- `lake env lean -DwarningAsError=true FormalConjecturesForMathlib/WrittenOnTheWallII/GraphConjecture142Proof.lean`
- clean build of `FormalConjectures.WrittenOnTheWallII.GraphConjecture142`
- proof module contains no `sorry`, `admit`, or `native_decide`
- axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`

Formal proof commit: https://github.com/AlperTheKing/formal-conjectures/commit/46bf39015f5c3c3ba3bfcf9f752b4b1e49b584ac