### PR TITLE
Add LaTeX linter and fix LaTeX in existing files

### DIFF
--- a/FormalConjectures/ErdosProblems/1125.lean
+++ b/FormalConjectures/ErdosProblems/1125.lean
@@ -30,7 +30,7 @@ namespace Erdos1125
 
 /--
 Let $f:\mathbb{R}\to \mathbb{R}$ be such that
-\[2f(x) \leq f(x+h)+f(x+2h)\]
+$$2f(x) \leq f(x+h)+f(x+2h)$$
 for every $x\in \mathbb{R}$ and $h>0$. Must $f$ be monotonic?
 
 A problem of Kemperman [Ke69], who proved it is true if $f$ is measurable. Erdős [Er81b] wrote 'if it were my problem I would offer \$500 for it'. This was solved by Laczkovich [La84].

--- a/FormalConjectures/ErdosProblems/1126.lean
+++ b/FormalConjectures/ErdosProblems/1126.lean
@@ -32,9 +32,9 @@ namespace Erdos1126
 
 /--
 If
-\[f(x+y)=f(x)+f(y)\]
+$$f(x+y)=f(x)+f(y)$$
 for almost all $x,y\in \mathbb{R}$ then there exists a function $g$ such that
-\[g(x+y)=g(x)+g(y)\]
+$$g(x+y)=g(x)+g(y)$$
 for all $x,y\in\mathbb{R}$ such that $f(x)=g(x)$ for almost all $x$.
 
 Proved independently by de Bruijn [dB66] and Jurkat [Ju65].

--- a/FormalConjectures/ErdosProblems/1133.lean
+++ b/FormalConjectures/ErdosProblems/1133.lean
@@ -34,7 +34,7 @@ Let $C>0$. There exists $\epsilon>0$ such that if $n$ is sufficiently large the 
 
 For any $x_1,\ldots,x_n\in [-1,1]$ there exist $y_1,\ldots,y_n\in [-1,1]$ such that, if $P$ is a
 polynomial of degree $m<(1+\epsilon)n$ with $P(x_i)=y_i$ for at least $(1-\epsilon)n$ many
-$1\leq i\leq n$, then \[\max_{x\in [-1,1]}\lvert P(x)\rvert >C.\]
+$1\leq i\leq n$, then $$\max_{x\in [-1,1]}\lvert P(x)\rvert >C.$$
 -/
 @[category research open, AMS 26 41]
 theorem erdos_1133 :

--- a/FormalConjectures/ErdosProblems/178.lean
+++ b/FormalConjectures/ErdosProblems/178.lean
@@ -34,7 +34,7 @@ open Finset BigOperators
 /--
 Let $A_1,A_2,\ldots$ be an infinite collection of infinite sets of integers, say
 $A_i=\{a_{i1}<a_{i2}<\cdots\}$. Does there exist some $f:\mathbb{N}\to\{-1,1\}$ such that
-\[\max_{m, 1\leq i\leq d} \left\lvert \sum_{1\leq j\leq m} f(a_{ij})\right\rvert \ll_d 1\]
+$$\max_{m, 1\leq i\leq d} \left\lvert \sum_{1\leq j\leq m} f(a_{ij})\right\rvert \ll_d 1$$
 for all $d\geq 1$?
 
 Erdős remarks 'it seems certain that the answer is affirmative'. This was solved by Beck [Be81]. Recently Beck [Be17] proved that one can replace $\ll_d 1$ with $\ll d^{4+\epsilon}$ for any $\epsilon>0$.

--- a/FormalConjectures/ErdosProblems/206.lean
+++ b/FormalConjectures/ErdosProblems/206.lean
@@ -77,11 +77,11 @@ def EventuallyGreedy (x : ℝ) : Prop :=
 
 /--
 Let $x>0$ be a real number. For any $n\geq 1$ let
-\[R_n(x) = \sum_{i=1}^n\frac{1}{m_i}<x\]
+$$R_n(x) = \sum_{i=1}^n\frac{1}{m_i}<x$$
 be the maximal sum of $n$ distinct unit fractions which is $<x$.
 
 Is it true that, for almost all $x$, for sufficiently large $n$, we have
-\[R_{n+1}(x)=R_n(x)+\frac{1}{m},\]
+$$R_{n+1}(x)=R_n(x)+\frac{1}{m},$$
 where $m$ is minimal such that $m$ does not appear in $R_n(x)$ and the right-hand side is
 $<x$? (That is, are the best underapproximations eventually always constructed in a 'greedy'
 fashion?)

