### PR TITLE
ci: point the linter label at the renamed util directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,7 +16,7 @@ green-problems:
 
 linter:
   - changed-files:
-    - any-glob-to-any-file: 'FormalConjectures/Util/Linters/**'
+    - any-glob-to-any-file: 'FormalConjecturesUtil/Linters/**'
 
 mathoverflow:
   - changed-files:


### PR DESCRIPTION
`.github/labeler.yml` still globs `FormalConjectures/Util/Linters/**`, a path the util rename removed, so the `linter` label stopped being applied to linter changes.

Checked the other eight globs while I was in there; they all still resolve.
