### PR TITLE
fix(WrittenOnTheWallII/31): correct path definition and source

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean
@@ -19,17 +19,18 @@ import FormalConjecturesUtil
 /-!
 # Written on the Wall II - Conjecture 31
 
-The WOWII page records this as **Chung's theorem**: proved in F. R. K. Chung,
-*The average distance and the independence number*, J. Graph Theory **12** (1988),
-229-235. We state it here as a theorem; the formal proof is left as `sorry`
-pending a Lean port of Chung's argument.
+The WOWII page records this as **Chung's theorem**. This radius bound is proved
+in Section 2 of P. Erdős, M. Saks, and V. T. Sós, *Maximum Induced Trees in
+Graphs*, J. Combin. Theory Ser. B **41** (1986), 61–79; the authors credit
+Fan Chung for the proof. We state it here as a theorem; the formal proof is left
+as `sorry` pending a Lean port of the argument.
 
-Here $\mathrm{path}(G)$ is the floor of the average distance over ordered pairs
-of distinct vertices (definition `path` in `FormalConjecturesForMathlib`), and
-$\mathrm{rad}(G)$ is the graph radius.
+Here $\mathrm{path}(G)$ is the maximum number of vertices in an induced path,
+and $\mathrm{rad}(G)$ is the graph radius.
 
-*Reference:*
-[E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+*References:*
+- [E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+- [P. Erdős, M. Saks, V. T. Sós, Maximum Induced Trees in Graphs](https://doi.org/10.1016/0095-8956(86)90028-6)
 -/
 
 namespace WrittenOnTheWallII.GraphConjecture31
@@ -40,12 +41,12 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
 /--
 WOWII [Conjecture 31](http://cms.uhd.edu/faculty/delavinae/research/wowII/all.html#conj31)
-(Chung 1988):
+(Chung):
 
 For every simple connected graph $G$,
 $\mathrm{path}(G) \ge 2 \cdot \mathrm{rad}(G) - 1$,
-where $\mathrm{path}(G)$ is the floor of the average distance and
-$\mathrm{rad}(G)$ is the graph radius.
+where $\mathrm{path}(G)$ is the maximum number of vertices in an induced path
+and $\mathrm{rad}(G)$ is the graph radius.
 -/
 @[category research solved, AMS 5]
 theorem conjecture31 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :


### PR DESCRIPTION
The module and theorem docstrings describe `path(G)` as the floor of the average
distance and cite Chung's 1988 paper on average distance and independence number.
That prose does not match `SimpleGraph.path`, which is the maximum number of
vertices in an induced path.

Section 2 of Erdős, Saks, and Sós, *Maximum Induced Trees in Graphs*, defines the
same induced-path invariant and proves
`path(G) ≥ 2 * radius(G) - 1`; the authors credit Fan Chung for the proof. This PR
corrects the definition and reference while leaving the theorem signature,
`research solved` classification, and proof placeholder unchanged.

Fixes #4566.

## Validation

- `git diff --check origin/main...HEAD`
- `lake env lean FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean`
- `.pr-gates/wowii31-proof/verify-source.sh ca8e34cae845185b1fc18d3148deaee146ee1ee8 base`
- `.pr-gates/wowii31-proof/verify-source.sh 9c01ba4915bccfe6311ce9aa128ad17b7e2bc728 head`
- `lake exe mk_all --lib FormalConjectures`
- `lake exe cache unpack`
- `lake exe cache get`
- `lake --wfail build`

The paired source audit uses the same documentation, Lean definition, and primary
paper on base and HEAD. The full Lean 4.27.0 warning-as-error build completed all
8,892 jobs against the exact unchanged source hash.

Review history: https://gist.github.com/50519425dfa21ec3a9bd0a30925748a7

## AI assistance disclosure

OpenAI Codex was used to compare the cited source with the Lean definition, prepare
the one-file documentation correction and paired base/HEAD source audit, and run
validation.
