### PR TITLE
feat(ErdosProblems/1064): prove erdos_1064.variants.k2

### DIFF
--- a/FormalConjectures/ErdosProblems/1064.lean
+++ b/FormalConjectures/ErdosProblems/1064.lean
@@ -36,24 +36,6 @@ os concerning the arithmetical functions {$\phi$} and
 theorem erdos_1064 : {n | φ n > φ (n - φ n)}.HasDensity 1 := by
   sorry
 
-/-- For the family `n = 30 * 2 ^ k = 2 ^ (k + 1) * 15`, `φ n = 8 * 2 ^ k`. -/
-private lemma phi_family (k : ℕ) : Nat.totient (30 * 2 ^ k) = 8 * 2 ^ k := by
-  have h1 : 30 * 2 ^ k = 2 ^ (k + 1) * 15 := by ring
-  rw [h1, Nat.totient_mul (by norm_num), Nat.totient_prime_pow Nat.prime_two (by omega),
-    show Nat.totient 15 = 8 from rfl, Nat.add_sub_cancel]
-  ring
-
-/-- For the family `n = 30 * 2 ^ k`, `n - φ n = 22 * 2 ^ k = 2 ^ (k + 1) * 11`. -/
-private lemma sub_family (k : ℕ) : 30 * 2 ^ k - Nat.totient (30 * 2 ^ k) = 22 * 2 ^ k := by
-  rw [phi_family]; omega
-
-/-- `φ (22 * 2 ^ k) = 10 * 2 ^ k`. -/
-private lemma phi_sub_family (k : ℕ) : Nat.totient (22 * 2 ^ k) = 10 * 2 ^ k := by
-  rw [show 22 * 2 ^ k = 2 ^ (k + 1) * 11 by ring, Nat.totient_mul (by norm_num),
-    Nat.totient_prime_pow (by norm_num) (by omega), show Nat.totient 11 = 10 from rfl,
-    Nat.add_sub_cancel]
-  ring
-
 /--
 Let $ϕ(n)$ be the Euler's totient function, there exist infinitely many $n$
 such that $ϕ(n)< ϕ(n - ϕ(n))$
@@ -69,7 +51,21 @@ theorem erdos_1064.variants.k2 : {n | φ n < φ (n - φ n)}.Infinite := by
     exact Nat.pow_right_injective (le_refl 2) this
   · intro k
     simp only [Set.mem_setOf_eq]
-    rw [sub_family, phi_family, phi_sub_family]
+    have hφ : Nat.totient (30 * 2 ^ k) = 8 * 2 ^ k := by
+      have h : 30 * 2 ^ k = 2 ^ (k + 1) * 15 := by ring
+      rw [h, Nat.totient_mul (by norm_num),
+        Nat.totient_prime_pow Nat.prime_two (by omega),
+        show Nat.totient 15 = 8 from rfl, Nat.add_sub_cancel]
+      ring
+    have hsub : 30 * 2 ^ k - Nat.totient (30 * 2 ^ k) = 22 * 2 ^ k := by
+      rw [hφ]
+      omega
+    have hφsub : Nat.totient (22 * 2 ^ k) = 10 * 2 ^ k := by
+      rw [show 22 * 2 ^ k = 2 ^ (k + 1) * 11 by ring,
+        Nat.totient_mul (by norm_num), Nat.totient_prime_pow (by norm_num) (by omega),
+        show Nat.totient 11 = 10 from rfl, Nat.add_sub_cancel]
+      ring
+    rw [hsub, hφ, hφsub]
     have : (0 : ℕ) < 2 ^ k := pow_pos (by norm_num) k
     omega
 

--- a/FormalConjectures/ErdosProblems/1064.lean
+++ b/FormalConjectures/ErdosProblems/1064.lean
@@ -36,6 +36,24 @@ os concerning the arithmetical functions {$\phi$} and
 theorem erdos_1064 : {n | φ n > φ (n - φ n)}.HasDensity 1 := by
   sorry
 
