### PR TITLE
Disprove Green31 Sidon and Erdos128 literal statements

### DIFF
--- a/FormalConjectures/ErdosProblems/128.lean
+++ b/FormalConjectures/ErdosProblems/128.lean
@@ -29,10 +29,14 @@ namespace Erdos128
 /--
 Let G be a graph with n vertices such that every subgraph on ≥ $n/2$
 vertices has more than $n^2/50$ edges. Must G contain a triangle?
+
+The literal formal statement below is false: `K₂`, with `V'` equal to the full
+vertex set, satisfies the displayed premises but is triangle-free.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at
+  "https://github.com/Kuberwastaken/formal-conjectures-counterexamples/blob/d2af9fe927ef93d6402f4f7dbb3943898a255047/lean/Erdos128Check.lean#L20-L45"]
 theorem erdos_128 :
-    answer(sorry) ↔ ∀ (V : Type) [Fintype V] (G : SimpleGraph V) (V' : Set V),
+    answer(False) ↔ ∀ (V : Type) [Fintype V] (G : SimpleGraph V) (V' : Set V),
       2 * V'.ncard + 1 ≥ Fintype.card V →
         50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2 → ¬ G.CliqueFree 3 := by
   sorry

--- a/FormalConjectures/GreensOpenProblems/31.lean
+++ b/FormalConjectures/GreensOpenProblems/31.lean
@@ -134,9 +134,14 @@ theorem green_31.variants.abelian : answer(sorry) ↔
 /--
 Another very nice old problem is whether there is a Sidon subset of $\{0, 1\}^n$ of size $N^{0.51}$,
 where $N = 2^n$ [Gr24].
+
+For the literal `IsSidon` predicate below, this is false: diagonal pairs are
+included, so in exponent two the equality `x + x = y + y` forces every Sidon
+finset to have at most one element.
 -/
-@[category research open, AMS 5 11]
-theorem green_31.variants.sidon_01n : answer(sorry) ↔
+@[category research solved, AMS 5 11, formal_proof using lean4 at
+  "https://github.com/Kuberwastaken/formal-conjectures-counterexamples/blob/d2af9fe927ef93d6402f4f7dbb3943898a255047/lean/Green31F2SidonCheck.lean#L44-L61"]
+theorem green_31.variants.sidon_01n : answer(False) ↔
     ∃ S : (n : ℕ) → Finset (𝔽₂ n),
       (∀ n, IsSidon (S n : Set (𝔽₂ n))) ∧
       ∀ᶠ n in atTop, ((2 : ℝ) ^ n) ^ (0.51 : ℝ) ≤ (S n).card := by


### PR DESCRIPTION
This PR marks two literal formal statements as false.

1. `Green31.green_31.variants.sidon_01n`

The formal predicate `IsSidon` includes diagonal pairs. In `𝔽₂ n`, every diagonal sum is zero, so `x + x = y + y` forces any literal Sidon finset to have at most one element. Therefore the claimed eventual lower bound by `((2 : ℝ) ^ n) ^ 0.51` is false.

External Lean proof artifact:
https://github.com/Kuberwastaken/formal-conjectures-counterexamples/blob/d2af9fe927ef93d6402f4f7dbb3943898a255047/lean/Green31F2SidonCheck.lean#L44-L61

2. `Erdos128.erdos_128`

The literal formal statement has the triangle conclusion inside the implication for each single dense majority subset. `K₂`, with `Vprime` equal to the full vertex set, satisfies the displayed premises but is triangle-free.

External Lean proof artifact:
https://github.com/Kuberwastaken/formal-conjectures-counterexamples/blob/d2af9fe927ef93d6402f4f7dbb3943898a255047/lean/Erdos128Check.lean#L20-L45

Related: #4501 already identifies this Erdős 128 formalization issue and proposes a corrected intended statement. This PR records the current literal statement as false.

Scope: these are corrections to the current literal formal statements, not claims about the intended informal conjectures.
