### PR TITLE
Mark WOWII conjecture 146 solved

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture146.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture146.lean
@@ -56,7 +56,9 @@ graph of $G$.
 We state the inequality in the form
 $\mathrm{tree}(G) \cdot \mathrm{rad}(G^2) \ge 2 \cdot \mathrm{ecc}(B)$ to avoid division.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using formal_conjectures at
+    "https://github.com/Mapika/formal-conjectures/blob/60a80606e38cb743326b70defe2cfe55f5b9fc1f/FormalConjectures/WrittenOnTheWallII/GraphConjecture146Proof.lean"]
 theorem conjecture146 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected)
     (hrad : 0 < graphSquareRadius G) :
     2 * eccSet G (maxEccentricityVertices G : Set α) ≤


### PR DESCRIPTION
## Summary

* mark Written on the Wall II Conjecture 146 as solved
* add an immutable `formal_proof` link to a kernel-checked Lean proof
* leave the formal statement unchanged

The complete proof is hosted on the contributor fork because the contribution guidelines ask that proofs longer than 25–50 lines remain outside the main repository.

## Proof outline

Let `B` be the graph periphery, let `f = ecc(B)`, and let `t` be the largest induced-tree size.

A geodesic from an eccentricity witness to a nearest peripheral vertex gives `f + 1 ≤ t`. This proves the conjecture when the radius of the graph square is at least two.

When the square radius is one, the original graph has diameter at most four. The only remaining sharp case has `f = 3` and diameter four. Two length-three geodesics from an eccentricity witness to diametral peripheral vertices then produce an induced tree on six vertices, using a four-case analysis of the possible cross edges.

Formal proof:

https://github.com/Mapika/formal-conjectures/blob/60a80606e38cb743326b70defe2cfe55f5b9fc1f/FormalConjectures/WrittenOnTheWallII/GraphConjecture146Proof.lean

## Attribution and AI assistance

This is an AI-assisted formal proof. OpenAI ChatGPT/Codex assisted with the mathematical proof search, Lean implementation, verification, and preparation of this contribution.

The proof builds on AlperTheKing’s formal proof of Written on the Wall II Conjecture 142, from commit `46bf39015f5c3c3ba3bfcf9f752b4b1e49b584ac`, which is imported unchanged as a prerequisite. The Conjecture 146 argument was developed independently.

This contribution makes no claim concerning historical priority outside this formalization.

## Verification

* `lake build FormalConjectures.WrittenOnTheWallII.GraphConjecture146`
* the exact repository theorem compiled successfully
* no `sorry`, `admit`, or `native_decide` occurs in the hosted Conjecture 146 proof
* the axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`
