### PR TITLE
feat(WrittenOnTheWallII): disprove Conjecture 109

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean
@@ -38,9 +38,17 @@ largest induced bipartite subgraph.
 This is false. A connected graph on 21 vertices has an independent set of size
 15, residue 8, and no induced bipartite subgraph with more than 18 vertices, so
 the conjectured right-hand side is at most 14.
+
+A smaller counterexample is the connected 13-vertex graph
+$\overline K_7 \vee (K_3 \sqcup K_3)$. It has independence number $7$, residue
+$2$, and largest induced bipartite subgraph size $9$, so its conjectured
+right-hand side is $6$.
 -/
 @[category research solved, AMS 5,
-  formal_proof using formal_conjectures at "https://github.com/DomTheDeveloper/formal-conjectures/blob/cf59008ef1cd432bf9803275dcf5d62ab1f094a3/FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean"]
+  formal_proof using formal_conjectures at
+    "https://github.com/DomTheDeveloper/formal-conjectures/blob/cf59008ef1cd432bf9803275dcf5d62ab1f094a3/FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean",
+  formal_proof using lean4 at
+    "https://github.com/chelokot/wowii-109-counterexample/blob/543a66ee78565b553f4ba6dc7fd32b5610557913/lean/GraphConjecture109.lean#L29-L139"]
 theorem conjecture109 : answer(False) ↔
     ∀ (α : Type) [Fintype α] [DecidableEq α] [Nontrivial α]
       (G : SimpleGraph α) [DecidableRel G.Adj] (_h : G.Connected),


### PR DESCRIPTION
## Summary

- mark Written on the Wall II Conjecture 109 as solved with answer `False`
- document the 13-vertex counterexample $\overline K_7 \vee (K_3 \sqcup K_3)$
- link an immutable external Lean 4 proof, following the repository policy for proofs longer than 25--50 lines

## Counterexample

More generally, for every $r \ge 3$ let

$$
G_r=\overline K_{2r+1}\vee(K_r\sqcup K_r).
$$

Then $\alpha(G_r)=2r+1$, $b(G_r)=2r+3$, and $\mathrm{res}(G_r)=2$. Hence the conjectured bound is

$$
\left\lfloor\frac{\mathrm{res}(G_r)+2b(G_r)}3\right\rfloor
=\left\lfloor\frac{4r+8}{3}\right\rfloor
<2r+1.
$$

For $r=3$, the graph has graph6 encoding `L???F~~~~{^p~b`, with $13$ vertices, $48$ edges, $\alpha=7$, $b=9$, residue $2$, and claimed upper bound $6$.

## Verification

- the linked Lean 4 certificate proves the concrete 13-vertex counterexample from the definitions
- self-contained Python and independent C++ verifiers exhaust all $2^{13}$ vertex subsets
- a separate verifier checks the infinite-family formulas through $r=100$ and exhausts the natural cluster-join family through order $13$
- `lake --wfail build FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean` passes locally; the full repository build runs in this PR's CI
- certificates and reproducible CI: https://github.com/chelokot/wowii-109-counterexample

The exact graph and family were also checked independently with NetworkX. The official WOWII page and this repository currently list the conjecture as open; repository, code, and literature searches found no prior resolution of this exact statement, although that cannot rule out unpublished or unindexed observations.

## AI provenance

Essentially all technical work—the search, counterexample family, proof, Lean formalization, verifiers, and write-up—was produced by GPT-5.6 Sol Max in Codex. Andrii Vlasenko initiated and directed the investigation and submits this change.

Closes #4493.
