### PR TITLE
fix(GreensOpenProblems/72): add N ≥ k

### DIFF
--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -20,7 +20,7 @@ import FormalConjecturesUtil
 
 More commonly known as the **no-three-in-line problem**.
 
-Given $N \lt 2$ and a more than $2 * N$ points on an $N \times N$-grid,
+Given $N > 2$ and more than $2 * N$ points on an $N \times N$-grid,
 are there $3$ of the points on a common line?
 
 *References:*
@@ -50,7 +50,7 @@ theorem allowedSetSize_le {k : ℕ} {N : ℕ} (h : k ≤ N) :
     AllowedSetSize k N ≤ (k - 1) * N := by
   sorry
 
-/-- $N, k$ when the AllowedSetSize of $N$ for $k$ is $k * N$. -/
+/-- The proposition that the allowed-set size for $k$ and $N$ is $(k - 1) * N$. -/
 def NoKInLineFor (k : ℕ) (N : ℕ) : Prop :=
   AllowedSetSize k N = (k - 1) * N
 
@@ -75,15 +75,16 @@ alias no_three_in_line := green_72
 theorem green_72.variants.eventually : answer(sorry) ↔ ∀ᶠ N in Filter.atTop, NoKInLineFor 3 N := by
   sorry
 
-/-- For $N \leq 60$, this has been verfied with computers. -/
+/-- For $N \leq 60$, this has been verified with computers. -/
 @[category research solved, AMS 5 52]
 theorem no_three_in_line_le {N : ℕ} (hN : 3 ≤ N) (hN' : N ≤ 60) :
     NoKInLineFor 3 N := by
   sorry
 
-/-- In [GK2025] Grebennikov and Kwan prove the no-k-in-line conjecture for $k > 10 ^ 37$. -/
+/-- In [GK2025] Grebennikov and Kwan prove the no-k-in-line conjecture for $k > 10 ^ 37$
+and $N \geq k$. -/
 @[category research solved, AMS 5 52]
-theorem no_k_in_line_big {k : ℕ} (N : ℕ) (h : 10 ^ 37 < k) :
+theorem no_k_in_line_big {k : ℕ} (N : ℕ) (h : 10 ^ 37 < k) (hN : k ≤ N) :
     NoKInLineFor k N := by
   sorry
 


### PR DESCRIPTION
Otherwise we can disprove `no_k_in_line_big` by taking `k = 10 ^ 37 + 1` and `N = 1`.

A retained Lean witness proves
`AllowedSetSize (10 ^ 37 + 1) 1 = 1`, hence
`¬ NoKInLineFor (10 ^ 37 + 1) 1`. The existing declaration nevertheless applies to this
case because it assumes only `10 ^ 37 < k`.

[Theorem 1.1 of GK2025](https://arxiv.org/abs/2510.17743) assumes that the grid size is at
least the number of collinear points. This PR therefore adds the missing `hN : k ≤ N`
hypothesis and records `N ≥ k` in the docstring. It does not change the predicate,
classification, or proof placeholder.

Fixes #4522.

## Update (2026-07-22)

Addressed the maintainer's three prose suggestions after checking the rendered file:

- corrected `N \lt 2` to `N > 2` and removed the extra article;
- documented the actual definition `AllowedSetSize k N = (k - 1) * N` with the parameters
  in declaration order; and
- corrected `verfied` to `verified` without the malformed trailing backtick in the rendered
  suggestion.

The branch was rebased onto current `main`, and the complete gate sequence was rerun on the
amended commit.

## Validation

- `git diff --check origin/main...HEAD`
- `lake env lean FormalConjectures/GreensOpenProblems/72.lean`
- `lake env lean .pr-gates/green72-grid-bound-witness.lean`
- `.pr-gates/proof-green72-74f5a6b/verify.sh` on base `9002c58` and HEAD `74f5a6b`
- `lake exe mk_all --lib FormalConjectures`
- `lake exe cache unpack`
- `lake exe cache get`
- `lake --wfail build`

The paired check uses the same `k = 10 ^ 37 + 1`, `N = 1` scenario on both revisions.
On the base, the theorem accepts a machine-checked false conclusion; on HEAD, the new
`k ≤ N` premise excludes that case. The full Lean 4.27.0 warning-as-error build completed
all 8,892 jobs against the exact unchanged source hash. Screenshots and performance testing
are not applicable to this statement-only correction.

Review history: https://gist.github.com/anagnorisis2peripeteia/dcf401e6c9d07eb4aa8ae2d851587006

## AI assistance disclosure

OpenAI Codex was used to compare the cited source with the Lean declaration, prepare the
one-file correction and paired base/HEAD witness, and run validation.
