### PR TITLE
Prove the basic divergence lemmas

### DIFF
--- a/FormalConjectures/Millenium/NavierStokes.lean
+++ b/FormalConjectures/Millenium/NavierStokes.lean
@@ -97,13 +97,15 @@ theorem divergence_const (c : ℝ^n) (x : ℝ^n) :
 theorem divergence_add {v w : ℝ^n → ℝ^n} {x : ℝ^n}
     (hv : DifferentiableAt ℝ v x) (hw : DifferentiableAt ℝ w x) :
     ∇⬝ (fun y => v y + w y) x = ∇⬝ v x + ∇⬝ w x := by
-  sorry
+  rw [divergence, fderiv_fun_add hv hw]
+  exact map_add _ _ _
 
 /-- Divergence commutes with scalar multiplication at differentiability points. -/
 @[category API, AMS 35]
 theorem divergence_smul (c : ℝ) {v : ℝ^n → ℝ^n} {x : ℝ^n}
     (hv : DifferentiableAt ℝ v x) : ∇⬝ (fun y => c • v y) x = c * ∇⬝ v x := by
-  sorry
+  rw [divergence, fderiv_fun_const_smul hv c]
+  simp [divergence]
 
 /--
 A function $f : \mathbb{R}^n \to \alpha$ is 1-periodic if it is periodic in each


### PR DESCRIPTION
Small cleanup in the Navier–Stokes file :) This proves `divergence_add` and `divergence_smul` using linearity of `fderiv` and trace. The four open Millennium problem statements are unchanged. `lake build` passes.

Closes #4642