### PR TITLE
fix(Other): use integer-valued sequences for Beaver Math Olympiad 8

### DIFF
--- a/FormalConjectures/Other/BeaverMathOlympiad.lean
+++ b/FormalConjectures/Other/BeaverMathOlympiad.lean
@@ -228,7 +228,7 @@ using `answer(sorry) ↔`.
 -/
 @[category research open, AMS 5 11 68]
 theorem beaver_math_olympiad_problem_8 : answer(sorry) ↔
-    ∀ᵉ (a : ℕ → ℕ) (b : ℕ → ℕ)
+    ∀ᵉ (a : ℕ → ℤ) (b : ℕ → ℤ)
     (a_ini : a 0 = 10)
     (a_rec : ∀ n, a (n + 1) =
       if b n / 2 < a n then a n - b n / 2 - 3 else 3 * a n + 5)


### PR DESCRIPTION
## Summary

Corrects the formalization of Beaver Math Olympiad Problem 8 by changing the value type of the sequences `a` and `b` from `ℕ` to `ℤ`.

The original problem permits negative sequence values, so natural-number subtraction incorrectly truncates at zero. The original two-branch recurrence is otherwise unchanged.

Fixes #4591.