### PR TITLE
feat(Paper/MonochromaticQuantumGraph): solve eqSystem6_no_solution_d3

### DIFF
--- a/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
+++ b/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
@@ -400,10 +400,15 @@ theorem eqSystem4_no_solution_ge4 :
   sorry
 
 /-- For $N = 6$ and $D = 3$, does there exist no solution to the monochromatic quantum graph
-equation system over $\mathbb{C}$? -/
-@[category research open, AMS 5 14 81]
+equation system over $\mathbb{C}$?
+
+A complete Lean 4 proof is available in the linked external certificate repository.
+-/
+@[category research solved, AMS 5 14 81,
+  formal_proof using lean4 at
+    "https://github.com/algal/krenn-gu-6x3-certificate/blob/c04696e515e0c02be140353fb52ea60c62e827b1/KrennGuCertificate/Unrestricted.lean#L201-L222"]
 theorem eqSystem6_no_solution_d3 :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 6 3 ℂ, EqSystemN 6 3 W := by
   sorry
 


### PR DESCRIPTION
Closes #4609.

## Summary

This marks `MonochromaticQuantumGraph.eqSystem6_no_solution_d3` as solved:

- changes `category research open` to `category research solved`;
- replaces `answer(sorry)` with `answer(True)`;
- adds a commit-pinned `formal_proof using lean4` link to the external proof.

The proof is intentionally kept in its external repository because it is substantially longer than the 25–50 line limit described in `CONTRIBUTING.md`:

https://github.com/algal/krenn-gu-6x3-certificate/blob/c04696e515e0c02be140353fb52ea60c62e827b1/KrennGuCertificate/Unrestricted.lean#L201-L222

The external theorem has exactly the proposition on the right-hand side of this benchmark:

```lean
¬ ∃ W : MonochromaticQuantumGraph.WeightsN 6 3 ℂ,
    MonochromaticQuantumGraph.EqSystemN 6 3 W
```

## Verification

For this status PR:

- `lake exe cache get`
- `lake --wfail build` — passed all 8,892 jobs
- `git diff --check`
- proof URL checked successfully

For the pinned external proof release, a clean GitHub clone passed:

- all 50 committed artifact checksums;
- all 8,421 Lean build jobs;
- exact theorem-type checking;
- the final axiom audit.

The reported axiom closure is:

```text
[propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]
```

There is no `sorryAx` or custom axiom in the external proof. `Lean.ofReduceBool` and `Lean.trustCompiler` arise from `native_decide` and are documented in the proof repository trust boundary.

## AI-use disclosure

The proof and this registration contribution were developed collaboratively with OpenAI Codex. The correctness claim rests on the committed Lean verification and reproducible certificate checks, not on model-generated prose.