### PR TITLE
fix(Wikipedia/PebblingNumberConjecture): quantify arbitrary connected factors

### DIFF
--- a/FormalConjectures/Wikipedia/PebblingNumberConjecture.lean
+++ b/FormalConjectures/Wikipedia/PebblingNumberConjecture.lean
@@ -19,7 +19,9 @@ import FormalConjecturesUtil
 /-!
 # Pebbling number conjecture
 
-*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Graph_pebbling)
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Graph_pebbling)
+- [Pebbling on Graph Products and Other Binary Graph Constructions](https://arxiv.org/abs/1801.07808)
 -/
 variable {V : Type} {G : SimpleGraph V} [DecidableEq V]
 
@@ -121,11 +123,13 @@ theorem PebblingNumber_completeGraph [Fintype V] :
 
 /--
 The pebbling number conjecture:
-the pebbling number of a Cartesian product of graphs is at most equal to the product of the
-pebbling numbers of the factors.
+the pebbling number of a Cartesian product of connected graphs is at most equal to the product
+of the pebbling numbers of the factors. See
+[Asplund, Hurlbert, and Kenter](https://arxiv.org/abs/1801.07808).
 -/
 @[category research open, AMS 5]
-theorem pebbling_number_conjecture [Fintype V] (G H : SimpleGraph V) :
+theorem pebbling_number_conjecture {W : Type} [Fintype V] [Fintype W] [DecidableEq W]
+    (G : SimpleGraph V) (H : SimpleGraph W) (hG : G.Connected) (hH : H.Connected) :
     PebblingNumber (G □ H) ≤ PebblingNumber G * PebblingNumber H := by
   sorry
 


### PR DESCRIPTION
# Description
I might have caught a quick fix in `Wikipedia`:

The implementation in `PebblingNumberConjecture.lean` quantifies both factors as
`G H : SimpleGraph V` and omits connectedness hypotheses. This does not match
[Graham's conjecture](https://arxiv.org/abs/1801.07808): Asplund, Hurlbert, and Kenter
define `V(G □ H) = V(G) × V(H)` and state the conjecture for “the box product of two
connected graphs.”

**Proposed changes:**
- Quantify the two factors over separate finite vertex types
- Require both factor graphs to be connected
- Retain the primary source in the module and theorem docstrings

Fixes #4516

# Testing
:white_check_mark: Builds fine
```shell
$ git diff --check origin/main...HEAD
$ lake env lean FormalConjectures/Wikipedia/PebblingNumberConjecture.lean
$ lake --wfail build
```

# Proof
The same source-domain/type harness was run against `origin/main` and this branch. On
`origin/main`, connected graphs on `Fin 2` and `Fin 3` cannot instantiate the theorem because
both factors must use `V`, while disconnected same-type factors require no connectedness proof.
On this branch, the `Fin 2`/`Fin 3` scenario compiles with connectedness proofs, and the
disconnected scenario is rejected without them.

# Review history
Full local review outputs and dispositions:
https://gist.github.com/anagnorisis2peripeteia/5bd69ba239ec2bee40cfff440f75352b

# AI disclosure
OpenAI Codex was used to compare the Lean statement with the cited source, prepare the minimal
edit and type-domain witnesses, and run the local validation and review gates.
