### PR TITLE
feat(ErdosProblems/456): prove variants.infinitely_many_n via the witness family n = 2^(2j+3)

### DIFF
--- a/FormalConjectures/ErdosProblems/456.lean
+++ b/FormalConjectures/ErdosProblems/456.lean
@@ -111,7 +111,45 @@ Erdős [Er79e] writes it is 'easy to show' that for infinitely many $n$ we have 
 @[category research solved, AMS 11]
 theorem erdos_456.variants.infinitely_many_n :
     { n | m n < p n }.Infinite := by
-  sorry
+  apply Set.infinite_of_injective_forall_mem (f := fun j : ℕ ↦ 2 ^ (2 * j + 3))
+  · intro a b hab
+    apply Nat.pow_right_injective (by decide) at hab
+    omega
+  · intro j
+    let k := 2 * j + 3
+    -- Witness n = 2^k for odd k ≥ 3; then m(n) ≤ 2n, while 3 ∣ n + 1 forces p(n) > 2n.
+    change m (2 ^ k) < p (2 ^ k)
+    have hm : m (2 ^ k) ≤ 2 ^ (k + 1) := by
+      unfold m
+      refine Nat.sInf_le ⟨by positivity, ?_⟩
+      rw [Nat.totient_prime_pow Nat.prime_two (by omega)]
+      norm_num
+    have hp : 2 ^ (k + 1) + 1 ≤ p (2 ^ k) := by
+      unfold p
+      let q := sInf {x | x.Prime ∧ x ≡ 1 [MOD 2 ^ k]}
+      change 2 ^ (k + 1) + 1 ≤ q
+      have hne : {x | x.Prime ∧ x ≡ 1 [MOD 2 ^ k]}.Nonempty := by
+        obtain ⟨r, _, hr, hmod⟩ := Nat.forall_exists_prime_gt_and_modEq 0
+          (pow_ne_zero k (by decide)) (Nat.coprime_one_left (2 ^ k))
+        exact ⟨r, hr, hmod⟩
+      obtain ⟨hprime, hmod⟩ : q.Prime ∧ q ≡ 1 [MOD 2 ^ k] := Nat.sInf_mem hne
+      rw [Nat.pow_succ]
+      by_contra hbound
+      have hxle : q ≤ 2 ^ k * 2 := by omega
+      have hlower : 2 ^ k + 1 ≤ q := by
+        simpa [add_comm] using hmod.symm.add_le_of_lt hprime.one_lt
+      have hupper : q ≤ 2 ^ k + 1 :=
+        (hmod.trans Nat.add_modEq_left.symm).le_of_lt_add (by omega)
+      have hxeq : q = 2 ^ k + 1 := by omega
+      have hkodd : Odd k := ⟨j + 1, by dsimp [k]; omega⟩
+      have hxeqthree : q = 3 := (hprime.dvd_iff_eq (by decide)).mp (by
+        rw [hxeq]
+        simpa using hkodd.nat_add_dvd_pow_add_pow 2 1)
+      have heighteen : 8 ≤ 2 ^ k := by
+        change 2 ^ 3 ≤ 2 ^ k
+        exact Nat.pow_le_pow_right (by decide) (by dsimp [k]; omega)
+      omega
+    omega
 
 /--
 Erdős [Er79e] writes it is 'easy to show' that $m_n/n \to \infty$ for almost all $n$.


### PR DESCRIPTION
Closes `erdos_456.variants.infinitely_many_n` using the witness family n = 2^k with k = 2j+3 odd.

For such n, m(n) <= 2n, since phi(2^(k+1)) = 2^k gives 2^k | phi(2^(k+1)). And p(n) > 2n, because the only candidate prime congruent to 1 mod 2^k that is at most 2n is 2^k + 1, which is divisible by 3 whenever k is odd and exceeds 3, hence composite. Together these give m(n) < p(n) for every n in the family, and j -> 2^(2j+3) is injective.

Sanity check at j = 0: n = 8, m(8) <= 16 and p(8) = 17, since 9 is composite.

Verified clean under the project linters (`lake build`, zero warnings). `#print axioms` on the target gives `[propext, Classical.choice, Quot.sound]`.

Assisted by OpenAI Codex; verified by me.