### PR TITLE
feat(Paper): mark Bézier–Bernstein Voronovskaja problem solved

### DIFF
--- a/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
+++ b/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
@@ -123,7 +123,8 @@ domain is the compact interval $[0,1]$, this also explains why no separate
 boundedness assumption is included here. The variants below record the unknown
 smoothness threshold more explicitly.
 -/
-@[category research open, AMS 26 40 47]
+@[category research solved, AMS 26 40 47,
+  formal_proof using lean4 at "https://github.com/KitaKen1/bezier-bernstein-voronovskaja-lean/blob/3f35c631d215b3841242275bf3ed2c59ea153a2d/Voronovskaja.lean"]
 theorem voronovskaja_theorem.bezier_bernstein_operators
     (α : ℝ) (hα_pos : 0 < α) (hα : α ≠ 1)
     (f : ℝ → ℝ) (x : ℝ) (hx : x ∈ I)

--- a/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
+++ b/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
@@ -122,6 +122,29 @@ The source asks for sufficiently smooth functions. This concrete version uses
 domain is the compact interval $[0,1]$, this also explains why no separate
 boundedness assumption is included here. The variants below record the unknown
 smoothness threshold more explicitly.
+
+The limit exists and equals $\mu(\alpha)\,\sqrt{x(1-x)}\,f'(x)$, where
+$\mu(\alpha) = \int_0^\infty \bigl( (1 - \Phi(t))^{\alpha}
+- (1 - \Phi(t)^{\alpha}) \bigr)\,dt$ and $\Phi$ is the standard normal
+distribution function.
+
+Informal proof: the weights
+$w_{n,k} = J_{n,k}(x)^{\alpha} - J_{n,k+1}(x)^{\alpha}$ are nonnegative and sum
+to $1$, so the quadratic Taylor bound for $f \in C^2$ gives
+$$
+B_{n,\alpha} f(x) - f(x)
+  = \sum_{k=0}^{n} \bigl( f(k/n) - f(x) \bigr) w_{n,k}
+  = f'(x) \sum_{k=0}^{n} (k/n - x)\, w_{n,k}
+    + O\Bigl( \sum_{k=0}^{n} (k/n - x)^2 w_{n,k} \Bigr).
+$$
+The two sums on the right satisfy
+$$
+\sqrt{n} \sum_{k=0}^{n} (k/n - x)\, w_{n,k}
+  \longrightarrow \mu(\alpha)\,\sqrt{x(1-x)},
+\qquad
+\sqrt{n} \sum_{k=0}^{n} (k/n - x)^2 w_{n,k} \longrightarrow 0,
+$$
+so multiplying by $\sqrt{n}$ gives the stated limit.
 -/
 @[category research solved, AMS 26 40 47,
   formal_proof using lean4 at "https://github.com/KitaKen1/bezier-bernstein-voronovskaja-lean/blob/3f35c631d215b3841242275bf3ed2c59ea153a2d/Voronovskaja.lean"]


### PR DESCRIPTION
This PR marks `voronovskaja_theorem.bezier_bernstein_operators` as `research solved` and adds a `formal_proof` link to the complete Lean 4 proof.

I, [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1), completed a Lean 4 formalization of this theorem and published the proof in the following GitHub repository.
Formal proof: [immutable commit](https://github.com/KitaKen1/bezier-bernstein-voronovskaja-lean/blob/3f35c631d215b3841242275bf3ed2c59ea153a2d/Voronovskaja.lean)
Lean4Web: [Open the single-file proof in your browser](https://live.lean-lang.org/#project=MathlibDemo&url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fbezier-bernstein-voronovskaja-lean%2F3f35c631d215b3841242275bf3ed2c59ea153a2d%2Flean4web%2FLean4Web.lean)

The proof compiles with Lean 4.27.0, contains no `sorry` or `admit`, and `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.

AI usage disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.