### PR TITLE
feat(GreensOpenProblems/5): largest product-free sets in finite groups

### DIFF
--- a/FormalConjectures/GreensOpenProblems/5.lean
+++ b/FormalConjectures/GreensOpenProblems/5.lean
@@ -21,6 +21,8 @@ import FormalConjecturesUtil
 
 *References:*
 - [Gr24] [Green, Ben. "100 open problems." (2024).](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.5)
+- [BaSo85] Babai L, Sós VT. Sidon sets in groups and induced subgraphs of Cayley graphs.
+  European Journal of Combinatorics. 1985 Jun 1;6(2):101-14.
 - [Ke97] Kedlaya, K. S., *Large product-free subsets of finite groups*, J. Combin. Theory
   Ser. A 77 (1997), no. 2, 339–343.
 - [Ke09] Kedlaya, K. S., *Product-free subsets of groups, then and now*, Contemp. Math., 479,
@@ -31,12 +33,14 @@ import FormalConjecturesUtil
 
 open scoped MatrixGroups
 
+local notation "SL₂" p => SL(2, ZMod p)
+
 namespace Green5
 
 /--
 Which finite groups have the smallest biggest product-free sets?
 
-We formalise this as: determine the largest exponent $\alpha$ such that every nontrivial
+We formalise this as: determine the supremum of exponents $\alpha$ such that every nontrivial
 finite group of order $n$ contains a product-free set of size $\geq c n^{\alpha}$ for some
 absolute constant $c > 0$. (The trivial group is excluded since its only product-free subset
 is empty.) Kedlaya [Ke97] showed that $\alpha = 11/14$ is admissible, and Green suggests this
@@ -45,14 +49,14 @@ $q = 3^{2m+1}$.
 -/
 @[category research open, AMS 5 20]
 theorem green_5 :
