### PR TITLE
disprove(Other): convex additive-VC₂ bound in ℝ³

### DIFF
--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -61,6 +61,13 @@ lemma hasAddVCNDimAtMost_two_one_of_convex_r3 :
     ¬ ∀ {C : Set ℝ³} (hC : Convex ℝ C),
       HasAddVCNDimAtMost C 2 1 := sorry
 
+/-- Every convex set in $\mathbb R^3$ has
+$\mathrm{VC}_2$ dimension at most 2. -/
+@[category research open, AMS 5 52]
+lemma hasAddVCNDimAtMost_two_two_of_convex_r3 :
+    ∀ {C : Set ℝ³} (hC : Convex ℝ C),
+      HasAddVCNDimAtMost C 2 2 := sorry
+
 /-- For every $n$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has
 $\mathrm{VC}_n$ dimension at most $d$. -/
 @[category research open, AMS 5 52]

--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -64,8 +64,7 @@ lemma hasAddVCNDimAtMost_two_one_of_convex_r3 :
 /-- Every convex set in $\mathbb R^3$ has
 $\mathrm{VC}_2$ dimension at most 2. -/
 @[category research open, AMS 5 52]
-lemma hasAddVCNDimAtMost_two_two_of_convex_r3 :
-    ∀ {C : Set ℝ³} (hC : Convex ℝ C),
+lemma hasAddVCNDimAtMost_two_two_of_convex_r3 {C : Set ℝ³} (hC : Convex ℝ C) :
       HasAddVCNDimAtMost C 2 2 := sorry
 
 /-- For every $n$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has

--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -52,10 +52,14 @@ lemma exists_convex_rn_add_two_vc_n_forall_not_hasAddVCNDimAtMost (n : ℕ) :
 
 /-  ### Conjectures -/
 
-/-- Every convex set in $\mathbb R^3$ has $\mathrm{VC}_2$ dimension at most 1. -/
-@[category research open, AMS 5 52]
-lemma hasAddVCNDimAtMost_two_one_of_convex_r3 {C : Set ℝ³} (hC : Convex ℝ C) :
-    HasAddVCNDimAtMost C 2 1 := sorry
+/-- Not every convex set in $\mathbb R^3$ has
+$\mathrm{VC}_2$ dimension at most 1. -/
+@[category research solved, AMS 5 52,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/vcdim-convex-counterexample/blob/ad7ffff1514843c886633f5408c6456dfb2e2a49/formal-conjectures-v4.27.0/VCDimConvexCounterexample.lean"]
+lemma hasAddVCNDimAtMost_two_one_of_convex_r3 :
+    ¬ ∀ {C : Set ℝ³} (hC : Convex ℝ C),
+      HasAddVCNDimAtMost C 2 1 := sorry
 
 /-- For every $n$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has
 $\mathrm{VC}_n$ dimension at most $d$. -/

--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -65,7 +65,7 @@ lemma hasAddVCNDimAtMost_two_one_of_convex_r3 :
 $\mathrm{VC}_2$ dimension at most 2. -/
 @[category research open, AMS 5 52]
 lemma hasAddVCNDimAtMost_two_two_of_convex_r3 {C : Set ℝ³} (hC : Convex ℝ C) :
-      HasAddVCNDimAtMost C 2 2 := sorry
+    HasAddVCNDimAtMost C 2 2 := sorry
 
 /-- For every $n$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has
 $\mathrm{VC}_n$ dimension at most $d$. -/


### PR DESCRIPTION
This PR replaces `VCDimConvex.hasAddVCNDimAtMost_two_one_of_convex_r3` with its negation and links a kernel-checked Lean proof.

The Lean proof was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes:

```lean
VCDimConvex.not_hasAddVCNDimAtMost_two_one_of_convex_r3 :
  ¬ (∀ {C : Set ℝ³} (hC : Convex ℝ C),
    HasAddVCNDimAtMost C 2 1)
```

Proof: https://github.com/KitaKen1/vcdim-convex-counterexample/blob/ad7ffff1514843c886633f5408c6456dfb2e2a49/formal-conjectures-v4.27.0/VCDimConvexCounterexample.lean

Repository: https://github.com/KitaKen1/vcdim-convex-counterexample

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fvcdim-convex-counterexample%2Fmain%2Flean4web-v4.33.0-rc1%2FVCDimConvexCounterexampleLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

Note: A prior counterexample was posted in [PR #88](https://github.com/DomTheDeveloper/formal-conjectures/pull/88), but its Lean CI did not pass and the draft PR was closed without being merged.