### PR TITLE
Update remaining references to `FormalConjecturesUtil` after directory rename

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,7 @@ kourovka:
 
 linter:
   - changed-files:
-    - any-glob-to-any-file: 'FormalConjectures/Util/Linters/**'
+    - any-glob-to-any-file: 'FormalConjecturesUtil/Linters/**'
 
 litt-problems:
   - changed-files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This document provides guidelines for AI agents working on the Formal Conjecture
   `FormalConjectures/ErdosProblems/README.md` defines naming patterns for multi-part questions,
   estimate questions, and variants that supplement the general conventions in this file.
 
-- **`FormalConjectures/Util/`**: Repository infrastructure and utilities:
+- **`FormalConjecturesUtil/`**: Repository infrastructure and utilities:
   - `Attributes/` - Defines the `category` and `AMS` attributes
   - `Answer.lean` - Implements the `answer()` elaborator for problems requiring answers
   - `Linters/` - Custom linters for the repository

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ lake build
 The directory structure is organised by the type of sources of the conjectures.
 There are two special directories:
 
--   `FormalConjectures/Util` contains utilities like the
-    [`category` attribute](./FormalConjectures/Util/Attributes/Basic.lean), the
-    [`answer( )` elaborator](./FormalConjectures/Util/Answer.lean) and some
+-   `FormalConjecturesUtil` contains utilities like the
+    [`category` attribute](./FormalConjecturesUtil/Attributes/Basic.lean), the
+    [`answer( )` elaborator](./FormalConjecturesUtil/Answer.lean) and some
     linters.
 -   `FormalConjecturesForMathlib` contains code potentially suitable to be upstreamed to
     [mathlib](https://github.com/leanprover-community/mathlib4). Here we follow


### PR DESCRIPTION
### Summary

There are still a few references in the repository that point to the old
`FormalConjectures/Util` location, even though the utility code now lives under
`FormalConjecturesUtil`. These outdated references can mislead contributors and
prevent repository automation from behaving as expected.

### Changes

* Update `README.md` to use the current utility directory and file links.
* Correct the repository layout documented in `AGENTS.md`.
* Update `.github/labeler.yml` to watch `FormalConjecturesUtil/Linters/**`.

This is a documentation and configuration cleanup only. No Lean source files,
imports, definitions, or conjectures are modified.

### Validation

* Confirmed the old path no longer appears in the affected tracked files.
* Verified the replacement utility files and linter directory exist.
* Parsed `.github/labeler.yml` successfully.
* Ran `git diff --check upstream/main...HEAD`.

### AI use

Codex was used to identify the stale path references, apply the three path-only
edits, and run the validation checks listed above.

Closes #4632
