### PR TITLE
Formalise WOW-284 as a solved conjecture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Michael Rothgang
 Mirek Olšák
 Paul Lezeau
 Salvatore Mercuri
+Samuil Petkov
 Seewoo Lee
 The bbchallenge Collaboration (bbchallenge.org)
 Thomas Hubert

--- a/FormalConjectures/Paper/WOW284.lean
+++ b/FormalConjectures/Paper/WOW284.lean
@@ -36,29 +36,35 @@ open scoped BigOperators
 
 noncomputable section
 
-variable {α : Type*} [Fintype α]
+/-- The degree of a vertex in a finite graph. -/
+def vertexDegree {α : Type*} [Fintype α] (G : SimpleGraph α) (v : α) : ℕ :=
+  letI : Fintype ↑(G.neighborSet v) := Fintype.ofFinite _
+  G.degree v
 
 /-- The average degree of the neighbors of a vertex. -/
-def dualDegree (G : SimpleGraph α) (v : α) : ℝ :=
-  (∑ u ∈ G.neighborFinset v, (G.degree u : ℝ)) / G.degree v
+def dualDegree {α : Type*} [Fintype α] (G : SimpleGraph α) (v : α) : ℝ :=
+  letI : Fintype ↑(G.neighborSet v) := Fintype.ofFinite _
+  (∑ u ∈ G.neighborFinset v, (vertexDegree G u : ℝ)) / vertexDegree G v
 
 /-- The minimum dual degree of a nonempty finite graph. -/
-def minimumDualDegree [Nonempty α] (G : SimpleGraph α) : ℝ :=
+def minimumDualDegree {α : Type*} [Fintype α] [Nonempty α] (G : SimpleGraph α) : ℝ :=
   Finset.univ.inf' Finset.univ_nonempty (dualDegree G)
 
 /-- The real distance matrix of a finite graph. -/
-def distanceMatrix (G : SimpleGraph α) : Matrix α α ℝ :=
+def distanceMatrix {α : Type*} (G : SimpleGraph α) : Matrix α α ℝ :=
   fun u v ↦ G.dist u v
 
 /-- The real distance matrix is Hermitian. -/
 @[category API, AMS 5]
-lemma distanceMatrix_isHermitian (G : SimpleGraph α) : (distanceMatrix G).IsHermitian := by
+lemma distanceMatrix_isHermitian {α : Type*} (G : SimpleGraph α) :
+    (distanceMatrix G).IsHermitian := by
   apply Matrix.IsHermitian.ext
   intro u v
   simp [distanceMatrix, SimpleGraph.dist_comm]
 
 /-- The least eigenvalue of the real distance matrix of a nonempty finite graph. -/
-def leastDistanceEigenvalue [DecidableEq α] [Nonempty α] (G : SimpleGraph α) : ℝ :=
+def leastDistanceEigenvalue {α : Type*} [Fintype α] [DecidableEq α] [Nonempty α]
+    (G : SimpleGraph α) : ℝ :=
   Finset.univ.inf' Finset.univ_nonempty (distanceMatrix_isHermitian G).eigenvalues
 
 /--

--- a/FormalConjectures/Paper/WOW284.lean
+++ b/FormalConjectures/Paper/WOW284.lean
@@ -50,6 +50,8 @@ def minimumDualDegree [Nonempty α] (G : SimpleGraph α) : ℝ :=
 def distanceMatrix (G : SimpleGraph α) : Matrix α α ℝ :=
   fun u v ↦ G.dist u v
 
+/-- The real distance matrix is Hermitian. -/
+@[category API, AMS 5]
 lemma distanceMatrix_isHermitian (G : SimpleGraph α) : (distanceMatrix G).IsHermitian := by
   apply Matrix.IsHermitian.ext
   intro u v

