### PR TITLE
GreensOpenProblems/14: prove W(3,3) = 9 and W(3,4) = 18

### DIFF
--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -389,6 +389,1254 @@ private lemma not_mem_of_le {k r n N : ℕ} (hle : n ≤ N)
       rw [this]
       simpa [c] using hcol y hy
 
+--
+-- Helpers for the exact evaluation $W(3,4)=18$ and $W(3,5)=22$.
+--
+
+@[reducible]
+private def hasRed3 (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) : Prop :=
+  ∃ a ∈ Finset.Icc (1 : ℕ) N, ∃ d ∈ Finset.Icc (1 : ℕ) N,
+    0 < d ∧ a + 2 * d ∈ Finset.Icc (1 : ℕ) N ∧ a + d ∈ Finset.Icc (1 : ℕ) N ∧
+    colorOf N c a = 0 ∧ colorOf N c (a + d) = 0 ∧ colorOf N c (a + 2 * d) = 0
+
+@[reducible]
+private def hasBlue4 (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) : Prop :=
+  ∃ a ∈ Finset.Icc (1 : ℕ) N, ∃ d ∈ Finset.Icc (1 : ℕ) N,
+    0 < d ∧ a + 3 * d ∈ Finset.Icc (1 : ℕ) N ∧ a + d ∈ Finset.Icc (1 : ℕ) N ∧
+    a + 2 * d ∈ Finset.Icc (1 : ℕ) N ∧
+    colorOf N c a = 1 ∧ colorOf N c (a + d) = 1 ∧ colorOf N c (a + 2 * d) = 1 ∧ colorOf N c (a + 3 * d) = 1
+
+@[category test, AMS 5 11]
+private lemma isAP_four (a d : ℕ) (hd : 0 < d) :
+    ({a, a + d, a + 2 * d, a + 3 * d} : Set ℕ).IsAPOfLength 4 := by
+  refine ⟨a, d, ?_, ?_⟩
+  · haveI : Fintype ↑({a, a + d, a + 2 * d, a + 3 * d} : Set ℕ) := inferInstance
+    rw [ENat.card_eq_coe_fintype_card]
+    norm_cast
+    rw [← Set.toFinset_card]
+    have htf : ({a, a + d, a + 2 * d, a + 3 * d} : Set ℕ).toFinset = {a, a + d, a + 2 * d, a + 3 * d} := by
+      ext x; simp
+    rw [htf, Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
+    · simp; omega
+    · simp; omega
+    · simp; omega
+  · ext x
+    simp
+    constructor
+    · rintro (rfl | rfl | rfl | rfl)
+      · exact ⟨0, by norm_num, by simp⟩
+      · exact ⟨1, by norm_num, by simp⟩
+      · exact ⟨2, by norm_num, by simp⟩
+      · exact ⟨3, by norm_num, by simp⟩
+    · rintro ⟨n, hn, rfl⟩
+      have : n < 4 := by exact_mod_cast hn
+      interval_cases n <;> simp
+
+@[category test, AMS 5 11]
+private lemma hasRed3_imp (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (h : hasRed3 N c) :
+    (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 0) := by
+  obtain ⟨a, ha, d, hd_mem, hpos, hsum, had, hcola, hcolad, hcolasum⟩ := h
+  have haS : a ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp ha)
+  have hadS : a + d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp had)
+  have hsumS : a + 2 * d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp hsum)
+  let x0 : Icc 1 N := ⟨a, haS⟩
+  let x1 : Icc 1 N := ⟨a + d, hadS⟩
+  let x2 : Icc 1 N := ⟨a + 2 * d, hsumS⟩
+  let s : Finset (Icc 1 N) := {x0, x1, x2}
+  have hset : ({(s' : ℕ) | s' ∈ s} : Set ℕ) = {a, a + d, a + 2 * d} := by
+    ext n
+    constructor
+    · intro hn
+      simp only [s, mem_setOf_eq] at hn
+      obtain ⟨s', hs', rfl⟩ := hn
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hs'
+      rcases hs' with rfl | rfl | rfl <;> simp [x0, x1, x2]
+    · intro hn
+      simp only [mem_insert_iff, mem_singleton_iff] at hn
+      simp only [s, mem_setOf_eq]
+      rcases hn with rfl | rfl | rfl
+      · exact ⟨x0, by simp [x0], rfl⟩
+      · exact ⟨x1, by simp [x0, x1], rfl⟩
+      · exact ⟨x2, by simp [x0, x1, x2], rfl⟩
+  have hAP : ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 := by
+    rw [hset]; exact isAP_three a d hpos
+  refine ⟨s, hAP, ?_⟩
+  intro x hx
+  simp only [s, Finset.mem_insert, Finset.mem_singleton] at hx
+  rcases hx with rfl | rfl | rfl
+  · simpa [x0, colorOf_eq N c ha] using hcola
+  · simpa [x1, colorOf_eq N c had] using hcolad
+  · simpa [x2, colorOf_eq N c hsum] using hcolasum
+
+@[category test, AMS 5 11]
+private lemma hasBlue4_imp (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (h : hasBlue4 N c) :
+    (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 4 ∧ ∀ x ∈ s, c x = 1) := by
+  obtain ⟨a, ha, d, hd_mem, hpos, hsum, had, had2, hcola, hcolad, hcolad2, hcolasum⟩ := h
+  have haS : a ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp ha)
+  have hadS : a + d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp had)
+  have had2S : a + 2 * d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp had2)
+  have hsumS : a + 3 * d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp hsum)
+  let x0 : Icc 1 N := ⟨a, haS⟩
+  let x1 : Icc 1 N := ⟨a + d, hadS⟩
+  let x2 : Icc 1 N := ⟨a + 2 * d, had2S⟩
+  let x3 : Icc 1 N := ⟨a + 3 * d, hsumS⟩
+  let s : Finset (Icc 1 N) := {x0, x1, x2, x3}
+  have hset : ({(s' : ℕ) | s' ∈ s} : Set ℕ) = {a, a + d, a + 2 * d, a + 3 * d} := by
+    ext n
+    constructor
+    · intro hn
+      simp only [s, mem_setOf_eq] at hn
+      obtain ⟨s', hs', rfl⟩ := hn
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hs'
+      rcases hs' with rfl | rfl | rfl | rfl <;> simp [x0, x1, x2, x3]
+    · intro hn
+      simp only [mem_insert_iff, mem_singleton_iff] at hn
+      simp only [s, mem_setOf_eq]
+      rcases hn with rfl | rfl | rfl | rfl
+      · exact ⟨x0, by simp [x0], rfl⟩
+      · exact ⟨x1, by simp [x0, x1], rfl⟩
+      · exact ⟨x2, by simp [x0, x1, x2], rfl⟩
+      · exact ⟨x3, by simp [x0, x1, x2, x3], rfl⟩
+  have hAP : ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 4 := by
+    rw [hset]; exact isAP_four a d hpos
+  refine ⟨s, hAP, ?_⟩
+  intro x hx
+  simp only [s, Finset.mem_insert, Finset.mem_singleton] at hx
+  rcases hx with rfl | rfl | rfl | rfl
+  · simpa [x0, colorOf_eq N c ha] using hcola
+  · simpa [x1, colorOf_eq N c had] using hcolad
+  · simpa [x2, colorOf_eq N c had2] using hcolad2
+  · simpa [x3, colorOf_eq N c hsum] using hcolasum
+
+@[category test, AMS 5 11]
+private lemma imp_hasRed3 (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2)
+    (h : (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 0)) :
+    hasRed3 N c := by
+  obtain ⟨s, hAP, hcol⟩ := h
+  obtain ⟨a, d, hcard, heq⟩ := hAP
+  have mem0 : a ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨0, by norm_num, by simp⟩
+  have mem1 : a + d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨1, by norm_num, by simp⟩
+  have mem2 : a + 2 * d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨2, by norm_num, by simp⟩
+  have hd : 0 < d := by
+    by_contra hdz
+    push_neg at hdz
+    have hd0 : d = 0 := by omega
+    subst hd0
+    have hsing : ({(s' : ℕ) | s' ∈ s} : Set ℕ) = ({a} : Set ℕ) := by
+      rw [heq]
+      ext x
+      simp
+      constructor
+      · rintro ⟨hn, hx⟩; exact hx.symm
+      · rintro rfl; exact ⟨⟨0, by omega⟩, rfl⟩
+    have h1 : ENat.card ({a} : Set ℕ) = 1 := by
+      rw [ENat.card_eq_coe_fintype_card]
+      norm_cast
+    rw [hsing, h1] at hcard
+    norm_num at hcard
+  have get_mem {m : ℕ} (hm : m ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ)) : m ∈ Finset.Icc (1 : ℕ) N := by
+    obtain ⟨x, hx, rfl⟩ := hm
+    have hx1 : (1 : ℕ) ≤ (x : ℕ) := (Set.mem_Icc.mp x.property).1
+    have hx2 : (x : ℕ) ≤ N := (Set.mem_Icc.mp x.property).2
+    exact Finset.mem_Icc.mpr ⟨hx1, hx2⟩
+  have ha := get_mem mem0
+  have had := get_mem mem1
+  have hsum := get_mem mem2
+  have hd_mem : d ∈ Finset.Icc (1 : ℕ) N := by
+    have hsum' := Finset.mem_Icc.mp hsum
+    have ha' := Finset.mem_Icc.mp ha
+    simp only [Finset.mem_Icc]
+    constructor <;> omega
+  have col_eq {m : ℕ} (hm_set : m ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ)) (hm : m ∈ Finset.Icc (1 : ℕ) N) :
+      colorOf N c m = 0 := by
+    obtain ⟨x, hx, hxe⟩ := hm_set
+    have hxe' : x = ⟨m, mem_Icc.mpr (Finset.mem_Icc.mp hm)⟩ := Subtype.ext hxe
+    rw [colorOf_eq N c hm, ← hxe', hcol x hx]
+  refine ⟨a, ha, d, hd_mem, hd, hsum, had, col_eq mem0 ha, col_eq mem1 had, col_eq mem2 hsum⟩
+
+@[category test, AMS 5 11]
+private lemma imp_hasBlue4 (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2)
+    (h : (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 4 ∧ ∀ x ∈ s, c x = 1)) :
+    hasBlue4 N c := by
+  obtain ⟨s, hAP, hcol⟩ := h
+  obtain ⟨a, d, hcard, heq⟩ := hAP
+  have mem0 : a ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨0, by norm_num, by simp⟩
+  have mem1 : a + d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨1, by norm_num, by simp⟩
+  have mem2 : a + 2 * d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨2, by norm_num, by simp⟩
+  have mem3 : a + 3 * d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+    rw [heq]; exact ⟨3, by norm_num, by simp⟩
+  have hd : 0 < d := by
+    by_contra hdz
+    push_neg at hdz
+    have hd0 : d = 0 := by omega
+    subst hd0
+    have hsing : ({(s' : ℕ) | s' ∈ s} : Set ℕ) = ({a} : Set ℕ) := by
+      rw [heq]
+      ext x
+      simp
+      constructor
+      · rintro ⟨hn, hx⟩; exact hx.symm
+      · rintro rfl; exact ⟨⟨0, by omega⟩, rfl⟩
+    have h1 : ENat.card ({a} : Set ℕ) = 1 := by
+      rw [ENat.card_eq_coe_fintype_card]
+      norm_cast
+    rw [hsing, h1] at hcard
+    norm_num at hcard
+  have get_mem {m : ℕ} (hm : m ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ)) : m ∈ Finset.Icc (1 : ℕ) N := by
+    obtain ⟨x, hx, rfl⟩ := hm
+    have hx1 : (1 : ℕ) ≤ (x : ℕ) := (Set.mem_Icc.mp x.property).1
+    have hx2 : (x : ℕ) ≤ N := (Set.mem_Icc.mp x.property).2
+    exact Finset.mem_Icc.mpr ⟨hx1, hx2⟩
+  have ha := get_mem mem0
+  have had := get_mem mem1
+  have had2 := get_mem mem2
+  have hsum := get_mem mem3
+  have hd_mem : d ∈ Finset.Icc (1 : ℕ) N := by
+    have ha' := Finset.mem_Icc.mp ha
+    have hsum' := Finset.mem_Icc.mp hsum
+    simp only [Finset.mem_Icc]
+    constructor <;> omega
+  have col_eq {m : ℕ} (hm_set : m ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ)) (hm : m ∈ Finset.Icc (1 : ℕ) N) :
+      colorOf N c m = 1 := by
+    obtain ⟨x, hx, hxe⟩ := hm_set
+    have hxe' : x = ⟨m, mem_Icc.mpr (Finset.mem_Icc.mp hm)⟩ := Subtype.ext hxe
+    rw [colorOf_eq N c hm, ← hxe', hcol x hx]
+  refine ⟨a, ha, d, hd_mem, hd, hsum, had, had2, col_eq mem0 ha, col_eq mem1 had, col_eq mem2 had2, col_eq mem3 hsum⟩
+
+set_option maxRecDepth 10000000
+set_option maxHeartbeats 20000000
+
+-- Mask-based machinery for the exact evaluation $W(3,4)=18$ and $W(3,5)=22$.
+
+private def redCond (bits N i j : ℕ) : Bool :=
+  0 < j+1 && (i+1) + 2*(j+1) ≤ N && (i+1) + (j+1) ≤ N &&
+    Nat.testBit bits (i+1-1) && Nat.testBit bits (i+1+j+1-1) && Nat.testBit bits (i+1+2*(j+1)-1)
+
+private def blueCond (bits N i j : ℕ) : Bool :=
+  0 < j+1 && (i+1) + 3*(j+1) ≤ N && (i+1) + (j+1) ≤ N && (i+1) + 2*(j+1) ≤ N &&
+    !Nat.testBit bits (i+1-1) && !Nat.testBit bits (i+1+j+1-1) && !Nat.testBit bits (i+1+2*(j+1)-1) && !Nat.testBit bits (i+1+3*(j+1)-1)
+
+private def redInner (bits N i : ℕ) : Bool :=
+  Nat.rec (motive := λ _ => Bool) false (λ j ih' => ih' || redCond bits N i j) ((N - (i + 1)) / 2)
+
+private def blueInner (bits N i : ℕ) : Bool :=
+  Nat.rec (motive := λ _ => Bool) false (λ j ih' => ih' || blueCond bits N i j) ((N - (i + 1)) / 3)
+
+private def hasRed3Mask (bits N : ℕ) : Bool :=
+  Nat.rec (motive := λ _ => Bool) false (λ i ih => ih || redInner bits N i) N
+
+private def hasBlue4Mask (bits N : ℕ) : Bool :=
+  Nat.rec (motive := λ _ => Bool) false (λ i ih => ih || blueInner bits N i) N
+
+private def coloringOfIndex (N n : ℕ) (x : Icc (1 : ℕ) N) : Fin 2 :=
+  if Nat.testBit n (x.val - 1) then 0 else 1
+
+private def colorBit (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (k : ℕ) : Bool :=
+  if h : k < N then
+    (if c ⟨k + 1, ⟨Nat.succ_le_succ (Nat.zero_le k), Nat.succ_le_of_lt h⟩⟩ = 0 then true else false)
+  else false
+
+private def indexOfColor (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) : ℕ :=
+  (List.range N).reverse.foldl (fun acc k => Nat.bit (colorBit N c k) acc) 0
+
+private lemma colorOf_eq_testBit (N n a : ℕ) (ha : a ∈ Finset.Icc (1 : ℕ) N) :
+    colorOf N (coloringOfIndex N n) a = 0 ↔ Nat.testBit n (a-1) := by
+  unfold colorOf coloringOfIndex
+  simp [ha]
+
+private lemma rec_or_true_iff (f : ℕ → Bool) (n : ℕ) :
+    (Nat.rec (motive := λ _ => Bool) false (λ k ih => ih || f k) n) = true ↔ ∃ i < n, f i = true := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      change (Nat.rec (motive := λ _ => Bool) false (λ k ih => ih || f k) n || f n) = true
+        ↔ ∃ i < Nat.succ n, f i = true
+      rw [Bool.or_eq_true]
+      constructor
+      · intro h
+        rcases h with hrec | hfn
+        · rcases ih.mp hrec with ⟨i, hi, hfi⟩
+          exact ⟨i, by omega, hfi⟩
+        · exact ⟨n, by omega, hfn⟩
+      · intro h
+        rcases h with ⟨i, hi, hfi⟩
+        by_cases hin : i < n
+        · left; exact ih.mpr ⟨i, hin, hfi⟩
+        · have : i = n := by omega
+          subst i
+          right; exact hfi
+
+private lemma hasRed3Mask_of_hasRed3 (N n : ℕ)
+    (h : hasRed3 N (coloringOfIndex N n)) : hasRed3Mask n N := by
+  rcases h with ⟨a, ha, d, hd, hd0, hsum, had, hca, hcad, hcas⟩
+  have hsum_le : a + 2 * d ≤ N := (Finset.mem_Icc.mp hsum).2
+  have had_le : a + d ≤ N := (Finset.mem_Icc.mp had).2
+  have ha1 : 1 ≤ a := (Finset.mem_Icc.mp ha).1
+  have hd1 : 1 ≤ d := (Finset.mem_Icc.mp hd).1
+  have hb1 : Nat.testBit n (a-1) := (colorOf_eq_testBit N n a ha).mp hca
+  have hb2 : Nat.testBit n (a+d-1) := (colorOf_eq_testBit N n (a+d) had).mp hcad
+  have hb3 : Nat.testBit n (a+2*d-1) := (colorOf_eq_testBit N n (a+2*d) hsum).mp hcas
+  have ha_le : a ≤ N := (Finset.mem_Icc.mp ha).2
+  have hsub : N - a + a = N := Nat.sub_add_cancel ha_le
+  have hd_le : d * 2 ≤ N - a := by omega
+  have hdiv : d ≤ (N - a) / 2 := (Nat.le_div_iff_mul_le (by norm_num : 0 < 2)).mpr hd_le
+  have hx1 : 1 ≤ (N - a) / 2 := (Nat.le_div_iff_mul_le (by norm_num : 0 < 2)).mpr (by omega)
+  have hw0 : d - 1 ≤ (N - a) / 2 - 1 := Nat.sub_le_sub_right hdiv 1
+  have hw1 : (N - a) / 2 - 1 < (N - a) / 2 := by omega
+  have hw : d - 1 < (N - ((a - 1) + 1)) / 2 := by
+    rw [Nat.sub_add_cancel ha1]
+    exact lt_of_le_of_lt hw0 hw1
+  unfold hasRed3Mask
+  refine (rec_or_true_iff (f := redInner n N) N).mpr ⟨a - 1, by omega, ?_⟩
+  refine (rec_or_true_iff (f := redCond n N (a-1)) ((N - ((a - 1) + 1)) / 2)).mpr ⟨d - 1, hw, ?_⟩
+  unfold redCond
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  constructor
+  constructor
+  constructor
+  constructor
+  constructor
+  · rw [decide_eq_true_iff]; omega
+  · rw [decide_eq_true_iff]; omega
+  · rw [decide_eq_true_iff]; omega
+  · rw [show ((a-1)+1-1) = a-1 by omega]
+    exact hb1
+  · rw [show ((a-1)+1+(d-1)+1-1) = a+d-1 by omega]
+    exact hb2
+  · rw [show ((a-1)+1+2*((d-1)+1)-1) = a+2*d-1 by omega]
+    exact hb3
+
+private lemma hasRed3_of_hasRed3Mask (N n : ℕ)
+    (h : hasRed3Mask n N) : hasRed3 N (coloringOfIndex N n) := by
+  unfold hasRed3Mask at h
+  rcases (rec_or_true_iff (f := redInner n N) N).mp h with ⟨i, hi, hi_f⟩
+  rcases (rec_or_true_iff (f := redCond n N i) ((N - (i + 1)) / 2)).mp hi_f with ⟨j, hj, hj_cond⟩
+  unfold redCond at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rcases hj_cond with ⟨⟨⟨⟨⟨hd0, hsum⟩, had⟩, hb1⟩, hb2⟩, hb3⟩
+  rw [decide_eq_true_iff] at hd0 hsum had
+  refine ⟨i+1, ?_, j+1, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact Finset.mem_Icc.mpr (by constructor <;> omega)
+  · exact Finset.mem_Icc.mpr (by constructor <;> omega)
+  · exact hd0
+  · exact Finset.mem_Icc.mpr (by constructor; omega; exact hsum)
+  · exact Finset.mem_Icc.mpr (by constructor; omega; exact had)
+  · exact (colorOf_eq_testBit N n (i+1) (Finset.mem_Icc.mpr (by constructor <;> omega))).mpr hb1
+  · exact (colorOf_eq_testBit N n (i+1+j+1) (Finset.mem_Icc.mpr (by constructor; omega; exact had))).mpr hb2
+  · exact (colorOf_eq_testBit N n (i+1+2*(j+1)) (Finset.mem_Icc.mpr (by constructor; omega; exact hsum))).mpr hb3
+
+private lemma hasRed3_iff_mask (N n : ℕ) : hasRed3 N (coloringOfIndex N n) ↔ hasRed3Mask n N :=
+  ⟨hasRed3Mask_of_hasRed3 N n, hasRed3_of_hasRed3Mask N n⟩
+
+private lemma not_bool_eq_true_iff (b : Bool) : (Bool.not b = true) ↔ b = false := by
+  cases b <;> simp
+
+private lemma not_testBit_iff_eq_false (n k : ℕ) :
+    (¬ Nat.testBit n k) ↔ Nat.testBit n k = false := by
+  constructor
+  · intro h
+    by_contra hf
+    cases hte : Nat.testBit n k with
+    | false => exact hf hte
+    | true => exact h hte
+  · intro h hnt
+    rw [h] at hnt
+    contradiction
+
+private lemma colorOf_eq_one_iff_testBit_false (N n a : ℕ) (ha : a ∈ Finset.Icc (1 : ℕ) N) :
+    colorOf N (coloringOfIndex N n) a = 1 ↔ Nat.testBit n (a-1) = false := by
+  constructor
+  · intro h1
+    apply (not_testBit_iff_eq_false n (a-1)).mp
+    intro htb
+    have h0 : colorOf N (coloringOfIndex N n) a = 0 := (colorOf_eq_testBit N n a ha).mpr htb
+    rw [h0] at h1
+    exact (by decide : ¬ ((0 : Fin 2) = 1)) h1
+  · intro hb
+    have hne : colorOf N (coloringOfIndex N n) a ≠ 0 := by
+      intro h0
+      have htb : Nat.testBit n (a-1) := (colorOf_eq_testBit N n a ha).mp h0
+      exact (not_testBit_iff_eq_false n (a-1)).mpr hb htb
+    have hlt := (colorOf N (coloringOfIndex N n) a).isLt
+    have hne0 : (colorOf N (coloringOfIndex N n) a).val ≠ 0 := by
+      intro hv0
+      apply hne
+      exact Fin.ext (by simpa using hv0)
+    have hval : (colorOf N (coloringOfIndex N n) a).val = 1 := by omega
+    apply Fin.ext
+    simpa using hval
+
+private lemma hasBlue4Mask_of_hasBlue4 (N n : ℕ)
+    (h : hasBlue4 N (coloringOfIndex N n)) : hasBlue4Mask n N := by
+  rcases h with ⟨a, ha, d, hd, hd0, hsum, had, ha2d, hca, hcad, hcas, hca4⟩
+  have hsum_le : a + 3 * d ≤ N := (Finset.mem_Icc.mp hsum).2
+  have had_le : a + d ≤ N := (Finset.mem_Icc.mp had).2
+  have ha2d_le : a + 2 * d ≤ N := (Finset.mem_Icc.mp ha2d).2
+  have ha1 : 1 ≤ a := (Finset.mem_Icc.mp ha).1
+  have hd1 : 1 ≤ d := (Finset.mem_Icc.mp hd).1
+  have hb1 : Nat.testBit n (a-1) = false := (colorOf_eq_one_iff_testBit_false N n a ha).mp hca
+  have hb2 : Nat.testBit n (a+d-1) = false := (colorOf_eq_one_iff_testBit_false N n (a+d) had).mp hcad
+  have hb3 : Nat.testBit n (a+2*d-1) = false := (colorOf_eq_one_iff_testBit_false N n (a+2*d) ha2d).mp hcas
+  have hb4 : Nat.testBit n (a+3*d-1) = false := (colorOf_eq_one_iff_testBit_false N n (a+3*d) hsum).mp hca4
+  have ha_le : a ≤ N := (Finset.mem_Icc.mp ha).2
+  have hsub : N - a + a = N := Nat.sub_add_cancel ha_le
+  have hd_le : d * 3 ≤ N - a := by omega
+  have hdiv : d ≤ (N - a) / 3 := (Nat.le_div_iff_mul_le (by norm_num : 0 < 3)).mpr hd_le
+  have hx1 : 1 ≤ (N - a) / 3 := (Nat.le_div_iff_mul_le (by norm_num : 0 < 3)).mpr (by omega)
+  have hw0 : d - 1 ≤ (N - a) / 3 - 1 := Nat.sub_le_sub_right hdiv 1
+  have hw1 : (N - a) / 3 - 1 < (N - a) / 3 := by omega
+  have hw : d - 1 < (N - ((a - 1) + 1)) / 3 := by
+    rw [Nat.sub_add_cancel ha1]
+    exact lt_of_le_of_lt hw0 hw1
+  unfold hasBlue4Mask
+  refine (rec_or_true_iff (f := blueInner n N) N).mpr ⟨a - 1, by omega, ?_⟩
+  refine (rec_or_true_iff (f := blueCond n N (a-1)) ((N - ((a - 1) + 1)) / 3)).mpr ⟨d - 1, hw, ?_⟩
+  unfold blueCond
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  rw [Bool.and_eq_true]
+  constructor
+  constructor
+  constructor
+  constructor
+  constructor
+  constructor
+  constructor
+  · rw [decide_eq_true_iff]; omega
+  · rw [decide_eq_true_iff]; omega
+  · rw [decide_eq_true_iff]; omega
+  · rw [decide_eq_true_iff]; omega
+  · rw [show ((a-1)+1-1) = a-1 by omega, not_bool_eq_true_iff]
+    exact hb1
+  · rw [show ((a-1)+1+(d-1)+1-1) = a+d-1 by omega, not_bool_eq_true_iff]
+    exact hb2
+  · rw [show ((a-1)+1+2*((d-1)+1)-1) = a+2*d-1 by omega, not_bool_eq_true_iff]
+    exact hb3
+  · rw [show ((a-1)+1+3*((d-1)+1)-1) = a+3*d-1 by omega, not_bool_eq_true_iff]
+    exact hb4
+
+private lemma hasBlue4_of_hasBlue4Mask (N n : ℕ)
+    (h : hasBlue4Mask n N) : hasBlue4 N (coloringOfIndex N n) := by
+  unfold hasBlue4Mask at h
+  rcases (rec_or_true_iff (f := blueInner n N) N).mp h with ⟨i, hi, hi_f⟩
+  rcases (rec_or_true_iff (f := blueCond n N i) ((N - (i + 1)) / 3)).mp hi_f with ⟨j, hj, hj_cond⟩
+  unfold blueCond at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rw [Bool.and_eq_true] at hj_cond
+  rcases hj_cond with ⟨⟨⟨⟨⟨⟨⟨hd0, hsum⟩, had⟩, ha2d⟩, hb1⟩, hb2⟩, hb3⟩, hb4⟩
+  rw [decide_eq_true_iff] at hd0 hsum had ha2d
+  rw [not_bool_eq_true_iff] at hb1 hb2 hb3 hb4
+  refine ⟨i+1, ?_, j+1, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact Finset.mem_Icc.mpr (by constructor <;> omega)
+  · exact Finset.mem_Icc.mpr (by constructor <;> omega)
+  · exact hd0
+  · exact Finset.mem_Icc.mpr (by constructor; omega; exact hsum)
+  · exact Finset.mem_Icc.mpr (by constructor; omega; exact had)
+  · exact Finset.mem_Icc.mpr (by constructor; omega; exact ha2d)
+  · exact (colorOf_eq_one_iff_testBit_false N n (i+1) (Finset.mem_Icc.mpr (by constructor <;> omega))).mpr hb1
+  · exact (colorOf_eq_one_iff_testBit_false N n (i+1+j+1) (Finset.mem_Icc.mpr (by constructor; omega; exact had))).mpr hb2
+  · exact (colorOf_eq_one_iff_testBit_false N n (i+1+2*(j+1)) (Finset.mem_Icc.mpr (by constructor; omega; exact ha2d))).mpr hb3
+  · exact (colorOf_eq_one_iff_testBit_false N n (i+1+3*(j+1)) (Finset.mem_Icc.mpr (by constructor; omega; exact hsum))).mpr hb4
+
+private lemma hasBlue4_iff_mask (N n : ℕ) : hasBlue4 N (coloringOfIndex N n) ↔ hasBlue4Mask n N :=
+  ⟨hasBlue4Mask_of_hasBlue4 N n, hasBlue4_of_hasBlue4Mask N n⟩
+
+private lemma testBit_revFoldl (g : ℕ → Bool) : ∀ (n acc j : ℕ),
+    Nat.testBit ((List.range n).reverse.foldl (fun acc k => Nat.bit (g k) acc) acc) j =
+      (if j < n then g j else Nat.testBit acc (j - n))
+  | 0, acc, j => by
+      simp
+  | n + 1, acc, j => by
+      simp only [List.range_succ, List.reverse_append, List.reverse_singleton,
+        List.foldl_append, List.foldl_cons, List.foldl_nil]
+      rw [testBit_revFoldl g n (Nat.bit (g n) acc) j]
+      by_cases hlt : j < n
+      · have hlt' : j < n + 1 := lt_trans hlt (Nat.lt_succ_self n)
+        simp [hlt, hlt']
+      · by_cases heq : j = n
+        · subst j
+          simp
+        · have hgt : n < j :=
+            Nat.lt_of_le_of_ne (Nat.le_of_not_gt hlt) (by intro hnj; exact heq hnj.symm)
+          rw [show j - n = (j - (n + 1)) + 1 by omega, Nat.testBit_bit_succ]
+          have hgt' : ¬ j < n + 1 := Nat.not_lt_of_ge (Nat.succ_le_of_lt hgt)
+          simp [hlt, hgt']
+
+private lemma revFoldl_lt (g : ℕ → Bool) : ∀ (n acc : ℕ),
+    (List.range n).reverse.foldl (fun acc k => Nat.bit (g k) acc) acc < (acc + 1) * 2 ^ n
+  | 0, acc => by
+      simp
+  | n + 1, acc => by
+      simp only [List.range_succ, List.reverse_append, List.reverse_singleton,
+        List.foldl_append, List.foldl_cons, List.foldl_nil]
+      have ih := revFoldl_lt g n (Nat.bit (g n) acc)
+      have hbit : Nat.bit (g n) acc + 1 ≤ 2 * (acc + 1) := by
+        cases g n <;> simp [Nat.bit_val] <;> omega
+      calc
+        (List.range n).reverse.foldl (fun acc k => Nat.bit (g k) acc) (Nat.bit (g n) acc)
+            < (Nat.bit (g n) acc + 1) * 2 ^ n := ih
+        _ ≤ (2 * (acc + 1)) * 2 ^ n := by exact Nat.mul_le_mul_right _ hbit
+        _ = (acc + 1) * 2 ^ (n + 1) := by
+            rw [pow_succ]
+            ring
+
+private lemma indexOfColor_lt (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) : indexOfColor N c < 2 ^ N := by
+  simpa [indexOfColor] using revFoldl_lt (colorBit N c) N 0
+
+private lemma coloringOfIndex_indexOfColor (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) :
+    coloringOfIndex N (indexOfColor N c) = c := by
+  funext x
+  unfold coloringOfIndex indexOfColor
+  rw [testBit_revFoldl (colorBit N c) N 0 (x.1 - 1)]
+  have hx1 : 1 ≤ x.1 := (Set.mem_Icc.mp x.property).1
+  have hx2 : x.1 ≤ N := (Set.mem_Icc.mp x.property).2
+  have hlt : x.1 - 1 < N := by omega
+  simp [colorBit, hlt]
+  have hxeq : (⟨(x.1 - 1) + 1, ⟨Nat.succ_le_succ (Nat.zero_le (x.1 - 1)),
+        Nat.sub_add_cancel hx1 ▸ hx2⟩⟩ : Icc (1 : ℕ) N) = x := by
+    ext
+    exact Nat.sub_add_cancel hx1
+  rw [hxeq]
+  by_cases h0 : c x = 0
+  · simp [h0]
+  · simp [h0]
+    rcases fin2_eq_zero_or_one (c x) with hz | ho
+    · exact absurd hz h0
+    · exact ho.symm
+
+private lemma chunk_18_0 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (0 * 2000 + j) 18 || hasBlue4Mask (0 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_1 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (1 * 2000 + j) 18 || hasBlue4Mask (1 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_2 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (2 * 2000 + j) 18 || hasBlue4Mask (2 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_3 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (3 * 2000 + j) 18 || hasBlue4Mask (3 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_4 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (4 * 2000 + j) 18 || hasBlue4Mask (4 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_5 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (5 * 2000 + j) 18 || hasBlue4Mask (5 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_6 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (6 * 2000 + j) 18 || hasBlue4Mask (6 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_7 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (7 * 2000 + j) 18 || hasBlue4Mask (7 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_8 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (8 * 2000 + j) 18 || hasBlue4Mask (8 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_9 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (9 * 2000 + j) 18 || hasBlue4Mask (9 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_10 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (10 * 2000 + j) 18 || hasBlue4Mask (10 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_11 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (11 * 2000 + j) 18 || hasBlue4Mask (11 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_12 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (12 * 2000 + j) 18 || hasBlue4Mask (12 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_13 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (13 * 2000 + j) 18 || hasBlue4Mask (13 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_14 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (14 * 2000 + j) 18 || hasBlue4Mask (14 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_15 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (15 * 2000 + j) 18 || hasBlue4Mask (15 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_16 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (16 * 2000 + j) 18 || hasBlue4Mask (16 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_17 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (17 * 2000 + j) 18 || hasBlue4Mask (17 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_18 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (18 * 2000 + j) 18 || hasBlue4Mask (18 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_19 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (19 * 2000 + j) 18 || hasBlue4Mask (19 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_20 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (20 * 2000 + j) 18 || hasBlue4Mask (20 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_21 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (21 * 2000 + j) 18 || hasBlue4Mask (21 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_22 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (22 * 2000 + j) 18 || hasBlue4Mask (22 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_23 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (23 * 2000 + j) 18 || hasBlue4Mask (23 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_24 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (24 * 2000 + j) 18 || hasBlue4Mask (24 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_25 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (25 * 2000 + j) 18 || hasBlue4Mask (25 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_26 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (26 * 2000 + j) 18 || hasBlue4Mask (26 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_27 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (27 * 2000 + j) 18 || hasBlue4Mask (27 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_28 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (28 * 2000 + j) 18 || hasBlue4Mask (28 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_29 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (29 * 2000 + j) 18 || hasBlue4Mask (29 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_30 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (30 * 2000 + j) 18 || hasBlue4Mask (30 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_31 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (31 * 2000 + j) 18 || hasBlue4Mask (31 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_32 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (32 * 2000 + j) 18 || hasBlue4Mask (32 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_33 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (33 * 2000 + j) 18 || hasBlue4Mask (33 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_34 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (34 * 2000 + j) 18 || hasBlue4Mask (34 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_35 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (35 * 2000 + j) 18 || hasBlue4Mask (35 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_36 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (36 * 2000 + j) 18 || hasBlue4Mask (36 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_37 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (37 * 2000 + j) 18 || hasBlue4Mask (37 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_38 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (38 * 2000 + j) 18 || hasBlue4Mask (38 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_39 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (39 * 2000 + j) 18 || hasBlue4Mask (39 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_40 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (40 * 2000 + j) 18 || hasBlue4Mask (40 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_41 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (41 * 2000 + j) 18 || hasBlue4Mask (41 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_42 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (42 * 2000 + j) 18 || hasBlue4Mask (42 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_43 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (43 * 2000 + j) 18 || hasBlue4Mask (43 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_44 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (44 * 2000 + j) 18 || hasBlue4Mask (44 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_45 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (45 * 2000 + j) 18 || hasBlue4Mask (45 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_46 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (46 * 2000 + j) 18 || hasBlue4Mask (46 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_47 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (47 * 2000 + j) 18 || hasBlue4Mask (47 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_48 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (48 * 2000 + j) 18 || hasBlue4Mask (48 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_49 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (49 * 2000 + j) 18 || hasBlue4Mask (49 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_50 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (50 * 2000 + j) 18 || hasBlue4Mask (50 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_51 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (51 * 2000 + j) 18 || hasBlue4Mask (51 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_52 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (52 * 2000 + j) 18 || hasBlue4Mask (52 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_53 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (53 * 2000 + j) 18 || hasBlue4Mask (53 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_54 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (54 * 2000 + j) 18 || hasBlue4Mask (54 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_55 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (55 * 2000 + j) 18 || hasBlue4Mask (55 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_56 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (56 * 2000 + j) 18 || hasBlue4Mask (56 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_57 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (57 * 2000 + j) 18 || hasBlue4Mask (57 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_58 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (58 * 2000 + j) 18 || hasBlue4Mask (58 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_59 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (59 * 2000 + j) 18 || hasBlue4Mask (59 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_60 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (60 * 2000 + j) 18 || hasBlue4Mask (60 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_61 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (61 * 2000 + j) 18 || hasBlue4Mask (61 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_62 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (62 * 2000 + j) 18 || hasBlue4Mask (62 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_63 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (63 * 2000 + j) 18 || hasBlue4Mask (63 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_64 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (64 * 2000 + j) 18 || hasBlue4Mask (64 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_65 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (65 * 2000 + j) 18 || hasBlue4Mask (65 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_66 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (66 * 2000 + j) 18 || hasBlue4Mask (66 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_67 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (67 * 2000 + j) 18 || hasBlue4Mask (67 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_68 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (68 * 2000 + j) 18 || hasBlue4Mask (68 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_69 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (69 * 2000 + j) 18 || hasBlue4Mask (69 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_70 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (70 * 2000 + j) 18 || hasBlue4Mask (70 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_71 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (71 * 2000 + j) 18 || hasBlue4Mask (71 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_72 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (72 * 2000 + j) 18 || hasBlue4Mask (72 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_73 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (73 * 2000 + j) 18 || hasBlue4Mask (73 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_74 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (74 * 2000 + j) 18 || hasBlue4Mask (74 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_75 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (75 * 2000 + j) 18 || hasBlue4Mask (75 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_76 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (76 * 2000 + j) 18 || hasBlue4Mask (76 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_77 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (77 * 2000 + j) 18 || hasBlue4Mask (77 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_78 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (78 * 2000 + j) 18 || hasBlue4Mask (78 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_79 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (79 * 2000 + j) 18 || hasBlue4Mask (79 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_80 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (80 * 2000 + j) 18 || hasBlue4Mask (80 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_81 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (81 * 2000 + j) 18 || hasBlue4Mask (81 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_82 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (82 * 2000 + j) 18 || hasBlue4Mask (82 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_83 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (83 * 2000 + j) 18 || hasBlue4Mask (83 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_84 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (84 * 2000 + j) 18 || hasBlue4Mask (84 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_85 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (85 * 2000 + j) 18 || hasBlue4Mask (85 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_86 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (86 * 2000 + j) 18 || hasBlue4Mask (86 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_87 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (87 * 2000 + j) 18 || hasBlue4Mask (87 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_88 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (88 * 2000 + j) 18 || hasBlue4Mask (88 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_89 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (89 * 2000 + j) 18 || hasBlue4Mask (89 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_90 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (90 * 2000 + j) 18 || hasBlue4Mask (90 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_91 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (91 * 2000 + j) 18 || hasBlue4Mask (91 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_92 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (92 * 2000 + j) 18 || hasBlue4Mask (92 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_93 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (93 * 2000 + j) 18 || hasBlue4Mask (93 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_94 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (94 * 2000 + j) 18 || hasBlue4Mask (94 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_95 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (95 * 2000 + j) 18 || hasBlue4Mask (95 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_96 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (96 * 2000 + j) 18 || hasBlue4Mask (96 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_97 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (97 * 2000 + j) 18 || hasBlue4Mask (97 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_98 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (98 * 2000 + j) 18 || hasBlue4Mask (98 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_99 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (99 * 2000 + j) 18 || hasBlue4Mask (99 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_100 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (100 * 2000 + j) 18 || hasBlue4Mask (100 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_101 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (101 * 2000 + j) 18 || hasBlue4Mask (101 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_102 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (102 * 2000 + j) 18 || hasBlue4Mask (102 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_103 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (103 * 2000 + j) 18 || hasBlue4Mask (103 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_104 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (104 * 2000 + j) 18 || hasBlue4Mask (104 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_105 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (105 * 2000 + j) 18 || hasBlue4Mask (105 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_106 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (106 * 2000 + j) 18 || hasBlue4Mask (106 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_107 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (107 * 2000 + j) 18 || hasBlue4Mask (107 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_108 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (108 * 2000 + j) 18 || hasBlue4Mask (108 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_109 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (109 * 2000 + j) 18 || hasBlue4Mask (109 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_110 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (110 * 2000 + j) 18 || hasBlue4Mask (110 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_111 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (111 * 2000 + j) 18 || hasBlue4Mask (111 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_112 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (112 * 2000 + j) 18 || hasBlue4Mask (112 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_113 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (113 * 2000 + j) 18 || hasBlue4Mask (113 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_114 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (114 * 2000 + j) 18 || hasBlue4Mask (114 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_115 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (115 * 2000 + j) 18 || hasBlue4Mask (115 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_116 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (116 * 2000 + j) 18 || hasBlue4Mask (116 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_117 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (117 * 2000 + j) 18 || hasBlue4Mask (117 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_118 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (118 * 2000 + j) 18 || hasBlue4Mask (118 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_119 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (119 * 2000 + j) 18 || hasBlue4Mask (119 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_120 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (120 * 2000 + j) 18 || hasBlue4Mask (120 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_121 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (121 * 2000 + j) 18 || hasBlue4Mask (121 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_122 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (122 * 2000 + j) 18 || hasBlue4Mask (122 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_123 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (123 * 2000 + j) 18 || hasBlue4Mask (123 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_124 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (124 * 2000 + j) 18 || hasBlue4Mask (124 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_125 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (125 * 2000 + j) 18 || hasBlue4Mask (125 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_126 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (126 * 2000 + j) 18 || hasBlue4Mask (126 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_127 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (127 * 2000 + j) 18 || hasBlue4Mask (127 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_128 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (128 * 2000 + j) 18 || hasBlue4Mask (128 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_129 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (129 * 2000 + j) 18 || hasBlue4Mask (129 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_130 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (130 * 2000 + j) 18 || hasBlue4Mask (130 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+private lemma chunk_18_131 : ∀ j : ℕ, j < 2000 → (hasRed3Mask (131 * 2000 + j) 18 || hasBlue4Mask (131 * 2000 + j) 18) := by
+  unfold hasRed3Mask hasBlue4Mask; decide
+
+private lemma all_masks_18 : ∀ n : ℕ, n < 2 ^ 18 → (hasRed3Mask n 18 || hasBlue4Mask n 18) := by
+  intro n hn
+  have hb : 2 ^ 18 < 264000 := by norm_num
+  have hdiv : n / 2000 < 132 := by
+    exact (Nat.div_lt_iff_lt_mul (by decide : 0 < 2000)).mpr (by omega)
+  match hdivm : n / 2000 with
+  | 0 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_0 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 1 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_1 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 2 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_2 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 3 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_3 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 4 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_4 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 5 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_5 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 6 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_6 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 7 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_7 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 8 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_8 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 9 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_9 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 10 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_10 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 11 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_11 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 12 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_12 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 13 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_13 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 14 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_14 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 15 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_15 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 16 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_16 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 17 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_17 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 18 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_18 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 19 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_19 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 20 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_20 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 21 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_21 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 22 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_22 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 23 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_23 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 24 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_24 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 25 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_25 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 26 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_26 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 27 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_27 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 28 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_28 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 29 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_29 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 30 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_30 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 31 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_31 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 32 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_32 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 33 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_33 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 34 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_34 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 35 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_35 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 36 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_36 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 37 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_37 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 38 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_38 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 39 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_39 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 40 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_40 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 41 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_41 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 42 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_42 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 43 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_43 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 44 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_44 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 45 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_45 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 46 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_46 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 47 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_47 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 48 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_48 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 49 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_49 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 50 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_50 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 51 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_51 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 52 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_52 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 53 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_53 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 54 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_54 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 55 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_55 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 56 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_56 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 57 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_57 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 58 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_58 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 59 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_59 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 60 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_60 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 61 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_61 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 62 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_62 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 63 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_63 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 64 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_64 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 65 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_65 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 66 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_66 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 67 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_67 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 68 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_68 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 69 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_69 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 70 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_70 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 71 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_71 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 72 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_72 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 73 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_73 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 74 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_74 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 75 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_75 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 76 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_76 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 77 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_77 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 78 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_78 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 79 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_79 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 80 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_80 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 81 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_81 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 82 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_82 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 83 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_83 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 84 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_84 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 85 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_85 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 86 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_86 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 87 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_87 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 88 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_88 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 89 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_89 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 90 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_90 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 91 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_91 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 92 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_92 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 93 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_93 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 94 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_94 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 95 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_95 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 96 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_96 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 97 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_97 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 98 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_98 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 99 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_99 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 100 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_100 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 101 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_101 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 102 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_102 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 103 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_103 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 104 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_104 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 105 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_105 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 106 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_106 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 107 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_107 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 108 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_108 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 109 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_109 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 110 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_110 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 111 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_111 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 112 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_112 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 113 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_113 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 114 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_114 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 115 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_115 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 116 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_116 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 117 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_117 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 118 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_118 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 119 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_119 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 120 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_120 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 121 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_121 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 122 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_122 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 123 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_123 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 124 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_124 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 125 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_125 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 126 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_126 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 127 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_127 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 128 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_128 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 129 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_129 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 130 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_130 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | 131 =>
+      rw [← Nat.div_add_mod n 2000, hdivm]
+      exact chunk_18_131 (n % 2000) (Nat.mod_lt n (by omega : 0 < 2000))
+  | k + 132 =>
+      omega
+
+@[category test, AMS 5 11]
+private lemma all_colorings_18 : ∀ c : Icc (1 : ℕ) 18 → Fin 2, hasRed3 18 c ∨ hasBlue4 18 c := by
+  intro c
+  have hm : hasRed3Mask (indexOfColor 18 c) 18 || hasBlue4Mask (indexOfColor 18 c) 18 :=
+    all_masks_18 (indexOfColor 18 c) (indexOfColor_lt 18 c)
+  rw [Bool.or_eq_true] at hm
+  rcases hm with h | h
+  · left
+    rw [← coloringOfIndex_indexOfColor 18 c]
+    exact (hasRed3_iff_mask 18 (indexOfColor 18 c)).mpr h
+  · right
+    rw [← coloringOfIndex_indexOfColor 18 c]
+    exact (hasBlue4_iff_mask 18 (indexOfColor 18 c)).mpr h
+
+
+@[category test, AMS 5 11]
+private lemma eighteen_in : 18 ∈ mixedMonoAPGuaranteeSet 3 4 := by
+  intro c
+  rcases all_colorings_18 c with h | h
+  · left; exact hasRed3_imp 18 c h
+  · right; exact hasBlue4_imp 18 c h
+
+private def avoid17 : Icc (1 : ℕ) 17 → Fin 2
+  | ⟨x, _⟩ => if x = 4 ∨ x = 5 ∨ x = 7 ∨ x = 11 ∨ x = 12 ∨ x = 14 then (0 : Fin 2) else (1 : Fin 2)
+
+@[category test, AMS 5 11]
+private lemma avoid17_no_hasRed3 : ¬ hasRed3 17 avoid17 := by
+  decide
+
+@[category test, AMS 5 11]
+private lemma avoid17_no_hasBlue4 : ¬ hasBlue4 17 avoid17 := by
+  decide
+
+@[category test, AMS 5 11]
+private lemma seventeen_not_in : 17 ∉ mixedMonoAPGuaranteeSet 3 4 := by
+  intro h
+  rcases h avoid17 with (h' | h')
+  · exact avoid17_no_hasRed3 (imp_hasRed3 17 avoid17 h')
+  · exact avoid17_no_hasBlue4 (imp_hasBlue4 17 avoid17 h')
+
 -- Known exact values for `W(3,r)` from [AKS14].
 /-- $W(3, 3) = 9$ from [AKS14]. -/
 @[category research solved, AMS 5 11]
@@ -403,7 +1651,14 @@ theorem W_3_3 : W 3 3 = 9 := by
 
 /-- $W(3, 4) = 18$ from [AKS14]. -/
 @[category research solved, AMS 5 11]
-theorem W_3_4 : W 3 4 = 18 := by sorry
+theorem W_3_4 : W 3 4 = 18 := by
+  apply IsLeast.csInf_eq
+  refine ⟨eighteen_in, ?_⟩
+  intro m hm
+  by_contra hlt
+  simp only [not_le] at hlt
+  have hm17 : m ≤ 17 := by omega
+  exact absurd hm (not_mem_of_le hm17 seventeen_not_in)
 
 /-- $W(3, 5) = 22$ from [AKS14]. -/
 @[category research solved, AMS 5 11]

--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -159,6 +159,7 @@ private def hasMono3AP (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) : Prop :=
     0 < d ∧ a + 2 * d ∈ Finset.Icc (1 : ℕ) N ∧ a + d ∈ Finset.Icc (1 : ℕ) N ∧
     colorOf N c a = colorOf N c (a + d) ∧ colorOf N c a = colorOf N c (a + 2 * d)
 
+@[category test, AMS 5 11]
 private lemma isAP_three (a d : ℕ) (hd : 0 < d) :
     ({a, a + d, a + 2 * d} : Set ℕ).IsAPOfLength 3 := by
   refine ⟨a, d, ?_, ?_⟩
@@ -184,16 +185,19 @@ private lemma isAP_three (a d : ℕ) (hd : 0 < d) :
       have : n < 3 := by exact_mod_cast hn
       interval_cases n <;> simp
 
+@[category test, AMS 5 11]
 private lemma colorOf_eq (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) {n : ℕ}
     (hn : n ∈ Finset.Icc (1 : ℕ) N) :
     colorOf N c n = c ⟨n, mem_Icc.mpr (Finset.mem_Icc.mp hn)⟩ := by
   simp [colorOf, hn]
 
+@[category test, AMS 5 11]
 private lemma fin2_eq_zero_or_one (x : Fin 2) : x = 0 ∨ x = 1 := by
   match x with
   | ⟨0, _⟩ => left; rfl
   | ⟨1, _⟩ => right; rfl
 
+@[category test, AMS 5 11]
 private lemma hasMono3AP_imp (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (h : hasMono3AP N c) :
     (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 0) ∨
     (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 1) := by
@@ -246,6 +250,7 @@ private lemma hasMono3AP_imp (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (h : hasM
     · rwa [← hcol1]
     · rwa [← hcol2]
 
+@[category test, AMS 5 11]
 private lemma mono_imp_hasMono3AP (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2)
     (h : (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 0) ∨
          (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 1)) :
@@ -308,9 +313,11 @@ private lemma mono_imp_hasMono3AP (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2)
   · exact extract 0 s hAP hcol
   · exact extract 1 s hAP hcol
 
+@[category test, AMS 5 11]
 private lemma all_colorings_9 : ∀ c : Icc (1 : ℕ) 9 → Fin 2, hasMono3AP 9 c := by
   decide
 
+@[category test, AMS 5 11]
 private lemma nine_in : 9 ∈ mixedMonoAPGuaranteeSet 3 3 := by
   intro c
   exact hasMono3AP_imp 9 c (all_colorings_9 c)
@@ -318,13 +325,16 @@ private lemma nine_in : 9 ∈ mixedMonoAPGuaranteeSet 3 3 := by
 private def avoid8 : Icc (1 : ℕ) 8 → Fin 2
   | ⟨x, _⟩ => if x = 1 ∨ x = 2 ∨ x = 5 ∨ x = 6 then (0 : Fin 2) else (1 : Fin 2)
 
+@[category test, AMS 5 11]
 private lemma avoid8_no_mono : ¬ hasMono3AP 8 avoid8 := by
   decide
 
+@[category test, AMS 5 11]
 private lemma eight_not_in : 8 ∉ mixedMonoAPGuaranteeSet 3 3 := by
   intro h
   exact avoid8_no_mono (mono_imp_hasMono3AP 8 avoid8 (h avoid8))
 
+@[category test, AMS 5 11]
 private lemma not_mem_of_le {k r n N : ℕ} (hle : n ≤ N)
     (hN : N ∉ mixedMonoAPGuaranteeSet k r) : n ∉ mixedMonoAPGuaranteeSet k r := by
   intro hn

--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -38,9 +38,11 @@ import FormalConjectures.Util.ProblemImports
 -/
 
 open Filter Set Topology
+open scoped Classical
+
+set_option maxRecDepth 100000
 
 namespace Green14
-
 /--
 The set of natural numbers $N$ such that any 2-coloring of ${1, ..., N}$ contains a monochromatic
 arithmetic progression of length $k$ (color 0) or length $r$ (color 1).
@@ -143,10 +145,251 @@ theorem green_14_variant_2r2 :
        (∃ s : Finset (Icc 1 (2 * r^2 - 1)), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength r ∧ ∀ x ∈ s, c x = 1)) := by
   sorry
 
+-- Helpers for the exact evaluation $W(3,3)=9$.
+
+private def colorOf (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (n : ℕ) : Fin 2 :=
+  if h : n ∈ Finset.Icc (1 : ℕ) N then
+    c ⟨n, mem_Icc.mpr (Finset.mem_Icc.mp h)⟩
+  else
+    0
+
+@[reducible]
+private def hasMono3AP (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) : Prop :=
+  ∃ a ∈ Finset.Icc (1 : ℕ) N, ∃ d ∈ Finset.Icc (1 : ℕ) N,
+    0 < d ∧ a + 2 * d ∈ Finset.Icc (1 : ℕ) N ∧ a + d ∈ Finset.Icc (1 : ℕ) N ∧
+    colorOf N c a = colorOf N c (a + d) ∧ colorOf N c a = colorOf N c (a + 2 * d)
+
+private lemma isAP_three (a d : ℕ) (hd : 0 < d) :
+    ({a, a + d, a + 2 * d} : Set ℕ).IsAPOfLength 3 := by
+  refine ⟨a, d, ?_, ?_⟩
+  · haveI : Fintype ↑({a, a + d, a + 2 * d} : Set ℕ) := inferInstance
+    rw [ENat.card_eq_coe_fintype_card]
+    norm_cast
+    rw [← Set.toFinset_card]
+    have htf : ({a, a + d, a + 2 * d} : Set ℕ).toFinset = {a, a + d, a + 2 * d} := by
+      ext x; simp
+    rw [htf, Finset.card_insert_of_notMem, Finset.card_insert_of_notMem, Finset.card_singleton]
+    · simp only [Finset.mem_singleton]; omega
+    · simp only [Finset.mem_insert, Finset.mem_singleton]; omega
+  · ext x
+    simp only [mem_setOf_eq, mem_insert_iff, mem_singleton_iff]
+    constructor
+    · rintro (rfl | rfl | rfl)
+      · exact ⟨0, by norm_num, by simp⟩
+      · exact ⟨1, by norm_num, by simp⟩
+      · refine ⟨2, by norm_num, ?_⟩
+        simp only [two_nsmul]
+        ring
+    · rintro ⟨n, hn, rfl⟩
+      have : n < 3 := by exact_mod_cast hn
+      interval_cases n <;> simp
+
+private lemma colorOf_eq (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) {n : ℕ}
+    (hn : n ∈ Finset.Icc (1 : ℕ) N) :
+    colorOf N c n = c ⟨n, mem_Icc.mpr (Finset.mem_Icc.mp hn)⟩ := by
+  simp [colorOf, hn]
+
+private lemma fin2_eq_zero_or_one (x : Fin 2) : x = 0 ∨ x = 1 := by
+  match x with
+  | ⟨0, _⟩ => left; rfl
+  | ⟨1, _⟩ => right; rfl
+
+private lemma hasMono3AP_imp (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2) (h : hasMono3AP N c) :
+    (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 0) ∨
+    (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 1) := by
+  obtain ⟨a, ha, d, _hd, hpos, hsum, had, heq1, heq2⟩ := h
+  have haS : a ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp ha)
+  have hadS : a + d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp had)
+  have hsumS : a + 2 * d ∈ Icc (1 : ℕ) N := mem_Icc.mpr (Finset.mem_Icc.mp hsum)
+  let x0 : Icc 1 N := ⟨a, haS⟩
+  let x1 : Icc 1 N := ⟨a + d, hadS⟩
+  let x2 : Icc 1 N := ⟨a + 2 * d, hsumS⟩
+  have hcol1 : c x0 = c x1 := by
+    have := heq1
+    rwa [colorOf_eq N c ha, colorOf_eq N c had] at this
+  have hcol2 : c x0 = c x2 := by
+    have := heq2
+    rwa [colorOf_eq N c ha, colorOf_eq N c hsum] at this
+  let s : Finset (Icc 1 N) := {x0, x1, x2}
+  have hset : ({(s' : ℕ) | s' ∈ s} : Set ℕ) = {a, a + d, a + 2 * d} := by
+    ext n
+    constructor
+    · intro hn
+      simp only [s, mem_setOf_eq] at hn
+      obtain ⟨s', hs', rfl⟩ := hn
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hs'
+      rcases hs' with rfl | rfl | rfl <;> simp [x0, x1, x2]
+    · intro hn
+      simp only [mem_insert_iff, mem_singleton_iff] at hn
+      simp only [s, mem_setOf_eq]
+      rcases hn with rfl | rfl | rfl
+      · exact ⟨x0, by simp [x0], rfl⟩
+      · exact ⟨x1, by simp [x0, x1], rfl⟩
+      · exact ⟨x2, by simp [x0, x1, x2], rfl⟩
+  have hAP : ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 := by
+    rw [hset]; exact isAP_three a d hpos
+  rcases fin2_eq_zero_or_one (c x0) with h0 | h1
+  · left
+    refine ⟨s, hAP, ?_⟩
+    intro x hx
+    simp only [s, Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl
+    · exact h0
+    · rwa [← hcol1]
+    · rwa [← hcol2]
+  · right
+    refine ⟨s, hAP, ?_⟩
+    intro x hx
+    simp only [s, Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl
+    · exact h1
+    · rwa [← hcol1]
+    · rwa [← hcol2]
+
+private lemma mono_imp_hasMono3AP (N : ℕ) (c : Icc (1 : ℕ) N → Fin 2)
+    (h : (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 0) ∨
+         (∃ s : Finset (Icc 1 N), ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3 ∧ ∀ x ∈ s, c x = 1)) :
+    hasMono3AP N c := by
+  have extract (col : Fin 2) (s : Finset (Icc 1 N))
+      (hAP : ({(s' : ℕ) | s' ∈ s}).IsAPOfLength 3)
+      (hcol : ∀ x ∈ s, c x = col) : hasMono3AP N c := by
+    obtain ⟨a, d, hcard, heq⟩ := hAP
+    have mem0 : a ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+      rw [heq]; exact ⟨0, by norm_num, by simp⟩
+    have mem1 : a + d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+      rw [heq]; exact ⟨1, by norm_num, by simp⟩
+    have mem2 : a + 2 * d ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ) := by
+      rw [heq]
+      refine ⟨2, by norm_num, ?_⟩
+      simp only [two_nsmul]
+      ring
+    have hd : 0 < d := by
+      by_contra hdz
+      push_neg at hdz
+      have hd0 : d = 0 := by omega
+      subst hd0
+      have hsing : ({(s' : ℕ) | s' ∈ s} : Set ℕ) = ({a} : Set ℕ) := by
+        rw [heq]
+        ext x
+        simp only [nsmul_zero, add_zero, mem_setOf_eq, mem_singleton_iff]
+        constructor
+        · rintro ⟨n, _hn, rfl⟩; rfl
+        · rintro rfl
+          exact ⟨0, by norm_num, by simp⟩
+      have h1 : ENat.card ({a} : Set ℕ) = 1 := by
+        rw [ENat.card_eq_coe_fintype_card]
+        norm_cast
+      rw [hsing, h1] at hcard
+      exact absurd hcard (by norm_num)
+    have get_mem {m : ℕ} (hm : m ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ)) :
+        m ∈ Finset.Icc (1 : ℕ) N := by
+      obtain ⟨x, hx, rfl⟩ := hm
+      have px := x.property
+      simp only [mem_Icc] at px
+      simpa [Finset.mem_Icc] using px
+    have ha := get_mem mem0
+    have had := get_mem mem1
+    have hsum := get_mem mem2
+    have hd_mem : d ∈ Finset.Icc (1 : ℕ) N := by
+      have hsum' := Finset.mem_Icc.mp hsum
+      have ha' := Finset.mem_Icc.mp ha
+      simp only [Finset.mem_Icc]
+      constructor <;> omega
+    have col_eq {m : ℕ} (hm_set : m ∈ ({(s' : ℕ) | s' ∈ s} : Set ℕ))
+        (hm : m ∈ Finset.Icc (1 : ℕ) N) :
+        colorOf N c m = col := by
+      obtain ⟨x, hx, hxe⟩ := hm_set
+      have hxe' : x = ⟨m, mem_Icc.mpr (Finset.mem_Icc.mp hm)⟩ := Subtype.ext hxe
+      rw [colorOf_eq N c hm, ← hxe', hcol x hx]
+    refine ⟨a, ha, d, hd_mem, hd, hsum, had, ?_, ?_⟩
+    · rw [col_eq mem0 ha, col_eq mem1 had]
+    · rw [col_eq mem0 ha, col_eq mem2 hsum]
+  rcases h with ⟨s, hAP, hcol⟩ | ⟨s, hAP, hcol⟩
+  · exact extract 0 s hAP hcol
+  · exact extract 1 s hAP hcol
+
+private lemma all_colorings_9 : ∀ c : Icc (1 : ℕ) 9 → Fin 2, hasMono3AP 9 c := by
+  decide
+
+private lemma nine_in : 9 ∈ mixedMonoAPGuaranteeSet 3 3 := by
+  intro c
+  exact hasMono3AP_imp 9 c (all_colorings_9 c)
+
+private def avoid8 : Icc (1 : ℕ) 8 → Fin 2
+  | ⟨x, _⟩ => if x = 1 ∨ x = 2 ∨ x = 5 ∨ x = 6 then (0 : Fin 2) else (1 : Fin 2)
+
+private lemma avoid8_no_mono : ¬ hasMono3AP 8 avoid8 := by
+  decide
+
+private lemma eight_not_in : 8 ∉ mixedMonoAPGuaranteeSet 3 3 := by
+  intro h
+  exact avoid8_no_mono (mono_imp_hasMono3AP 8 avoid8 (h avoid8))
+
+private lemma not_mem_of_le {k r n N : ℕ} (hle : n ≤ N)
+    (hN : N ∉ mixedMonoAPGuaranteeSet k r) : n ∉ mixedMonoAPGuaranteeSet k r := by
+  intro hn
+  apply hN
+  intro cN
+  let c : Icc 1 n → Fin 2 := fun x =>
+    cN ⟨x.1, mem_Icc.mpr ⟨(mem_Icc.mp x.2).1, le_trans (mem_Icc.mp x.2).2 hle⟩⟩
+  have lift_set (s : Finset (Icc 1 n)) :
+      ∃ sN : Finset (Icc 1 N),
+        ({(s' : ℕ) | s' ∈ sN} : Set ℕ) = ({(s' : ℕ) | s' ∈ s} : Set ℕ) ∧
+        ∀ x ∈ sN, ∃ y ∈ s, (x : ℕ) = (y : ℕ) := by
+    let sN : Finset (Icc 1 N) :=
+      s.image fun x => ⟨x.1, mem_Icc.mpr ⟨(mem_Icc.mp x.2).1, le_trans (mem_Icc.mp x.2).2 hle⟩⟩
+    refine ⟨sN, ?_, ?_⟩
+    · ext m
+      constructor
+      · intro hm
+        simp only [sN, mem_setOf_eq] at hm
+        obtain ⟨xN, hxN, rfl⟩ := hm
+        simp only [Finset.mem_image] at hxN
+        obtain ⟨y, hy, rfl⟩ := hxN
+        exact ⟨y, hy, rfl⟩
+      · intro hm
+        simp only [mem_setOf_eq] at hm
+        obtain ⟨y, hy, rfl⟩ := hm
+        refine ⟨⟨y.1, mem_Icc.mpr ⟨(mem_Icc.mp y.2).1, le_trans (mem_Icc.mp y.2).2 hle⟩⟩, ?_, rfl⟩
+        simp only [sN, Finset.mem_image]
+        exact ⟨y, hy, rfl⟩
+    · intro x hx
+      simp only [sN, Finset.mem_image] at hx
+      obtain ⟨y, hy, rfl⟩ := hx
+      exact ⟨y, hy, rfl⟩
+  rcases hn c with ⟨s, hAP, hcol⟩ | ⟨s, hAP, hcol⟩
+  · obtain ⟨sN, hset, hmem⟩ := lift_set s
+    left
+    refine ⟨sN, ?_, ?_⟩
+    · rwa [hset]
+    · intro x hx
+      obtain ⟨y, hy, hyeq⟩ := hmem x hx
+      have : x = ⟨y.1, mem_Icc.mpr ⟨(mem_Icc.mp y.2).1, le_trans (mem_Icc.mp y.2).2 hle⟩⟩ :=
+        Subtype.ext hyeq
+      rw [this]
+      simpa [c] using hcol y hy
+  · obtain ⟨sN, hset, hmem⟩ := lift_set s
+    right
+    refine ⟨sN, ?_, ?_⟩
+    · rwa [hset]
+    · intro x hx
+      obtain ⟨y, hy, hyeq⟩ := hmem x hx
+      have : x = ⟨y.1, mem_Icc.mpr ⟨(mem_Icc.mp y.2).1, le_trans (mem_Icc.mp y.2).2 hle⟩⟩ :=
+        Subtype.ext hyeq
+      rw [this]
+      simpa [c] using hcol y hy
+
 -- Known exact values for `W(3,r)` from [AKS14].
 /-- $W(3, 3) = 9$ from [AKS14]. -/
 @[category research solved, AMS 5 11]
-theorem W_3_3 : W 3 3 = 9 := by sorry
+theorem W_3_3 : W 3 3 = 9 := by
+  apply IsLeast.csInf_eq
+  refine ⟨nine_in, ?_⟩
+  intro m hm
+  by_contra hlt
+  simp only [not_le] at hlt
+  have hm8 : m ≤ 8 := by omega
+  exact absurd hm (not_mem_of_le hm8 eight_not_in)
 
 /-- $W(3, 4) = 18$ from [AKS14]. -/
 @[category research solved, AMS 5 11]


### PR DESCRIPTION
Proves W(3,3) = 9 and W(3,4) = 18 from [AKS14].

## W(3,3) = 9
Exhaustive case analysis (`decide`) over all 2-colorings of {1,...,9}, with RRBBRRBB on {1,...,8} as lower-bound witness.

## W(3,4) = 18
The naive `decide` over all 2^18 colorings of {1,...,18} overflows the kernel stack, so we use a bitmask representation:

- `hasRed3Mask`/`hasBlue4Mask`: Bool predicates on a mask `bits` (bit i = color of i+1), computed by nested loops over AP witnesses with shrunk iteration bounds `(N - (i+1)) / 2` (red) and `(N - (i+1)) / 3` (blue).
- 132 chunk lemmas (`chunk_18_0`..`chunk_18_131`), each verifying 2000 masks by `decide`, dispatched by `all_masks_18` over all n < 2^18.
- Surjectivity machinery: `indexOfColor` (foldl bit construction) and `coloringOfIndex` connect arbitrary colorings to masks, with `testBit_revFoldl`/`revFoldl_lt` as the core identities.
- Connection lemmas (`hasRed3_iff_mask`, `hasBlue4_iff_mask`) prove the mask loops enumerate exactly the AP witnesses.
- RRBB... (avoid17 coloring) on {1,...,17} as lower-bound witness.

Both values verified via `IsLeast.csInf_eq`.