+/-- For the family `n = 30 * 2 ^ k = 2 ^ (k + 1) * 15`, `φ n = 8 * 2 ^ k`. -/
+private lemma phi_family (k : ℕ) : Nat.totient (30 * 2 ^ k) = 8 * 2 ^ k := by
+  have h1 : 30 * 2 ^ k = 2 ^ (k + 1) * 15 := by ring
+  rw [h1, Nat.totient_mul (by norm_num), Nat.totient_prime_pow Nat.prime_two (by omega),
+    show Nat.totient 15 = 8 from rfl, Nat.add_sub_cancel]
+  ring
+
+/-- For the family `n = 30 * 2 ^ k`, `n - φ n = 22 * 2 ^ k = 2 ^ (k + 1) * 11`. -/
+private lemma sub_family (k : ℕ) : 30 * 2 ^ k - Nat.totient (30 * 2 ^ k) = 22 * 2 ^ k := by
+  rw [phi_family]; omega
+
+/-- `φ (22 * 2 ^ k) = 10 * 2 ^ k`. -/
+private lemma phi_sub_family (k : ℕ) : Nat.totient (22 * 2 ^ k) = 10 * 2 ^ k := by
+  rw [show 22 * 2 ^ k = 2 ^ (k + 1) * 11 by ring, Nat.totient_mul (by norm_num),
+    Nat.totient_prime_pow (by norm_num) (by omega), show Nat.totient 11 = 10 from rfl,
+    Nat.add_sub_cancel]
+  ring
+
 /--
 Let $ϕ(n)$ be the Euler's totient function, there exist infinitely many $n$
 such that $ϕ(n)< ϕ(n - ϕ(n))$
@@ -44,7 +62,16 @@ Reference: [GLW01] Grytczuk, A. and Luca, F. and W\'ojtowicz, M., A conjecture o
 -/
 @[category research solved, AMS 11]
 theorem erdos_1064.variants.k2 : {n | φ n < φ (n - φ n)}.Infinite := by
-  sorry
+  apply Set.infinite_of_injective_forall_mem (f := fun k : ℕ => 30 * 2 ^ k)
+  · intro a b hab
+    simp only at hab
+    have : (2 : ℕ) ^ a = 2 ^ b := by omega
+    exact Nat.pow_right_injective (le_refl 2) this
+  · intro k
+    simp only [Set.mem_setOf_eq]
+    rw [sub_family, phi_family, phi_sub_family]
+    have : (0 : ℕ) < 2 ^ k := pow_pos (by norm_num) k
+    omega
 
 open Asymptotics Filter
 


### PR DESCRIPTION
This PR proves `erdos_1064.variants.k2` in `ErdosProblems/1064.lean`, which was still `sorry`: there are infinitely many `n` with `φ(n) < φ(n - φ(n))` (Grytczuk-Luca-Wójtowicz).

I use the explicit family `n = 30 * 2^k = 2^(k+1) * 15`. For every `k`, `φ(n) = 8·2^k` (since `2^(k+1)` and `15` are coprime and `φ(15) = 8`), then `n - φ(n) = 22·2^k = 2^(k+1)·11`, and `φ(22·2^k) = 10·2^k` (since `φ(11) = 10`), so `φ(n) = 8·2^k < 10·2^k = φ(n - φ(n))`. The map `k ↦ 30·2^k` is injective, so the set is infinite via `Set.infinite_of_injective_forall_mem`. Three small private lemmas do the totient arithmetic; the only real step is `Nat.totient_prime_pow` on the power of two.

`#print axioms erdos_1064.variants.k2` gives `[propext, Classical.choice, Quot.sound]`, so no `sorry`, no `native_decide`, no new axioms. I left the other two theorems in the file untouched. The k2 variant was still `sorry` on main, and the earlier PRs #3312, #2796 and #2501 were closed because they used the "formally solved elsewhere" placeholder instead of an actual proof; this one is a real, kernel-checked proof.

AI disclosure (per the contribution guidelines): the proof was generated by my autonomous pipeline (UNICO/NOUS), which uses Claude Fable 5, Claude Opus 4.8 and GPT-5.6-Sol, iterating against the Lean compiler under my direction. It should be considered LLM-generated; I understand and can justify each step.
