### PR TITLE
fix(ErdosProblems/128): quantify all induced subgraphs

### DIFF
--- a/FormalConjectures/ErdosProblems/128.lean
+++ b/FormalConjectures/ErdosProblems/128.lean
@@ -27,14 +27,14 @@ variable {V : Type*} {G : SimpleGraph V} [Fintype V]
 namespace Erdos128
 
 /--
-Let G be a graph with n vertices such that every subgraph on ≥ $n/2$
+Let G be a graph with n vertices such that every induced subgraph on ≥ $n/2$
 vertices has more than $n^2/50$ edges. Must G contain a triangle?
 -/
 @[category research open, AMS 5]
 theorem erdos_128 :
-    answer(sorry) ↔ ∀ (V : Type) [Fintype V] (G : SimpleGraph V) (V' : Set V),
-      2 * V'.ncard + 1 ≥ Fintype.card V →
-        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2 → ¬ G.CliqueFree 3 := by
+    answer(sorry) ↔ ∀ (V : Type) [Fintype V] (G : SimpleGraph V),
+      (∀ V' : Set V, 2 * V'.ncard + 1 ≥ Fintype.card V →
+        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2) → ¬ G.CliqueFree 3 := by
   sorry
 
 end Erdos128


### PR DESCRIPTION
The current formalization quantifies the vertex subset `V'` alongside `G`, outside the
density hypothesis:

```lean
∀ (V : Type) [Fintype V] (G : SimpleGraph V) (V' : Set V),
  large V' → dense (G.induce V') → ¬ G.CliqueFree 3
```

This says that any one chosen induced subgraph satisfying the size and density bounds forces
`G` to contain a triangle. The source instead assumes that the density bound holds for every
sufficiently large induced subgraph.

This PR moves the quantifier over `V'` inside a parenthesized antecedent:

```lean
∀ (V : Type) [Fintype V] (G : SimpleGraph V),
  (∀ V' : Set V, large V' → dense (G.induce V')) → ¬ G.CliqueFree 3
```

The complete graph on two vertices gives a trivial witness for the old statement: with
`V' = univ`, `3 ≥ 2` and `50 · 1 > 2²`, but the graph is triangle-free. It does not satisfy
the corrected premise because a one-vertex induced subgraph has zero edges. This is a
formalization correction, not a claimed solution of Erdős Problem 128.

Fixes #4424.

## Validation

- `git diff --check origin/main...HEAD`
- `lake env lean FormalConjectures/ErdosProblems/128.lean`
- `/tmp/verify_erdos128_quantifier.sh` on base `35707f0` and HEAD `44025ec`
- `lake --wfail build`

The same-scenario proof compiles the K₂ witness in Lean on both revisions; the retained base
and HEAD logs are SHA-256-locked by the local proof gate. Screenshots and performance testing
are not applicable to this statement-only correction.

<details>
<summary>K₂ before/after proof</summary>

```text
revision=35707f0567ff46872371f0fba8ac55c9f3fd750c
result=limitation
The density hypothesis is attached to one outer V' witness.
The checked K2 witness uses V' = univ: 3 >= 2, 50 * 1 > 2^2, and K2 is triangle-free.

revision=44025ecde40da70df4b459660eb43b9e09633ac4
result=success
The density hypothesis universally quantifies every qualifying induced subgraph.
The checked K2 scenario is rejected by V' = {0}: 3 >= 2 but the induced graph has 0 edges.
```

</details>

Review history: https://gist.github.com/anagnorisis2peripeteia/44413be77b5e3651d480b40fdcbf64ef

## AI assistance disclosure

OpenAI Codex was used to identify the quantifier mismatch, prepare the one-file Lean edit,
construct the K₂ witness, and run validation.