--- a/FormalConjectures/ErdosProblems/221.lean
+++ b/FormalConjectures/ErdosProblems/221.lean
@@ -31,12 +31,12 @@ namespace Erdos221
 
 /--
 Is there a set $A\subset\mathbb{N}$ such that, for all large $N$,
-\[\lvert A\cap\{1,\ldots,N\}\rvert \ll N/\log N\]
+$$\lvert A\cap\{1,\ldots,N\}\rvert \ll N/\log N$$
 and such that every large integer can be written as $2^k+a$ for some
 $k\geq 0$ and $a\in A$?
 
 Lorentz [Lo54] proved there is such a set with, for all large $N$,
-\[\lvert A\cap\{1,\ldots,N\}\rvert \ll \frac{\log\log N}{\log N}N\]
+$$\lvert A\cap\{1,\ldots,N\}\rvert \ll \frac{\log\log N}{\log N}N$$
 The answer is yes, proved by Ruzsa [Ru72].
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Woett/Lean-files/blob/main/ErdosProblem221.lean"]

--- a/FormalConjectures/ErdosProblems/280.lean
+++ b/FormalConjectures/ErdosProblems/280.lean
@@ -40,9 +40,9 @@ noncomputable def uncoveredCount (n a : ℕ → ℕ) (k : ℕ) : ℕ := by
 
 /--
 Let $n_1<n_2<\cdots $ be an infinite sequence of integers with associated $a_k\pmod{n_k}$, such that for some $\epsilon>0$ we have $n_k>(1+\epsilon)k\log k$ for all $k$. Then
-\[
+$$
 \#\{ m<n_k : m\not\equiv a_i\pmod{n_i} \textrm{ for }1\leq i\leq k\}\neq o(k).
-\]
+$$
 
 Cambie observed that this is false.
 -/

