### PR TITLE
Add HasPosLowerDensity; fix 'positive density' misformalization in 424, 822 (#4553)

### DIFF
--- a/FormalConjectures/ErdosProblems/424.lean
+++ b/FormalConjectures/ErdosProblems/424.lean
@@ -50,9 +50,12 @@ def generatedSet : Set ℕ := ⋃ n : ℕ, sequenceSet n
 Let $a_1 = 2$ and $a_2 = 3$ and continue the sequence by appending to $a_1, \ldots, a_n$ all possible
 values of $a_i a_j - 1$ with $i \neq j$.
 Is it true that the set of integers which eventually appear has positive density?
+
+Here "positive density" is read as *positive lower density* (the usual meaning of Erdős'
+informal "positive density"), rather than requiring the density to exist.
 -/
 @[category research open, AMS 11]
-theorem erdos_424 : answer(sorry) ↔ generatedSet.HasPosDensity := by
+theorem erdos_424 : answer(sorry) ↔ generatedSet.HasPosLowerDensity := by
   sorry
 
 -- TODO(firsching): formalize the statements from the additional material

--- a/FormalConjectures/ErdosProblems/822.lean
+++ b/FormalConjectures/ErdosProblems/822.lean
@@ -33,7 +33,7 @@ Does the set of integers of the form $n + \varphi(n)$ have positive (lower) dens
 -/
 @[category research solved, AMS 11]
 theorem erdos_822 :
-    answer(True) ↔ (Set.range fun n => n + Nat.totient n).HasPosDensity := by
+    answer(True) ↔ (Set.range fun n => n + Nat.totient n).HasPosLowerDensity := by
   -- TODO: Replace `sorry` with a formal proof using the results of
   -- Gabdullin–Iudelevich–Luca once an appropriate library interface is available.
   sorry

--- a/FormalConjecturesForMathlib/Data/Set/Density.lean
+++ b/FormalConjecturesForMathlib/Data/Set/Density.lean
@@ -101,6 +101,19 @@ def HasPosDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) : Prop :=
   ∃ α > 0, S.HasDensity α A
 
+/--
+A set `S` in an order `β` where all intervals bounded above are finite is said to have
+positive *lower* density (relative to a set `A`) if its lower density is positive.
+
+This is weaker than `Set.HasPosDensity`, which additionally requires the density to *exist*
+(lower density equals upper density). As Erdős' informal "positive density" most often means
+"positive lower density", this is usually the faithful reading. See
+[erdosproblems.com/424](https://www.erdosproblems.com/424).
+-/
+def HasPosLowerDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
+    (S : Set β) (A : Set β := Set.univ) : Prop :=
+  0 < S.lowerDensity A
+
 open Classical in
 /--
 The two-sided partial natural density of a set of integers, counted inside the interval


### PR DESCRIPTION
Draft, addresses #4553.

Erdős' "positive density" almost always means positive *lower* density: some `c > 0` with `liminf ≥ c`. The current `Set.HasPosDensity` is `∃ α > 0, HasDensity α`, which also requires the density to exist (lower equals upper). That's strictly stronger, so any problem phrased with "positive density" but written against `HasPosDensity` is over-constrained.

This PR adds `Set.HasPosLowerDensity S := 0 < S.lowerDensity` (the `lowerDensity` liminf is already in `Density.lean`) and switches the two files where the reading isn't in doubt:

* **424**, the case from the issue.
* **822**, whose docstring already says "positive (lower) density" while the code used `HasPosDensity`.

Both build.

### The other twelve `HasPosDensity` users

The issue also asks to scan the rest, so here are all 14, with how each reads against its own problem statement.

| # | How the problem reads | Call |
|--:|---|---|
| 424, 822 | positive lower density | switched here |
| 298 | "set of positive density" (a hypothesis; [Bl21] uses positive *upper*) | switch |
| 318 | "a set with positive density" (a witness) | switch |
| 330 | "minimal basis with positive density" | switch |
| 340 | difference set "has positive density" | switch |
| 413 | barrier set "has positive density" | switch |
| 418 | "a positive density set" | switch |
| 470 | weird numbers "have positive density" | switch |
| 125 | asks which of upper/lower/exact density `A+B` can have | keep (about the density existing) |
| 741 | carries an explicit "literal interpretation of positive density" note | keep (author's intent) |
| 859 | exact density `dₜ` with two-sided asymptotics | keep (exact) |
| 968 | "positive *natural* density" | keep, or worth a look |
| 978 | powerfree values, exact density proven in [Ho67] | keep (exact) |

I didn't touch the seven "switch" files here, since reinterpreting someone else's formalizations felt like it wanted a second opinion first. If the calls look right, I'll change them in this PR or a follow-up, whichever you prefer. The five "keep" files read as deliberate exact-density statements.
