### PR TITLE
feat(Paper/MonochromaticQuantumGraph): solve three sharp high-color cases

### DIFF
--- a/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
+++ b/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
@@ -419,9 +419,11 @@ theorem eqSystem6_no_solution_d4 :
 
 /-- For $N = 6$ and $D = 5$, does there exist no solution to the monochromatic quantum graph
 equation system over $\mathbb{C}$? -/
-@[category research open, AMS 5 14 81]
+@[category research solved, AMS 5 14 81,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c53403/lean/QuantumCR/FormalConjecturesWrappers.lean#L55-L62"]
 theorem eqSystem6_no_solution_d5 :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 6 5 ℂ, EqSystemN 6 5 W := by
   sorry
 
@@ -516,9 +518,11 @@ theorem eqSystem10_no_solution_d8 :
 
 /-- For $N = 10$ and $D = 9$, does there exist no solution to the monochromatic quantum graph
 equation system over $\mathbb{C}$? -/
-@[category research open, AMS 5 14 81]
+@[category research solved, AMS 5 14 81,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c53403/lean/QuantumCR/FormalConjecturesWrappers.lean#L73-L80"]
 theorem eqSystem10_no_solution_d9 :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 10 9 ℂ, EqSystemN 10 9 W := by
   sorry
 
@@ -595,9 +599,11 @@ theorem eqSystem6_no_solution_d3_real :
 
 /-- For $N = 6$ and $D = 5$, does there exist no solution to the monochromatic quantum graph
 equation system over $\mathbb{R}$? -/
-@[category research open, AMS 5 14 81]
+@[category research solved, AMS 5 14 81,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c53403/lean/QuantumCR/FormalConjecturesWrappers.lean#L64-L71"]
 theorem eqSystem6_no_solution_d5_real :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 6 5 ℝ, EqSystemN 6 5 W := by
   sorry
 


### PR DESCRIPTION
This PR marks three high-color declarations in `MonochromaticQuantumGraph.lean` as solved:

- `eqSystem6_no_solution_d5` over `ℂ`
- `eqSystem6_no_solution_d5_real` over `ℝ`
- `eqSystem10_no_solution_d9` over `ℂ`

They follow from a single solver-free Lean theorem over arbitrary integral domains:

```lean
theorem colorCount_le_vertices_sub_two_of_eqSystem_domain
    {K : Type} [CommRing K] [IsDomain K] {n D : Nat}
    (hn : 4 ≤ n) (hEven : Even (n + 2)) (hD : 3 ≤ D)
    (W : WeightsN (n + 2) D K) (hW : EqSystemN (n + 2) D W) :
    D ≤ n
```

Thus every solution on an even number `N ≥ 6` of vertices satisfies `D ≤ N - 2`.

The Lean proof was developed and formalized by KitaKen1 (Kenta Kitamura).

Proof repository: https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean

FormalConjecturesWrappers.lean: https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c53403/lean/QuantumCR/FormalConjecturesWrappers.lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fmonochromatic-quantum-graph-sharp-bound-lean%2Frefs%2Fheads%2Fmain%2Flean4web%2FQuantumGraphSharpDegreeBoundLean4Web.lean

Verification: the external proof contains no `sorry`, and its final axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`.

AI Usage Disclosure: This formalization is assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.