### PR TITLE
docs(WrittenOnTheWallII/31): link a Lean proof of Chung's induced-path bound

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean
@@ -47,7 +47,9 @@ $\mathrm{path}(G) \ge 2 \cdot \mathrm{rad}(G) - 1$,
 where $\mathrm{path}(G)$ is the floor of the average distance and
 $\mathrm{rad}(G)$ is the graph radius.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/wowii-graph-conjecture-31-lean/blob/a948e9fc07e11b786aee8dadb1376b4d938454d6/lean/GraphConjecture31.lean"]
 theorem conjecture31 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
     2 * (G.radius.toNat : ℤ) - 1 ≤ (path G : ℤ) := by
   sorry


### PR DESCRIPTION
Adds an immutable `formal_proof using lean4` link for WOWII Graph Conjecture 31.

The linked artifact formalizes the proof of $p(G) \ge 2\,\mathrm{rad}(G)-1$ given in Theorem 2.2 of Erdős–Saks–Sós, *Maximum Induced Trees in Graphs* (1986). The paper attributes the proof to Fan Chung.

The Lean proof was developed and formalized by KitaKen1 (Kenta Kitamura).
Lean file: https://github.com/KitaKen1/wowii-graph-conjecture-31-lean/blob/a948e9fc07e11b786aee8dadb1376b4d938454d6/lean/GraphConjecture31.lean
Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fwowii-graph-conjecture-31-lean%2Fmain%2Flean4web%2FGraphConjecture31Lean4Web.lean
Repo: https://github.com/KitaKen1/wowii-graph-conjecture-31-lean

Note: This PR is complementary to #4567, which corrects the inaccurate prose description of `path(G)` and the permanent bibliographic references in the Lean source.

AI Usage Disclosure: This formalization is assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.