### PR TITLE
fix(GreensOpenProblems/16): encode Zhao's question as open

### DIFF
--- a/FormalConjectures/GreensOpenProblems/16.lean
+++ b/FormalConjectures/GreensOpenProblems/16.lean
@@ -80,7 +80,8 @@ noncomputable def g (N : ℕ) : ℕ :=
 $N^{1/3 - o(1)}$ with no nontrivial solutions to $x + 2y + 3z = x' + 2y' + 3z'$? -/
 @[category research open, AMS 5 11]
 theorem zhao_question :
-    ¬∃ h : ℕ → ℝ, Tendsto h atTop (𝓝 0) ∧ ∀ᶠ N in atTop, (g N : ℝ) ≥ (N : ℝ) ^ (1 / 3 - h N) := by
+    answer(sorry) ↔ ∃ h : ℕ → ℝ, Tendsto h atTop (𝓝 0) ∧
+      ∀ᶠ N in atTop, (g N : ℝ) ≥ (N : ℝ) ^ (1 / 3 - h N) := by
   sorry
 
 end Green16


### PR DESCRIPTION
The cited source asks whether there are Zhao-solution-free subsets of `[N]` of size
`N^(1/3 - o(1))`. The current `research open` declaration instead asserts the negative
answer directly:

```lean
¬∃ h : ℕ → ℝ, Tendsto h atTop (𝓝 0) ∧
  ∀ᶠ N in atTop, (g N : ℝ) ≥ (N : ℝ) ^ (1 / 3 - h N)
```

This PR restores the repository's open yes/no encoding:

```lean
answer(sorry) ↔ ∃ h : ℕ → ℝ, Tendsto h atTop (𝓝 0) ∧
  ∀ᶠ N in atTop, (g N : ℝ) ≥ (N : ℝ) ^ (1 / 3 - h N)
```

The underlying `ZhaoSolutionFree` predicate, extremal function `g`, category, and proof
placeholder are unchanged.

Source: [Ben Green's Open Problem 16](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.16)

Fixes #4524.

## Validation

- `git diff --check origin/main...HEAD`
- `lake env lean FormalConjectures/GreensOpenProblems/16.lean`
- `.pr-gates/proof-green16-3184d35/verify.sh` on base `fbcd076` and HEAD `3184d35`
- `lake exe mk_all --lib FormalConjectures`
- `lake exe cache unpack`
- `lake exe cache get`
- `lake --wfail build`

The paired check hash-verifies and compiles the exact theorem blob on both revisions. The
base directly chooses the negative answer; HEAD asks the affirmative source question behind
`answer(sorry)`. The full Lean 4.27.0 warning-as-error build completed all 8,877 jobs against
the exact unchanged source hash. Screenshots and performance testing are not applicable to
this statement-only correction.

Review history: https://gist.github.com/anagnorisis2peripeteia/7f2ef06d60eca08602c07bc18ace0972

## AI assistance disclosure

OpenAI Codex was used to compare the primary source with the Lean declaration, prepare the
one-file correction and paired base/HEAD check, and run validation.
