### PR TITLE
fix(Kourovka/19.25): add missing same-order hypothesis

### DIFF
--- a/FormalConjectures/Kourovka/19_25.lean
+++ b/FormalConjectures/Kourovka/19_25.lean
@@ -37,6 +37,7 @@ $H$ necessarily simple?
 @[category research open, AMS 20]
 theorem kourovka.«19.25» : answer(sorry) ↔
     ∀ (G H : Type) [Group G] [Group H] [Fintype G] [Fintype H],
+       Fintype.card G = Fintype.card H →
        ∑ g : G, φ (orderOf g) = ∑ h : H, φ (orderOf h) →
        IsSimpleGroup G → IsSimpleGroup H := by
   sorry


### PR DESCRIPTION
The docstring of `kourovka.«19.25»` states that $G$ and $H$ are finite groups **of the same order**, matching the original Kourovka Notebook problem 19.25 (Curtin–Pourgholi), but the formal statement omitted the hypothesis `Fintype.card G = Fintype.card H`.

Without it, the quantified statement is provably false rather than open. Counterexample: take $G = C_{193}$ and $H = C_{297}$. For a cyclic group $C_n$ we have $\sum_{x} \varphi(\mathrm{ord}(x)) = \sum_{d \mid n} \varphi(d)^2$, and

$$S(C_{193}) = 1^2 + 192^2 = 36{,}865 = 1^2+2^2+6^2+10^2+18^2+20^2+60^2+180^2 = S(C_{297}).$$

$C_{193}$ is simple (prime order), while $C_{297}$ is abelian of composite order and hence not simple. So the hypotheses held but the conclusion failed. Adding the same-order hypothesis restores faithfulness to the stated problem, which remains open.

Fixes #4608.

Original formalization: #1923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