--- a/FormalConjectures/Paper/WOW284.lean
+++ b/FormalConjectures/Paper/WOW284.lean
@@ -1,0 +1,81 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Written on the Wall conjecture 284
+
+*References:*
+- [Distance Spectra of Graphs: A Survey](https://doi.org/10.1016/j.laa.2014.06.010),
+  by *Mustapha Aouchiche and Pierre Hansen*, Linear Algebra and its Applications 458 (2014),
+  Conjecture 7.16.
+- [Moore Graphs of Diameter Two and the Failure of WOW-284](https://github.com/SamPetkov/wow284),
+  by *Samuil Petkov*.
+
+The survey attributes the conjecture to Siemion Fajtlowicz's 1998
+*Written on the Wall* report.
+-/
+
+namespace WOW284
+
+open scoped BigOperators
+
+noncomputable section
+
+variable {α : Type*} [Fintype α]
+
+/-- The average degree of the neighbors of a vertex. -/
+def dualDegree (G : SimpleGraph α) (v : α) : ℝ :=
+  (∑ u ∈ G.neighborFinset v, (G.degree u : ℝ)) / G.degree v
+
+/-- The minimum dual degree of a nonempty finite graph. -/
+def minimumDualDegree [Nonempty α] (G : SimpleGraph α) : ℝ :=
+  Finset.univ.inf' Finset.univ_nonempty (dualDegree G)
+
+/-- The real distance matrix of a finite graph. -/
+def distanceMatrix (G : SimpleGraph α) : Matrix α α ℝ :=
+  fun u v ↦ G.dist u v
+
+lemma distanceMatrix_isHermitian (G : SimpleGraph α) : (distanceMatrix G).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro u v
+  simp [distanceMatrix, SimpleGraph.dist_comm]
+
+/-- The least eigenvalue of the real distance matrix of a nonempty finite graph. -/
+def leastDistanceEigenvalue [DecidableEq α] [Nonempty α] (G : SimpleGraph α) : ℝ :=
+  Finset.univ.inf' Finset.univ_nonempty (distanceMatrix_isHermitian G).eigenvalues
+
+/--
+WOW-284 asserted that every connected graph on at least three vertices with girth at least five
+has minimum dual degree at most the negative of its least distance eigenvalue. It is false: the
+50-vertex Hoffman--Singleton graph is a counterexample.
+
+See Conjecture 7.16 of
+[Aouchiche--Hansen](https://doi.org/10.1016/j.laa.2014.06.010).
+-/
+@[category research solved, AMS 5,
+  formal_proof using lean4 at
+    "https://github.com/SamPetkov/wow284/tree/08ae20d27792d5f5c2a2587d51b5e2256c1ae06a/lean"]
+theorem wow_284 :
+    ¬ ∀ (α : Type*) [Fintype α] [DecidableEq α] [Nonempty α] (G : SimpleGraph α),
+        3 ≤ Fintype.card α → G.Connected → 5 ≤ G.egirth →
+          minimumDualDegree G ≤ -leastDistanceEigenvalue G := by
+  sorry
+
+end
+
+end WOW284


### PR DESCRIPTION
## Summary

- formalise WOW-284 as the negation of its original universal graph inequality;
- define dual degree, minimum dual degree, the real graph-distance matrix, and its least eigenvalue;
- mark the conjecture `research solved` and link the external Lean 4.31 verification of the explicit 50-vertex Hoffman–Singleton counterexample;
- add Samuil Petkov to `AUTHORS`.

## Mathematical scope

The formalised statement says that it is false that every finite connected graph on at least three vertices with extended girth at least five satisfies

`minimumDualDegree G ≤ -leastDistanceEigenvalue G`.

The counterexample covered by the linked formal proof is only the 50-vertex Hoffman–Singleton graph. Its distance spectrum is `{91^(1), 1^(21), (-4)^(28)}`, while its minimum dual degree is `7`, so the asserted inequality fails strictly. Other examples and a generalisation are still under development and are intentionally not claimed in this PR.

The proof is hosted externally because it is substantially longer than the repository's 25–50-line proof limit:
https://github.com/SamPetkov/wow284/tree/08ae20d27792d5f5c2a2587d51b5e2256c1ae06a/lean

## Formalisation choices

- `SimpleGraph.egirth` is used so acyclic graphs retain infinite girth, matching the informal convention.
- The distance matrix is the real cast of `SimpleGraph.dist`.
- The least eigenvalue is the infimum over the finite Hermitian eigenvalue family.

## Validation

- diff whitespace checks pass;
- the complete repository build is delegated to this PR's GitHub Actions on the repository's Lean/Mathlib 4.27 toolchain.

AI assistance: OpenAI Codex assisted with drafting and compatibility checking. The contributor reviewed the statement and accepts responsibility for the submission.

Closes #4556.