### PR TITLE
Formalize Pardon's three-dimensional Hilbert–Smith theorem

### DIFF
--- a/FormalConjectures/HilbertProblems/5.lean
+++ b/FormalConjectures/HilbertProblems/5.lean
@@ -28,7 +28,8 @@ connected finite-dimensional topological manifold.
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Hilbert%E2%80%93Smith_conjecture)
 - [Tao's blog](https://terrytao.wordpress.com/2011/08/13/the-hilbert-smith-conjecture/)
-- [Pardon 2013, arXiv:1112.2324](https://arxiv.org/abs/1112.2324)
+- [Pardon, *The Hilbert–Smith conjecture for three-manifolds*, JAMS 26 (2013)]
+  (https://www.ams.org/journals/jams/2013-26-03/S0894-0347-2013-00766-3/)
 - [arXiv:math/0103145](https://arxiv.org/abs/math/0103145)
 -/
 
@@ -84,7 +85,8 @@ theorem hilbert_smith_conjecture.variants.riemannian
   sorry
 
 /-- Pardon (2013): the Hilbert–Smith conjecture holds for 3-dimensional manifolds.
-See [arXiv:1112.2324](https://arxiv.org/abs/1112.2324). -/
+See [Pardon, Theorem 1.5]
+(https://www.ams.org/journals/jams/2013-26-03/S0894-0347-2013-00766-3/). -/
 @[category research solved, AMS 22 57 58]
 theorem hilbert_smith_conjecture.variants.dimension_three {X : Type*}
     [TopologicalSpace X] [T2Space X] [ConnectedSpace X]
@@ -92,6 +94,17 @@ theorem hilbert_smith_conjecture.variants.dimension_three {X : Type*}
     [IsTopologicalGroup G] [LocallyCompactSpace G]
     [MulAction G X] [ContinuousSMul G X] [FaithfulSMul G X] :
     AdmitsLieGroupStructure G := by
+  sorry
+
+/-- Pardon (2013), Theorem 1.5: the $p$-adic integers cannot act continuously and faithfully
+on a connected 3-manifold. -/
+@[category research solved, AMS 20 22 54 57]
+theorem hilbert_smith_padic_formulation.variants.dimension_three (p : ℕ) [Fact p.Prime]
+    {X : Type*} [TopologicalSpace X] [T2Space X] [ConnectedSpace X]
+    [ChartedSpace (EuclideanSpace ℝ (Fin 3)) X]
+    [AddAction (PadicInt p) X] [ContinuousVAdd (PadicInt p) X]
+    [FaithfulVAdd (PadicInt p) X] :
+    False := by
   sorry
 
 /-- Equivalent p-adic formulation: the p-adic integers `ℤ_[p]` cannot act continuously and


### PR DESCRIPTION
## Summary

- Add the exact p-adic formulation of Pardon’s Theorem 1.5: the p-adic integers admit no continuous faithful action on a connected 3-manifold.
- Classify the statement as a solved research result with the relevant AMS subjects.
- Cite the published JAMS article directly in the module references and theorem documentation.

This PR contains no changes to the general Hilbert-fifth or Hilbert–Smith formulations; those are handled separately in draft PR #4595.

## Validation

- lake --wfail build