### PR TITLE
Mark WOWII Graph Conjecture 217 as solved by an external Lean proof

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture217.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture217.lean
@@ -52,7 +52,9 @@ then $G$ has a Hamiltonian path. Here $L_s(G)$ is the maximum number of
 leaves over all spanning trees and $\chi_{\mathrm{residue}=2}(G)$ is the indicator
 of $\mathrm{residue}(G) = 2$.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/wowii-graph-conjecture-217-lean/blob/6a2fb82fcd17aa15ec734736740794bb8bd194c0/lean/GraphConjecture217Audit.lean"]
 theorem conjecture217 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected)
     (hL : Ls G ≤ 4 * (residueEqTwoIndicator G : ℝ) + 2) :
     ∃ a b : α, ∃ p : G.Walk a b, p.IsHamiltonian := by


### PR DESCRIPTION
This pull request marks WOWII Graph Conjecture 217 as `research solved` and adds an immutable `formal_proof using lean4` link.

The Lean proof was developed by KitaKen1 (Kenta Kitamura).
Proof repository: https://github.com/KitaKen1/wowii-graph-conjecture-217-lean
Immutable audit file: https://github.com/KitaKen1/wowii-graph-conjecture-217-lean/blob/6a2fb82fcd17aa15ec734736740794bb8bd194c0/lean/GraphConjecture217Audit.lean

The axiom audit for `conjecture217` reports only `propext`, `Classical.choice`, and `Quot.sound`, with no `sorryAx`.
For reference, a batch check of the single-file audit artifact with Lean v4.27.0 took 27m42s on a 24 GB Apple Silicon Mac.

AI disclosure: ChatGPT 5.6 sol and Codex GPT-5.6 sol with xhigh reasoning were used during proof development and documentation.