### PR TITLE
feat(ErdosProblems/933): prove variants.lower_bound via Steinerberger's witness family

### DIFF
--- a/FormalConjectures/ErdosProblems/933.lean
+++ b/FormalConjectures/ErdosProblems/933.lean
@@ -65,6 +65,33 @@ integer $r\geq 1$, when $k=3^r$ and $l=r+1$.
 @[category research solved, AMS 11]
 theorem erdos_933.variants.lower_bound :
     Set.Infinite { n : ℕ | ((2 ^ k n * 3 ^ l n : ℕ) : ℝ) > (n : ℝ) * Real.log (n : ℝ) } := by
-  sorry
+  -- Witness: n = 2^(3^(r+1)); k n = 3^(r+1), l n = r+2 by LTE, and 3 > log 2.
+  refine Set.infinite_of_injective_forall_mem
+    (f := fun r : ℕ ↦ 2 ^ (3 ^ (r + 1))) ?_ fun r ↦ ?_
+  · exact (Nat.pow_right_injective (a := 2) (by norm_num)).comp
+      ((Nat.pow_right_injective (a := 3) (by norm_num)).comp (add_left_injective 1))
+  let m := 3 ^ (r + 1)
+  have hk : k (2 ^ m) = m := by
+    rw [k, padicValNat.mul (by positivity) (by positivity), padicValNat.prime_pow,
+      padicValNat.eq_zero_of_not_dvd
+        ((Even.pow_of_ne_zero (by norm_num) (by positivity)).add_one).not_two_dvd_nat, add_zero]
+  have hl : l (2 ^ m) = r + 2 := by
+    rw [l, padicValNat.mul (by positivity) (by positivity),
+      padicValNat_prime_prime_pow (p := 3) (q := 2) m (by norm_num), zero_add]
+    rw [show 2 ^ m + 1 = 2 ^ m + 1 ^ m by simp,
+      padicValNat.pow_add_pow (p := 3) (x := 2) (y := 1) (by norm_num)
+        (by norm_num) (by norm_num) (by simpa [m] using (by norm_num : Odd 3).pow)]
+    simp [m, padicValNat.prime_pow]
+    omega
+  have hlog : (m : ℝ) * Real.log 2 < (3 : ℝ) ^ (r + 2) := by
+    calc
+      _ < (m : ℝ) * 3 := mul_lt_mul_of_pos_left (by linarith [Real.log_two_lt_d9]) (by positivity)
+      _ = _ := by norm_num [m, pow_succ]
+  change 2 ^ m ∈ {n | ((2 ^ k n * 3 ^ l n : ℕ) : ℝ) > (n : ℝ) * Real.log (n : ℝ)}
+  simp only [Set.mem_setOf_eq, hk, hl]
+  push_cast
+  rw [Real.log_pow]
+  exact mul_lt_mul_of_pos_left hlog (by positivity)
 
 end Erdos933
+


### PR DESCRIPTION
Closes `erdos_933.variants.lower_bound` via the witness family n = 2^(3^(r+1)): lifting the exponent gives l n = r + 2, so 2^(k n) · 3^(l n) = n · 3^(r+2) > n · log n. Verified clean under the project linters. Assisted by OpenAI Codex; verified by me.