### PR TITLE
feat(Mathoverflow/507128): mark as formally solved

### DIFF
--- a/FormalConjectures/Mathoverflow/507128.lean
+++ b/FormalConjectures/Mathoverflow/507128.lean
@@ -24,10 +24,18 @@ asked by user [*Junyan Xu*](https://mathoverflow.net/users/3332/junyan-xu)
 
 namespace Mathoverflow507128
 
-/-- There exists a proper ideal `I` in a (commutative) total ring `R` of fractions that is an
-invertible module. If `I ⊊ R` is such an example, `I` must have infinite order in the Picard group,
-and `R` must not be Noetherian (otherwise it must be semi-local and therefore have trivial Picard
-group). -/
+/-- There exists a proper ideal `I` in a (commutative) total ring `R` of fractions that is an invertible module.
+If `I ⊊ R` is such an example, `I` must have infinite order in the Picard group.
+Moreover, `R` must not be Noetherian (otherwise it must be semi-local and therefore have trivial Picard group).
+
+The linked formal proof gives the following explicit construction.
+
+Let `D = ℂ[X, Y] / (Y² - X³)` be the coordinate ring of the cuspidal cubic.
+Let `P = (X - 1, Y - 1)`, which is an invertible ideal.
+Let `M` be the direct sum of the evaluation fibres at cusp parameters `r ≠ 1`.
+Form the idealization `R = D ⋉ M`.
+The desired ideal is the range of the multiplication map `R ⊗[D] P → R`.
+-/
 @[category research solved, AMS 13,
   formal_proof using lean4 at
     "https://github.com/KitaKen1/mo507128-lean/commit/e9507429c01c4288089e4af1c92a03b7d1e17f74"]

--- a/FormalConjectures/Mathoverflow/507128.lean
+++ b/FormalConjectures/Mathoverflow/507128.lean
@@ -28,7 +28,9 @@ namespace Mathoverflow507128
 invertible module. If `I ⊊ R` is such an example, `I` must have infinite order in the Picard group,
 and `R` must not be Noetherian (otherwise it must be semi-local and therefore have trivial Picard
 group). -/
-@[category research open, AMS 13]
+@[category research solved, AMS 13,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/mo507128-lean/commit/e9507429c01c4288089e4af1c92a03b7d1e17f74"]
 theorem exists_isFractionRing_self_ideal_ne_top_invertible :
     ∃ (R : Type) (_ : CommRing R) (_ : IsFractionRing R R) (I : Ideal R),
       I ≠ ⊤ ∧ Module.Invertible R I := by


### PR DESCRIPTION
I present a Lean proof for MathOverflow 507128 (located at `FormalConjectures/Mathoverflow/507128.lean`) and propose changing the status of this Formal Conjectures entry from "open" to "solved."

The Lean proof provided is by KitaKen1 (Kenta Kitamura).

GitHub: https://github.com/KitaKen1/mo507128-lean
Main Lean proof: https://github.com/KitaKen1/mo507128-lean/blob/e9507429c01c4288089e4af1c92a03b7d1e17f74/MO507128.lean
Lean4Web: https://live.lean-lang.org/#project=MathlibDemo&url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fmo507128-lean%2Fmain%2FMO507128_Lean4Web.lean

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.