### PR TITLE
Fix antiRamseyNum being identically zero, and CDSColorable's implicit graph

### DIFF
--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -148,7 +148,7 @@ noncomputable def indepNumK (G : SimpleGraph V) (k : ℕ) : ℕ :=
 by natural numbers such that for all `k > 0`, the number of
 vertices with color `< k` equals the maximum size of
 the union of `k` independent sets. -/
-def CDSColorable [Fintype α] {G : SimpleGraph α} : Prop :=
+def CDSColorable [Fintype α] (G : SimpleGraph α) : Prop :=
     ∃ (C : G.Coloring Nat), ∀ k : Nat,
    ∑ i < k, (C.colorClass i).ncard = indepNumK G k
 
@@ -161,4 +161,4 @@ def IsRainbow {α V : Type*} {H : SimpleGraph α} {G : SimpleGraph V} (f : H →
 The anti-Ramsey number $\mathrm{AR}(n, H)$: maximum colors to edge-color $K_n$ without rainbow $H$.
 -/
 noncomputable def antiRamseyNum {α : Type*} [Fintype α] (H : SimpleGraph α) (n : ℕ) : ℕ :=
-  sSup {k | ∃ c : Sym2 (Fin n) → Fin k, ∀ f : H →g ⊤, ¬IsRainbow f c}
+  sSup {k | ∃ c : Sym2 (Fin n) → Fin k, Function.Surjective c ∧ ∀ f : H →g ⊤, ¬IsRainbow f c}


### PR DESCRIPTION
`antiRamseyNum` returns `0` for every input.

Its defining set `{k | ∃ c : Sym2 (Fin n) → Fin k, ∀ f, ¬IsRainbow f c}` is upward closed in `k`: compose a witness with `Fin.castSucc` and you get one for `k+1`, since `castSucc` is injective and `IsRainbow` survives it. The set is therefore empty or unbounded, and `sSup` on `ℕ` gives `0` either way. Requiring `c` to be surjective bounds the set by the edge count, and the supremum becomes the maximum the docstring describes.

That matters beyond the docstring. `ErdosProblems/1105.lean` states specific values of `antiRamseyNum`, and those statements were vacuous while the function was constant.

`CDSColorable` takes `G` implicitly, but `G` never appears in the resulting `Prop`, so unification cannot infer it and the only way to use the definition is `CDSColorable (G := G)`. It is now explicit.

`ErdosProblems/1105.lean` and `Paper/LatinTableau.lean` both still typecheck.
