### PR TITLE
fix(ErdosProblems/128): quantify all dense induced subgraphs

### DIFF
--- a/FormalConjectures/ErdosProblems/128.lean
+++ b/FormalConjectures/ErdosProblems/128.lean
@@ -32,9 +32,10 @@ vertices has more than $n^2/50$ edges. Must G contain a triangle?
 -/
 @[category research open, AMS 5]
 theorem erdos_128 :
-    answer(sorry) ↔ ∀ (V : Type) [Fintype V] (G : SimpleGraph V) (V' : Set V),
-      2 * V'.ncard + 1 ≥ Fintype.card V →
-        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2 → ¬ G.CliqueFree 3 := by
+    answer(sorry) ↔ ∀ (V : Type) [Fintype V] (G : SimpleGraph V),
+      (∀ V' : Set V, 2 * V'.ncard + 1 ≥ Fintype.card V →
+        50 * (G.induce V').edgeSet.ncard > Fintype.card V ^ 2) →
+      ¬ G.CliqueFree 3 := by
   sorry
 
 end Erdos128


### PR DESCRIPTION
The two changes from #4604 are split as requested. This PR fixes only the Erdős 128 quantifier placement.

The source assumes the density bound for every sufficiently large induced subgraph. The existing statement instead quantifies one subset outside the implication, so a single dense subset can trigger the triangle conclusion. This moves `V′` into the antecedent and leaves the problem open.

Validation:
- `git diff --check`

Split from and supersedes the Erdős 128 portion of #4604.