--- a/FormalConjectures/ErdosProblems/290.lean
+++ b/FormalConjectures/ErdosProblems/290.lean
@@ -35,8 +35,8 @@ noncomputable def harmonicDen (a b : ℕ) : ℕ := (∑ n ∈ Finset.Icc a b, (1
 
 /--
 Let $a\geq 1$. Must there exist some $b>a$ such that
-\[\sum_{a\leq n\leq b}\frac{1}{n}=\frac{r_1}{s_1}\textrm{ and }
-\sum_{a\leq n\leq b+1}\frac{1}{n}=\frac{r_2}{s_2},\]
+$$\sum_{a\leq n\leq b}\frac{1}{n}=\frac{r_1}{s_1}\textrm{ and }
+\sum_{a\leq n\leq b+1}\frac{1}{n}=\frac{r_2}{s_2},$$
 with $(r_i,s_i)=1$ and $s_2<s_1$? If so, how does this $b(a)$ grow with $a$?
 
 This was resolved in the affirmative by van Doorn [vD24], who proved $b=b(a)$ always exists, and in

--- a/FormalConjectures/ErdosProblems/34.lean
+++ b/FormalConjectures/ErdosProblems/34.lean
@@ -42,9 +42,9 @@ def consecutiveSums (n : ℕ) (p : Equiv.Perm (Fin n)) : Finset ℕ :=
 
 /--
 For any permutation $\pi\in S_n$ of $\{1,\ldots,n\}$ let $S(\pi)$ count the number of distinct consecutive sums, that is, sums of the shape $\sum_{u\leq i\leq v}\pi(i)$. Is it true that
-\[
+$$
 S(\pi) = o(n^2)
-\]
+$$
 for all $\pi\in S_n$?
 
 Hegyvári [He86] gave a counterexample.

--- a/FormalConjectures/ErdosProblems/363.lean
+++ b/FormalConjectures/ErdosProblems/363.lean
@@ -46,7 +46,7 @@ def IsValidCollection (S : List (Finset ℕ)) : Prop :=
   IsSquare ((S.map (fun I => ∏ m ∈ I, m)).prod)
 
 /--
-Is it true that there are only finitely many collections of disjoint intervals $I_1,\ldots,I_n$ of size $\lvert I_i\rvert \geq 4$ for $1\leq i\leq n$ such that\[\prod_{1\leq i\leq n}\prod_{m\in I_i}m\]is a square?
+Is it true that there are only finitely many collections of disjoint intervals $I_1,\ldots,I_n$ of size $\lvert I_i\rvert \geq 4$ for $1\leq i\leq n$ such that$$\prod_{1\leq i\leq n}\prod_{m\in I_i}m$$is a square?
 
 This is false: Ulas [Ul05] constructed infinitely many such collections.
 -/

--- a/FormalConjectures/ErdosProblems/403.lean
+++ b/FormalConjectures/ErdosProblems/403.lean
@@ -31,12 +31,12 @@ namespace Erdos403
 
 /--
 Does the equation
-\[2^m=a_1!+\cdots+a_k!\]
+$$2^m=a_1!+\cdots+a_k!$$
 with $a_1<a_2<\cdots <a_k$ have only finitely many solutions?
 
 Asked by Burr and Erdős. Frankl and Lin [Li76] independently showed that the answer is yes, and
 the largest solution is
-\[2^7=2!+3!+5!.\]
+$$2^7=2!+3!+5!.$$
 In fact Lin showed that the largest power of $2$ which can divide a sum of distinct factorials
 containing $2$ is $2^{254}$, and that there are only 5 solutions to $3^m=a_1!+\cdots+a_k!$
 (when $m=0,1,2,3,6$).

--- a/FormalConjectures/ErdosProblems/419.lean
+++ b/FormalConjectures/ErdosProblems/419.lean
@@ -42,9 +42,9 @@ def limitPointSet : Set ℝ :=
 
 /--
 If $\tau(n)$ counts the number of divisors of $n$, then what is the set of limit points of
-\[
+$$
 \frac{\tau((n+1)!)}{\tau(n!)}?
-\]
+$$
 
 The limit points are exactly $\{1\} \cup \{1+1/k : k \geq 1\}$.
 -/

--- a/FormalConjectures/ErdosProblems/426.lean
+++ b/FormalConjectures/ErdosProblems/426.lean
@@ -48,12 +48,12 @@ theorem isUniqueSubgraph_bot_bot {V : Type*} : IsUniqueSubgraph (⊥ : SimpleGra
 /--
 We say $H$ is a unique subgraph of $G$ if there is exactly one way to find $H$ as a subgraph
 (not necessarily induced) of $G$. Is there a graph on $n$ vertices with
-\[\gg \frac{2^{\binom{n}{2}}}{n!}\]
+$$\gg \frac{2^{\binom{n}{2}}}{n!}$$
 many distinct unique subgraphs?
 
 Bradač and Christoph [BrCh24] have proved the answer is no: if $f(n)$ is the maximum number of
 unique subgraphs in a graph on $n$ vertices then
-\[f(n) = o\left(\frac{2^{\binom{n}{2}}}{n!}\right).\]
+$$f(n) = o\left(\frac{2^{\binom{n}{2}}}{n!}\right).$$
 
 The $\gg$ below is read as: some constant $c>0$ works for arbitrarily large $n$. The negation
 of the proposition on the right is then exactly $f(n) = o(2^{\binom{n}{2}}/n!)$, the form in

--- a/FormalConjectures/ErdosProblems/453.lean
+++ b/FormalConjectures/ErdosProblems/453.lean
@@ -46,9 +46,9 @@ def EventuallyHasPrimeWitness : Prop :=
 
 /--
 Is it true that, for all sufficiently large $n$, there exists some $i<n$ such that
-\[
+$$
 p_n^2 < p_{n+i}p_{n-i},
-\]
+$$
 where $p_k$ is the $k$th prime?
 
 Pomerance proved that the answer is no.

--- a/FormalConjectures/ErdosProblems/476.lean
+++ b/FormalConjectures/ErdosProblems/476.lean
@@ -34,13 +34,13 @@ namespace Erdos476
 
 /--
 Let $A\subseteq \mathbb{F}_p$. Let
-\[
+$$
 A\hat{+}A = \{ a+b : a\neq b \in A\}.
-\]
+$$
 Is it true that
-\[
+$$
 \lvert A\hat{+}A\rvert \geq \min(2\lvert A\rvert-3,p)?
-\]
+$$
 
 This is the Erdős-Heilbronn inequality, proved by Dias da Silva and Hamidoune.
 -/

--- a/FormalConjectures/ErdosProblems/493.lean
+++ b/FormalConjectures/ErdosProblems/493.lean
@@ -28,7 +28,7 @@ namespace Erdos493
 
 /--
 Does there exist a $k$ such that every sufficiently large integer can be written in the form
-\[\prod_{i=1}^k a_i - \sum_{i=1}^k a_i\]
+$$\prod_{i=1}^k a_i - \sum_{i=1}^k a_i$$
 for some integers $a_i\geq 2$?
 
 Erdős attributes this question to Schinzel. Eli Seamans has observed that the answer is yes (with $k=2$) for a very simple reason: $n = 2(n+2)-(2+(n+2))$. There may well have been some additional constraint in the problem as Schinzel posed it, but [Er61] does not record what this is.

--- a/FormalConjectures/ErdosProblems/512.lean
+++ b/FormalConjectures/ErdosProblems/512.lean
@@ -35,7 +35,7 @@ namespace Erdos512
 
 /--
 Is it true that, if $A\subset \mathbb{Z}$ is a finite set of size $N$, then
-\[\int_0^1 \left\lvert \sum_{n\in A}e(n\theta)\right\rvert \mathrm{d}\theta \gg \log N,\]
+$$\int_0^1 \left\lvert \sum_{n\in A}e(n\theta)\right\rvert \mathrm{d}\theta \gg \log N,$$
 where $e(x)=e^{2\pi ix }$?
 
 Littlewood's conjecture, proved independently by Konyagin [Ko81] and McGehee, Pigno, and

--- a/FormalConjectures/ErdosProblems/519.lean
+++ b/FormalConjectures/ErdosProblems/519.lean
@@ -46,9 +46,9 @@ noncomputable def powerSum {n : ℕ} (z : Fin n → ℂ) (k : ℕ) : ℂ :=
 /--
 Let $z_1,\ldots,z_n\in \mathbb{C}$ with $z_1=1$. Must there exist an absolute constant $c>0$ such
 that
-\[
+$$
 \max_{1\leq k\leq n}\left\lvert \sum_{i}z_i^k\right\rvert>c?
-\]
+$$
 
 Atkinson proved that $c=1/6$ suffices.
 -/

--- a/FormalConjectures/ErdosProblems/532.lean
+++ b/FormalConjectures/ErdosProblems/532.lean
@@ -31,7 +31,7 @@ namespace Erdos532
 
 /--
 If $\mathbb{N}$ is 2-coloured then is there some infinite set $A\subseteq \mathbb{N}$ such that
-all finite subset sums\[ \sum_{n\in S}n\](as $S$ ranges over all non-empty finite subsets of $A$)
+all finite subset sums$$ \sum_{n\in S}n$$(as $S$ ranges over all non-empty finite subsets of $A$)
 are monochromatic?
 
 Asked by Graham and Rothschild. Proved by Hindman [Hi74] (for any number of colours).

--- a/FormalConjectures/ErdosProblems/621.lean
+++ b/FormalConjectures/ErdosProblems/621.lean
@@ -38,7 +38,7 @@ Let $G$ be a graph on $n$ vertices, $\alpha_1(G)$ be the maximum number of edges
 at most one edge from every triangle, and $\tau_1(G)$ be the minimum number of edges that
 contain at least one edge from every triangle.
 
-Is it true that\[\alpha_1(G)+\tau_1(G) \leq \frac{n^2}{4}?\]
+Is it true that$$\alpha_1(G)+\tau_1(G) \leq \frac{n^2}{4}?$$
 
 A problem of Erdős, Gallai, and Tuza [EGT96], who observe that this is probably quite difficult
 since there are different examples where equality hold: the complete graph, the complete
@@ -46,7 +46,7 @@ bipartite graph, and the graph obtained from $K_{m,m}$ by adding one vertex join
 other.
 
 This is true, and was proved by Norin and Sun [NoSu16], who in fact proved
-that\[\alpha_1(G)+\tau_B(G) \leq \frac{n^2}{4},\]where $\tau_B(G)$ is the minimum number of
+that$$\alpha_1(G)+\tau_B(G) \leq \frac{n^2}{4},$$where $\tau_B(G)$ is the minimum number of
 edges that need to be removed to make the graph bipartite.
 
 Here $\alpha_1(G)$ and $\tau_1(G)$ are taken over subsets of the edge set of $G$, and the

--- a/FormalConjectures/ErdosProblems/648.lean
+++ b/FormalConjectures/ErdosProblems/648.lean
@@ -48,12 +48,12 @@ noncomputable def g (n : ℕ) : ℕ :=
 
 /--
 Let $g(n)$ denote the largest $t$ such that there exist integers $2\leq a_1<a_2<\cdots <a_t <n$
-such that \[P(a_1)>P(a_2)>\cdots >P(a_t)\] where $P(m)$ is the greatest prime factor of $m$.
+such that $$P(a_1)>P(a_2)>\cdots >P(a_t)$$ where $P(m)$ is the greatest prime factor of $m$.
 Estimate $g(n)$.
 
-Stijn Cambie has proved [Ca25b] \[g(n) \asymp \left(\frac{n}{\log n}\right)^{1/2}.\]
+Stijn Cambie has proved [Ca25b] $$g(n) \asymp \left(\frac{n}{\log n}\right)^{1/2}.$$
 Cambie further asks whether there exists a constant $c$ such that
-\[g(n) \sim c \left(\frac{n}{\log n}\right)^{1/2}.\]
+$$g(n) \sim c \left(\frac{n}{\log n}\right)^{1/2}.$$
 Cambie's proof shows that such a $c$ must satisfy $2\leq c\leq 2\sqrt{2}$.
 
 The sequence $a_1<a_2<\cdots<a_t$ is packaged as a strictly monotone map `a : Fin t → ℕ`

--- a/FormalConjectures/ErdosProblems/729.lean
+++ b/FormalConjectures/ErdosProblems/729.lean
@@ -29,7 +29,7 @@ namespace Erdos729
 
 /--
 Let $C>0$ be a constant. Are there infinitely many integers $a,b,n$ with $a+b> n+C\log n$ such
-that the denominator of\[\frac{n!}{a!b!}\]contains only primes $\ll_C 1$?
+that the denominator of $$\frac{n!}{a!b!}$$contains only primes $\ll_C 1$?
 
 Erdős [Er68c] proved that if $a!b!\mid n!$ then $a+b\leq n+O(\log n)$. This has been proved in the affirmative by Barreto and Leeham, using ChatGPT and Aristotle, with a modification of the argument used for [728].
 -/

--- a/FormalConjectures/ErdosProblems/904.lean
+++ b/FormalConjectures/ErdosProblems/904.lean
@@ -43,7 +43,7 @@ Let $r\geq 2$ and let $t_r(n)$ be the Turán number (the maximal number of edges
 vertices with no $K_{r+1}$).
 
 If $G$ is a graph with $n$ vertices and $m\geq t_r(n)$ edges there exists a clique on $r$ vertices,
-say $x_1,\ldots,x_r$, such that\[d(x_1)+\cdots+d(x_r)\geq \frac{2rm}{n}.\]
+say $x_1,\ldots,x_r$, such that $$d(x_1)+\cdots+d(x_r)\geq \frac{2rm}{n}.$$
 
 A conjecture of Bollobás and Erdős. This was conjectured in [Er75] only in the special case $r=3$. Edwards [Ed78] proved the conjecture for $2\leq r\leq 8$ (under the additional assumption that $n\geq r^2$). Faudree [Fa92] proved the conjecture for all $r\geq 2$ provided $n>\frac{r-1}{4}r^2$. The full conjecture was proved by Bollobás and Nikiforov [BoNi05].
 -/

--- a/FormalConjectures/Paper/CatchUpConjecture.lean
+++ b/FormalConjectures/Paper/CatchUpConjecture.lean
@@ -171,9 +171,9 @@ noncomputable def value (S : Finset ℕ) : Outcome :=
   valueAux S 0 0 true
 
 /--
-Let \(T_N = \sum_{k=1}^{N} k = \frac{N(N+1)}{2}\).
-If \(T_N\) is even (equivalently \(N \equiv 0 \pmod 4\) or \(N \equiv 3 \pmod 4\)),
-then under optimal play the game `Catch-Up(\(\{1, \ldots, N\}\))` ends in a draw.
+Let $T_N = \sum_{k=1}^{N} k = \frac{N(N+1)}{2}$.
+If $T_N$ is even (equivalently $N \equiv 0 \pmod 4$ or $N \equiv 3 \pmod 4$),
+then under optimal play the game `Catch-Up($\{1, \ldots, N\}$)` ends in a draw.
 -/
 @[category research open, AMS 11 91]
 theorem value_of_even_mul_succ_self_div_two

--- a/FormalConjecturesUtil.lean
+++ b/FormalConjecturesUtil.lean
@@ -24,6 +24,7 @@ public import FormalConjecturesUtil.Linters.CategoryDocstringLinter
 public import FormalConjecturesUtil.Linters.CategoryLinter
 public import FormalConjecturesUtil.Linters.CopyrightLinter
 public import FormalConjecturesUtil.Linters.ExistsImplicationLinter
+public import FormalConjecturesUtil.Linters.LatexDocstringLinter
 public import FormalConjecturesUtil.Linters.ModuleDocstringLinter
 public import FormalConjecturesUtil.Linters.NamespaceLinter
 

--- a/FormalConjecturesUtil/Linters/LatexDocstringLinter.lean
+++ b/FormalConjecturesUtil/Linters/LatexDocstringLinter.lean
@@ -1,0 +1,64 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Lean
+
+/-! # The LaTeX Docstring Linter
+
+The `LatexDocstringLinter` ensures that docstrings use `$ $` or `$$ $$` for math formulas instead of `\[ \]` or `\( \)`.
+-/
+
+public section
+
+open Lean Elab Meta Linter Command Parser
+
+register_option linter.style.latex_docstring : Bool := {
+  defValue := true
+  descr := "enable the LaTeX docstring style linter"
+}
+
+namespace LatexDocstringLinter
+
+def containsLatex (s : String) : Bool :=
+  (s.splitOn "\\[").length > 1 || (s.splitOn "\\]").length > 1 ||
+  (s.splitOn "\\(").length > 1 || (s.splitOn "\\)").length > 1
+
+def getDocstringText (stx : TSyntax ``Command.declModifiers) : String :=
+  let docstring := stx.raw[0]!
+  Syntax.getAtomVal (docstring[0]![1]!)
+
+/-- The linter checking for LaTeX block/inline math in docstrings. -/
+def latexDocstringLinter : Linter where
+  run := withSetOptionIn fun stx => do
+    if stx.getKind == ``Lean.Parser.Command.moduleDoc then
+      let text := Syntax.getAtomVal stx[1]!
+      if containsLatex text then
+        logLintIf linter.style.latex_docstring stx
+          "Docstrings should use `$ $` or `$$ $$` for math formulas instead of `\\[ \\]` or `\\( \\)`."
+      return
+    match stx with
+    | `(command| $mods:declModifiers theorem $name:declId $sig:declSig $val:declVal) =>
+      let text := getDocstringText mods
+      if text != "" && containsLatex text then
+        logLintIf linter.style.latex_docstring name
+          "Docstrings should use `$ $` or `$$ $$` for math formulas instead of `\\[ \\]` or `\\( \\)`."
+    | _ => return
+
+initialize do
+  addLinter latexDocstringLinter
+
+end LatexDocstringLinter

--- a/FormalConjecturesUtil/Linters/LatexDocstringLinterTest.lean
+++ b/FormalConjecturesUtil/Linters/LatexDocstringLinterTest.lean
@@ -1,0 +1,54 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil.Linters.LatexDocstringLinter
+
+/-!
+# Tests for the LaTeX docstring linter
+
+This file contains test cases for the `LatexDocstringLinter`, verifying that
+docstrings with backslash-bracket or backslash-parenthesis are flagged.
+-/
+
+namespace LatexDocstringLinter
+
+
+/--
+warning: Docstrings should use `$ $` or `$$ $$` for math formulas instead of `\[ \]` or `\( \)`.
+
+Note: This linter can be disabled with `set_option linter.style.latex_docstring false`
+-/
+#guard_msgs in
+/-- This is a bad docstring with \[ math \]. -/
+theorem flagged_with_bracket_math : True := by
+  trivial
+
+/--
+warning: Docstrings should use `$ $` or `$$ $$` for math formulas instead of `\[ \]` or `\( \)`.
+
+Note: This linter can be disabled with `set_option linter.style.latex_docstring false`
+-/
+#guard_msgs in
+/-- This is a bad docstring with \( math \). -/
+theorem flagged_with_paren_math : True := by
+  trivial
+
+#guard_msgs in
+/-- This is a good docstring with $$ math $$. -/
+theorem not_flagged_with_good_math : True := by
+  trivial
+
+end LatexDocstringLinter

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -52,6 +52,7 @@ warn.sorry = false
 weak.linter.style.ams_attribute = true
 weak.linter.style.category_attribute = true
 weak.linter.style.moduleDocstring = true
+weak.linter.style.latex_docstring = true
 
 [[lean_lib]]
 name = "FormalConjecturesAnswerPostpone"
@@ -63,6 +64,7 @@ warn.sorry = false
 weak.linter.style.ams_attribute = true
 weak.linter.style.category_attribute = true
 weak.linter.style.moduleDocstring = true
+weak.linter.style.latex_docstring = true
 weak.google.answer = "postpone"
 
 


### PR DESCRIPTION
Follow up to https://github.com/google-deepmind/formal-conjectures/pull/4526#pullrequestreview-4754546590

Adds a linter to check for `\[`, `\]`, `\(`, and `\)` in docstrings.