### PR TITLE
fix(WrittenOnTheWallII/291): remove extra order hypothesis

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
@@ -42,7 +42,7 @@ is the *total* number of reduction steps until *every* entry is zero, whereas $k
 only requires that *some* entry has hit zero — and a $0$ typically appears well
 before the all-zero state is reached.
 
-**Conjecture 291:** For a simple connected graph $G$ with $n > 2$,
+**Conjecture 291:** For a simple connected graph $G$,
 $\gamma_t(G) \le k + \mathrm{frequency}(t_{\min}(v))$
 where $\gamma_t(G)$ is the total domination number, $k$ is the Havel-Hakimi zero
 step, and $\mathrm{frequency}(t_{\min}(v))$ is the number of vertices achieving
@@ -96,7 +96,7 @@ noncomputable def havelHakimiZeroStep (G : SimpleGraph α) [DecidableRel G.Adj] 
 /--
 WOWII [Conjecture 291](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph $G$ with $n > 2$,
+For a simple connected graph $G$,
 $\gamma_t(G) \le k + \mathrm{frequency}(t_{\min}(v))$
 where:
 
@@ -106,8 +106,7 @@ where:
   minimum triangle count.
 -/
 @[category research open, AMS 5]
-theorem conjecture291 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected)
-    (hn : 2 < Fintype.card α) :
+theorem conjecture291 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     G.totalDominationNumber ≤
     havelHakimiZeroStep G + freqMinTriangles G := by
   sorry


### PR DESCRIPTION
# Description
I might have caught a quick fix in `WrittenOnTheWallII`:

The implementation in `GraphConjecture291.lean` assumes `2 < Fintype.card α`, which does not match [Conjecture 291](http://cms.uhd.edu/faculty/delavinae/research/wowII/open.html), whose statement begins “If G is a simple connected graph, then” without an `n > 2` restriction. The existing `[Nontrivial α]` assumption already excludes the one-vertex graph.

**Proposed changes:**
- Remove the unsupported `2 < Fintype.card α` hypothesis
- Update the module and theorem docstrings to match the source

Fixes #4509

# Testing
:white_check_mark: Builds fine
```shell
$ lake env lean FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
$ lake --wfail build
```

# Proof
The same source-domain/K₂ harness was run against `origin/main` and this branch. On `origin/main`, K₂ is connected and nontrivial but cannot instantiate the theorem because `2 < 2` is false. On this branch, K₂ is included in the formal domain. Its independently computed values satisfy the boundary case: `γₜ(K₂) = 2`, `k = 1`, and `frequency(t_min(v)) = 2`, so `2 ≤ 1 + 2`.

# Review history
Full local review outputs and dispositions: https://gist.github.com/1461c4b6a4a542473a9524a1e99732c9

# AI disclosure
OpenAI Codex was used to compare the Lean statement with the cited source, prepare the minimal edit and K₂ boundary check, and run the local validation and review gates.
