### PR TITLE
feat(Arxiv): add the Poisson conjecture (math/0608009)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Google LLC
 
 # Please keep the list sorted alphabetically
 Abel Doñate
+Alex Korbonits
 Aditya Ramabadran
 Amogh Parab
 Anirudh Rao

--- a/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
+++ b/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
@@ -1,0 +1,183 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+import FormalConjectures.Wikipedia.JacobianConjecture
+
+/-!
+# The Poisson Conjecture
+
+*References:*
+- [AvdE07] [arxiv/math.0608009](https://arxiv.org/abs/math/0608009)
+  **On the equivalence of the Jacobian, Dixmier and Poisson Conjectures in any characteristic**
+  by *Kossivi Adjamagbo, Arno van den Essen*. Published as *A proof of the equivalence of the
+  Dixmier, Jacobian and Poisson conjectures*, Acta Math. Vietnam. 32 (2007), 205–214.
+- [BCW82] [The Jacobian conjecture: reduction of degree and formal expansion of the inverse](https://doi.org/10.1090/S0273-0979-1982-15032-7)
+  by *Hyman Bass, Edwin H. Connell, David Wright*, Bull. Amer. Math. Soc. 7 (1982), 287–330.
+- [Alp26] [Counterexample to the Jacobian conjecture](https://x.com/__alpoge__/status/2079028340955197566)
+  by *Levent Alpöge* (2026), disproving the Jacobian conjecture in dimension 3; formalised
+  against this repository's statement in
+  [PR #4474](https://github.com/google-deepmind/formal-conjectures/pull/4474).
+
+The Poisson Conjecture `PC_n` ([AvdE07], Notations 5) asserts that, over a field of
+characteristic zero, every endomorphism of the `n`-th canonical Poisson algebra
+$P_n(K)$ — the polynomial algebra $K[X_1, \dots, X_{2n}]$ equipped with the canonical
+Poisson bracket — is an automorphism.
+
+By [AvdE07], Theorem 7 (the "United Conjectures Theorem"), for every `n` there is a chain
+of implications
+$$JC_{2n} \Longrightarrow PC_n \Longrightarrow DC_n \Longrightarrow JC_n,$$
+where `JC_n` is the Jacobian Conjecture in dimension `n` and `DC_n` the Dixmier Conjecture
+for the `n`-th Weyl algebra (the implication `DC_n ⟹ JC_n` being classical [BCW82]).
+Since the Jacobian conjecture was disproved in dimension 3 [Alp26] — and hence in every
+dimension `n ≥ 3` by padding with identity coordinates — `PC_n` is false for all `n ≥ 3`:
+composing the counterexample's failure of `JC_3` through `PC_3 ⟹ DC_3 ⟹ JC_3` refutes
+`PC_3`, and directly, the cotangent (symplectic) lift of the counterexample map
+([AvdE07], Theorem 1 in reverse) is a non-invertible Poisson endomorphism of $P_3(K)$.
+The cases `n = 1` and `n = 2` remain open.
+
+Indexing note: we index the `2n` variables of $P_n(K)$ by `Fin n ⊕ Fin n`, with
+`Sum.inl i` playing the role of $X_i$ and `Sum.inr i` the role of $X_{i+n}$ of [AvdE07],
+so that the canonical bracket reads $\{X_i, X_{i+n}\} = 1$; see
+`MvPolynomial.poissonBracket`.
+-/
+
+namespace Arxiv.«math.0608009»
+
+open MvPolynomial
+
+variable {K : Type*} [Field K] [CharZero K]
+
+/-- A `K`-algebra endomorphism `φ` of the polynomial algebra in `2n` variables is an
+endomorphism of the `n`-th canonical Poisson algebra $P_n(K)$ if it preserves the canonical
+Poisson bracket. Following [AvdE07], Lemma 2, it is equivalent to require preservation on
+the generators only, which is the form used here (the brackets of generators are constants,
+so preserving and intertwining them agree). -/
+def IsPoissonEndomorphism {n : ℕ}
+    (φ : MvPolynomial (Fin n ⊕ Fin n) K →ₐ[K] MvPolynomial (Fin n ⊕ Fin n) K) : Prop :=
+  ∀ v w, poissonBracket (φ (X v)) (φ (X w)) = poissonBracket (X v) (X w)
+
+variable (K) in
+/-- The Poisson Conjecture in dimension `n` (`PC_n` in the notation of [AvdE07]): every
+endomorphism of the `n`-th canonical Poisson algebra over `K` is an automorphism.
+An endomorphism is an automorphism iff it is bijective, since the inverse of a bijective
+algebra endomorphism preserving the Poisson bracket is again such. -/
+def PoissonConjectureFor (n : ℕ) : Prop :=
+  ∀ φ : MvPolynomial (Fin n ⊕ Fin n) K →ₐ[K] MvPolynomial (Fin n ⊕ Fin n) K,
+    IsPoissonEndomorphism φ → Function.Bijective φ
+
+variable (K) in
+/-- The Jacobian Conjecture in dimension `m`, the per-dimension form of
+`JacobianConjecture.jacobian_conjecture`: every polynomial endomorphism of $K^m$ with unit
+Jacobian determinant has a polynomial inverse. -/
+def JacobianConjectureFor (m : ℕ) : Prop :=
+  ∀ F : JacobianConjecture.RegularFunction K (Fin m) (Fin m), IsUnit F.Jacobian.det →
+    ∃ G : JacobianConjecture.RegularFunction K (Fin m) (Fin m),
+      G.comp F = JacobianConjecture.RegularFunction.id K (Fin m) ∧
+      F.comp G = JacobianConjecture.RegularFunction.id K (Fin m)
+
+/--
+The **Poisson Conjecture** ([AvdE07], the characteristic zero case): for every `n`, every
+endomorphism of the `n`-th canonical Poisson algebra over a field `K` of characteristic
+zero is an automorphism. This is **false**: the Jacobian conjecture fails in dimension 3
+[Alp26], hence so does `PC_3` (via [AvdE07], Theorem 7, or directly via the symplectic
+lift of the counterexample map).
+-/
+@[category research solved, AMS 14 17]
+theorem poisson_conjecture : ¬ ∀ n, PoissonConjectureFor K n := by
+  sorry
+
+/--
+The Poisson Conjecture in dimension 1 (`PC_1`) is open. By [AvdE07], Theorem 7, it is
+implied by the Jacobian conjecture in dimension 2 (Keller's original problem, open) and
+implies the Dixmier conjecture for the first Weyl algebra (Problem 1 of Dixmier (1968),
+open).
+-/
+@[category research open, AMS 14 17]
+theorem poisson_conjecture.variants.dimension_one : PoissonConjectureFor K 1 := by
+  sorry
+
+/--
+The Poisson Conjecture in dimension 2 (`PC_2`) is open. Since the Jacobian conjecture is
+false in every dimension `n ≥ 3` [Alp26], no known implication bounds `PC_2` from above
+any more; the chain of [AvdE07], Theorem 7 places it as the strongest of the remaining
+open conjectures $PC_2 ⟹ DC_2 ⟹ JC_2 ⟹ PC_1 ⟹ DC_1$.
+-/
+@[category research open, AMS 14 17]
+theorem poisson_conjecture.variants.dimension_two : PoissonConjectureFor K 2 := by
+  sorry
+
+/--
+The Poisson Conjecture is false in dimension 3: the cotangent (symplectic) lift
+$\Phi(X_i) = F_i$, $\Phi(X_{i+3}) = \sum_j M_{ij} X_{j+3}$ with $M = (JF)^{-\top}$ of the
+degree-6 counterexample map $F$ of [Alp26] (whose Jacobian determinant is the constant
+$-2$, so $M$ is a polynomial matrix) is a Poisson endomorphism of $P_3(K)$ that is not
+injective on points — e.g. it identifies $(0, 6, -142, 0, 0, 0)$ and $(1, 0, 2, 0, 0, 0)$
+— and is therefore no automorphism. Alternatively, `PC_3` fails by [AvdE07], Theorem 7,
+as it implies the Jacobian conjecture in dimension 3, contradicting [Alp26].
+-/
+@[category research solved, AMS 14 17]
+theorem poisson_conjecture.variants.dimension_three : ¬ PoissonConjectureFor K 3 := by
+  sorry
+
+/--
+The Poisson Conjecture is false in every dimension `n ≥ 3`, by padding the dimension 3
+counterexample with identity coordinates.
+-/
+@[category research solved, AMS 14 17]
+theorem poisson_conjecture.variants.dimension_ge_three (n : ℕ) (hn : 3 ≤ n) :
+    ¬ PoissonConjectureFor K n := by
+  sorry
+
+/--
+The Jacobian conjecture in dimension `2n` implies the Poisson conjecture in dimension `n`
+([AvdE07], Theorem 1 and Theorem 7).
+-/
+@[category research solved, AMS 14 17]
+theorem poisson_conjecture.variants.jacobian_implication (n : ℕ)
+    (h : JacobianConjectureFor K (2 * n)) : PoissonConjectureFor K n := by
+  sorry
+
+section Tests
+
+omit [CharZero K] in
+/-- The identity is a Poisson endomorphism. -/
+@[category test, AMS 17]
+theorem isPoissonEndomorphism_id (n : ℕ) :
+    IsPoissonEndomorphism (AlgHom.id K (MvPolynomial (Fin n ⊕ Fin n) K)) := by
+  intro v w
+  simp
+
+omit [CharZero K] in
+/-- The canonical bracket pairs each position variable with its momentum variable. -/
+@[category test, AMS 17]
+theorem poissonBracket_X_pairing (n : ℕ) (i : Fin n) :
+    poissonBracket (X (Sum.inl i) : MvPolynomial (Fin n ⊕ Fin n) K) (X (Sum.inr i)) = 1 := by
+  simp
+
+omit [CharZero K] in
+/-- The Poisson conjecture holds trivially in dimension 0, where the Poisson algebra is `K`
+itself and the identity is the only endomorphism. -/
+@[category test, AMS 17]
+theorem poissonConjectureFor_zero : PoissonConjectureFor K 0 := by
+  intro φ _
+  have : φ = AlgHom.id K _ := algHom_ext fun i => i.elim (fun h => h.elim0) fun h => h.elim0
+  rw [this]
+  exact Function.bijective_id
+
+end Tests
+
+end Arxiv.«math.0608009»

--- a/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
+++ b/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjecturesUtil
-import FormalConjectures.Wikipedia.JacobianConjecture
 
 /-!
 # The Poisson Conjecture
@@ -28,11 +27,9 @@ import FormalConjectures.Wikipedia.JacobianConjecture
 - [BCW82] [The Jacobian conjecture: reduction of degree and formal expansion of the inverse](https://doi.org/10.1090/S0273-0979-1982-15032-7)
   by *Hyman Bass, Edwin H. Connell, David Wright*, Bull. Amer. Math. Soc. 7 (1982), 287–330.
 - [Alp26] [Counterexample to the Jacobian conjecture](https://x.com/__alpoge__/status/2079028340955197566)
-  by *Levent Alpöge* (2026), disproving the Jacobian conjecture in dimension 3; formalised
-  against this repository's statement in
-  [PR #4474](https://github.com/google-deepmind/formal-conjectures/pull/4474).
+  by *Levent Alpöge* (2026), disproving the Jacobian conjecture in dimension $3$
 
-The Poisson Conjecture `PC_n` ([AvdE07], Notations 5) asserts that, over a field of
+The Poisson Conjecture $PC_n$ ([AvdE07], Notations 5) asserts that, over a field of
 characteristic zero, every endomorphism of the `n`-th canonical Poisson algebra
 $P_n(K)$ — the polynomial algebra $K[X_1, \dots, X_{2n}]$ equipped with the canonical
 Poisson bracket — is an automorphism.
@@ -40,16 +37,16 @@ Poisson bracket — is an automorphism.
 By [AvdE07], Theorem 7 (the "United Conjectures Theorem"), for every `n` there is a chain
 of implications
 $$JC_{2n} \Longrightarrow PC_n \Longrightarrow DC_n \Longrightarrow JC_n,$$
-where `JC_n` is the Jacobian Conjecture in dimension `n` and `DC_n` the Dixmier Conjecture
-for the `n`-th Weyl algebra (the implication `DC_n ⟹ JC_n` being classical [BCW82]).
-Since the Jacobian conjecture was disproved in dimension 3 [Alp26] — and hence in every
-dimension `n ≥ 3` by padding with identity coordinates — `PC_n` is false for all `n ≥ 3`:
-composing the counterexample's failure of `JC_3` through `PC_3 ⟹ DC_3 ⟹ JC_3` refutes
-`PC_3`, and directly, the cotangent (symplectic) lift of the counterexample map
+where $JC_n$ is the Jacobian Conjecture in dimension `n` and $DC_n$ the Dixmier Conjecture
+for the `n`-th Weyl algebra (the implication $DC_n \Longrightarrow JC_n$ being classical [BCW82]).
+Since the Jacobian conjecture was disproved in dimension $3$ [Alp26] — and hence in every
+dimension $n ≥ 3$ by padding with identity coordinates — $PC_n$ is false for all $n ≥ 3$:
+composing the counterexample's failure of $JC_3$ through $PC_3 \Longrightarrow DC_3 \Longrightarrow JC_3$ refutes
+$PC_3$, and directly, the cotangent (symplectic) lift of the counterexample map
 ([AvdE07], Theorem 1 in reverse) is a non-invertible Poisson endomorphism of $P_3(K)$.
-The cases `n = 1` and `n = 2` remain open.
+The cases $n = 1$ and $n = 2$ remain open.
 
-Indexing note: we index the `2n` variables of $P_n(K)$ by `Fin n ⊕ Fin n`, with
+Indexing note: we index the $2n$ variables of $P_n(K)$ by `Fin n ⊕ Fin n`, with
 `Sum.inl i` playing the role of $X_i$ and `Sum.inr i` the role of $X_{i+n}$ of [AvdE07],
 so that the canonical bracket reads $\{X_i, X_{i+n}\} = 1$; see
 `MvPolynomial.poissonBracket`.
@@ -61,7 +58,7 @@ open MvPolynomial
 
 variable {K : Type*} [Field K] [CharZero K]
 
-/-- A `K`-algebra endomorphism `φ` of the polynomial algebra in `2n` variables is an
+/-- A `K`-algebra endomorphism `φ` of the polynomial algebra in $2n$ variables is an
 endomorphism of the `n`-th canonical Poisson algebra $P_n(K)$ if it preserves the canonical
 Poisson bracket. Following [AvdE07], Lemma 2, it is equivalent to require preservation on
 the generators only, which is the form used here (the brackets of generators are constants,
@@ -71,7 +68,7 @@ def IsPoissonEndomorphism {n : ℕ}
   ∀ v w, poissonBracket (φ (X v)) (φ (X w)) = poissonBracket (X v) (X w)
 
 variable (K) in
-/-- The Poisson Conjecture in dimension `n` (`PC_n` in the notation of [AvdE07]): every
+/-- The Poisson Conjecture in dimension `n` ($PC_n$ in the notation of [AvdE07]): every
 endomorphism of the `n`-th canonical Poisson algebra over `K` is an automorphism.
 An endomorphism is an automorphism iff it is bijective, since the inverse of a bijective
 algebra endomorphism preserving the Poisson bracket is again such. -/
@@ -80,20 +77,21 @@ def PoissonConjectureFor (n : ℕ) : Prop :=
     IsPoissonEndomorphism φ → Function.Bijective φ
 
 variable (K) in
-/-- The Jacobian Conjecture in dimension `m`, the per-dimension form of
-`JacobianConjecture.jacobian_conjecture`: every polynomial endomorphism of $K^m$ with unit
-Jacobian determinant has a polynomial inverse. -/
+/-- The Jacobian Conjecture in dimension `m`: every polynomial endomorphism of $K^m$ with
+unit Jacobian determinant has a polynomial inverse. This is the per-dimension form of the
+statement in `FormalConjectures.Wikipedia.JacobianConjecture`, which quantifies over all
+finite variable types at once. -/
 def JacobianConjectureFor (m : ℕ) : Prop :=
-  ∀ F : JacobianConjecture.RegularFunction K (Fin m) (Fin m), IsUnit F.Jacobian.det →
-    ∃ G : JacobianConjecture.RegularFunction K (Fin m) (Fin m),
-      G.comp F = JacobianConjecture.RegularFunction.id K (Fin m) ∧
-      F.comp G = JacobianConjecture.RegularFunction.id K (Fin m)
+  ∀ F : RegularFunction K (Fin m) (Fin m), IsUnit F.Jacobian.det →
+    ∃ G : RegularFunction K (Fin m) (Fin m),
+      G.comp F = RegularFunction.id K (Fin m) ∧
+      F.comp G = RegularFunction.id K (Fin m)
 
 /--
 The **Poisson Conjecture** ([AvdE07], the characteristic zero case): for every `n`, every
 endomorphism of the `n`-th canonical Poisson algebra over a field `K` of characteristic
-zero is an automorphism. This is **false**: the Jacobian conjecture fails in dimension 3
-[Alp26], hence so does `PC_3` (via [AvdE07], Theorem 7, or directly via the symplectic
+zero is an automorphism. This is **false**: the Jacobian conjecture fails in dimension $3$
+[Alp26], hence so does $PC_3$ (via [AvdE07], Theorem 7, or directly via the symplectic
 lift of the counterexample map).
 -/
 @[category research solved, AMS 14 17]
@@ -101,8 +99,8 @@ theorem poisson_conjecture : ¬ ∀ n, PoissonConjectureFor K n := by
   sorry
 
 /--
-The Poisson Conjecture in dimension 1 (`PC_1`) is open. By [AvdE07], Theorem 7, it is
-implied by the Jacobian conjecture in dimension 2 (Keller's original problem, open) and
+The Poisson Conjecture in dimension $1$ ($PC_1$) is open. By [AvdE07], Theorem 7, it is
+implied by the Jacobian conjecture in dimension $2$ (Keller's original problem, open) and
 implies the Dixmier conjecture for the first Weyl algebra (Problem 1 of Dixmier (1968),
 open).
 -/
@@ -111,30 +109,30 @@ theorem poisson_conjecture.variants.dimension_one : PoissonConjectureFor K 1 := 
   sorry
 
 /--
-The Poisson Conjecture in dimension 2 (`PC_2`) is open. Since the Jacobian conjecture is
-false in every dimension `n ≥ 3` [Alp26], no known implication bounds `PC_2` from above
+The Poisson Conjecture in dimension $2$ ($PC_2$) is open. Since the Jacobian conjecture is
+false in every dimension $n ≥ 3$ [Alp26], no known implication bounds $PC_2$ from above
 any more; the chain of [AvdE07], Theorem 7 places it as the strongest of the remaining
-open conjectures $PC_2 ⟹ DC_2 ⟹ JC_2 ⟹ PC_1 ⟹ DC_1$.
+open conjectures $PC_2 \Longrightarrow DC_2 \Longrightarrow JC_2 \Longrightarrow PC_1 \Longrightarrow DC_1$.
 -/
 @[category research open, AMS 14 17]
 theorem poisson_conjecture.variants.dimension_two : PoissonConjectureFor K 2 := by
   sorry
 
 /--
-The Poisson Conjecture is false in dimension 3: the cotangent (symplectic) lift
+The Poisson Conjecture is false in dimension $3$: the cotangent (symplectic) lift
 $\Phi(X_i) = F_i$, $\Phi(X_{i+3}) = \sum_j M_{ij} X_{j+3}$ with $M = (JF)^{-\top}$ of the
-degree-6 counterexample map $F$ of [Alp26] (whose Jacobian determinant is the constant
+degree-$6$ counterexample map $F$ of [Alp26] (whose Jacobian determinant is the constant
 $-2$, so $M$ is a polynomial matrix) is a Poisson endomorphism of $P_3(K)$ that is not
 injective on points — e.g. it identifies $(0, 6, -142, 0, 0, 0)$ and $(1, 0, 2, 0, 0, 0)$
-— and is therefore no automorphism. Alternatively, `PC_3` fails by [AvdE07], Theorem 7,
-as it implies the Jacobian conjecture in dimension 3, contradicting [Alp26].
+— and is therefore no automorphism. Alternatively, $PC_3$ fails by [AvdE07], Theorem 7,
+as it implies the Jacobian conjecture in dimension $3$, contradicting [Alp26].
 -/
 @[category research solved, AMS 14 17]
 theorem poisson_conjecture.variants.dimension_three : ¬ PoissonConjectureFor K 3 := by
   sorry
 
 /--
-The Poisson Conjecture is false in every dimension `n ≥ 3`, by padding the dimension 3
+The Poisson Conjecture is false in every dimension $n ≥ 3$, by padding the dimension $3$
 counterexample with identity coordinates.
 -/
 @[category research solved, AMS 14 17]
@@ -143,7 +141,7 @@ theorem poisson_conjecture.variants.dimension_ge_three (n : ℕ) (hn : 3 ≤ n) 
   sorry
 
 /--
-The Jacobian conjecture in dimension `2n` implies the Poisson conjecture in dimension `n`
+The Jacobian conjecture in dimension $2n$ implies the Poisson conjecture in dimension `n`
 ([AvdE07], Theorem 1 and Theorem 7).
 -/
 @[category research solved, AMS 14 17]
@@ -169,7 +167,7 @@ theorem poissonBracket_X_pairing (n : ℕ) (i : Fin n) :
   simp
 
 omit [CharZero K] in
-/-- The Poisson conjecture holds trivially in dimension 0, where the Poisson algebra is `K`
+/-- The Poisson conjecture holds trivially in dimension $0$, where the Poisson algebra is `K`
 itself and the identity is the only endomorphism. -/
 @[category test, AMS 17]
 theorem poissonConjectureFor_zero : PoissonConjectureFor K 0 := by

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -24,55 +24,9 @@ import FormalConjecturesUtil
 
 namespace JacobianConjecture
 
-section Prelims
-
-variable {k : Type*} [CommRing k]
-variable {σ τ ι : Type*}
-
-variable (k σ τ) in
-
-/-- The type of regular functions from $k^σ$ to $k^τ$. -/
-abbrev RegularFunction := τ → MvPolynomial σ k
-
-namespace RegularFunction
-
-/-- The Jacobian of a vector valued polynomial function, viewed as a polynomial. -/
-noncomputable def Jacobian (F : RegularFunction k σ τ) :
-    Matrix σ τ (MvPolynomial σ k) :=
-  Matrix.of fun i j => MvPolynomial.pderiv i (F j)
-
-/-- The composition of two vector valued polynomial functions. -/
-noncomputable def comp
-    (F : RegularFunction k σ τ) (G : RegularFunction k τ ι) :
-    RegularFunction k σ ι :=
-  fun (i : ι) ↦ MvPolynomial.bind₁ F (G i)
-
-variable (k σ) in
-noncomputable def id : RegularFunction k σ σ := MvPolynomial.X
-
-/-- The evaluation of a regular function `f` over `k` at some point `a`
-with coordinates in some algebra over `k`-/
-noncomputable def aeval {σ τ : Type*} {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
-    (F : RegularFunction k σ τ) : (σ → S₁) → τ → S₁ :=
-  fun a t ↦ MvPolynomial.aeval a (F t)
-
-/--`aeval` is compatible with composition of regular functions. -/
-@[category API, AMS 14]
-lemma comp_aeval
-    {σ τ ι : Type*}
-    (F : RegularFunction k σ τ) (G : RegularFunction k τ ι)
-    (a : σ → k) : (F.comp G).aeval a = G.aeval (F.aeval a) := by
-  ext i
-  rw [aeval, comp, MvPolynomial.aeval_bind₁, ←aeval]
-  rfl
-
-end RegularFunction
-
-end Prelims
-
 section Conjecture
 
-open RegularFunction MvPolynomial
+open MvPolynomial RegularFunction
 
 variable (k : Type*)
 
@@ -167,7 +121,7 @@ end Conjecture
 
 section Tests
 
-open RegularFunction
+open MvPolynomial RegularFunction
 
 variable {k σ : Type} [Fintype σ] [DecidableEq σ] [Field k]
 

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -19,6 +19,7 @@ public import FormalConjecturesForMathlib.Algebra.GCDMonoid.Finset
 public import FormalConjecturesForMathlib.Algebra.Group.Action.Pointwise.Set.Basic
 public import FormalConjecturesForMathlib.Algebra.Group.GrowthFunction
 public import FormalConjecturesForMathlib.Algebra.Group.Indicator
+public import FormalConjecturesForMathlib.Algebra.MvPolynomial.PoissonBracket
 public import FormalConjecturesForMathlib.Algebra.Order.Group.Pointwise.Interval
 public import FormalConjecturesForMathlib.Algebra.Polynomial.Algebra
 public import FormalConjecturesForMathlib.Algebra.Polynomial.Basic

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -20,6 +20,7 @@ public import FormalConjecturesForMathlib.Algebra.Group.Action.Pointwise.Set.Bas
 public import FormalConjecturesForMathlib.Algebra.Group.GrowthFunction
 public import FormalConjecturesForMathlib.Algebra.Group.Indicator
 public import FormalConjecturesForMathlib.Algebra.MvPolynomial.PoissonBracket
+public import FormalConjecturesForMathlib.Algebra.MvPolynomial.RegularFunction
 public import FormalConjecturesForMathlib.Algebra.Order.Group.Pointwise.Interval
 public import FormalConjecturesForMathlib.Algebra.Polynomial.Algebra
 public import FormalConjecturesForMathlib.Algebra.Polynomial.Basic

--- a/FormalConjecturesForMathlib/Algebra/MvPolynomial/PoissonBracket.lean
+++ b/FormalConjecturesForMathlib/Algebra/MvPolynomial/PoissonBracket.lean
@@ -1,0 +1,102 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.MvPolynomial.CommRing
+public import Mathlib.Algebra.MvPolynomial.PDeriv
+
+public section
+
+/-!
+# The canonical Poisson bracket on a polynomial algebra in `2n` variables
+
+For a commutative ring `R` and a finite type `σ`, we equip `MvPolynomial (σ ⊕ σ) R`
+with its canonical Poisson bracket
+$$\{f, g\} = \sum_{i} \left(\frac{\partial f}{\partial x_i}\frac{\partial g}{\partial y_i}
+  - \frac{\partial f}{\partial y_i}\frac{\partial g}{\partial x_i}\right),$$
+where $x_i$ (resp. $y_i$) denotes the variable indexed by `Sum.inl i` (resp. `Sum.inr i`).
+This is the polynomial algebra underlying the `n`-th *canonical Poisson algebra* $P_n(R)$
+when `σ = Fin n`.
+
+Classical sources index the same object by `2n` variables $X_1, \dots, X_{2n}$ with bracket
+$\{f, g\} = \sum_{i=1}^n (\partial f/\partial X_i \cdot \partial g/\partial X_{i+n}
+- \partial f/\partial X_{i+n} \cdot \partial g/\partial X_i)$; here `Sum.inl i`
+plays the role of $X_i$ and `Sum.inr i` the role of $X_{i+n}$
+(see e.g. [AvdE07](https://arxiv.org/abs/math/0608009), Notations 1).
+-/
+
+namespace MvPolynomial
+
+variable {R σ : Type*} [CommRing R] [Fintype σ]
+
+/-- The canonical Poisson bracket on `MvPolynomial (σ ⊕ σ) R`, given by
+$\{f, g\} = \sum_{i} (\partial_{x_i} f \cdot \partial_{y_i} g
+- \partial_{y_i} f \cdot \partial_{x_i} g)$ where $x_i$ (resp. $y_i$) is the variable
+indexed by `Sum.inl i` (resp. `Sum.inr i`). -/
+noncomputable def poissonBracket (f g : MvPolynomial (σ ⊕ σ) R) : MvPolynomial (σ ⊕ σ) R :=
+  ∑ i : σ, (pderiv (Sum.inl i) f * pderiv (Sum.inr i) g -
+    pderiv (Sum.inr i) f * pderiv (Sum.inl i) g)
+
+@[simp]
+theorem poissonBracket_self (f : MvPolynomial (σ ⊕ σ) R) : poissonBracket f f = 0 :=
+  Finset.sum_eq_zero fun i _ => by rw [mul_comm, sub_self]
+
+theorem poissonBracket_swap (f g : MvPolynomial (σ ⊕ σ) R) :
+    poissonBracket f g = -poissonBracket g f := by
+  rw [poissonBracket, poissonBracket, ← Finset.sum_neg_distrib]
+  exact Finset.sum_congr rfl fun i _ => by ring
+
+@[simp]
+theorem poissonBracket_X_inl_inl (i j : σ) :
+    poissonBracket (X (Sum.inl i) : MvPolynomial (σ ⊕ σ) R) (X (Sum.inl j)) = 0 :=
+  Finset.sum_eq_zero fun k _ => by
+    rw [pderiv_X_of_ne (show (Sum.inl j : σ ⊕ σ) ≠ Sum.inr k from by simp),
+      pderiv_X_of_ne (show (Sum.inl i : σ ⊕ σ) ≠ Sum.inr k from by simp), mul_zero, zero_mul,
+      sub_self]
+
+@[simp]
+theorem poissonBracket_X_inr_inr (i j : σ) :
+    poissonBracket (X (Sum.inr i) : MvPolynomial (σ ⊕ σ) R) (X (Sum.inr j)) = 0 :=
+  Finset.sum_eq_zero fun k _ => by
+    rw [pderiv_X_of_ne (show (Sum.inr i : σ ⊕ σ) ≠ Sum.inl k from by simp),
+      pderiv_X_of_ne (show (Sum.inr j : σ ⊕ σ) ≠ Sum.inl k from by simp), zero_mul, mul_zero,
+      sub_self]
+
+@[simp]
+theorem poissonBracket_X_inl_inr [DecidableEq σ] (i j : σ) :
+    poissonBracket (X (Sum.inl i) : MvPolynomial (σ ⊕ σ) R) (X (Sum.inr j)) =
+      if i = j then 1 else 0 := by
+  rw [poissonBracket, Finset.sum_eq_single i]
+  · rw [pderiv_X_self, one_mul,
+      pderiv_X_of_ne (show (Sum.inl i : σ ⊕ σ) ≠ Sum.inr i from by simp), zero_mul, sub_zero]
+    rcases eq_or_ne i j with rfl | h
+    · simp
+    · rw [pderiv_X_of_ne (show (Sum.inr j : σ ⊕ σ) ≠ Sum.inr i from by simpa using Ne.symm h),
+        if_neg h]
+  · intro k _ hk
+    rw [pderiv_X_of_ne (show (Sum.inl i : σ ⊕ σ) ≠ Sum.inl k from by simpa using Ne.symm hk),
+      pderiv_X_of_ne (show (Sum.inl i : σ ⊕ σ) ≠ Sum.inr k from by simp)]
+    simp
+  · simp
+
+@[simp]
+theorem poissonBracket_X_inr_inl [DecidableEq σ] (i j : σ) :
+    poissonBracket (X (Sum.inr i) : MvPolynomial (σ ⊕ σ) R) (X (Sum.inl j)) =
+      if i = j then -1 else 0 := by
+  rw [poissonBracket_swap, poissonBracket_X_inl_inr]
+  split_ifs with h₁ h₂ h₂ <;> simp_all [Ne.symm]
+
+end MvPolynomial

--- a/FormalConjecturesForMathlib/Algebra/MvPolynomial/PoissonBracket.lean
+++ b/FormalConjecturesForMathlib/Algebra/MvPolynomial/PoissonBracket.lean
@@ -21,7 +21,7 @@ public import Mathlib.Algebra.MvPolynomial.PDeriv
 public section
 
 /-!
-# The canonical Poisson bracket on a polynomial algebra in `2n` variables
+# The canonical Poisson bracket on a polynomial algebra in $2n$ variables
 
 For a commutative ring `R` and a finite type `σ`, we equip `MvPolynomial (σ ⊕ σ) R`
 with its canonical Poisson bracket
@@ -31,7 +31,7 @@ where $x_i$ (resp. $y_i$) denotes the variable indexed by `Sum.inl i` (resp. `Su
 This is the polynomial algebra underlying the `n`-th *canonical Poisson algebra* $P_n(R)$
 when `σ = Fin n`.
 
-Classical sources index the same object by `2n` variables $X_1, \dots, X_{2n}$ with bracket
+Classical sources index the same object by $2n$ variables $X_1, \dots, X_{2n}$ with bracket
 $\{f, g\} = \sum_{i=1}^n (\partial f/\partial X_i \cdot \partial g/\partial X_{i+n}
 - \partial f/\partial X_{i+n} \cdot \partial g/\partial X_i)$; here `Sum.inl i`
 plays the role of $X_i$ and `Sum.inr i` the role of $X_{i+n}$

--- a/FormalConjecturesForMathlib/Algebra/MvPolynomial/RegularFunction.lean
+++ b/FormalConjecturesForMathlib/Algebra/MvPolynomial/RegularFunction.lean
@@ -1,0 +1,74 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.MvPolynomial.Monad
+public import Mathlib.Algebra.MvPolynomial.PDeriv
+public import Mathlib.Data.Matrix.Basic
+
+public section
+
+/-!
+# Regular functions between affine spaces
+
+A *regular function* from $k^σ$ to $k^τ$ is a $τ$-indexed family of polynomials in the
+variables $σ$, i.e. a vector valued polynomial function. This file provides the basic
+API: the Jacobian matrix, composition, the identity, and evaluation at a point.
+-/
+
+namespace MvPolynomial
+
+variable {k : Type*} [CommRing k]
+variable {σ τ ι : Type*}
+
+variable (k σ τ) in
+/-- The type of regular functions from $k^σ$ to $k^τ$. -/
+abbrev RegularFunction := τ → MvPolynomial σ k
+
+namespace RegularFunction
+
+/-- The Jacobian of a vector valued polynomial function, viewed as a polynomial. -/
+noncomputable def Jacobian (F : RegularFunction k σ τ) :
+    Matrix σ τ (MvPolynomial σ k) :=
+  Matrix.of fun i j => MvPolynomial.pderiv i (F j)
+
+/-- The composition of two vector valued polynomial functions. -/
+noncomputable def comp
+    (F : RegularFunction k σ τ) (G : RegularFunction k τ ι) :
+    RegularFunction k σ ι :=
+  fun (i : ι) ↦ MvPolynomial.bind₁ F (G i)
+
+variable (k σ) in
+noncomputable def id : RegularFunction k σ σ := MvPolynomial.X
+
+/-- The evaluation of a regular function `f` over `k` at some point `a`
+with coordinates in some algebra over `k`-/
+noncomputable def aeval {σ τ : Type*} {S₁ : Type*} [CommSemiring S₁] [Algebra k S₁]
+    (F : RegularFunction k σ τ) : (σ → S₁) → τ → S₁ :=
+  fun a t ↦ MvPolynomial.aeval a (F t)
+
+/--`aeval` is compatible with composition of regular functions. -/
+lemma comp_aeval
+    {σ τ ι : Type*}
+    (F : RegularFunction k σ τ) (G : RegularFunction k τ ι)
+    (a : σ → k) : (F.comp G).aeval a = G.aeval (F.aeval a) := by
+  ext i
+  rw [aeval, comp, MvPolynomial.aeval_bind₁, ←aeval]
+  rfl
+
+end RegularFunction
+
+end MvPolynomial


### PR DESCRIPTION
Part of google-deepmind/formal-conjectures#4489.

Adds the **Poisson conjecture** of [Adjamagbo–van den Essen, arXiv:math/0608009](https://arxiv.org/abs/math/0608009) (the "United Conjectures" paper), as a follow-up to the disproof of the Jacobian conjecture (#4474). Announced in the Zulip thread [#AI authored projects > Counterexample to the Jacobian conjecture](https://leanprover.zulipchat.com/#narrow/channel/AI.20authored.20projects/topic/Counterexample.20to.20the.20Jacobian.20conjecture); as far as I can tell nobody else is working on this family.

**Contents**

- `FormalConjecturesForMathlib/Algebra/MvPolynomial/PoissonBracket.lean` — the canonical Poisson bracket on `MvPolynomial (σ ⊕ σ) R` and its values on generators (all proved, no sorries).
- `FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean` — per-dimension statements `PC_n` in the `ConjectureFor` house style:
  - `poisson_conjecture` — the full family (∀ n), now **false**;
  - `variants.dimension_one`, `variants.dimension_two` — still open; with the former ceiling `JC_4` gone, the surviving open cases form the totally ordered chain `PC_2 ⟹ DC_2 ⟹ JC_2 ⟹ PC_1 ⟹ DC_1`;
  - `variants.dimension_three`, `variants.dimension_ge_three` — false: `PC_3 ⟹ DC_3 ⟹ JC_3` ([AvdE07] Thm 7 + [BCW82]) contradicts the counterexample; directly, the cotangent (symplectic) lift of the counterexample map ([AvdE07] Thm 1 in reverse) is a Poisson endomorphism of `P₃(K)` that is not injective on points;
  - `variants.jacobian_implication` — `JC_{2n} ⟹ PC_n` ([AvdE07] Thm 1/Thm 7), registered as a cited sorry;
  - proved `category test` sanity checks for the bracket, the identity endomorphism, and the trivial `n = 0` case.

**Conventions — maintainer input welcome**

1. *Freshly-falsified statements.* I tagged the now-false statements `@[category research solved]` with negated statements, per CONTRIBUTING ("solved to the negative"). If you'd rather have a different convention for newly-falsified conjectures (this is somewhat new territory after this summer), happy to adjust.
2. *Old-style arXiv ID.* The paper's identifier is `arXiv:math/0608009`; since `/` cannot appear in a directory name, the files live in `FormalConjectures/Arxiv/math.0608009/` with namespace `Arxiv.«math.0608009»`. There is no existing precedent for old-style IDs — happy to move if you prefer another scheme.
3. *Indexing.* The `2n` variables are indexed by `Fin n ⊕ Fin n` (`Sum.inl i` ↔ `Xᵢ`, `Sum.inr i` ↔ `X_{i+n}`), matching [AvdE07] Notations 1, so that `{Xᵢ, X_{i+n}} = 1` holds literally; the bracket-preservation hypothesis is stated on generators, which is equivalent to the full condition by [AvdE07] Lemma 2.

A companion PR (stacked on this one) adds the Weyl algebra and the Dixmier side `DC_n` with the remaining implications `DC_n ⟹ JC_n` [BCW82] and `PC_n ⟹ DC_n` [AvdE07].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
