### PR TITLE
Mark WOWII Graph Conjecture 217 solved

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture217.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture217.lean
@@ -52,7 +52,8 @@ then $G$ has a Hamiltonian path. Here $L_s(G)$ is the maximum number of
 leaves over all spanning trees and $\chi_{\mathrm{residue}=2}(G)$ is the indicator
 of $\mathrm{residue}(G) = 2$.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using formal_conjectures at "https://github.com/anagnorisis2peripeteia/formal-conjectures/blob/fbc19805daf7c4ea6e300f449562c269a6bc1663/FormalConjectures/WrittenOnTheWallII/Proofs/GraphConjecture217.lean"]
 theorem conjecture217 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected)
     (hL : Ls G ≤ 4 * (residueEqTwoIndicator G : ℝ) + 2) :
     ∃ a b : α, ∃ p : G.Walk a b, p.IsHamiltonian := by


### PR DESCRIPTION
Marks WOWII Graph Conjecture 217 as `research solved` and links the complete Lean 4 proof. Closes #4667.

Proof (same fork, branch `wowii-217-proof-full`):
- Proof assembly entry point: https://github.com/anagnorisis2peripeteia/formal-conjectures/blob/fbc19805daf7c4ea6e300f449562c269a6bc1663/FormalConjectures/WrittenOnTheWallII/Proofs/GraphConjecture217.lean
- Supporting modules on that branch: `WOWII217Classification`, `WOWII217SmallN`, `WOWII217SmallNExceptions`, `WOWII217Bridge.*`, and the `WOWII217*Chunks` certificate libraries.

Axiom check on the statement as formalised here:

```
#print axioms WrittenOnTheWallII.GraphConjecture217.conjecture217
  [propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]
```

`Lean.ofReduceBool` and `Lean.trustCompiler` come from `native_decide`, used for the exhaustive finite-graph certificates. That is the main trust assumption and reviewers should weigh it explicitly.

The proof splits on `residue G`. The `residue ≠ 2` branch forces `Ls ≤ 2`. The `residue = 2` branch forces `Ls ≤ 6` and reduces to connected graphs on `n ≤ 12` vertices with `maxDegree ≤ 6`, settled by certified case analysis over degree sequences: Bondy–Chvátal closure certificates where the closure completes, Held–Karp DP certificates for the residual regular classes, and Chvátal's path condition for the remainder.

One point worth recording: the `Ls ≤ 6` bound has to be carried into the finite cases rather than weakened to `maxDegree ≤ 6` first. K(4,6) is connected, has `residue = 2`, `maxDegree = 6` and degree sequence `[6,6,6,6,4,4,4,4,4,4]`, but has no Hamiltonian path, and is excluded from the conjecture only by `Ls(K(4,6)) = 8 > 6`. Not a counterexample to the conjecture, but a decomposition that discards `Ls` early yields false intermediate lemmas.

The proof is correct but not golfed: the three residual theorem families share near-identical routing and their branch lemmas do not use the `hNotBig`/`hNotOutOK`/`hStuck` hypotheses, so the certificate modules could be consolidated substantially. Happy to do that before or after merge, whichever you prefer.

The submission branch is one commit and one changed file over upstream.

AI assistance disclosure: the proof and submission preparation used Claude Opus 5, with Gemini 3.1 Pro, GPT-5.3-Codex-Spark and Grok 4.5 for bounded mechanical subtasks; the mathematical argument and Lean artifact should receive normal maintainer review.