-    IsGreatest {α : ℝ | ∃ c > (0 : ℝ), ∀ (G : Type) [Group G] [Fintype G], Nontrivial G →
+    IsLUB {α : ℝ | ∃ c > (0 : ℝ), ∀ (G : Type) [Group G] [Fintype G], Nontrivial G →
       ∃ S : Finset G, IsProductFree (S : Set G) ∧
         c * (Fintype.card G : ℝ) ^ α ≤ (S.card : ℝ)}
       answer(sorry) := by
   sorry
 
 /--
-Kedlaya [Ke97] observed, refining some work of Babai and Sós, that it follows from the
+Kedlaya [Ke97] observed, refining some work of Babai and Sós [BaSo85], that it follows from the
 classification of finite simple groups that every finite group $G$ of order $n$ has a
 product-free subset of size $\gg n^{11/14}$.
 -/
@@ -63,14 +67,16 @@ theorem green_5.variants.kedlaya :
         c * (Fintype.card G : ℝ) ^ ((11 : ℝ) / 14) ≤ (S.card : ℝ) := by
   sorry
 
+-- TODO(theebayuser): implement Ree groups variant (candidate sharp example for `green_5`)
+
 /--
 A good model problem would be to determine the largest product-free subsets of
 $\mathrm{SL}_2(\mathbb{F}_p)$.
 -/
 @[category research open, AMS 5 20]
 theorem green_5.variants.sl_two (p : ℕ) [Fact p.Prime] :
-    let S : ∀ q : ℕ, Set (SL(2, ZMod q)) := answer(sorry)
-    MaximalFor (IsProductFree (M := SL(2, ZMod p))) Set.ncard (S p) := by
+    let S : Finset (SL₂ p) := answer(sorry)
+    MaximalFor (IsProductFree (M := SL₂ p)) Set.ncard (S : Set (SL₂ p)) := by
   sorry
 
 /--
@@ -79,9 +85,9 @@ best-known upper bound is $O(n^{8/9})$, due to Gowers [Go08].
 -/
 @[category research solved, AMS 5 20]
 theorem green_5.variants.gowers_sl_two :
-    ∃ C > (0 : ℝ), ∀ (p : ℕ) [Fact p.Prime], ∀ S : Finset SL(2, ZMod p),
-      IsProductFree (S : Set SL(2, ZMod p)) →
-      (S.card : ℝ) ≤ C * (Fintype.card SL(2, ZMod p) : ℝ) ^ ((8 : ℝ) / 9) := by
+    ∃ C > (0 : ℝ), ∀ (p : ℕ) [Fact p.Prime], ∀ S : Finset (SL₂ p),
+      IsProductFree (S : Set (SL₂ p)) →
+      (S.card : ℝ) ≤ C * (Fintype.card (SL₂ p) : ℝ) ^ ((8 : ℝ) / 9) := by
   sorry
 
 end Green5

--- a/FormalConjectures/GreensOpenProblems/5.lean
+++ b/FormalConjectures/GreensOpenProblems/5.lean
@@ -1,0 +1,87 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Ben Green's Open Problem 5
+
+*References:*
+- [Gr24] [Green, Ben. "100 open problems." (2024).](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.5)
+- [Ke97] Kedlaya, K. S., *Large product-free subsets of finite groups*, J. Combin. Theory
+  Ser. A 77 (1997), no. 2, 339–343.
+- [Ke09] Kedlaya, K. S., *Product-free subsets of groups, then and now*, Contemp. Math., 479,
+  American Mathematical Society, Providence, RI, 2009, 169–177.
+- [Go08] Gowers, W. T., *Quasirandom groups*, Combin. Probab. Comput. 17 (2008), no. 3,
+  363–387.
+-/
+
+open scoped MatrixGroups
+
+namespace Green5
+
+/--
+Which finite groups have the smallest biggest product-free sets?
+
+We formalise this as: determine the largest exponent $\alpha$ such that every nontrivial
+finite group of order $n$ contains a product-free set of size $\geq c n^{\alpha}$ for some
+absolute constant $c > 0$. (The trivial group is excluded since its only product-free subset
+is empty.) Kedlaya [Ke97] showed that $\alpha = 11/14$ is admissible, and Green suggests this
+exponent may well be sharp; the candidate extremal family is the Ree groups ${}^2G_2(q)$,
+$q = 3^{2m+1}$.
+-/
+@[category research open, AMS 5 20]
+theorem green_5 :
+    IsGreatest {α : ℝ | ∃ c > (0 : ℝ), ∀ (G : Type) [Group G] [Fintype G], Nontrivial G →
+      ∃ S : Finset G, IsProductFree (S : Set G) ∧
+        c * (Fintype.card G : ℝ) ^ α ≤ (S.card : ℝ)}
+      answer(sorry) := by
+  sorry
+
+/--
+Kedlaya [Ke97] observed, refining some work of Babai and Sós, that it follows from the
+classification of finite simple groups that every finite group $G$ of order $n$ has a
+product-free subset of size $\gg n^{11/14}$.
+-/
+@[category research solved, AMS 5 20]
+theorem green_5.variants.kedlaya :
+    ∃ c > (0 : ℝ), ∀ (G : Type) [Group G] [Fintype G], Nontrivial G →
+      ∃ S : Finset G, IsProductFree (S : Set G) ∧
+        c * (Fintype.card G : ℝ) ^ ((11 : ℝ) / 14) ≤ (S.card : ℝ) := by
+  sorry
+
+/--
+A good model problem would be to determine the largest product-free subsets of
+$\mathrm{SL}_2(\mathbb{F}_p)$.
+-/
+@[category research open, AMS 5 20]
+theorem green_5.variants.sl_two (p : ℕ) [Fact p.Prime] :
+    let S : ∀ q : ℕ, Set (SL(2, ZMod q)) := answer(sorry)
+    MaximalFor (IsProductFree (M := SL(2, ZMod p))) Set.ncard (S p) := by
+  sorry
+
+/--
+For the largest product-free subsets of $\mathrm{SL}_2(\mathbb{F}_p)$ of order $n$, the
+best-known upper bound is $O(n^{8/9})$, due to Gowers [Go08].
+-/
+@[category research solved, AMS 5 20]
+theorem green_5.variants.gowers_sl_two :
+    ∃ C > (0 : ℝ), ∀ (p : ℕ) [Fact p.Prime], ∀ S : Finset SL(2, ZMod p),
+      IsProductFree (S : Set SL(2, ZMod p)) →
+      (S.card : ℝ) ≤ C * (Fintype.card SL(2, ZMod p) : ℝ) ^ ((8 : ℝ) / 9) := by
+  sorry
+
+end Green5

--- a/FormalConjecturesForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Basic.lean
@@ -33,6 +33,17 @@ if the equation $a + b = c$ has no solution with $a, b, c \in A$.
 def IsSumFree (A : Set α) : Prop := Disjoint (A + A) A
 
 /--
+A set $S$ is said to be product-free if the product set $S \cdot S$ is disjoint from $S$,
+i.e. if the equation $x \cdot y = z$ has no solution with $x, y, z \in S$.
+-/
+def IsProductFree {M : Type*} [Mul M] (S : Set M) : Prop := Disjoint (S * S) S
+
+theorem isProductFree_iff {M : Type*} [Mul M] {S : Set M} :
+    IsProductFree S ↔ ∀ x ∈ S, ∀ y ∈ S, x * y ∉ S := by
+  simp [IsProductFree, Set.disjoint_left, Set.mem_mul]
+  aesop
+
+/--
 `allUniqueSums A` is the set of elements in `α` that can be written as the sum of exactly one
 unordered pair of elements from `A`.
 -/

--- a/FormalConjecturesForMathlib/Combinatorics/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Basic.lean
@@ -27,17 +27,16 @@ open scoped Pointwise
 variable {α : Type*} [AddCommMonoid α]
 
 /--
-A set $A$ is said to be sum-free if the sumset $A + A$ is disjoint from $A$, i.e.
-if the equation $a + b = c$ has no solution with $a, b, c \in A$.
--/
-def IsSumFree (A : Set α) : Prop := Disjoint (A + A) A
-
-/--
 A set $S$ is said to be product-free if the product set $S \cdot S$ is disjoint from $S$,
 i.e. if the equation $x \cdot y = z$ has no solution with $x, y, z \in S$.
 -/
+@[to_additive IsSumFree /--
+A set $A$ is said to be sum-free if the sumset $A + A$ is disjoint from $A$, i.e.
+if the equation $a + b = c$ has no solution with $a, b, c \in A$.
+-/]
 def IsProductFree {M : Type*} [Mul M] (S : Set M) : Prop := Disjoint (S * S) S
 
+@[to_additive isSumFree_iff]
 theorem isProductFree_iff {M : Type*} [Mul M] {S : Set M} :
     IsProductFree S ↔ ∀ x ∈ S, ∀ y ∈ S, x * y ∉ S := by
   simp [IsProductFree, Set.disjoint_left, Set.mem_mul]


### PR DESCRIPTION
Resolves #893

## Summary
- Formalises [Ben Green's Open Problem 5](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.5): "Which finite groups have the smallest biggest product-free sets?"
- The main statement `green_5` renders this as the sharp-exponent question via `IsGreatest … answer(sorry)`: the largest $\alpha$ such that every nontrivial finite group of order $n$ has a product-free set of size $\geq c\,n^{\alpha}$.
- Variants: `kedlaya` (every finite group has a product-free subset of size $\gg n^{11/14}$ [Ke97]); `sl_two` (the $\mathrm{SL}_2(\mathbb{F}_p)$ model problem, open); `gowers_sl_two` (the $O(n^{8/9})$ upper bound for $\mathrm{SL}_2(\mathbb{F}_p)$ [Go08]).
- Adds a shared `IsProductFree` definition and `isProductFree_iff` to `FormalConjecturesForMathlib/Combinatorics/Basic.lean`, next to the existing `IsSumFree`. Mathlib has no product-free predicate.

Note: the candidate extremal family (Ree groups ${}^2G_2(q)$) that Green suggests may witness sharpness is not available in Mathlib, so it is described in the docstring rather than formalised.

## Test plan
- [x] `lake --wfail build 'FormalConjectures.GreensOpenProblems.«5»'` passes with no errors or warnings (the `isProductFree_iff` proof in ForMathlib is complete — no `sorry`).
- [x] Problem statement and bibliography checked against Green's "100 open problems" PDF.