### PR TITLE
feat(Arxiv/1609.08688): prove the n² upper bound for 2-increasing sequences

### DIFF
--- a/FormalConjectures/Arxiv/1609.08688/sIncreasingrTuples.lean
+++ b/FormalConjectures/Arxiv/1609.08688/sIncreasingrTuples.lean
@@ -178,10 +178,37 @@ lemma exists_pair_of_mem_Icc {s : List (Fin 3 → ℕ)} {n : ℕ} (_hn : 2 ≤ n
     Finset.exists_ne_map_eq_of_card_lt_of_maps_to ht_card hf
   exact ⟨i, j, hij, congrArg Prod.fst hfij, congrArg Prod.snd hfij⟩
 
-/-- For all $n$ we have $F(n) \leq n^2$. -/
+/--
+For all $n$ we have $F(n) \leq n^2$.
+
+This is the upper bound in [GoLo21, Proposition 1.4], proved by applying the
+pigeonhole principle to the first two coordinates.
+-/
 @[category research solved, AMS 5]
 theorem maximalLength_le (n : ℕ) : F n ≤ n ^ 2 := by
-  sorry
+  by_cases hn : 2 ≤ n
+  · rw [maximalLength]
+    refine csSup_le ?_ ?_
+    · exact ⟨0, ⟨[], by simp, isIncreasing₂_nil, rfl⟩⟩
+    · intro _ hm
+      rcases hm with ⟨s, hs_range, hs_inc, rfl⟩
+      by_contra hle
+      have hs_length : n ^ 2 < s.length := Nat.lt_of_not_ge hle
+      obtain ⟨i, j, hij, h0, h1⟩ :=
+        exists_pair_of_mem_Icc hn hs_range hs_length
+      have hp : s.Pairwise lt₂ := hs_inc
+      rcases lt_or_gt_of_ne hij with hij | hji
+      · exact (not_lt₂_of_exists 0 1 zero_ne_one h0.ge h1.ge)
+          (List.pairwise_iff_get.1 hp i j hij)
+      · exact (not_lt₂_of_exists 0 1 zero_ne_one h0.le h1.le)
+          (List.pairwise_iff_get.1 hp j i hji)
+  · cases n with
+    | zero => simp [maximalLength_zero]
+    | succ n =>
+      cases n with
+      | zero => simp [maximalLength_one]
+      | succ n =>
+        exact (hn (Nat.succ_le_succ (Nat.succ_le_succ (Nat.zero_le _)))).elim
 
 /-- Moreover, whenever $n$ is a perfect square we have $F(n) \geq n^{3/2}$. -/
 @[category research solved, AMS 5]


### PR DESCRIPTION
Closes #4615.

Replaces `maximalLength_le`'s `sorry` with a Lean proof of
`maximalLength n ≤ n ^ 2`.

The argument formalizes the pigeonhole proof from Gowers–Long,
Proposition 1.4: two triples among more than `n²` have the same first two
coordinates and therefore cannot be 2-less.

Tested with Lean 4.27.0 on the target module.

AI assistance: the mathematical verification, Lean formalization, and
submission preparation used OpenAI ChatGPT 5.6 Sol.
