### PR TITLE
ErdosProblems/349: sharp threshold on the strip 1 < α < 3/2 — entirely complete iff t < 2

### DIFF
--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -156,4 +156,18 @@ theorem integer_isGoodPair_iff (t α : ℤ) (ht : 1 ≤ t) (hα : 1 ≤ α) :
     IsGoodPair (t : ℝ) (α : ℝ) ↔ t = 1 ∧ α = 2 := by
   sorry
 
+/-- **The pair $(3/2, 2)$ is NOT good.** The negative companion of `dyadic_two_isGoodPair`:
+while every dyadic coefficient $1/2^k$ gives a good pair at $\alpha = 2$, the non-dyadic rational
+$t = 3/2$ does not. The sequence $\lfloor (3/2)\cdot 2^n\rfloor = 1, 3, 6, 12, 24, \ldots$ is not
+additively complete because every term but the first $\lfloor 3/2\rfloor = 1$ is a multiple of
+$3$ (namely $\lfloor (3/2)\cdot 2^{n+1}\rfloor = 3\cdot 2^n$), so every subset sum is
+$\equiv 0$ or $1 \pmod 3$; the infinitely many integers $\equiv 2 \pmod 3$ are never reached.
+A partial result on Erdős Problem 349 in the same divisibility family as
+`int_coeff_ge_two_not_isGoodPair` (here the modulus is $3$). -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/erdos-349-three-halves-fiber-proof/FormalConjectures/ErdosProblems/349.lean"]
+theorem three_halves_two_not_isGoodPair : ¬ IsGoodPair (3 / 2) 2 := by
+  sorry
+
 end Erdos349

--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -182,8 +182,9 @@ def IsEntirelyAddComplete (A : Set ℤ) : Prop :=
   ∀ k : ℤ, 1 ≤ k → k ∈ subsetSums A
 
 /-- **Glue.** Entire completeness implies (eventual) completeness: if every $k \ge 1$ is a subset
-sum, then in particular all sufficiently large $k$ are. -/
-@[category research solved, AMS 11]
+sum, then in particular all sufficiently large $k$ are. Textbook-level: an immediate consequence
+of the definitions, not itself a partial result on Erdős Problem 349. -/
+@[category textbook, AMS 11]
 theorem isEntirelyAddComplete_imp_isAddComplete {A : Set ℤ}
     (h : IsEntirelyAddComplete A) : IsAddComplete A :=
   Filter.eventually_atTop.mpr ⟨1, fun k hk => h k hk⟩
@@ -194,8 +195,10 @@ hence the range of $a$ is not entirely additively complete.
 
 This is the pure-$\mathbb{Z}$ core of `alpha_gt_two_not_isGoodPair`'s
 `by_cases ∃ b ∈ B, a (r+1) ≤ b` case-split, with $m$ *given* rather than constructed via
