### PR TITLE
feat: add Jacobian disproof

### DIFF
--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -132,8 +132,8 @@ theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
 set_option linter.style.answer_attribute false in
 /-- Does the Jacobian conjecture hold in the two variable case? -/
 @[category research open, AMS 14]
-theorem jacobian_conjecture_two_variables {k : Type} [Field k] [CharZero k] :
-    answer(sorry) ↔ JacobianConjectureProp k (Fin 2) := by
+theorem jacobian_conjecture_two_variables :
+    answer(sorry) ↔ ∀ (k : Type) [Field k] [CharZero k], JacobianConjectureProp k (Fin 2) := by
   sorry
 
 end Conjecture

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -52,14 +52,14 @@ noncomputable def id : RegularFunction k σ σ := MvPolynomial.X
 
 /-- The evaluation of a regular function `f` over `k` at some point `a`
 with coordinates in some algebra over `k`-/
-noncomputable def aeval {σ τ : Type*} [Fintype σ] {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
+noncomputable def aeval {σ τ : Type*} {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
     (F : RegularFunction k σ τ) : (σ → S₁) → τ → S₁ :=
   fun a t ↦ MvPolynomial.aeval a (F t)
 
 /--`aeval` is compatible with composition of regular functions. -/
 @[category API, AMS 14]
 lemma comp_aeval
-    {σ τ ι : Type*} [Fintype σ] [Fintype τ]
+    {σ τ ι : Type*}
     (F : RegularFunction k σ τ) (G : RegularFunction k τ ι)
     (a : σ → k) : (F.comp G).aeval a = G.aeval (F.aeval a) := by
   ext i
@@ -70,11 +70,9 @@ end RegularFunction
 
 end Prelims
 
-variable {k : Type*} [Field k] [CharZero k]
-
 section Conjecture
 
-open RegularFunction
+open RegularFunction MvPolynomial
 
 def JacobianConjectureProp (k σ : Type) [CommRing k] [Fintype σ] [DecidableEq σ] :
     Prop :=
@@ -82,207 +80,52 @@ def JacobianConjectureProp (k σ : Type) [CommRing k] [Fintype σ] [DecidableEq 
     ∃ (G : RegularFunction k σ σ), G.comp F = id k σ ∧
     F.comp G = id k σ
 
+/-- Alpöge/Fable's counterexample: a polynomial self-map of `k³` with Jacobian
+determinant `1` which is not injective. -/
+noncomputable def F (k : Type) [Field k] : RegularFunction k (Fin 3) (Fin 3) :=
+  ![(1 + C 2 * X 0 * X 1) ^ 3 * X 2
+      + C 4 * X 1 ^ 2 * (1 + C 2 * X 0 * X 1) * (C 2 + C 3 * (X 0 * X 1)),
+    X 1 + C 3 * X 0 * (1 + C 2 * X 0 * X 1) ^ 2 * X 2
+      + C 12 * X 0 * X 1 ^ 2 * (C 2 + C 3 * (X 0 * X 1)),
+    -X 0 + C 3 * X 0 ^ 2 * X 1 + X 0 ^ 3 * X 2]
+
+@[category API, AMS 14]
+lemma det_jacobian_F (k : Type) [Field k] : (F k).Jacobian.det = 1 := by
+  simp only [F, Jacobian, Matrix.det_fin_three, Matrix.of_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons, map_add,
+    map_neg, Derivation.map_one_eq_zero, pderiv_mul, pderiv_pow, pderiv_C, pderiv_X_self,
+    pderiv_X_of_ne, ne_eq, Fin.reduceEq, not_false_eq_true]
+  simp only [map_ofNat]
+  ring
+
+/-- `F` identifies the two distinct points `(1, -3/4, 13/4)` and `(-1, 3/4, 13/4)`. -/
+@[category API, AMS 14]
+lemma aeval_F_eq (k : Type) [Field k] [CharZero k] :
+    (F k).aeval ![1, -(3 / 4), (13 / 4 : k)] = (F k).aeval ![-1, 3 / 4, 13 / 4] := by
+  funext i
+  fin_cases i <;> simp [RegularFunction.aeval, F] <;> field_simp <;> ring
+
 set_option linter.style.answer_attribute false in
-set_option maxHeartbeats 0 in
 /-- The **Jacobian Conjecture**: any regular function
 (i.e. vector valued polynomial function from) `kⁿ → kᵐ`
 whose Jacobian is a non-zero constant has an inverse that
-is given by a regular function, where `k` is a field of characteristic `0`-/
-@[category research open, AMS 14]
+is given by a regular function, where `k` is a field of characteristic `0`.
+
+This is false: `F` has Jacobian determinant `1` but identifies
+two distinct points, so it admits no inverse. -/
+@[category research solved, AMS 14]
 theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
     answer(False) ↔ ∀ {σ : Type} [Fintype σ] [DecidableEq σ],
       JacobianConjectureProp k σ := by
-  simp
-  use Fin 3
-  set x := MvPolynomial.X (R := k) (0 : Fin 3) with hx
-  set y := MvPolynomial.X (R := k) (1 : Fin 3) with hy
-  set z := MvPolynomial.X (R := k) (2 : Fin 3) with hz
-
-  let F : RegularFunction k (Fin 3) (Fin 3) :=
-      ![(MvPolynomial.C 1 + x * y)^3 * z + y ^ 2 * (MvPolynomial.C  1 + x * y) * (MvPolynomial.C 4 + MvPolynomial.C 3 * x * y),
-        y + MvPolynomial.C 3 * x * (MvPolynomial.C 1 + x * y) ^ 2 * z + MvPolynomial.C 3 * x * y ^ 2 * (MvPolynomial.C 4 + MvPolynomial.C 3 * x * y),
-        MvPolynomial.C 2 * x - MvPolynomial.C 3 * x ^ 2 * y - x ^ 3 * z]
-
-  have F_det : F.Jacobian.det = .C (-2) := by
-    have hC2 : MvPolynomial.C (σ := Fin 3) (2 : k) =
-        (2 : MvPolynomial (Fin 3) k) := by
-      simpa using map_ofNat (MvPolynomial.C : k →+* MvPolynomial (Fin 3) k) 2
-    have hC3 : MvPolynomial.C (σ := Fin 3) (3 : k) =
-        (3 : MvPolynomial (Fin 3) k) := by
-      simpa using map_ofNat (MvPolynomial.C : k →+* MvPolynomial (Fin 3) k) 3
-    have hC4 : MvPolynomial.C (σ := Fin 3) (4 : k) =
-        (4 : MvPolynomial (Fin 3) k) := by
-      simpa using map_ofNat (MvPolynomial.C : k →+* MvPolynomial (Fin 3) k) 4
-    have hCneg2 :
-        MvPolynomial.C (σ := Fin 3) (-2 : k) = (-2 : MvPolynomial (Fin 3) k) := by
-      rw [map_neg]
-      exact congrArg Neg.neg hC2
-    let t := 1 + x * y
-    let h := t ^ 2 * z + y ^ 2 * (4 + 3 * x * y)
-    let r := 2 * x - 3 * x ^ 2 * y - x ^ 3 * z
-    let G : RegularFunction k (Fin 3) (Fin 3) :=
-      ![t * h, y + 3 * x * h, r]
-    have hF : F = G := by
-      funext i
-      fin_cases i <;> simp [F, G, t, h, r, hC2, hC3, hC4] <;> ring
-    rw [hF]
-    rw [hCneg2]
-
-    let a := MvPolynomial.pderiv (0 : Fin 3) h
-    let b := MvPolynomial.pderiv (1 : Fin 3) h
-    let rx := 2 - 6 * x * y - 3 * x ^ 2 * z
-    have hx_x : MvPolynomial.pderiv (0 : Fin 3) x = 1 := by simp [hx]
-    have hx_y : MvPolynomial.pderiv (1 : Fin 3) x = 0 := by simp [hx]
-    have hx_z : MvPolynomial.pderiv (2 : Fin 3) x = 0 := by simp [hx]
-    have hy_x : MvPolynomial.pderiv (0 : Fin 3) y = 0 := by simp [hy]
-    have hy_y : MvPolynomial.pderiv (1 : Fin 3) y = 1 := by simp [hy]
-    have hy_z : MvPolynomial.pderiv (2 : Fin 3) y = 0 := by simp [hy]
-    have hz_x : MvPolynomial.pderiv (0 : Fin 3) z = 0 := by simp [hz]
-    have hz_y : MvPolynomial.pderiv (1 : Fin 3) z = 0 := by simp [hz]
-    have hpderiv2 (i : Fin 3) :
-        MvPolynomial.pderiv i (2 : MvPolynomial (Fin 3) k) = 0 := by
-      rw [← hC2, MvPolynomial.pderiv_C]
-    have hpderiv3 (i : Fin 3) :
-        MvPolynomial.pderiv i (3 : MvPolynomial (Fin 3) k) = 0 := by
-      rw [← hC3, MvPolynomial.pderiv_C]
-    have hpderiv4 (i : Fin 3) :
-        MvPolynomial.pderiv i (4 : MvPolynomial (Fin 3) k) = 0 := by
-      rw [← hC4, MvPolynomial.pderiv_C]
-    have ht_x : MvPolynomial.pderiv (0 : Fin 3) t = y := by
-      simp [t, hx, hy]
-    have ht_y : MvPolynomial.pderiv (1 : Fin 3) t = x := by
-      simp [t, hx, hy]
-    have ht_z : MvPolynomial.pderiv (2 : Fin 3) t = 0 := by
-      simp [t, hx, hy]
-    have hz_h_left : MvPolynomial.pderiv (2 : Fin 3) (t ^ 2 * z) = t ^ 2 := by
-      rw [MvPolynomial.pderiv_mul, MvPolynomial.pderiv_pow, ht_z, hz]
-      simp
-    have hz_h_right : MvPolynomial.pderiv (2 : Fin 3)
-        (y ^ 2 * (4 + 3 * x * y)) = 0 := by
-      rw [hx, hy]
-      simp [hpderiv3, hpderiv4]
-    have hz_h : MvPolynomial.pderiv (2 : Fin 3) h = t ^ 2 := by
-      dsimp only [h]
-      rw [map_add, hz_h_left, hz_h_right, add_zero]
-
-    have hf_x : MvPolynomial.pderiv (0 : Fin 3) (t * h) = y * h + t * a := by
-      dsimp only [a]
-      rw [MvPolynomial.pderiv_mul, ht_x]
-    have hf_y : MvPolynomial.pderiv (1 : Fin 3) (t * h) = x * h + t * b := by
-      dsimp only [b]
-      rw [MvPolynomial.pderiv_mul, ht_y]
-    have hf_z : MvPolynomial.pderiv (2 : Fin 3) (t * h) = t ^ 3 := by
-      rw [MvPolynomial.pderiv_mul, ht_z, hz_h]
-      ring
-    have hg_x : MvPolynomial.pderiv (0 : Fin 3)
-        (y + 3 * x * h) = 3 * h + 3 * x * a := by
-      dsimp only [a]
-      rw [map_add, MvPolynomial.pderiv_mul, MvPolynomial.pderiv_mul,
-        hy_x, hpderiv3, hx_x]
-      ring
-    have hg_y : MvPolynomial.pderiv (1 : Fin 3)
-        (y + 3 * x * h) = 1 + 3 * x * b := by
-      dsimp only [b]
-      rw [map_add, MvPolynomial.pderiv_mul, MvPolynomial.pderiv_mul,
-        hy_y, hpderiv3, hx_y]
-      ring
-    have hg_z : MvPolynomial.pderiv (2 : Fin 3)
-        (y + 3 * x * h) = 3 * x * t ^ 2 := by
-      rw [map_add, MvPolynomial.pderiv_mul, MvPolynomial.pderiv_mul,
-        hy_z, hpderiv3, hx_z, hz_h]
-      ring
-    have hr_x : MvPolynomial.pderiv (0 : Fin 3) r = rx := by
-      simp [r, rx, hx, hy, hz, hpderiv2, hpderiv3]
-      ring
-    have hr_y : MvPolynomial.pderiv (1 : Fin 3) r = -3 * x ^ 2 := by
-      simp [r, hx, hy, hz, hpderiv2, hpderiv3]
-    have hr_z : MvPolynomial.pderiv (2 : Fin 3) r = -x ^ 3 := by
-      simp [r, hx, hy, hz, hpderiv2, hpderiv3]
-    have hJac : G.Jacobian =
-        !![y * h + t * a, 3 * h + 3 * x * a, rx;
-           x * h + t * b, 1 + 3 * x * b, -3 * x ^ 2;
-           t ^ 3, 3 * x * t ^ 2, -x ^ 3] := by
-      apply Matrix.ext
-      intro i j
-      fin_cases i <;> fin_cases j <;>
-        simp only [RegularFunction.Jacobian, Matrix.of_apply, G, Matrix.cons_val_zero,
-          Matrix.cons_val_one, Matrix.cons_val_two]
-      all_goals assumption
-    rw [hJac]
-    rw [Matrix.det_fin_three]
-    simp
-
-    have ha : x ^ 3 * a =
-        2 * t - 2 * t * y * r - t ^ 2 * rx - 3 * x ^ 2 * h := by
-      dsimp only [a, h]
-      simp [ht_x, hx_x, hy_x, hz_x, hpderiv3, hpderiv4, r, rx]
-      ring
-    have hb : x ^ 3 * b =
-        x ^ 2 - 2 * t * x * r + 3 * t ^ 2 * x ^ 2 := by
-      dsimp only [b, h]
-      simp [ht_y, hx_y, hy_y, hz_y, hpderiv3, hpderiv4, r]
-      ring
-    have hr : t ^ 2 * r + x ^ 3 * h = x * (t + 1) := by
-      simp [t, h, r]
-      ring
-    have hr' : t ^ 2 * r = x * (t + 1) - x ^ 3 * h := by
-      rw [eq_sub_iff_add_eq]
-      exact hr
-
-    calc
-      _ = (3 * x ^ 2 * h - t) * (x ^ 3 * a) +
-            3 * h * (x ^ 3 * b) + x ^ 3 * y * h * (-1 + 9 * t ^ 2) +
-            3 * x ^ 4 * h ^ 2 - 9 * x ^ 2 * h * t ^ 3 +
-            rx * t ^ 2 * (3 * x ^ 2 * h - t) := by ring
-      _ = -2 * t ^ 2 + (8 * t + 4) * x ^ 2 * h - 6 * x ^ 4 * h ^ 2 -
-            6 * t ^ 2 * x * h * r + 2 * t ^ 2 * y * r := by
-          rw [ha, hb]
-          dsimp only [t]
-          ring
-      _ = -2 * t ^ 2 + (8 * t + 4) * x ^ 2 * h - 6 * x ^ 4 * h ^ 2 +
-            (-6 * x * h + 2 * y) * (t ^ 2 * r) := by ring
-      _ = -2 := by
-          rw [hr']
-          dsimp only [t]
-          ring
-  suffices ¬ (Function.Injective (RegularFunction.aeval (S₁ := k) F)) by
-    use inferInstance, inferInstance
-    unfold JacobianConjectureProp
-    push ¬ _
-    use F
-    constructor
-    · rw [F_det, MvPolynomial.isUnit_iff_eq_C_of_isReduced]
-      use -2
-      simp
-    · intro x hx HxF
-      apply this
-      intro a b hab
-      calc
-        a = aeval (RegularFunction.id k (Fin 3)) a := by
-          unfold aeval RegularFunction.id
-          simp
-        _ = aeval (F.comp x) a := by
-          rw [HxF]
-        _ = aeval x (aeval F a) := by
-          rw [comp_aeval]
-        _ = aeval x (aeval F b) := by
-          rw [hab]
-        _ = aeval (F.comp x) b := by
-          rw [comp_aeval]
-        _ = b := by
-          rw [HxF]
-          unfold aeval RegularFunction.id
-          simp
-  simp [F]
-  rw [Function.not_injective_iff]
-  use ![0, 0, -1/4], ![1, -3/2, 13/2]
-  unfold RegularFunction.aeval
-  simp
-  ext t
-  fin_cases t
-  all_goals
-    simp [MvPolynomial.eval_X, hx, hy, hz]
-    grind
+  rw [false_iff]
+  intro h
+  obtain ⟨G, -, hFG⟩ := h (F k) (det_jacobian_F k ▸ isUnit_one)
+  have hleft : Function.LeftInverse (G.aeval (S₁ := k)) ((F k).aeval) := fun a => by
+    rw [← RegularFunction.comp_aeval, hFG]
+    funext t
+    simp [RegularFunction.aeval, RegularFunction.id]
+  have h1 : (1 : k) = -1 := congrFun (hleft.injective (aeval_F_eq k)) 0
+  norm_num at h1
 
 end Conjecture
 
@@ -298,9 +141,7 @@ variable {k σ τ ι : Type} [Fintype σ] [Fintype τ] [DecidableEq σ] [Decidab
 lemma sanity_check_condition_1 (F : RegularFunction k σ σ) :
     IsUnit F.Jacobian.det ↔ (∃ (c : k), c ≠ 0 ∧
         F.Jacobian.det = .C c) := by
-  -- TODO(lezeau): this is a little annoying to prove since this depends on a general statement that
-  -- seems to be something missing from Mathlib
-  sorry
+  simp [MvPolynomial.isUnit_iff_eq_C_of_isReduced, isUnit_iff_ne_zero]
 
 
 -- Let's apply the conjecture to a trivial case to make sure things

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -80,27 +80,29 @@ def JacobianConjectureProp (k σ : Type) [CommRing k] [Fintype σ] [DecidableEq 
     ∃ (G : RegularFunction k σ σ), G.comp F = id k σ ∧
     F.comp G = id k σ
 
+variable (k : Type) [Field k]
+
+name_poly_vars X, Y, Z over k
+
 /-- Alpöge/Fable's counterexample: a polynomial self-map of `k³` with Jacobian
 determinant `1` which is not injective. -/
-noncomputable def F (k : Type) [Field k] : RegularFunction k (Fin 3) (Fin 3) :=
-  ![(1 + C 2 * X 0 * X 1) ^ 3 * X 2
-      + C 4 * X 1 ^ 2 * (1 + C 2 * X 0 * X 1) * (C 2 + C 3 * (X 0 * X 1)),
-    X 1 + C 3 * X 0 * (1 + C 2 * X 0 * X 1) ^ 2 * X 2
-      + C 12 * X 0 * X 1 ^ 2 * (C 2 + C 3 * (X 0 * X 1)),
-    -X 0 + C 3 * X 0 ^ 2 * X 1 + X 0 ^ 3 * X 2]
+noncomputable def F : RegularFunction k (Fin 3) (Fin 3) :=
+  ![(1 + 2 * X * Y) ^ 3 * Z + 4 * Y ^ 2 * (1 + 2 * X * Y) * (2 + 3 * (X * Y)),
+    Y + 3 * X * (1 + 2 * X * Y) ^ 2 * Z + 12 * X * Y ^ 2 * (2 + 3 * (X * Y)),
+    -X + 3 * X ^ 2 * Y + X ^ 3 * Z]
 
 @[category API, AMS 14]
-lemma det_jacobian_F (k : Type) [Field k] : (F k).Jacobian.det = 1 := by
-  simp only [F, Jacobian, Matrix.det_fin_three, Matrix.of_apply, Matrix.cons_val_zero,
-    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons, map_add,
-    map_neg, Derivation.map_one_eq_zero, pderiv_mul, pderiv_pow, pderiv_C, pderiv_X_self,
-    pderiv_X_of_ne, ne_eq, Fin.reduceEq, not_false_eq_true]
+lemma det_jacobian_F : (F k).Jacobian.det = 1 := by
+  simp only [F, Jacobian, ← map_ofNat (C : k →+* MvPolynomial (Fin 3) k), Matrix.det_fin_three,
+    Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+    Matrix.head_cons, Matrix.tail_cons, map_add, map_neg, Derivation.map_one_eq_zero, pderiv_mul,
+    pderiv_pow, pderiv_C, pderiv_X_self, pderiv_X_of_ne, ne_eq, Fin.reduceEq, not_false_eq_true]
   simp only [map_ofNat]
   ring
 
 /-- `F` identifies the two distinct points `(1, -3/4, 13/4)` and `(-1, 3/4, 13/4)`. -/
 @[category API, AMS 14]
-lemma aeval_F_eq (k : Type) [Field k] [CharZero k] :
+lemma aeval_F_eq [CharZero k] :
     (F k).aeval ![1, -(3 / 4), (13 / 4 : k)] = (F k).aeval ![-1, 3 / 4, 13 / 4] := by
   funext i
   fin_cases i <;> simp [RegularFunction.aeval, F] <;> field_simp <;> ring

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -127,6 +127,13 @@ theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
   have h1 : (1 : k) = -1 := congrFun (hleft.injective (aeval_F_eq k)) 0
   norm_num at h1
 
+set_option linter.style.answer_attribute false in
+/-- Does the Jacobian conjecture hold in the two variable case? -/
+@[category research open, AMS 14]
+theorem jacobian_conjecture_two_variables {k : Type} [Field k] [CharZero k] :
+    answer(sorry) ↔ JacobianConjectureProp k (Fin 2) := by
+  sorry
+
 end Conjecture
 
 section Tests

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -103,12 +103,148 @@ theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
         y + MvPolynomial.C 3 * x * (MvPolynomial.C 1 + x * y) ^ 2 * z + MvPolynomial.C 3 * x * y ^ 2 * (MvPolynomial.C 4 + MvPolynomial.C 3 * x * y),
         MvPolynomial.C 2 * x - MvPolynomial.C 3 * x ^ 2 * y - x ^ 3 * z]
 
-  have F_det : F.Jacobian.det = .C (- 2) := by
-    unfold RegularFunction.Jacobian
-    unfold F
+  have F_det : F.Jacobian.det = .C (-2) := by
+    have hC2 : MvPolynomial.C (σ := Fin 3) (2 : k) =
+        (2 : MvPolynomial (Fin 3) k) := by
+      simpa using map_ofNat (MvPolynomial.C : k →+* MvPolynomial (Fin 3) k) 2
+    have hC3 : MvPolynomial.C (σ := Fin 3) (3 : k) =
+        (3 : MvPolynomial (Fin 3) k) := by
+      simpa using map_ofNat (MvPolynomial.C : k →+* MvPolynomial (Fin 3) k) 3
+    have hC4 : MvPolynomial.C (σ := Fin 3) (4 : k) =
+        (4 : MvPolynomial (Fin 3) k) := by
+      simpa using map_ofNat (MvPolynomial.C : k →+* MvPolynomial (Fin 3) k) 4
+    have hCneg2 :
+        MvPolynomial.C (σ := Fin 3) (-2 : k) = (-2 : MvPolynomial (Fin 3) k) := by
+      rw [map_neg]
+      exact congrArg Neg.neg hC2
+    let t := 1 + x * y
+    let h := t ^ 2 * z + y ^ 2 * (4 + 3 * x * y)
+    let r := 2 * x - 3 * x ^ 2 * y - x ^ 3 * z
+    let G : RegularFunction k (Fin 3) (Fin 3) :=
+      ![t * h, y + 3 * x * h, r]
+    have hF : F = G := by
+      funext i
+      fin_cases i <;> simp [F, G, t, h, r, hC2, hC3, hC4] <;> ring
+    rw [hF]
+    rw [hCneg2]
+
+    let a := MvPolynomial.pderiv (0 : Fin 3) h
+    let b := MvPolynomial.pderiv (1 : Fin 3) h
+    let rx := 2 - 6 * x * y - 3 * x ^ 2 * z
+    have hx_x : MvPolynomial.pderiv (0 : Fin 3) x = 1 := by simp [hx]
+    have hx_y : MvPolynomial.pderiv (1 : Fin 3) x = 0 := by simp [hx]
+    have hx_z : MvPolynomial.pderiv (2 : Fin 3) x = 0 := by simp [hx]
+    have hy_x : MvPolynomial.pderiv (0 : Fin 3) y = 0 := by simp [hy]
+    have hy_y : MvPolynomial.pderiv (1 : Fin 3) y = 1 := by simp [hy]
+    have hy_z : MvPolynomial.pderiv (2 : Fin 3) y = 0 := by simp [hy]
+    have hz_x : MvPolynomial.pderiv (0 : Fin 3) z = 0 := by simp [hz]
+    have hz_y : MvPolynomial.pderiv (1 : Fin 3) z = 0 := by simp [hz]
+    have hpderiv2 (i : Fin 3) :
+        MvPolynomial.pderiv i (2 : MvPolynomial (Fin 3) k) = 0 := by
+      rw [← hC2, MvPolynomial.pderiv_C]
+    have hpderiv3 (i : Fin 3) :
+        MvPolynomial.pderiv i (3 : MvPolynomial (Fin 3) k) = 0 := by
+      rw [← hC3, MvPolynomial.pderiv_C]
+    have hpderiv4 (i : Fin 3) :
+        MvPolynomial.pderiv i (4 : MvPolynomial (Fin 3) k) = 0 := by
+      rw [← hC4, MvPolynomial.pderiv_C]
+    have ht_x : MvPolynomial.pderiv (0 : Fin 3) t = y := by
+      simp [t, hx, hy]
+    have ht_y : MvPolynomial.pderiv (1 : Fin 3) t = x := by
+      simp [t, hx, hy]
+    have ht_z : MvPolynomial.pderiv (2 : Fin 3) t = 0 := by
+      simp [t, hx, hy]
+    have hz_h_left : MvPolynomial.pderiv (2 : Fin 3) (t ^ 2 * z) = t ^ 2 := by
+      rw [MvPolynomial.pderiv_mul, MvPolynomial.pderiv_pow, ht_z, hz]
+      simp
+    have hz_h_right : MvPolynomial.pderiv (2 : Fin 3)
+        (y ^ 2 * (4 + 3 * x * y)) = 0 := by
+      rw [hx, hy]
+      simp [hpderiv3, hpderiv4]
+    have hz_h : MvPolynomial.pderiv (2 : Fin 3) h = t ^ 2 := by
+      dsimp only [h]
+      rw [map_add, hz_h_left, hz_h_right, add_zero]
+
+    have hf_x : MvPolynomial.pderiv (0 : Fin 3) (t * h) = y * h + t * a := by
+      dsimp only [a]
+      rw [MvPolynomial.pderiv_mul, ht_x]
+    have hf_y : MvPolynomial.pderiv (1 : Fin 3) (t * h) = x * h + t * b := by
+      dsimp only [b]
+      rw [MvPolynomial.pderiv_mul, ht_y]
+    have hf_z : MvPolynomial.pderiv (2 : Fin 3) (t * h) = t ^ 3 := by
+      rw [MvPolynomial.pderiv_mul, ht_z, hz_h]
+      ring
+    have hg_x : MvPolynomial.pderiv (0 : Fin 3)
+        (y + 3 * x * h) = 3 * h + 3 * x * a := by
+      dsimp only [a]
+      rw [map_add, MvPolynomial.pderiv_mul, MvPolynomial.pderiv_mul,
+        hy_x, hpderiv3, hx_x]
+      ring
+    have hg_y : MvPolynomial.pderiv (1 : Fin 3)
+        (y + 3 * x * h) = 1 + 3 * x * b := by
+      dsimp only [b]
+      rw [map_add, MvPolynomial.pderiv_mul, MvPolynomial.pderiv_mul,
+        hy_y, hpderiv3, hx_y]
+      ring
+    have hg_z : MvPolynomial.pderiv (2 : Fin 3)
+        (y + 3 * x * h) = 3 * x * t ^ 2 := by
+      rw [map_add, MvPolynomial.pderiv_mul, MvPolynomial.pderiv_mul,
+        hy_z, hpderiv3, hx_z, hz_h]
+      ring
+    have hr_x : MvPolynomial.pderiv (0 : Fin 3) r = rx := by
+      simp [r, rx, hx, hy, hz, hpderiv2, hpderiv3]
+      ring
+    have hr_y : MvPolynomial.pderiv (1 : Fin 3) r = -3 * x ^ 2 := by
+      simp [r, hx, hy, hz, hpderiv2, hpderiv3]
+    have hr_z : MvPolynomial.pderiv (2 : Fin 3) r = -x ^ 3 := by
+      simp [r, hx, hy, hz, hpderiv2, hpderiv3]
+    have hJac : G.Jacobian =
+        !![y * h + t * a, 3 * h + 3 * x * a, rx;
+           x * h + t * b, 1 + 3 * x * b, -3 * x ^ 2;
+           t ^ 3, 3 * x * t ^ 2, -x ^ 3] := by
+      apply Matrix.ext
+      intro i j
+      fin_cases i <;> fin_cases j <;>
+        simp only [RegularFunction.Jacobian, Matrix.of_apply, G, Matrix.cons_val_zero,
+          Matrix.cons_val_one, Matrix.cons_val_two]
+      all_goals assumption
+    rw [hJac]
     rw [Matrix.det_fin_three]
-    simp [hx, hy, hz]
-    sorry
+    simp
+
+    have ha : x ^ 3 * a =
+        2 * t - 2 * t * y * r - t ^ 2 * rx - 3 * x ^ 2 * h := by
+      dsimp only [a, h]
+      simp [ht_x, hx_x, hy_x, hz_x, hpderiv3, hpderiv4, r, rx]
+      ring
+    have hb : x ^ 3 * b =
+        x ^ 2 - 2 * t * x * r + 3 * t ^ 2 * x ^ 2 := by
+      dsimp only [b, h]
+      simp [ht_y, hx_y, hy_y, hz_y, hpderiv3, hpderiv4, r]
+      ring
+    have hr : t ^ 2 * r + x ^ 3 * h = x * (t + 1) := by
+      simp [t, h, r]
+      ring
+    have hr' : t ^ 2 * r = x * (t + 1) - x ^ 3 * h := by
+      rw [eq_sub_iff_add_eq]
+      exact hr
+
+    calc
+      _ = (3 * x ^ 2 * h - t) * (x ^ 3 * a) +
+            3 * h * (x ^ 3 * b) + x ^ 3 * y * h * (-1 + 9 * t ^ 2) +
+            3 * x ^ 4 * h ^ 2 - 9 * x ^ 2 * h * t ^ 3 +
+            rx * t ^ 2 * (3 * x ^ 2 * h - t) := by ring
+      _ = -2 * t ^ 2 + (8 * t + 4) * x ^ 2 * h - 6 * x ^ 4 * h ^ 2 -
+            6 * t ^ 2 * x * h * r + 2 * t ^ 2 * y * r := by
+          rw [ha, hb]
+          dsimp only [t]
+          ring
+      _ = -2 * t ^ 2 + (8 * t + 4) * x ^ 2 * h - 6 * x ^ 4 * h ^ 2 +
+            (-6 * x * h + 2 * y) * (t ^ 2 * r) := by ring
+      _ = -2 := by
+          rw [hr']
+          dsimp only [t]
+          ring
   suffices ¬ (Function.Injective (RegularFunction.aeval (S₁ := k) F)) by
     use inferInstance, inferInstance
     unfold JacobianConjectureProp

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -24,8 +24,6 @@ import FormalConjecturesUtil
 
 namespace JacobianConjecture
 
-open Classical
-
 section Prelims
 
 variable {k : Type*} [CommRing k]
@@ -52,6 +50,22 @@ noncomputable def comp
 variable (k σ) in
 noncomputable def id : RegularFunction k σ σ := MvPolynomial.X
 
+/-- The evaluation of a regular function `f` over `k` at some point `a`
+with coordinates in some algebra over `k`-/
+noncomputable def aeval {σ τ : Type*} [Fintype σ] {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
+    (F : RegularFunction k σ τ) : (σ → S₁) → τ → S₁ :=
+  fun a t ↦ MvPolynomial.aeval a (F t)
+
+/--`aeval` is compatible with composition of regular functions. -/
+@[category API, AMS 14]
+lemma comp_aeval
+    {σ τ ι : Type*} [Fintype σ] [Fintype τ]
+    (F : RegularFunction k σ τ) (G : RegularFunction k τ ι)
+    (a : σ → k) : (F.comp G).aeval a = G.aeval (F.aeval a) := by
+  ext i
+  rw [aeval, comp, MvPolynomial.aeval_bind₁, ←aeval]
+  rfl
+
 end RegularFunction
 
 end Prelims
@@ -62,18 +76,77 @@ section Conjecture
 
 open RegularFunction
 
-variable {σ : Type*} [Fintype σ]
+def JacobianConjectureProp (k σ : Type) [CommRing k] [Fintype σ] [DecidableEq σ] :
+    Prop :=
+  ∀ (F : RegularFunction k σ σ), IsUnit F.Jacobian.det →
+    ∃ (G : RegularFunction k σ σ), G.comp F = id k σ ∧
+    F.comp G = id k σ
 
+set_option linter.style.answer_attribute false in
+set_option maxHeartbeats 0 in
 /-- The **Jacobian Conjecture**: any regular function
 (i.e. vector valued polynomial function from) `kⁿ → kᵐ`
 whose Jacobian is a non-zero constant has an inverse that
 is given by a regular function, where `k` is a field of characteristic `0`-/
 @[category research open, AMS 14]
-theorem jacobian_conjecture (F : RegularFunction k σ σ)
-    (H : IsUnit F.Jacobian.det) :
-    ∃ (G : RegularFunction k σ σ), G.comp F = id k σ ∧
-    F.comp G = id k σ := by
-  sorry
+theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
+    answer(False) ↔ ∀ {σ : Type} [Fintype σ] [DecidableEq σ],
+      JacobianConjectureProp k σ := by
+  simp
+  use Fin 3
+  set x := MvPolynomial.X (R := k) (0 : Fin 3) with hx
+  set y := MvPolynomial.X (R := k) (1 : Fin 3) with hy
+  set z := MvPolynomial.X (R := k) (2 : Fin 3) with hz
+
+  let F : RegularFunction k (Fin 3) (Fin 3) :=
+      ![(MvPolynomial.C 1 + x * y)^3 * z + y ^ 2 * (MvPolynomial.C  1 + x * y) * (MvPolynomial.C 4 + MvPolynomial.C 3 * x * y),
+        y + MvPolynomial.C 3 * x * (MvPolynomial.C 1 + x * y) ^ 2 * z + MvPolynomial.C 3 * x * y ^ 2 * (MvPolynomial.C 4 + MvPolynomial.C 3 * x * y),
+        MvPolynomial.C 2 * x - MvPolynomial.C 3 * x ^ 2 * y - x ^ 3 * z]
+
+  have F_det : F.Jacobian.det = .C (- 2) := by
+    unfold RegularFunction.Jacobian
+    unfold F
+    rw [Matrix.det_fin_three]
+    simp [hx, hy, hz]
+    sorry
+  suffices ¬ (Function.Injective (RegularFunction.aeval (S₁ := k) F)) by
+    use inferInstance, inferInstance
+    unfold JacobianConjectureProp
+    push ¬ _
+    use F
+    constructor
+    · rw [F_det, MvPolynomial.isUnit_iff_eq_C_of_isReduced]
+      use -2
+      simp
+    · intro x hx HxF
+      apply this
+      intro a b hab
+      calc
+        a = aeval (RegularFunction.id k (Fin 3)) a := by
+          unfold aeval RegularFunction.id
+          simp
+        _ = aeval (F.comp x) a := by
+          rw [HxF]
+        _ = aeval x (aeval F a) := by
+          rw [comp_aeval]
+        _ = aeval x (aeval F b) := by
+          rw [hab]
+        _ = aeval (F.comp x) b := by
+          rw [comp_aeval]
+        _ = b := by
+          rw [HxF]
+          unfold aeval RegularFunction.id
+          simp
+  simp [F]
+  rw [Function.not_injective_iff]
+  use ![0, 0, -1/4], ![1, -3/2, 13/2]
+  unfold RegularFunction.aeval
+  simp
+  ext t
+  fin_cases t
+  all_goals
+    simp [MvPolynomial.eval_X, hx, hy, hz]
+    grind
 
 end Conjecture
 
@@ -81,25 +154,7 @@ section Tests
 
 open RegularFunction
 
-variable {σ τ ι : Type*} [Fintype σ]
-
-/-- The evaluation of a regular function `f` over `k` at some point `a`
-with coordinates in some algebra over `k`-/
-noncomputable def RegularFunction.aeval {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
-    (F : RegularFunction k σ τ) : (σ → S₁) → τ → S₁ :=
-  fun a t ↦ MvPolynomial.aeval a (F t)
-
-
-omit [CharZero k] [Fintype σ] in
-/--`aeval` is compatible with composition of regular functions. -/
-@[category API, AMS 14]
-lemma comp_aeval
-    (F : RegularFunction k σ τ) (G : RegularFunction k τ ι)
-    (a : σ → k) : (F.comp G).aeval a = G.aeval (F.aeval a) := by
-  ext i
-  rw [aeval, comp, MvPolynomial.aeval_bind₁, ←aeval]
-  rfl
-
+variable {k σ τ ι : Type} [Fintype σ] [Fintype τ] [DecidableEq σ] [DecidableEq τ] [Field k]
 
 -- Let's check that we've stated the "invertible Jacobian" condition correctly
 -- by proving an equivalence
@@ -115,10 +170,10 @@ lemma sanity_check_condition_1 (F : RegularFunction k σ σ) :
 -- Let's apply the conjecture to a trivial case to make sure things
 -- are working as expected.
 @[category test, AMS 14]
-theorem jacobian_conjecture_identity :
+theorem jacobian_conjecture_identity (H : JacobianConjectureProp k σ) :
     ∃ (G : RegularFunction k σ σ), G.comp (id k σ) = id k σ ∧
     (id k σ).comp G = id k σ := by
-  apply jacobian_conjecture
+  apply H
   suffices (RegularFunction.id k σ).Jacobian = 1 by simp only [this, isUnit_one, Matrix.det_one]
   ext i j
   simp only [RegularFunction.Jacobian, RegularFunction.id, MvPolynomial.pderiv_X,

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -129,7 +129,6 @@ theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
   have h1 : (1 : k) = -1 := congrFun (hleft.injective (aeval_F_eq k)) 0
   norm_num at h1
 
-set_option linter.style.answer_attribute false in
 /-- Does the Jacobian conjecture hold in the two variable case? -/
 @[category research open, AMS 14]
 theorem jacobian_conjecture_two_variables :

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -141,7 +141,7 @@ section Tests
 
 open RegularFunction
 
-variable {k σ τ ι : Type} [Fintype σ] [Fintype τ] [DecidableEq σ] [DecidableEq τ] [Field k]
+variable {k σ : Type} [Fintype σ] [DecidableEq σ] [Field k]
 
 -- Let's check that we've stated the "invertible Jacobian" condition correctly
 -- by proving an equivalence

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -24,6 +24,8 @@ import FormalConjecturesUtil
 
 namespace JacobianConjecture
 
+open Classical
+
 section Prelims
 
 variable {k : Type*} [CommRing k]
@@ -74,66 +76,64 @@ section Conjecture
 
 open RegularFunction MvPolynomial
 
-def JacobianConjectureProp (k σ : Type) [CommRing k] [Fintype σ] [DecidableEq σ] :
-    Prop :=
-  ∀ (F : RegularFunction k σ σ), IsUnit F.Jacobian.det →
-    ∃ (G : RegularFunction k σ σ), G.comp F = id k σ ∧
-    F.comp G = id k σ
-
-variable (k : Type) [Field k]
+variable (k : Type*) [Field k]
 
 name_poly_vars X, Y, Z over k
 
 /-- Alpöge/Fable's counterexample: a polynomial self-map of `k³` with Jacobian
-determinant `1` which is not injective. -/
-noncomputable def F : RegularFunction k (Fin 3) (Fin 3) :=
-  ![(1 + 2 * X * Y) ^ 3 * Z + 4 * Y ^ 2 * (1 + 2 * X * Y) * (2 + 3 * (X * Y)),
-    Y + 3 * X * (1 + 2 * X * Y) ^ 2 * Z + 12 * X * Y ^ 2 * (2 + 3 * (X * Y)),
-    -X + 3 * X ^ 2 * Y + X ^ 3 * Z]
+determinant `-2` which is not injective. -/
+noncomputable abbrev F : RegularFunction k (Fin 3) (Fin 3) :=
+  ![(1 + X * Y)^3 * Z + Y ^ 2 * (1 + X * Y) * (4 + 3 * X * Y),
+    Y + 3 * X * (1 + X * Y) ^ 2 * Z + 3 * X * Y ^ 2 * (4 + 3 * X * Y),
+    2 * X - 3 * X ^ 2 * Y - X ^ 3 * Z]
 
 @[category API, AMS 14]
-lemma det_jacobian_F : (F k).Jacobian.det = 1 := by
-  simp only [F, Jacobian, ← map_ofNat (C : k →+* MvPolynomial (Fin 3) k), Matrix.det_fin_three,
-    Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
-    Matrix.head_cons, Matrix.tail_cons, map_add, map_neg, Derivation.map_one_eq_zero, pderiv_mul,
-    pderiv_pow, pderiv_C, pderiv_X_self, pderiv_X_of_ne, ne_eq, Fin.reduceEq, not_false_eq_true]
+lemma det_jacobian_F : (F k).Jacobian.det = -2 := by
+  simp only [Jacobian, F, Fin.isValue, ← map_ofNat (C : k →+* MvPolynomial (Fin 3) k),
+    Matrix.det_fin_three, Matrix.of_apply, Matrix.cons_val_zero, map_add, Derivation.leibniz,
+    pderiv_X, ne_eq, Fin.reduceEq, not_false_eq_true, Pi.single_eq_of_ne, smul_eq_mul, mul_zero,
+    Derivation.leibniz_pow, Nat.add_one_sub_one, Derivation.map_one_eq_zero, one_ne_zero,
+    Pi.single_eq_same, mul_one, zero_add, nsmul_eq_mul, Nat.cast_ofNat, derivation_C, add_zero,
+    pow_one,  Matrix.cons_val_one, zero_ne_one, Matrix.cons_val_two, Nat.succ_eq_add_one,
+    Nat.reduceAdd, Matrix.tail_cons, Matrix.head_cons, map_sub, sub_self, zero_sub, mul_neg,
+    sub_zero, neg_mul, sub_neg_eq_add]
   simp only [map_ofNat]
   ring
 
-/-- `F` identifies the two distinct points `(1, -3/4, 13/4)` and `(-1, 3/4, 13/4)`. -/
-@[category API, AMS 14]
-lemma aeval_F_eq [CharZero k] :
-    (F k).aeval ![1, -(3 / 4), (13 / 4 : k)] = (F k).aeval ![-1, 3 / 4, 13 / 4] := by
-  funext i
-  fin_cases i <;> simp [RegularFunction.aeval, F] <;> field_simp <;> ring
+variable [CharZero k]
 
-set_option linter.style.answer_attribute false in
+/-- `F` identifies the two distinct points `(0, 0, -1/4)` and `(1, -3/2, 13/2)`. -/
+@[category API, AMS 14]
+lemma aeval_F_eq :
+    (F k).aeval ![(0 : k), 0, -1/4] = (F k).aeval ![(1 : k), -3/2, 13/2]  := by
+  funext i
+  fin_cases i <;> simp [RegularFunction.aeval] <;> grind
+
 /-- The **Jacobian Conjecture**: any regular function
 (i.e. vector valued polynomial function from) `kⁿ → kᵐ`
 whose Jacobian is a non-zero constant has an inverse that
 is given by a regular function, where `k` is a field of characteristic `0`.
 
-This is false: `F` has Jacobian determinant `1` but identifies
+This is false: `F` has Jacobian determinant `-2` but identifies
 two distinct points, so it admits no inverse. -/
 @[category research solved, AMS 14]
-theorem jacobian_conjecture {k : Type} [Field k] [CharZero k] :
-    answer(False) ↔ ∀ {σ : Type} [Fintype σ] [DecidableEq σ],
-      JacobianConjectureProp k σ := by
-  rw [false_iff]
+theorem jacobian_conjecture  :
+    ¬ ∀ {σ : Type} [Fintype σ] (F : RegularFunction k σ σ)
+    (_H : IsUnit F.Jacobian.det),
+    ∃ (G : RegularFunction k σ σ), G.comp F = id k σ ∧
+    F.comp G = id k σ := by
   intro h
-  obtain ⟨G, -, hFG⟩ := h (F k) (det_jacobian_F k ▸ isUnit_one)
+  have : IsUnit (F k).Jacobian.det := by
+    rw [det_jacobian_F k, MvPolynomial.isUnit_iff_eq_C_of_isReduced]
+    use -2, by simp
+    rw [C_neg, neg_inj, _root_.map_ofNat]
+  obtain ⟨G, -, hFG⟩ := h (F k) (by convert this)
   have hleft : Function.LeftInverse (G.aeval (S₁ := k)) ((F k).aeval) := fun a => by
     rw [← RegularFunction.comp_aeval, hFG]
     funext t
     simp [RegularFunction.aeval, RegularFunction.id]
-  have h1 : (1 : k) = -1 := congrFun (hleft.injective (aeval_F_eq k)) 0
+  have h1 : (0 : k) = 1 := congrFun (hleft.injective (aeval_F_eq k)) 0
   norm_num at h1
-
-/-- Does the Jacobian conjecture hold in the two variable case? -/
-@[category research open, AMS 14]
-theorem jacobian_conjecture_two_variables :
-    answer(sorry) ↔ ∀ (k : Type) [Field k] [CharZero k], JacobianConjectureProp k (Fin 2) := by
-  sorry
 
 end Conjecture
 
@@ -147,22 +147,8 @@ variable {k σ τ ι : Type} [Fintype σ] [Fintype τ] [DecidableEq σ] [Decidab
 -- by proving an equivalence
 @[category API, AMS 14]
 lemma sanity_check_condition_1 (F : RegularFunction k σ σ) :
-    IsUnit F.Jacobian.det ↔ (∃ (c : k), c ≠ 0 ∧
-        F.Jacobian.det = .C c) := by
+    IsUnit F.Jacobian.det ↔ (∃ (c : k), c ≠ 0 ∧ F.Jacobian.det = .C c) := by
   simp [MvPolynomial.isUnit_iff_eq_C_of_isReduced, isUnit_iff_ne_zero]
-
-
--- Let's apply the conjecture to a trivial case to make sure things
--- are working as expected.
-@[category test, AMS 14]
-theorem jacobian_conjecture_identity (H : JacobianConjectureProp k σ) :
-    ∃ (G : RegularFunction k σ σ), G.comp (id k σ) = id k σ ∧
-    (id k σ).comp G = id k σ := by
-  apply H
-  suffices (RegularFunction.id k σ).Jacobian = 1 by simp only [this, isUnit_one, Matrix.det_one]
-  ext i j
-  simp only [RegularFunction.Jacobian, RegularFunction.id, MvPolynomial.pderiv_X,
-    Matrix.of_apply, Matrix.one_eq_pi_single]
 
 end Tests
 

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -33,7 +33,7 @@ variable {σ τ ι : Type*}
 
 variable (k σ τ) in
 
-/-- Implicitly use `σ` as an index set and `k` as coefficient ring. -/
+/-- The type of regular functions from $k^σ$ to $k^τ$. -/
 abbrev RegularFunction := τ → MvPolynomial σ k
 
 namespace RegularFunction


### PR DESCRIPTION
This PR adds the disproof of the Jacobian conjecture.

This makes a minor change to the statement, namely negating it (the original formalisation expected the conjecture to be true so couldn't be directly adapted by a disproof). In a subsequent PR (#4635), I'll update the statement so it aligns with the `answer(sorry)` convention that we often use in this repo, and state a disproof for all characteristics (see discussion and reviews below).

The tweet containing the original disproof can be found here: https://x.com/__alpoge__/status/2079028340955197566?s=46

Some independent formalisations were written by other people - see thread here https://leanprover.zulipchat.com/#narrow/channel/583339-AI-authored-projects/topic/Counterexample.20to.20the.20Jacobean.20conjecture/with/611589771. 

Many thanks to @deancureton for the golfing! 