### PR TITLE
Disprove WOWII Conjecture 200

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture200.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture200.lean
@@ -21,13 +21,34 @@ import FormalConjecturesUtil
 
 *Reference:*
 [E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+
+## Counterexample
+
+For every integer $q \geq 5$, let $C = \{a,b\} \cup D$ have $q$ vertices and
+induce $K_q$ minus the edge $ab$. Add two nonadjacent vertices $x,y$, each
+complete to $C$; a vertex $z$ adjacent exactly to $a,b$; and, for every
+$d \in D$, a pendant vertex $p_d$ adjacent exactly to $d$.
+
+The local-neighbourhood independence numbers are $2$ at $x,y,z$, $1$ at each
+$p_d$, and $3$ at every vertex of $C$. Their sum is $4q+4$, while the graph has
+$2q+1$ vertices, so
+$$\left\lceil 1 + l_{\mathrm{avg}}(G)\right\rceil = 4.$$
+The vertices $\{a,x,y,z\}$ induce a claw, and a case split on the number of
+vertices from $C$ shows that no induced tree has more than four vertices.
+Thus $\operatorname{tree}(G)=4$. Finally, the graph has $q-2 \geq 3$ pendant
+vertices, but a Hamiltonian path has only two endpoints.
+
+The smallest member of this family has 11 vertices and graph6 encoding
+`J??FFBRq}N_`.
+This is a smallest counterexample overall: an exhaustive search over all
+11,989,760 connected graphs on 4 ≤ n ≤ 10 vertices (via nauty's `geng`;
+graphs on at most 3 vertices are trivially traceable) found no graph
+satisfying the premise without a Hamiltonian path.
 -/
 
 namespace WrittenOnTheWallII.GraphConjecture200
 
 open Classical SimpleGraph
-
-variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
 /--
 WOWII [Conjecture 200](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
@@ -37,11 +58,17 @@ Here `tree(G)` is the number of vertices of a largest induced tree subgraph, and
 `l_avg(G) = averageIndepNeighbors G` is the average over all vertices of the independence number
 of the neighbourhood.
 A Hamiltonian path is a walk visiting every vertex exactly once.
+
+This conjecture is false. The counterexample family in the module docstring
+satisfies the equality hypothesis and has no Hamiltonian path.
 -/
-@[category research open, AMS 5]
-theorem conjecture200 (G : SimpleGraph α) (h : G.Connected)
-    (htree : (largestInducedTreeSize G : ℝ) = ⌈1 + averageIndepNeighbors G⌉) :
-    ∃ a b : α, ∃ p : G.Walk a b, p.IsHamiltonian := by
+@[category research solved, AMS 5, formal_proof using formal_conjectures at
+  "https://github.com/infinityscroll/formal-conjectures/blob/9dd290db402c49922fa42793e4a7cfb802daf5c1/FormalConjectures/WrittenOnTheWallII/GraphConjecture200Counterexample.lean#L24-L195"]
+theorem conjecture200 : answer(False) ↔
+    ∀ (α : Type) [Fintype α] [DecidableEq α] [Nontrivial α]
+      (G : SimpleGraph α) (_h : G.Connected),
+      (largestInducedTreeSize G : ℝ) = ⌈1 + averageIndepNeighbors G⌉ →
+      ∃ a b : α, ∃ p : G.Walk a b, p.IsHamiltonian := by
   sorry
 
 -- Sanity checks


### PR DESCRIPTION
## Summary

For every integer `q ≥ 5`, start with `K_q` minus one edge `ab`; add two nonadjacent vertices complete to the core, one vertex adjacent exactly to `a,b`, and a pendant vertex at each of the other `q - 2` core vertices. The largest induced tree has order `4`, and `ceil(1 + l_avg(G)) = 4`, but the graph has at least three pendant vertices and therefore no Hamiltonian path.

The smallest family member has 11 vertices and graph6 encoding `J??FFBRq}N_`. This is a smallest counterexample overall, and in fact the unique one of minimum order: an exhaustive search over all 1,018,690,325 connected graphs on 4–11 vertices (nauty `geng`; graphs on ≤ 3 vertices are trivially traceable) found no counterexample on ≤ 10 vertices and exactly this one on 11.

Closes #4499.