-`Tendsto` (strictly easier, and enough for the band $5/3 \le \alpha < 2$ below). -/
-@[category research solved, AMS 11,
+`Tendsto` (strictly easier, and enough for the band $5/3 \le \alpha < 2$ below). A textbook-level
+combinatorial fact about monotone integer sequences, phrased abstractly (no $t, \alpha$); the
+research content of Erdős Problem 349 is in its application below. -/
+@[category textbook, AMS 11,
   formal_proof using formal_conjectures at
   "https://github.com/cepadugato/formal-conjectures/blob/erdos-349-entire-gap-criterion-proof/FormalConjectures/ErdosProblems/349.lean"]
 theorem entire_gap_not_complete (a : ℕ → ℤ) (hmono : Monotone a) (hnn : ∀ n, 0 ≤ a n)
@@ -204,18 +207,21 @@ theorem entire_gap_not_complete (a : ℕ → ℤ) (hmono : Monotone a) (hnn : �
     ¬ IsEntirelyAddComplete (Set.range a) := by
   sorry
 
-/-- The $0$-th term of $\lfloor t\alpha^n\rfloor$ is $\lfloor t\rfloor$ (since $\alpha^0 = 1$). -/
-@[category research solved, AMS 11]
+/-- The $0$-th term of $\lfloor t\alpha^n\rfloor$ is $\lfloor t\rfloor$ (since $\alpha^0 = 1$).
+Textbook-level: a one-line simplification, not a partial result on Erdős Problem 349. -/
+@[category textbook, AMS 11]
 theorem floorSeq_zero (t α : ℝ) : ⌊t * α ^ (0 : ℕ)⌋ = ⌊t⌋ := by
   simp [pow_zero, mul_one]
 
-/-- The $1$-st term of $\lfloor t\alpha^n\rfloor$ is $\lfloor t\alpha\rfloor$. -/
-@[category research solved, AMS 11]
+/-- The $1$-st term of $\lfloor t\alpha^n\rfloor$ is $\lfloor t\alpha\rfloor$. Textbook-level:
+a one-line simplification, not a partial result on Erdős Problem 349. -/
+@[category textbook, AMS 11]
 theorem floorSeq_one (t α : ℝ) : ⌊t * α ^ (1 : ℕ)⌋ = ⌊t * α⌋ := by
   simp [pow_one]
 
-/-- $n \mapsto \lfloor t\alpha^n\rfloor$ is monotone when $0 \le t$ and $1 \le \alpha$. -/
-@[category research solved, AMS 11]
+/-- $n \mapsto \lfloor t\alpha^n\rfloor$ is monotone when $0 \le t$ and $1 \le \alpha$.
+Textbook-level: elementary monotonicity of `Int.floor` composed with a monotone power. -/
+@[category textbook, AMS 11]
 theorem floorSeq_monotone (t α : ℝ) (ht : 0 ≤ t) (hα : 1 ≤ α) :
     Monotone (fun n => ⌊t * α ^ n⌋) := by
   intro n m hnm
@@ -224,8 +230,9 @@ theorem floorSeq_monotone (t α : ℝ) (ht : 0 ≤ t) (hα : 1 ≤ α) :
   apply mul_le_mul_of_nonneg_left _ ht
   exact pow_le_pow_right₀ hα hnm
 
-/-- $n \mapsto \lfloor t\alpha^n\rfloor$ is nonnegative when $0 \le t$ and $0 \le \alpha$. -/
-@[category research solved, AMS 11]
+/-- $n \mapsto \lfloor t\alpha^n\rfloor$ is nonnegative when $0 \le t$ and $0 \le \alpha$.
+Textbook-level: an immediate `positivity` consequence, not a partial result on Erdős Problem 349. -/
+@[category textbook, AMS 11]
 theorem floorSeq_nonneg (t α : ℝ) (ht : 0 ≤ t) (hα : 0 ≤ α) (n : ℕ) :
     0 ≤ (fun n => ⌊t * α ^ n⌋) n := by
   simp only

--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -106,8 +106,9 @@ theorem alpha_le_one_not_isGoodPair (t α : ℝ) (ht : 0 < t) (hα0 : 0 < α) (h
 
 /-- **Binary expansion.** Every natural number $k$ is a sum of distinct powers of two: there is
 a finite set $E$ of exponents with $k = \sum_{i \in E} 2^i$. Proved by strong induction:
-subtract the largest power $2^m \le k$, recurse on the remainder. -/
-@[category research solved, AMS 11,
+subtract the largest power $2^m \le k$, recurse on the remainder. A textbook-level building
+block for `one_two_isGoodPair` below; it says nothing about `IsGoodPair` itself. -/
+@[category textbook, AMS 11,
   formal_proof using formal_conjectures at
   "https://github.com/cepadugato/formal-conjectures/blob/erdos-349-integer-characterization-proof/FormalConjectures/ErdosProblems/349.lean"]
 theorem exists_finset_sum_two_pow (k : ℕ) :

--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -171,4 +171,84 @@ A partial result on Erdős Problem 349 in the same divisibility family as
 theorem three_halves_two_not_isGoodPair : ¬ IsGoodPair (3 / 2) 2 := by
   sorry
 
+/-- A set $A \subseteq \mathbb{Z}$ is *entirely additively complete* if **every** positive integer
+is a finite subset sum of $A$ (van Doorn's "entirely complete": $P(A) = \mathbb{N}_{\ge 1}$).
+Strictly stronger than `IsAddComplete`, which only requires all *sufficiently large* integers.
+
+This is a problem-local definition; it could be promoted to
+`FormalConjecturesForMathlib/NumberTheory/AdditivelyComplete.lean` (next to `IsAddComplete`) if
+the maintainers prefer it to live there. -/
+def IsEntirelyAddComplete (A : Set ℤ) : Prop :=
+  ∀ k : ℤ, 1 ≤ k → k ∈ subsetSums A
+
+/-- **Glue.** Entire completeness implies (eventual) completeness: if every $k \ge 1$ is a subset
+sum, then in particular all sufficiently large $k$ are. -/
+@[category research solved, AMS 11]
+theorem isEntirelyAddComplete_imp_isAddComplete {A : Set ℤ}
+    (h : IsEntirelyAddComplete A) : IsAddComplete A :=
+  Filter.eventually_atTop.mpr ⟨1, fun k hk => h k hk⟩
+
+/-- **Abstract single-gap criterion.** For a monotone, nonnegative integer sequence $a$, a single
+gap $\sum_{k < r+1} a_k < m < a_{r+1}$ with $m \ge 1$ already shows that $m$ is not a subset sum,
+hence the range of $a$ is not entirely additively complete.
+
+This is the pure-$\mathbb{Z}$ core of `alpha_gt_two_not_isGoodPair`'s
+`by_cases ∃ b ∈ B, a (r+1) ≤ b` case-split, with $m$ *given* rather than constructed via
+`Tendsto` (strictly easier, and enough for the band $5/3 \le \alpha < 2$ below). -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/erdos-349-entire-gap-criterion-proof/FormalConjectures/ErdosProblems/349.lean"]
+theorem entire_gap_not_complete (a : ℕ → ℤ) (hmono : Monotone a) (hnn : ∀ n, 0 ≤ a n)
+    (r : ℕ) (m : ℤ) (hm : 1 ≤ m)
+    (hlo : (∑ k ∈ Finset.range (r + 1), a k) < m) (hhi : m < a (r + 1)) :
+    ¬ IsEntirelyAddComplete (Set.range a) := by
+  sorry
+
+/-- The $0$-th term of $\lfloor t\alpha^n\rfloor$ is $\lfloor t\rfloor$ (since $\alpha^0 = 1$). -/
+@[category research solved, AMS 11]
+theorem floorSeq_zero (t α : ℝ) : ⌊t * α ^ (0 : ℕ)⌋ = ⌊t⌋ := by
+  simp [pow_zero, mul_one]
+
+/-- The $1$-st term of $\lfloor t\alpha^n\rfloor$ is $\lfloor t\alpha\rfloor$. -/
+@[category research solved, AMS 11]
+theorem floorSeq_one (t α : ℝ) : ⌊t * α ^ (1 : ℕ)⌋ = ⌊t * α⌋ := by
+  simp [pow_one]
+
+/-- $n \mapsto \lfloor t\alpha^n\rfloor$ is monotone when $0 \le t$ and $1 \le \alpha$. -/
+@[category research solved, AMS 11]
+theorem floorSeq_monotone (t α : ℝ) (ht : 0 ≤ t) (hα : 1 ≤ α) :
+    Monotone (fun n => ⌊t * α ^ n⌋) := by
+  intro n m hnm
+  simp only
+  apply Int.floor_le_floor
+  apply mul_le_mul_of_nonneg_left _ ht
+  exact pow_le_pow_right₀ hα hnm
+
+/-- $n \mapsto \lfloor t\alpha^n\rfloor$ is nonnegative when $0 \le t$ and $0 \le \alpha$. -/
+@[category research solved, AMS 11]
+theorem floorSeq_nonneg (t α : ℝ) (ht : 0 ≤ t) (hα : 0 ≤ α) (n : ℕ) :
+    0 ≤ (fun n => ⌊t * α ^ n⌋) n := by
+  simp only
+  rw [Int.floor_nonneg]
+  positivity
+
+/-- **Application inside the band $5/3 \le \alpha < 2$.** For $t \ge 3$ and $5/3 \le \alpha < 2$,
+the sequence $\lfloor t\alpha^n\rfloor$ is NOT entirely additively complete: the very first gap
+$\lfloor t\rfloor < \lfloor t\rfloor+1 < \lfloor t\alpha\rfloor$ already misses the positive
+integer $\lfloor t\rfloor+1$.
+
+This is the $r = 0$, $m = \lfloor t\rfloor + 1$ instance of `entire_gap_not_complete`. The gap
+inequality comes from $t\alpha \ge t\cdot(5/3) = t + 2t/3 \ge t + 2 \ge \lfloor t\rfloor + 2$.
+The constant $5/3$ (not $\varphi$) is the sharp clean threshold uniform in $t \ge 3$: at
+$\alpha = \varphi$, $t = 3$ gives $\lfloor 3\varphi\rfloor = 4 = \lfloor t\rfloor+1$, so the first
+gap closes. This is *entire* (not eventual) incompleteness; the gap need not recur for
+$\varphi \le \alpha < 2$, where Erdős Problem 349 stays open. -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/erdos-349-entire-gap-criterion-proof/FormalConjectures/ErdosProblems/349.lean"]
+theorem floorSeq_not_entirelyComplete_of_le_two
+    (t α : ℝ) (ht : 3 ≤ t) (hα : 5 / 3 ≤ α) (hα2 : α < 2) :
+    ¬ IsEntirelyAddComplete (Set.range (fun n => ⌊t * α ^ n⌋)) := by
+  sorry
+
 end Erdos349

--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -325,4 +325,130 @@ theorem isGoodPair_one_alpha_of_lt_three_halves (α : ℝ) (hα_lo : 1 < α) (h�
     IsGoodPair 1 α := by
   sorry
 
+/-- **First-term value for $1 \le t < 2$.** The $0$-th term of the floor sequence is
+$\lfloor t\alpha^0\rfloor = \lfloor t\rfloor = 1$. Textbook-level: an immediate consequence of
+`floorSeq_zero` and `Int.floor_eq_iff`, not itself a partial result on Erdős Problem 349. -/
+@[category textbook, AMS 11]
+theorem floorSeq_zero_eq_one_of_lt_two (t α : ℝ) (ht1 : 1 ≤ t) (ht2 : t < 2) :
+    ⌊t * α ^ (0 : ℕ)⌋ = 1 := by
+  simp only [pow_zero, mul_one]
+  rw [Int.floor_eq_iff]
+  constructor
+  · push_cast; linarith
+  · push_cast; linarith
+
+/-- **Doubling bound for a general floor power sequence.** For $1 < \alpha < 3/2$, $1 \le t$, and
+any $n \ge 0$, $\lfloor t\alpha^{n+1}\rfloor \le 2\lfloor t\alpha^n\rfloor$.
+
+Generalizes `floor_pow_succ_le_two_mul_floor_pow` (the $t = 1$ case) to every $t \ge 1$: the
+argument only needs $\lfloor t\alpha^n\rfloor \ge 1$, which now comes from $t \ge 1$ rather than
+from $\alpha > 1$ alone. Textbook-level floor/inequality fact, not itself a partial result on
+Erdős Problem 349. -/
+@[category textbook, AMS 11]
+theorem floor_mul_pow_succ_le_two_mul (t α : ℝ) (hα_lo : 1 < α) (hα_hi : α < 3 / 2)
+    (ht1 : 1 ≤ t) (n : ℕ) :
+    ⌊t * α ^ (n + 1)⌋ ≤ 2 * ⌊t * α ^ n⌋ := by
+  have hpos : (0 : ℝ) < α ^ n := by positivity
+  have hone : (1 : ℝ) ≤ α ^ n := one_le_pow₀ hα_lo.le
+  have htpow : (1 : ℝ) ≤ t * α ^ n := by nlinarith [ht1, hone]
+  have hm1 : (1 : ℤ) ≤ ⌊t * α ^ n⌋ := by rw [Int.le_floor]; push_cast; linarith
+  have hflo : (↑(⌊t * α ^ n⌋) : ℝ) ≤ t * α ^ n := Int.floor_le _
+  have hfle : (t * α ^ n) - 1 < (↑(⌊t * α ^ n⌋) : ℝ) := by
+    linarith [Int.sub_one_lt_floor (t * α ^ n)]
+  rw [Int.floor_le_iff]
+  push_cast
+  have hsucc : t * α ^ (n + 1) = α * (t * α ^ n) := by ring
+  rw [hsucc]
+  have hm1r : (1 : ℝ) ≤ (↑(⌊t * α ^ n⌋) : ℝ) := by exact_mod_cast hm1
+  nlinarith [mul_pos (by linarith : (0 : ℝ) < α) (by nlinarith [htpow] : (0 : ℝ) < t * α ^ n),
+    hflo, hfle, hm1r]
+
+/-- **Erdős Problem 349, sharp entire completeness for $1 \le t < 2$ on the strip
+$1 < \alpha < 3/2$.**
+
+The sequence $\lfloor t\alpha^n\rfloor$ is *entirely* additively complete: every positive
+integer $k \ge 1$ is a finite subset sum of distinct terms.
+
+A **partial result** on the open Erdős Problem 349 and on the named open conjecture
+`complete_for_alpha_in_Ioo_one_to_goldenRatio` (restricted to $\alpha < 3/2$, entire sense, and
+$t < 2$). Sharpens `isGoodPair_one_alpha_of_lt_three_halves` (its $t = 1$ special case) by taking
+$t < 2$ as a direct hypothesis instead of deriving it from $t\alpha < 2$: the doubling bound
+`floor_mul_pow_succ_le_two_mul` already holds for every $1 \le t$ on this strip, so the widening
+is free. E.g. $(t, \alpha) = (1.7, 1.4)$ has $t\alpha = 2.38 > 2$ yet is covered here.
+
+Proof: instantiate `entirely_complete_of_doubling` with $a_n = \lfloor t\alpha^n\rfloor$, using
+`floorSeq_zero_eq_one_of_lt_two` for $a_0 = 1$ and `floor_mul_pow_succ_le_two_mul` for the
+doubling bound.
+
+The proof is recorded via the `formal_proof` mechanism rather than written inline, as it exceeds
+the repository's proof-length guideline. -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/fc02fb6d4045478b070742b7d04d09ceed561183/FormalConjectures/ErdosProblems/349.lean#L949"]
+theorem isEntirelyAddComplete_of_one_le_lt_two (t α : ℝ) (hα_lo : 1 < α) (hα_hi : α < 3 / 2)
+    (ht1 : 1 ≤ t) (ht2 : t < 2) :
+    IsEntirelyAddComplete (Set.range (fun n : ℕ ↦ ⌊t * α ^ n⌋)) := by
+  sorry
+
+/-- **Erdős Problem 349, good pair for $1 \le t < 2$ on the strip $1 < \alpha < 3/2$.**
+
+Corollary of `isEntirelyAddComplete_of_one_le_lt_two`, lifted from entire to eventual
+completeness via `isEntirelyAddComplete_imp_isAddComplete`. A partial result on the named open
+conjecture `complete_for_alpha_in_Ioo_one_to_goldenRatio`, restricted to $\alpha < 3/2$ and
+$t < 2$.
+
+The proof is recorded via the `formal_proof` mechanism rather than written inline, as it exceeds
+the repository's proof-length guideline (it depends on a linked theorem). -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/fc02fb6d4045478b070742b7d04d09ceed561183/FormalConjectures/ErdosProblems/349.lean#L983"]
+theorem isGoodPair_of_one_le_lt_two (t α : ℝ) (hα_lo : 1 < α) (hα_hi : α < 3 / 2)
+    (ht1 : 1 ≤ t) (ht2 : t < 2) :
+    IsGoodPair t α := by
+  sorry
+
+/-- **Erdős Problem 349, not entirely complete for $2 \le t$.**
+
+For $2 \le t$ and $1 \le \alpha$, every term $\lfloor t\alpha^n\rfloor \ge \lfloor t\rfloor \ge 2$,
+so every subset sum of the range is $0$ (empty subset) or $\ge 2$ (nonempty subset of values each
+$\ge 2$): the value $1$ is never a subset sum, so the range is not entirely additively complete.
+
+This is the DeepMind-faithful "only if" direction of the sharp threshold ($t \ge 2$), and it
+matters to state precisely: the superficially plausible stronger claim "$t\alpha \ge 2 \Rightarrow$
+not entirely complete" is FALSE under this repository's $n = 0$ indexing — e.g.
+$(t, \alpha) = (3/2, 7/5)$ has $t\alpha = 2.1 \ge 2$ yet IS entirely complete, because
+$a_0 = \lfloor t\rfloor = 1$ already saves it. The correct sharp threshold is on $t$ alone, not on
+$t\alpha$; that is exactly `entirelyComplete_floorSeq_iff_lt_two` below.
+
+The proof is recorded via the `formal_proof` mechanism rather than written inline, as it exceeds
+the repository's proof-length guideline. -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/fc02fb6d4045478b070742b7d04d09ceed561183/FormalConjectures/ErdosProblems/349.lean#L1006"]
+theorem not_entirelyComplete_of_two_le (t α : ℝ) (ht : 2 ≤ t) (hα : 1 ≤ α) :
+    ¬ IsEntirelyAddComplete (Set.range (fun n : ℕ ↦ ⌊t * α ^ n⌋)) := by
+  sorry
+
+/-- **Erdős Problem 349, sharp entire characterization on the strip $1 < \alpha < 3/2$.**
+
+For $1 \le t$ and $1 < \alpha < 3/2$:
+$$\text{IsEntirelyAddComplete}\big(\operatorname{range}(n \mapsto \lfloor t\alpha^n\rfloor)\big)
+\iff t < 2.$$
+Assembles `isEntirelyAddComplete_of_one_le_lt_two` and `not_entirelyComplete_of_two_le`, split on
+$t < 2 \lor 2 \le t$. The threshold is exactly $t = 2$: that is where the front term $a_0$ jumps
+from $1$ to $2$ and blocks the value $1$. A partial result on the named open conjecture
+`complete_for_alpha_in_Ioo_one_to_goldenRatio`, sharp on the sub-strip $1 < \alpha < 3/2$ (in the
+entire sense).
+
+The proof is recorded via the `formal_proof` mechanism rather than written inline, as it exceeds
+the repository's proof-length guideline (it depends on two linked theorems). -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/fc02fb6d4045478b070742b7d04d09ceed561183/FormalConjectures/ErdosProblems/349.lean#L1041"]
+theorem entirelyComplete_floorSeq_iff_lt_two (t α : ℝ) (hα_lo : 1 < α) (hα_hi : α < 3 / 2)
+    (ht1 : 1 ≤ t) :
+    IsEntirelyAddComplete (Set.range (fun n : ℕ ↦ ⌊t * α ^ n⌋)) ↔ t < 2 := by
+  sorry
+
+
 end Erdos349

--- a/FormalConjectures/ErdosProblems/349.lean
+++ b/FormalConjectures/ErdosProblems/349.lean
@@ -258,4 +258,71 @@ theorem floorSeq_not_entirelyComplete_of_le_two
     ¬ IsEntirelyAddComplete (Set.range (fun n => ⌊t * α ^ n⌋)) := by
   sorry
 
+/-- **Abstract doubling criterion** (van Doorn's Lemma 3, applied with base phase length $r = 0$).
+
+Let $a : \mathbb{N} \to \mathbb{Z}$ be a monotone integer sequence with $a_0 = 1$, satisfying the
+doubling bound $a_{n+1} \le 2 a_n$ for every $n$, and unbounded ($\forall M,\ \exists n,\ M \le
+a_n$). Then every positive integer is a finite subset sum of distinct values of $a$, i.e. the
+range of $a$ is entirely additively complete.
+
+A textbook-level combinatorial fact about monotone integer sequences (no $t, \alpha$); its
+application to $a_n = \lfloor \alpha^n \rfloor$ below (`isGoodPair_one_alpha_of_lt_three_halves`)
+is the research content of Erdős Problem 349.
+
+The proof is recorded via the `formal_proof` mechanism rather than written inline, as it exceeds
+the repository's proof-length guideline. -/
+@[category textbook, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/6e869b32eccf185e6c57f3f5cae571a8ce1bb4fb/FormalConjectures/ErdosProblems/349.lean#L708"]
+theorem entirely_complete_of_doubling (a : ℕ → ℤ)
+    (ha0 : a 0 = 1)
+    (hmono : Monotone a)
+    (hdouble : ∀ n, a (n + 1) ≤ 2 * a n)
+    (hub : ∀ M : ℤ, ∃ n, M ≤ a n) :
+    IsEntirelyAddComplete (Set.range a) := by
+  sorry
+
+/-- **Doubling bound for the floor of a power sequence.** For $1 < \alpha < 3/2$ and any
+$n \ge 0$, $\lfloor \alpha^{n+1} \rfloor \le 2 \lfloor \alpha^n \rfloor$.
+
+Proof: $\alpha^{n+1} = \alpha \cdot \alpha^n < \tfrac{3}{2}\alpha^n \le \tfrac{3}{2}(\lfloor
+\alpha^n\rfloor + 1) \le 2\lfloor \alpha^n\rfloor + 1$, using $\lfloor \alpha^n\rfloor \ge 1$
+(since $\alpha > 1$). A textbook-level floor/inequality fact. -/
+@[category textbook, AMS 11]
+theorem floor_pow_succ_le_two_mul_floor_pow (α : ℝ) (hα_lo : 1 < α) (hα_hi : α < 3 / 2)
+    (n : ℕ) :
+    ⌊α ^ (n + 1)⌋ ≤ 2 * ⌊α ^ n⌋ := by
+  have hpos : (0 : ℝ) < α ^ n := by positivity
+  have hone : (1 : ℝ) ≤ α ^ n := one_le_pow₀ hα_lo.le
+  have hm1 : (1 : ℤ) ≤ ⌊α ^ n⌋ := by rw [Int.le_floor]; push_cast; linarith
+  have hflo : (↑(⌊α ^ n⌋) : ℝ) ≤ α ^ n := Int.floor_le _
+  have hfle : α ^ n - 1 < (↑(⌊α ^ n⌋) : ℝ) := by linarith [Int.sub_one_lt_floor (α ^ n)]
+  rw [Int.floor_le_iff]
+  push_cast
+  have hsucc : α ^ (n + 1) = α * α ^ n := by ring
+  rw [hsucc]
+  have hm1r : (1 : ℝ) ≤ (↑(⌊α ^ n⌋) : ℝ) := by exact_mod_cast hm1
+  nlinarith [mul_pos (by linarith : (0 : ℝ) < α) hpos, hflo, hfle, hm1r]
+
+/-- **Erdős Problem 349, Proposition 6 (van Doorn), "if" direction, case $t = 1$.**
+
+For $1 < \alpha < 3/2$, the pair $(1, \alpha)$ is good: the sequence $\lfloor \alpha^n\rfloor$ is
+additively complete (in fact *entirely* additively complete — every $k \ge 1$ is a finite subset
+sum of distinct terms $\lfloor \alpha^n\rfloor$).
+
+A **partial result** on the open Erdős Problem 349: it complements
+`floorSeq_not_entirelyComplete_of_le_two` (which rules out $5/3 \le \alpha < 2$ for $t \ge 3$) and
+the integer-pair characterization `integer_isGoodPair_iff`. Proof: instantiate
+`entirely_complete_of_doubling` with $a_n = \lfloor \alpha^n\rfloor$, using
+`floor_pow_succ_le_two_mul_floor_pow` for the doubling bound.
+
+The proof is recorded via the `formal_proof` mechanism rather than written inline, as it exceeds
+the repository's proof-length guideline. -/
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+  "https://github.com/cepadugato/formal-conjectures/blob/6e869b32eccf185e6c57f3f5cae571a8ce1bb4fb/FormalConjectures/ErdosProblems/349.lean#L864"]
+theorem isGoodPair_one_alpha_of_lt_three_halves (α : ℝ) (hα_lo : 1 < α) (hα_hi : α < 3 / 2) :
+    IsGoodPair 1 α := by
+  sorry
+
 end Erdos349


### PR DESCRIPTION
## Summary

Stacks on #4470 (`erdos-349-prop-six`, already open), which proves the $t=1$ case
`isGoodPair_one_alpha_of_lt_three_halves` for $1 < \alpha < 3/2$. This PR proves the
**sharp characterization for the whole strip**: for $1 \le t$ and $1 < \alpha < 3/2$,

$$\text{IsEntirelyAddComplete}\big(\operatorname{range}(n \mapsto \lfloor t\alpha^n\rfloor)\big) \iff t < 2.$$

Four new `research solved` declarations plus two `textbook` helper lemmas:

- `isEntirelyAddComplete_of_one_le_lt_two` — positive direction: $1 \le t < 2$, $1 < \alpha < 3/2$ $\Rightarrow$ entirely additively complete.
- `isGoodPair_of_one_le_lt_two` — the `IsGoodPair` corollary (lifted from entire to eventual completeness).
- `not_entirelyComplete_of_two_le` — negative ("only if") direction: $2 \le t$, $1 \le \alpha$ $\Rightarrow$ **not** entirely complete.
- `entirelyComplete_floorSeq_iff_lt_two` — the sharp iff, assembling both directions.
- `floorSeq_zero_eq_one_of_lt_two`, `floor_mul_pow_succ_le_two_mul` — short inline helper lemmas (textbook).

**This is a PARTIAL result on the open Erdős Problem 349**, not a resolution. The main
`erdos_349` theorem (`answer(sorry)`, `research open`) and the named open conjecture
`complete_for_alpha_in_Ioo_one_to_goldenRatio` (which covers $1 < \alpha < \varphi$) are
**untouched**. Our result covers only the sub-interval $1 < \alpha < 3/2$, and only in the
*entire*-completeness sense (`IsEntirelyAddComplete`), plus the derived `IsGoodPair` corollary.

**Why the widening from $t\alpha < 2$ to $t < 2$ is free.** `isGoodPair_one_alpha_of_lt_three_halves`
(the $t=1$ case, #4470) used $t\alpha < 2$ only to derive $t < 2$. The doubling bound
$\lfloor t\alpha^{n+1}\rfloor \le 2\lfloor t\alpha^n\rfloor$ actually holds for *every* $t \ge 1$
on this strip (it only needs $\lfloor t\alpha^n\rfloor \ge 1$, which now comes directly from
$t \ge 1$ rather than from $\alpha > 1$). Taking $t < 2$ as a direct hypothesis therefore
generalizes the positive direction for free. Documented gain: $(t,\alpha) = (1.7, 1.4)$ has
$t\alpha = 2.38 > 2$ — outside the old range — yet is a good pair.

**A clarification on the "only if" direction.** The naturally-guessed stronger claim
"$t\alpha \ge 2 \Rightarrow$ not entirely complete" is **FALSE** under this repository's
$n=0$ indexing: $(t,\alpha) = (3/2, 7/5)$ has $t\alpha = 2.1 \ge 2$ yet **is** entirely complete,
because the front term $a_0 = \lfloor t\rfloor = 1$ already saves it. The correct sharp
threshold is on $t$ alone ($t \ge 2$, i.e. $\lfloor t\rfloor \ge 2$), which is exactly what
`not_entirelyComplete_of_two_le` / `entirelyComplete_floorSeq_iff_lt_two` establish. I mention
this explicitly in case it's a useful clarification for anyone else exploring this problem.

## Proof location

Following the repo's proof-length convention, the four `research solved` theorems are recorded
via the `formal_proof` mechanism (`:= by sorry` here, full proof on the fork at a pinned commit)
since they exceed the ~25–50 line guideline. The two short helper lemmas are proved inline.

Full proofs (no `sorry`, self-contained continuation of the existing `erdos-349-prop-six-proof`
branch): https://github.com/cepadugato/formal-conjectures/blob/fc02fb6d4045478b070742b7d04d09ceed561183/FormalConjectures/ErdosProblems/349.lean (branch `erdos-349-strip-iff-proof`).

`#print axioms` on all six new declarations (both the inline ones and the four linked ones, checked on the proof branch) shows only:

```
[propext, Classical.choice, Quot.sound]
```

No `sorryAx`, no custom axioms, no `native_decide`.

## Build

Verified against this repo's pinned toolchain (`leanprover/lean4:v4.27.0`):

```
$ lake env lean FormalConjectures/ErdosProblems/349.lean   # exit 0
$ lake build FormalConjectures.ErdosProblems.«349»          # exit 0, Build completed successfully
```

The only `sorry` warnings emitted are the pre-existing ones from the open-problem statements
(`erdos_349`, `complete_for_alpha_in_Ioo_one_to_goldenRatio`, `exists_t_for_k_disjoint_segments`,
the two `.variants` theorems) and the `formal_proof`-linked theorems (this PR's four, plus the
ones already on `erdos-349-prop-six`) — exactly as expected.

## Test plan

- [x] `lake env lean FormalConjectures/ErdosProblems/349.lean` exits 0 on this branch
- [x] `lake build FormalConjectures.ErdosProblems.«349»` exits 0 on this branch
- [x] `#print axioms` on the full proof (fork commit `fc02fb6d`) shows only the standard three axioms for all six new declarations
- [x] `erdos_349` and `complete_for_alpha_in_Ioo_one_to_goldenRatio` left untouched (`answer(sorry)` / `research open` unchanged)
- [x] Exactly one `@[category]` + `@[AMS 11]` per new statement
- [x] Docstrings in LaTeX markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)