### PR TITLE
feat(Paper/MonochromaticQuantumGraph): solve N = 6, D = 4 over C

### DIFF
--- a/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
+++ b/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
@@ -412,7 +412,7 @@ theorem eqSystem6_no_solution_d3 :
 equation system over $\mathbb{C}$? -/
 @[category research solved, AMS 5 14 81,
   formal_proof using lean4 at
-    "https://github.com/KitaKen1/monochromatic-quantum-graph-n6-d4-lean/blob/7d30141a19714986d6f9e632314fd880c9a1e86e/lean4web/QuantumGraphSixFourStructuredLean4Web.lean#L32583-L32590"]
+    "https://github.com/KitaKen1/monochromatic-quantum-graph-n6-d4-lean/blob/7d30141a19714986d6f9e632314fd880c9a1e86e/lean/QuantumCR/FormalConjecturesWrapper.lean#L30-L37"]
 theorem eqSystem6_no_solution_d4 :
     answer(True) ↔
       ¬ ∃ W : WeightsN 6 4 ℂ, EqSystemN 6 4 W := by

--- a/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
+++ b/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
@@ -410,9 +410,11 @@ theorem eqSystem6_no_solution_d3 :
 
 /-- For $N = 6$ and $D = 4$, does there exist no solution to the monochromatic quantum graph
 equation system over $\mathbb{C}$? -/
-@[category research open, AMS 5 14 81]
+@[category research solved, AMS 5 14 81,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/monochromatic-quantum-graph-n6-d4-lean/blob/7d30141a19714986d6f9e632314fd880c9a1e86e/lean4web/QuantumGraphSixFourStructuredLean4Web.lean#L32583-L32590"]
 theorem eqSystem6_no_solution_d4 :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 6 4 ℂ, EqSystemN 6 4 W := by
   sorry
 

--- a/FormalConjectures/Subsets/FC100OpenSet1.lean
+++ b/FormalConjectures/Subsets/FC100OpenSet1.lean
@@ -221,6 +221,6 @@ end Subsets.FC100OpenSet1
 
 open Lean Meta ProblemAttributes in
 #eval verifyCategoryCounts Subsets.FC100OpenSet1.problems [
-  ("research open", 94),
-  ("research solved", 6)
+  ("research open", 93),
+  ("research solved", 7)
 ]


### PR DESCRIPTION
This PR marks `eqSystem6_no_solution_d4` as solved.

The linked Lean 4 proof establishes:

```lean
¬ ∃ W : WeightsN 6 4 ℂ, EqSystemN 6 4 W
```

The proof in fact works over every commutative integral domain.

The Lean proof was developed and formalized by KitaKen1 (Kenta Kitamura).

Proof repository: https://github.com/KitaKen1/monochromatic-quantum-graph-n6-d4-lean

Formal proof: https://github.com/KitaKen1/monochromatic-quantum-graph-n6-d4-lean/blob/7d30141a19714986d6f9e632314fd880c9a1e86e/lean/QuantumCR/FormalConjecturesWrapper.lean#L30-L37

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fmonochromatic-quantum-graph-n6-d4-lean%2F7d30141a19714986d6f9e632314fd880c9a1e86e%2Flean4web%2FQuantumGraphSixFourStructuredLean4Web.lean

Verification: the proof contains no `sorry` or `admit`, and its final axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`.

AI Usage Disclosure: This formalization is assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.