### PR TITLE
chore: improve classical vs constructive reasoning

### DIFF
--- a/FormalConjectures/Arxiv/2602.05192/FirstProof4.lean
+++ b/FormalConjectures/Arxiv/2602.05192/FirstProof4.lean
@@ -27,7 +27,6 @@ by *Mohammed Abouzaid, Andrew J. Blumberg, Martin Hairer, Joe Kileel, Tamara G. 
 open Polynomial Finset ENNReal
 open scoped Nat
 
-open Classical
 
 namespace Arxiv.«2602.05192»
 

--- a/FormalConjectures/Arxiv/2602.05192/FirstProof6.lean
+++ b/FormalConjectures/Arxiv/2602.05192/FirstProof6.lean
@@ -32,7 +32,6 @@ open Matrix Polynomial SimpleGraph
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-open Classical in
 /--
 For a graph $G = (V, E)$, let $G_S = (V, E(S,S))$ denote the graph with the same vertex set,
 but only the edges between vertices in $S$.
@@ -42,6 +41,7 @@ I say that a set of vertices $S$ is $\epsilon$-light if the matrix $\epsilon L -
 positive semidefinite.
 -/
 def IsEpsilonLight (G : SimpleGraph V) (ε : ℝ) (S : Finset V) : Prop :=
+  open scoped Classical in
   letI G_S := G.induce S |>.spanningCoe
   letI L := lapMatrix ℝ G
   letI L_S := lapMatrix ℝ (G_S)

--- a/FormalConjectures/Arxiv/2602.05192/FirstProof6.lean
+++ b/FormalConjectures/Arxiv/2602.05192/FirstProof6.lean
@@ -29,10 +29,10 @@ namespace Arxiv.«2602.05192»
 
 open Matrix Polynomial SimpleGraph
 
-open Classical
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
+open Classical in
 /--
 For a graph $G = (V, E)$, let $G_S = (V, E(S,S))$ denote the graph with the same vertex set,
 but only the edges between vertices in $S$.

--- a/FormalConjectures/ErdosProblems/1041.lean
+++ b/FormalConjectures/ErdosProblems/1041.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/1041](https://www.erdosproblems.com/1041)
 -/
 
-open Polynomial MeasureTheory ENNReal Classical
+open Polynomial MeasureTheory ENNReal
 
 namespace Erdos1041
 
@@ -37,6 +37,7 @@ Hausdorff measure $\mathcal{H}^1(s)$.
 -/
 noncomputable def length (s : Set ℂ) : ℝ≥0∞ := μH[1] s
 
+open scoped Classical in
 /--
 **Erdős–Herzog–Piranian Component Lemma** (Metric Properties of Polynomials, 1958):
 If $f$ is a monic degree $n$ polynomial with all roots in the unit disk,

--- a/FormalConjectures/ErdosProblems/1054.lean
+++ b/FormalConjectures/ErdosProblems/1054.lean
@@ -24,8 +24,9 @@ import FormalConjecturesUtil
 
 namespace Erdos1054
 
-open Classical Filter Asymptotics
+open Filter Asymptotics
 
+open Classical in
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest
 divisors of $m$ for some $k\geq 1$. -/
 noncomputable def f (n : ℕ) : ℕ :=

--- a/FormalConjectures/ErdosProblems/1054.lean
+++ b/FormalConjectures/ErdosProblems/1054.lean
@@ -26,10 +26,10 @@ namespace Erdos1054
 
 open Filter Asymptotics
 
-open Classical in
 /-- Let $f(n)$ be the minimal integer $m$ such that $n$ is the sum of the $k$ smallest
 divisors of $m$ for some $k\geq 1$. -/
 noncomputable def f (n : ℕ) : ℕ :=
+  open scoped Classical in
   if h : ∃ᵉ (m) (k ≥ 1), n = ∑ i < k, Nat.nth (· ∈ m.divisors) i then
     Nat.find h
   else 0

--- a/FormalConjectures/ErdosProblems/1055.lean
+++ b/FormalConjectures/ErdosProblems/1055.lean
@@ -45,12 +45,13 @@ theorem exists_p (r : ℕ+) : ∃ p, p.Prime ∧ IsOfClass r p := by
   sorry
 
 
-open Classical in
 /-- A prime $p$ is in class $1$ if the only prime divisors of $p+1$ are
 $2$ or $3$. In general, a prime $p$ is in class $r$ if every prime factor
 of $p+1$ is in some class $\leq r-1$, with equality for at least one prime factor.
 Let $p_r$ is the least prime in class $r$. -/
-noncomputable def p (r : ℕ+) : ℕ := Nat.find (exists_p r)
+noncomputable def p (r : ℕ+) : ℕ :=
+  open scoped Classical in
+  Nat.find (exists_p r)
 
 /-- A prime $p$ is in class $1$ if the only prime divisors of $p+1$ are
 $2$ or $3$. In general, a prime $p$ is in class $r$ if every prime factor

--- a/FormalConjectures/ErdosProblems/1055.lean
+++ b/FormalConjectures/ErdosProblems/1055.lean
@@ -44,8 +44,8 @@ Show that for each $r$ there exists a prime $p$ of class $r$. -/
 theorem exists_p (r : ℕ+) : ∃ p, p.Prime ∧ IsOfClass r p := by
   sorry
 
-open Classical
 
+open Classical in
 /-- A prime $p$ is in class $1$ if the only prime divisors of $p+1$ are
 $2$ or $3$. In general, a prime $p$ is in class $r$ if every prime factor
 of $p+1$ is in some class $\leq r-1$, with equality for at least one prime factor.

--- a/FormalConjectures/ErdosProblems/1062.lean
+++ b/FormalConjectures/ErdosProblems/1062.lean
@@ -33,10 +33,10 @@ other elements of `A`. -/
 def ForkFree (A : Set ℕ) : Prop :=
   ∀ a ∈ A, ({b | b ∈ A \ {a} ∧ a ∣ b} : Set ℕ).Subsingleton
 
-open scoped Classical in
 /-- The extremal function from Erdős problem 1062: the largest size of a fork-free subset of
 `{1,...,n}`. -/
 noncomputable def f (n : ℕ) : ℕ :=
+  open scoped Classical in
   Nat.findGreatest (fun k => ∃ A ⊆ Set.Icc 1 n, ForkFree A ∧ A.ncard = k) n
 
 -- TODO: Add erdos_1062.parts.i: How large can $f(n)$ be?

--- a/FormalConjectures/ErdosProblems/1077.lean
+++ b/FormalConjectures/ErdosProblems/1077.lean
@@ -26,6 +26,7 @@ open Finset Filter SimpleGraph
 
 namespace Erdos1077
 
+open Classical in
 /--
 We call a graph $D$-balanced (or $D$-almost-regular) if the maximum degree is at most $D$ times the
 minimum degree.

--- a/FormalConjectures/ErdosProblems/1077.lean
+++ b/FormalConjectures/ErdosProblems/1077.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/1077](https://www.erdosproblems.com/1077)
 -/
 
-open Classical Finset Filter SimpleGraph
+open Finset Filter SimpleGraph
 
 namespace Erdos1077
 

--- a/FormalConjectures/ErdosProblems/1077.lean
+++ b/FormalConjectures/ErdosProblems/1077.lean
@@ -26,7 +26,7 @@ open Finset Filter SimpleGraph
 
 namespace Erdos1077
 
-open Classical in
+open scoped Classical in
 /--
 We call a graph $D$-balanced (or $D$-almost-regular) if the maximum degree is at most $D$ times the
 minimum degree.

--- a/FormalConjectures/ErdosProblems/1092.lean
+++ b/FormalConjectures/ErdosProblems/1092.lean
@@ -26,7 +26,6 @@ import FormalConjecturesUtil
 
 namespace Erdos1092
 
-open Classical
 open SimpleGraph
 open Finset
 open Asymptotics

--- a/FormalConjectures/ErdosProblems/1146.lean
+++ b/FormalConjectures/ErdosProblems/1146.lean
@@ -24,7 +24,6 @@ import FormalConjecturesUtil
 - [Ru99] Ruzsa, I., Erdős and the Integers. Journal of Number Theory (1999), 115-163.
 -/
 
-open Classical
 open scoped Pointwise
 
 namespace Erdos1146

--- a/FormalConjectures/ErdosProblems/1146.lean
+++ b/FormalConjectures/ErdosProblems/1146.lean
@@ -28,7 +28,6 @@ open scoped Pointwise
 
 namespace Erdos1146
 
-open Classical in
 /--
 We say that $A\subset \mathbb{N}$ is an essential component if $d_s(A \oplus B)>d_s(B)$ for every
 $B\subset \mathbb{N}$ with $0<d_s(B)<1$ where $d_s$ is the Schnirelmann density.
@@ -36,6 +35,7 @@ Here, the sumset is the appropriate one for Schnirelmann density, $A \oplus B = 
 This avoids the trivial case where the sumset misses $1$ simply because neither $A$ nor $B$ contains $0$.
 -/
 def IsEssentialComponent (A : Set ℕ) : Prop :=
+  open scoped Classical in
   ∀ B : Set ℕ,
     let b := schnirelmannDensity B;
     0 < b → b < 1 → schnirelmannDensity ((A ∪ {0}) + (B ∪ {0})) > b

--- a/FormalConjectures/ErdosProblems/1146.lean
+++ b/FormalConjectures/ErdosProblems/1146.lean
@@ -28,6 +28,7 @@ open scoped Pointwise
 
 namespace Erdos1146
 
+open Classical in
 /--
 We say that $A\subset \mathbb{N}$ is an essential component if $d_s(A \oplus B)>d_s(B)$ for every
 $B\subset \mathbb{N}$ with $0<d_s(B)<1$ where $d_s$ is the Schnirelmann density.

--- a/FormalConjectures/ErdosProblems/1192.lean
+++ b/FormalConjectures/ErdosProblems/1192.lean
@@ -27,7 +27,7 @@ import FormalConjecturesUtil
 -/
 
 open Nat Filter Finset Set
-open scoped Asymptotics Classical BigOperators
+open scoped Asymptotics BigOperators
 
 namespace Erdos1192
 
@@ -99,6 +99,7 @@ theorem erdos_1192 :
           (fun (x : ℕ) ↦ (x : ℝ)) := by
   sorry
 
+open scoped Classical in
 /--
 Erdős and Rényi proved by the probabilistic method that there exists a set $A$ such that
 $$\sum_{n\leq x}f_r(n)^2 \ll x$$ and $$\lvert A\cap [1,x]\rvert\gg x^{1/r}$$ for all $x$.

--- a/FormalConjectures/ErdosProblems/12.lean
+++ b/FormalConjectures/ErdosProblems/12.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/12](https://www.erdosproblems.com/12)
 -/
 
-open Classical Filter Set
+open Filter Set
 
 namespace Erdos12
 

--- a/FormalConjectures/ErdosProblems/1201.lean
+++ b/FormalConjectures/ErdosProblems/1201.lean
@@ -34,6 +34,7 @@ noncomputable def Erdos1201Set (ε : ℝ) (k : ℕ) : Set ℕ :=
   { n : ℕ |
     ((sSup {p : ℕ | p.Prime ∧ p ∣ ∏ i ∈ range (k + 1), (n + i)} : ℕ) : ℝ) > (n : ℝ) ^ (1 - ε) }
 
+open Classical in
 /--
 Is it true that for every $\epsilon,\eta>0$ there exists a $k$ such that the density of $n$
 for which $P(n(n+1)\cdots(n+k))>n^{1-\epsilon}$ is at least $1-\eta$ (where $P(m)$ is the greatest
@@ -47,6 +48,7 @@ theorem erdos_1201 :
           (((count (Erdos1201Set ε k) x : ℝ) / (x : ℝ)) : EReal)) ≥ (1 - η : EReal) := by
   sorry
 
+open Classical in
 /--
 Erdős wrote he could prove this for $\epsilon=1/2$.
 -/

--- a/FormalConjectures/ErdosProblems/1201.lean
+++ b/FormalConjectures/ErdosProblems/1201.lean
@@ -23,7 +23,6 @@ import FormalConjecturesUtil
 -/
 
 open Nat Filter Finset
-open Classical
 
 namespace Erdos1201
 

--- a/FormalConjectures/ErdosProblems/1201.lean
+++ b/FormalConjectures/ErdosProblems/1201.lean
@@ -34,7 +34,7 @@ noncomputable def Erdos1201Set (ε : ℝ) (k : ℕ) : Set ℕ :=
   { n : ℕ |
     ((sSup {p : ℕ | p.Prime ∧ p ∣ ∏ i ∈ range (k + 1), (n + i)} : ℕ) : ℝ) > (n : ℝ) ^ (1 - ε) }
 
-open Classical in
+open scoped Classical in
 /--
 Is it true that for every $\epsilon,\eta>0$ there exists a $k$ such that the density of $n$
 for which $P(n(n+1)\cdots(n+k))>n^{1-\epsilon}$ is at least $1-\eta$ (where $P(m)$ is the greatest
@@ -48,7 +48,7 @@ theorem erdos_1201 :
           (((count (Erdos1201Set ε k) x : ℝ) / (x : ℝ)) : EReal)) ≥ (1 - η : EReal) := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Erdős wrote he could prove this for $\epsilon=1/2$.
 -/

--- a/FormalConjectures/ErdosProblems/156.lean
+++ b/FormalConjectures/ErdosProblems/156.lean
@@ -27,13 +27,14 @@ import FormalConjecturesUtil
 -/
 
 open Finset Filter
-open scoped Classical
 
 namespace Erdos156
+
 /--
 The size of the smallest maximal Sidon set in $\{1, \dots, N\}$.
 -/
 noncomputable def minMaximalSidonSet (N : ℕ) : ℕ :=
+  open scoped Classical in
   sInf (((Icc 1 N).powerset.filter fun (A : Finset ℕ) ↦
     Set.IsMaximalSidonSetIn (A : Set ℕ) N).image card : Set ℕ)
 

--- a/FormalConjectures/ErdosProblems/16.lean
+++ b/FormalConjectures/ErdosProblems/16.lean
@@ -28,7 +28,7 @@ import FormalConjecturesUtil
 -/
 
 open Nat Filter Set
-open scoped Topology Classical
+open scoped Topology
 
 namespace Erdos16
 
@@ -42,6 +42,7 @@ def Erdos16Set : Set ℕ :=
 A set of natural numbers has density 0.
 -/
 def density_zero (S : Set ℕ) : Prop :=
+  open scoped Classical in
   Tendsto (fun x : ℕ ↦ (count S x : ℝ) / (x : ℝ)) atTop (𝓝 0)
 
 /--
@@ -66,6 +67,7 @@ theorem erdos_16 :
 A set of natural numbers has positive lower density.
 -/
 def positive_lower_density (S : Set ℕ) : Prop :=
+  open scoped Classical in
   0 < atTop.liminf (fun n : ℕ ↦ ((count S n : ℝ) / (n : ℝ) : EReal))
 
 /--

--- a/FormalConjectures/ErdosProblems/184.lean
+++ b/FormalConjectures/ErdosProblems/184.lean
@@ -31,7 +31,7 @@ import FormalConjecturesUtil
   Mathematics and its Applications (Proc. Conf., Oxford, 1969) (1971), 97-109.
 -/
 
-open Filter SimpleGraph Classical
+open Filter SimpleGraph
 
 namespace Erdos184
 
@@ -39,6 +39,7 @@ namespace Erdos184
 A graph $H$ is a cycle or an edge if it is connected and 2-regular, or if it has exactly one edge.
 -/
 def IsCycleOrEdge {U : Type*} [Fintype U] (H : SimpleGraph U) : Prop :=
+  open scoped Classical in
   (H.Connected ∧ H.IsRegularOfDegree 2) ∨ H.edgeFinset.card = 1
 
 /-- D is a decomposition of G into subgraphs. -/
@@ -46,6 +47,7 @@ def IsDecomposition {V : Type*} (G : SimpleGraph V) (D : Finset G.Subgraph) : Pr
   Set.PairwiseDisjoint (D : Set G.Subgraph) (fun H ↦ H.edgeSet) ∧
   (⋃ H ∈ D, H.edgeSet) = G.edgeSet
 
+open scoped Classical in
 /--
 Any graph on $n$ vertices can be decomposed into $O(n)$ many edge-disjoint cycles and edges.
 -/
@@ -60,6 +62,7 @@ theorem erdos_184 :
         (D.card : ℝ) ≤ f (Fintype.card V) := by
   sorry
 
+open scoped Classical in
 /--
 Erdős and Gallai [EGP66] proved that $O(n \log n)$ many cycles and edges suffices.
 -/
@@ -88,6 +91,7 @@ theorem erdos_184.variants.lower_bound :
         (1 + c) * (n : ℝ) ≤ (D.card : ℝ) := by
   sorry
 
+open scoped Classical in
 /--
 In [Er71] Erdős suggests that only $n-1$ many cycles and edges are required if we do not
 require them to be edge-disjoint.
@@ -102,6 +106,7 @@ theorem erdos_184.variants.covering :
         (D.card : ℝ) ≤ (Fintype.card V : ℝ) - 1 := by
   sorry
 
+open scoped Classical in
 /--
 The best bound available is due to Bucić and Montgomery [BM22], who prove that $O(n\log^* n)$ many
 cycles and edges suffice, where $\log^*$ is the iterated logarithm function.
@@ -117,6 +122,7 @@ theorem erdos_184.variants.bucic_montgomery :
         (D.card : ℝ) ≤ f (Fintype.card V) := by
   sorry
 
+open scoped Classical in
 /--
 Conlon, Fox, and Sudakov [CFS14] proved that $O_\epsilon(n)$ cycles and edges suffice if $G$ has
 minimum degree at least $\epsilon n$, for any $\epsilon>0$.

--- a/FormalConjectures/ErdosProblems/22.lean
+++ b/FormalConjectures/ErdosProblems/22.lean
@@ -40,7 +40,7 @@ and Zhao [FLZ15].
   Ramsey-Turán problem*. Combinatorica 35 (2015), 435--476.
 -/
 
-open Classical Filter SimpleGraph
+open Filter SimpleGraph
 
 namespace Erdos22
 

--- a/FormalConjectures/ErdosProblems/23.lean
+++ b/FormalConjectures/ErdosProblems/23.lean
@@ -26,7 +26,7 @@ import FormalConjecturesUtil
 * [McKay, Extremal graphs for bipartization of triangle-free graphs](https://users.cecs.anu.edu.au/~bdm/data/graphs.html)
 -/
 
-open SimpleGraph BigOperators Classical
+open SimpleGraph BigOperators
 
 namespace Erdos23
 
@@ -94,6 +94,7 @@ theorem blowupC5_tight (n : ℕ) (_hn : 0 < n) (H : SimpleGraph (ZMod 5 × Fin n
     n ^ 2 ≤ ((blowupC5 n).edgeFinset \ H.edgeFinset).card := by
   sorry
 
+open scoped Classical in
 /--
 Can every triangle-free graph on $5n$ vertices be made bipartite by deleting at most $n^2$ edges?
 -/

--- a/FormalConjectures/ErdosProblems/241.lean
+++ b/FormalConjectures/ErdosProblems/241.lean
@@ -29,7 +29,7 @@ import FormalConjecturesUtil
 -/
 
 open Filter Finset
-open scoped Asymptotics Classical
+open scoped Asymptotics
 
 namespace Erdos241
 
@@ -40,6 +40,7 @@ $a,b,c\in A$ are all distinct (aside from the trivial coincidences).
 Formalization note: this is generalized to allow for different $r$.
 -/
 noncomputable def f (N r : ℕ) : ℕ :=
+  open scoped Classical in
   letI candidates := (Icc 1 N).powerset.filter (fun A ↦
     ∀ m₁ m₂ : Multiset ℕ,
       m₁.card = r → m₂.card = r →

--- a/FormalConjectures/ErdosProblems/25.lean
+++ b/FormalConjectures/ErdosProblems/25.lean
@@ -23,7 +23,6 @@ import FormalConjecturesUtil
 
 open Filter Finset Real Nat Set
 open scoped Topology
-open Classical
 
 namespace Erdos25
 

--- a/FormalConjectures/ErdosProblems/295.lean
+++ b/FormalConjectures/ErdosProblems/295.lean
@@ -22,7 +22,6 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/295](https://www.erdosproblems.com/295)
 -/
 
-open Classical
 open scoped Real
 
 namespace Erdos295

--- a/FormalConjectures/ErdosProblems/295.lean
+++ b/FormalConjectures/ErdosProblems/295.lean
@@ -35,6 +35,7 @@ lemma exists_k (N : ℕ) : ∃ (k : ℕ) (n : Fin k.succ → ℕ),
     (∀ i, N ≤ n i) ∧ StrictMono n ∧ ∑ i, (1 / n i : ℝ) = 1 := by
   sorry
 
+open Classical in
 /--
 Let $k(N)$ denote the smallest $k$ such that there exists
 $N ≤ n_1 < ⋯ < n_k$ with $\frac 1 {n_1} + ... + \frac 1 {n_k} = 1$.

--- a/FormalConjectures/ErdosProblems/295.lean
+++ b/FormalConjectures/ErdosProblems/295.lean
@@ -35,12 +35,13 @@ lemma exists_k (N : ℕ) : ∃ (k : ℕ) (n : Fin k.succ → ℕ),
     (∀ i, N ≤ n i) ∧ StrictMono n ∧ ∑ i, (1 / n i : ℝ) = 1 := by
   sorry
 
-open Classical in
 /--
 Let $k(N)$ denote the smallest $k$ such that there exists
 $N ≤ n_1 < ⋯ < n_k$ with $\frac 1 {n_1} + ... + \frac 1 {n_k} = 1$.
 -/
-noncomputable abbrev k (N : ℕ) : ℕ := Nat.find (exists_k N)
+noncomputable abbrev k (N : ℕ) : ℕ :=
+  open scoped Classical in
+  Nat.find (exists_k N)
 
 
 /--

--- a/FormalConjectures/ErdosProblems/32.lean
+++ b/FormalConjectures/ErdosProblems/32.lean
@@ -38,7 +38,7 @@ large natural number can be written as $p + a$ for some prime $p$ and $a \in A$.
 def IsAdditiveComplementToPrimes (A : Set ℕ) : Prop :=
   ∀ᶠ n in atTop, ∃ p, p.Prime ∧ ∃ a ∈ A, n = p + a
 
-open Classical in
+open scoped Classical in
 /--
 Erdős proved in [Erd54] that there exists an additive complement $A$ to the primes with
 $|A \cap \{1, \ldots, N\}| = O((\log N)^2)$.
@@ -50,7 +50,7 @@ theorem erdos_32.variants.log_squared : ∃ A : Set ℕ,
       fun N => (Real.log N) ^ 2 := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Must every additive complement $A$ to the primes satisfy
 $\liminf_{N \to \infty} \frac{|A \cap \{1, \ldots, N\}|}{\log N} > 1$?
@@ -62,7 +62,7 @@ theorem erdos_32.variants.liminf_gt_one : ∀ A : Set ℕ,
       atTop := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Does there exist a set $A \subseteq \mathbb{N}$ such that $|A \cap \{1, \ldots, N\}| = o((\log N)^2)$
 and every sufficiently large integer can be written as $p + a$ for some prime $p$ and $a \in A$?
@@ -74,7 +74,7 @@ theorem erdos_32 : answer(sorry) ↔ ∃ A : Set ℕ,
       fun N => (Real.log N) ^ 2 := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Can the bound $O(\log N)$ be achieved for an additive complement to the primes? [Guy04] writes
 that Erdős offered \$50 for the solution.
@@ -86,7 +86,7 @@ theorem erdos_32.variants.log_bound : answer(sorry) ↔ ∃ A : Set ℕ,
       fun N => Real.log N := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Ruzsa proved that any additive complement $A$ to the primes must satisfy
 $\liminf_{N \to \infty} \frac{|A \cap \{1, \ldots, N\}|}{\log N} \geq e^\gamma$,

--- a/FormalConjectures/ErdosProblems/32.lean
+++ b/FormalConjectures/ErdosProblems/32.lean
@@ -27,7 +27,6 @@ import FormalConjecturesUtil
 * [Ru98c] Ruzsa, Imre Z., On the additive completion of primes. Acta Arith. (1998), 269-275.
 -/
 
-open Classical
 
 namespace Erdos32
 

--- a/FormalConjectures/ErdosProblems/32.lean
+++ b/FormalConjectures/ErdosProblems/32.lean
@@ -38,6 +38,7 @@ large natural number can be written as $p + a$ for some prime $p$ and $a \in A$.
 def IsAdditiveComplementToPrimes (A : Set ℕ) : Prop :=
   ∀ᶠ n in atTop, ∃ p, p.Prime ∧ ∃ a ∈ A, n = p + a
 
+open Classical in
 /--
 Erdős proved in [Erd54] that there exists an additive complement $A$ to the primes with
 $|A \cap \{1, \ldots, N\}| = O((\log N)^2)$.
@@ -49,6 +50,7 @@ theorem erdos_32.variants.log_squared : ∃ A : Set ℕ,
       fun N => (Real.log N) ^ 2 := by
   sorry
 
+open Classical in
 /--
 Must every additive complement $A$ to the primes satisfy
 $\liminf_{N \to \infty} \frac{|A \cap \{1, \ldots, N\}|}{\log N} > 1$?
@@ -60,6 +62,7 @@ theorem erdos_32.variants.liminf_gt_one : ∀ A : Set ℕ,
       atTop := by
   sorry
 
+open Classical in
 /--
 Does there exist a set $A \subseteq \mathbb{N}$ such that $|A \cap \{1, \ldots, N\}| = o((\log N)^2)$
 and every sufficiently large integer can be written as $p + a$ for some prime $p$ and $a \in A$?
@@ -71,6 +74,7 @@ theorem erdos_32 : answer(sorry) ↔ ∃ A : Set ℕ,
       fun N => (Real.log N) ^ 2 := by
   sorry
 
+open Classical in
 /--
 Can the bound $O(\log N)$ be achieved for an additive complement to the primes? [Guy04] writes
 that Erdős offered \$50 for the solution.
@@ -82,6 +86,7 @@ theorem erdos_32.variants.log_bound : answer(sorry) ↔ ∃ A : Set ℕ,
       fun N => Real.log N := by
   sorry
 
+open Classical in
 /--
 Ruzsa proved that any additive complement $A$ to the primes must satisfy
 $\liminf_{N \to \infty} \frac{|A \cap \{1, \ldots, N\}|}{\log N} \geq e^\gamma$,

--- a/FormalConjectures/ErdosProblems/33.lean
+++ b/FormalConjectures/ErdosProblems/33.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/33](https://www.erdosproblems.com/33)
 -/
 variable {α : Type} [AddCommMonoid α]
-open Classical Set
+open Set
 open scoped goldenRatio
 
 namespace Erdos33

--- a/FormalConjectures/ErdosProblems/331.lean
+++ b/FormalConjectures/ErdosProblems/331.lean
@@ -23,10 +23,11 @@ import FormalConjecturesUtil
 -/
 
 open Nat Filter
-open scoped Asymptotics Classical
+open scoped Asymptotics
 
 namespace Erdos331
 
+open scoped Classical in
 /--
 Let $A,B\subseteq \mathbb{N}$ such that for all large $N$$$\lvert A\cap \{1,\ldots,N\}\rvert \gg
 N^{1/2}$$and$$\lvert B\cap \{1,\ldots,N\}\rvert \gg N^{1/2}.$$
@@ -51,6 +52,7 @@ theorem erdos_331 :
         a₁ ≠ a₂ ∧ a₁ + b₂ = a₂ + b₁ }.Infinite := by
   sorry
 
+open scoped Classical in
 /--
 Ruzsa suggests that a non-trivial variant of this problem arises if one imposes the stronger
 condition that $|A \cap \{1,\dots,N\}| \sim c_A N^{1/2}$ for some constant $c_A>0$, and similarly

--- a/FormalConjectures/ErdosProblems/38.lean
+++ b/FormalConjectures/ErdosProblems/38.lean
@@ -29,6 +29,7 @@ open Set Pointwise
 
 namespace Erdos38
 
+open Classical in
 /--
 Does there exist $B \subset \mathbb{N}$ which is not an additive basis,
 but is such that for every set $A \subseteq \mathbb{N}$ of Schnirelmann density $\alpha$

--- a/FormalConjectures/ErdosProblems/38.lean
+++ b/FormalConjectures/ErdosProblems/38.lean
@@ -29,7 +29,7 @@ open Set Pointwise
 
 namespace Erdos38
 
-open Classical in
+open scoped Classical in
 /--
 Does there exist $B \subset \mathbb{N}$ which is not an additive basis,
 but is such that for every set $A \subseteq \mathbb{N}$ of Schnirelmann density $\alpha$

--- a/FormalConjectures/ErdosProblems/38.lean
+++ b/FormalConjectures/ErdosProblems/38.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
   Colloque sur la Théorie des Nombres, Bruxelles, 1955 (1956), 127-137.)
 -/
 
-open Classical Set Pointwise
+open Set Pointwise
 
 namespace Erdos38
 

--- a/FormalConjectures/ErdosProblems/416.lean
+++ b/FormalConjectures/ErdosProblems/416.lean
@@ -27,9 +27,9 @@ open scoped Topology Real
 
 namespace Erdos416
 
-open Classical in
 /-- Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable. -/
 noncomputable abbrev V (x : ℝ) : ℝ :=
+  open scoped Classical in
   (Finset.Icc 1 ⌊x⌋₊ |>.filter (fun n => ∃ (m : ℕ), m.totient = n)).card
 
 /--

--- a/FormalConjectures/ErdosProblems/416.lean
+++ b/FormalConjectures/ErdosProblems/416.lean
@@ -27,6 +27,7 @@ open scoped Topology Real
 
 namespace Erdos416
 
+open Classical in
 /-- Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable. -/
 noncomputable abbrev V (x : ℝ) : ℝ :=
   (Finset.Icc 1 ⌊x⌋₊ |>.filter (fun n => ∃ (m : ℕ), m.totient = n)).card

--- a/FormalConjectures/ErdosProblems/416.lean
+++ b/FormalConjectures/ErdosProblems/416.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/416](https://www.erdosproblems.com/416)
 -/
 
-open Classical Filter
+open Filter
 open scoped Topology Real
 
 namespace Erdos416

--- a/FormalConjectures/ErdosProblems/456.lean
+++ b/FormalConjectures/ErdosProblems/456.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 -/
 
 open Nat Filter
-open scoped Topology Classical Asymptotics
+open scoped Topology Asymptotics
 
 namespace Erdos456
 
@@ -41,6 +41,7 @@ Let $m_n$ be the smallest integer such that $n\mid \phi(m_n)$.
 noncomputable def m (n : ℕ) : ℕ :=
   sInf { k | 0 < k ∧ n ∣ totient k }
 
+open scoped Classical in
 /--
 Is it true that $m_n<p_n$ for almost all $n$?
 -/
@@ -50,6 +51,7 @@ theorem erdos_456.parts.i :
       Tendsto (fun N ↦ (count { n | m n < p n } N : ℝ) / (N : ℝ)) atTop (𝓝 1) := by
   sorry
 
+open scoped Classical in
 /--
 Does $p_n/m_n \to \infty$ for almost all $n$?
 -/
@@ -151,6 +153,7 @@ theorem erdos_456.variants.infinitely_many_n :
       omega
     omega
 
+open scoped Classical in
 /--
 Erdős [Er79e] writes it is 'easy to show' that $m_n/n \to \infty$ for almost all $n$.
 -/

--- a/FormalConjectures/ErdosProblems/488.lean
+++ b/FormalConjectures/ErdosProblems/488.lean
@@ -22,7 +22,6 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/488](https://www.erdosproblems.com/488)
 -/
 
-open Classical
 
 namespace Erdos488
 

--- a/FormalConjectures/ErdosProblems/489.lean
+++ b/FormalConjectures/ErdosProblems/489.lean
@@ -24,7 +24,7 @@ import FormalConjecturesUtil
 
 namespace Erdos489
 
-open Classical Filter
+open Filter
 open scoped Topology
 
 /-- The set of positive integers not divisible by any element of `A`. -/

--- a/FormalConjectures/ErdosProblems/489.lean
+++ b/FormalConjectures/ErdosProblems/489.lean
@@ -30,15 +30,15 @@ open scoped Topology
 /-- The set of positive integers not divisible by any element of `A`. -/
 def sievedSet (A : Set ℕ) : Set ℕ := {n : ℕ | 0 < n ∧ ∀ a ∈ A, ¬(a ∣ n)}
 
-open Classical in
 /-- The squared-gap sum `∑_{b_i < x} (b_{i+1} - b_i)²`, where `b_i` enumerates the positive
 integers not divisible by any element of `A`. -/
 noncomputable def GapSumSq (A : Set ℕ) (x : ℕ) : ℝ :=
+  open scoped Classical in
   letI B := sievedSet A
   let b := Nat.nth (· ∈ B)
   ∑ i < Nat.count (· ∈ B) x, ((b (i + 1) : ℝ) - b i) ^ 2
 
-open Classical in
+open scoped Classical in
 /--
 Let $A\subseteq \mathbb{N}$ be a set such that $\lvert A\cap [1,x]\rvert=o(x^{1/2})$. Let
 $B=\{ n\geq 1 : a\nmid n\textrm{ for all }a\in A\}$.

--- a/FormalConjectures/ErdosProblems/489.lean
+++ b/FormalConjectures/ErdosProblems/489.lean
@@ -30,6 +30,7 @@ open scoped Topology
 /-- The set of positive integers not divisible by any element of `A`. -/
 def sievedSet (A : Set ℕ) : Set ℕ := {n : ℕ | 0 < n ∧ ∀ a ∈ A, ¬(a ∣ n)}
 
+open Classical in
 /-- The squared-gap sum `∑_{b_i < x} (b_{i+1} - b_i)²`, where `b_i` enumerates the positive
 integers not divisible by any element of `A`. -/
 noncomputable def GapSumSq (A : Set ℕ) (x : ℕ) : ℝ :=
@@ -37,6 +38,7 @@ noncomputable def GapSumSq (A : Set ℕ) (x : ℕ) : ℝ :=
   let b := Nat.nth (· ∈ B)
   ∑ i < Nat.count (· ∈ B) x, ((b (i + 1) : ℝ) - b i) ^ 2
 
+open Classical in
 /--
 Let $A\subseteq \mathbb{N}$ be a set such that $\lvert A\cap [1,x]\rvert=o(x^{1/2})$. Let
 $B=\{ n\geq 1 : a\nmid n\textrm{ for all }a\in A\}$.

--- a/FormalConjectures/ErdosProblems/505.lean
+++ b/FormalConjectures/ErdosProblems/505.lean
@@ -46,7 +46,7 @@ Lean 4 code in this file was drafted with assistance from Claude (Anthropic).
 The mathematical content and references are the author's own work.
 -/
 
-open Metric Set Classical
+open Metric Set
 
 namespace Erdos505
 

--- a/FormalConjectures/ErdosProblems/522.lean
+++ b/FormalConjectures/ErdosProblems/522.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/522](https://www.erdosproblems.com/522)
 -/
 
-open MeasureTheory Classical Filter
+open MeasureTheory Filter
 open scoped ProbabilityTheory Topology Real
 
 namespace Erdos522
@@ -73,7 +73,9 @@ noncomputable def roots (c : KacCoefficients S Ω μ) (n : ℕ) : Ω → Multise
 
 /-- Counts the number of roots of a Kac polynomial in the unit disk with multiplicity. -/
 noncomputable def numRootsInUnitDisk [PseudoMetricSpace k] (c : KacCoefficients S Ω μ) (n : ℕ)
-    (ω : Ω) : ℕ := (c.roots n ω).countP (· ∈ Metric.closedBall 0 1)
+    (ω : Ω) : ℕ :=
+  open scoped Classical in
+  (c.roots n ω).countP (· ∈ Metric.closedBall 0 1)
 
 end KacCoefficients
 
@@ -128,6 +130,7 @@ theorem erdos_522.variants.number_real_roots : ∃ p o : ℕ → ℝ,
       (ℙ {ω | |(f.roots n ω).card / (n : ℝ).log - 2 / π| ≥ o n}).toReal ≤ p n := by
   sorry
 
+open scoped Classical in
 /--
 Yakir proved that almost all Kac polynomials have `n/2+O(n^(9/10))` many roots in `{z∈C:|z|≤1}`.
 -/

--- a/FormalConjectures/ErdosProblems/533.lean
+++ b/FormalConjectures/ErdosProblems/533.lean
@@ -33,7 +33,7 @@ import FormalConjecturesUtil
   [arXiv:2103.10423](https://arxiv.org/abs/2103.10423) (2021).
 -/
 
-open Classical Filter SimpleGraph
+open Filter SimpleGraph
 
 namespace Erdos533
 

--- a/FormalConjectures/ErdosProblems/579.lean
+++ b/FormalConjectures/ErdosProblems/579.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
   type problems*, Combinatorica **3** (1983), 69–81.
 -/
 
-open Classical Filter SimpleGraph
+open Filter SimpleGraph
 
 namespace Erdos579
 

--- a/FormalConjectures/ErdosProblems/600.lean
+++ b/FormalConjectures/ErdosProblems/600.lean
@@ -30,7 +30,6 @@ open scoped Topology
 
 namespace Erdos600
 
-open Classical in
 /--
 Let $e(n,r)$ be minimal such that every graph on $n$ vertices with at least $e(n,r)$ edges,
 each edge contained in at least one triangle, must have an edge contained in at least
@@ -42,6 +41,7 @@ private noncomputable def trianglesContaining
   (uv : Sym2 α)
   [Fintype α] :
   Finset (Finset α) :=
+  open scoped Classical in
   (G.cliqueFinset 3).filter (fun t ↦ uv.toFinset ⊆ t)
 
 def Erdos600Prop (n : ℕ) (e : ℕ) (r : ℕ) : Prop :=

--- a/FormalConjectures/ErdosProblems/600.lean
+++ b/FormalConjectures/ErdosProblems/600.lean
@@ -30,6 +30,7 @@ open scoped Topology
 
 namespace Erdos600
 
+open Classical in
 /--
 Let $e(n,r)$ be minimal such that every graph on $n$ vertices with at least $e(n,r)$ edges,
 each edge contained in at least one triangle, must have an edge contained in at least

--- a/FormalConjectures/ErdosProblems/600.lean
+++ b/FormalConjectures/ErdosProblems/600.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 - [RuSz78] Ruzsa, I. Z. and Szemerédi, E., _Triple systems with no six points carrying three triangles_. Combinatorics (Proc. Fifth Hungarian Colloq., Keszthely, 1976), Vol. II (1978), 939-945.
 -/
 
-open Classical Filter
+open Filter
 open scoped Topology
 
 namespace Erdos600

--- a/FormalConjectures/ErdosProblems/615.lean
+++ b/FormalConjectures/ErdosProblems/615.lean
@@ -41,7 +41,7 @@ $\mathrm{rt}(n; 4, ne^{-f(n)}) = o(n^2)$ whenever $f(n)/\sqrt{\log n} \to \infty
   Ramsey-Turán problem*. Combinatorica 35 (2015), 435--476.
 -/
 
-open Classical Filter SimpleGraph
+open Filter SimpleGraph
 
 namespace Erdos615
 

--- a/FormalConjectures/ErdosProblems/621.lean
+++ b/FormalConjectures/ErdosProblems/621.lean
@@ -29,7 +29,7 @@ import FormalConjecturesUtil
   (2016).
 -/
 
-open SimpleGraph Classical
+open SimpleGraph
 
 namespace Erdos621
 

--- a/FormalConjectures/ErdosProblems/688.lean
+++ b/FormalConjectures/ErdosProblems/688.lean
@@ -23,7 +23,7 @@ import FormalConjecturesUtil
 - [Er80] Erdős, Paul, _A survey of problems in combinatorial number theory_. Ann. Discrete Math. (1980), 89-115.
 -/
 
-open Classical Real Filter
+open Real Filter
 
 namespace Erdos688
 

--- a/FormalConjectures/ErdosProblems/755.lean
+++ b/FormalConjectures/ErdosProblems/755.lean
@@ -29,7 +29,7 @@ import FormalConjecturesUtil
   The number of regular simplices in higher dimensions. arXiv:2507.19841 (2025).
 -/
 
-open Filter Metric Classical
+open Filter Metric
 open scoped EuclideanGeometry Asymptotics
 
 namespace Erdos755
@@ -52,11 +52,13 @@ def IsAnySizeEquilateralTriangle {d : ℕ}
 /-- Number of unit equilateral triangles spanned by a finite point set. -/
 noncomputable def unitEquilateralTriangleCount (d : ℕ)
     (P : Finset (EuclideanSpace ℝ (Fin d))) : ℕ :=
+  open scoped Classical in
   ((P.powersetCard 3).filter fun T => IsUnitEquilateralTriangle T).card
 
 /-- Number of equilateral triangles of any positive side length spanned by a finite point set. -/
 noncomputable def anySizeEquilateralTriangleCount (d : ℕ)
     (P : Finset (EuclideanSpace ℝ (Fin d))) : ℕ :=
+  open scoped Classical in
   ((P.powersetCard 3).filter fun T => IsAnySizeEquilateralTriangle T).card
 
 /-- Maximum number of unit equilateral triangles spanned by $n$ points in $\mathbb{R}^d$. -/

--- a/FormalConjectures/ErdosProblems/82.lean
+++ b/FormalConjectures/ErdosProblems/82.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/82](https://www.erdosproblems.com/82)
 -/
 
-open Classical SimpleGraph Filter
+open SimpleGraph Filter
 
 namespace Erdos82
 

--- a/FormalConjectures/ErdosProblems/82.lean
+++ b/FormalConjectures/ErdosProblems/82.lean
@@ -28,14 +28,13 @@ namespace Erdos82
 
 variable {V : Type*} [Fintype V]
 
-open Classical in
 /--
 A predicate that holds if $S$ is a regular induced subgraph of $G$
 -/
 def IsRegularInduced {G : SimpleGraph V} (S : Subgraph G) : Prop :=
+  open scoped Classical in
   S.IsInduced ∧ ∃ k, (S.coe).IsRegularOfDegree k
 
-open Classical in
 /--
 $F(n)$ is the maximal integer such that every graph on $n$ vertices
 contains a regular induced subgraph on at least $F(n)$ vertices.

--- a/FormalConjectures/ErdosProblems/82.lean
+++ b/FormalConjectures/ErdosProblems/82.lean
@@ -28,12 +28,14 @@ namespace Erdos82
 
 variable {V : Type*} [Fintype V]
 
+open Classical in
 /--
 A predicate that holds if $S$ is a regular induced subgraph of $G$
 -/
 def IsRegularInduced {G : SimpleGraph V} (S : Subgraph G) : Prop :=
   S.IsInduced ∧ ∃ k, (S.coe).IsRegularOfDegree k
 
+open Classical in
 /--
 $F(n)$ is the maximal integer such that every graph on $n$ vertices
 contains a regular induced subgraph on at least $F(n)$ vertices.

--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -23,7 +23,7 @@ import FormalConjecturesUtil
 -/
 
 open scoped ArithmeticFunction.sigma
-open Classical Filter Real
+open Filter Real
 
 namespace Erdos830
 

--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -27,6 +27,7 @@ open Filter Real
 
 namespace Erdos830
 
+open Classical in
 /--
 Let $A(x)$ counts the number of amicable $1\leq a\leq b\leq x$.
 -/

--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -27,7 +27,7 @@ open Filter Real
 
 namespace Erdos830
 
-open Classical in
+open scoped Classical in
 /--
 Let $A(x)$ counts the number of amicable $1\leq a\leq b\leq x$.
 -/

--- a/FormalConjectures/ErdosProblems/846.lean
+++ b/FormalConjectures/ErdosProblems/846.lean
@@ -26,7 +26,6 @@ open EuclideanGeometry
 namespace Erdos846
 
 section Prelims
-open Classical
 
 /-- We say a subset `A` of points in the plane is `ε`-non-trilinear if any subset
 `B` of `A`, contains a non-trilinear subset `C` of size at least `ε|B|`. -/

--- a/FormalConjectures/ErdosProblems/85.lean
+++ b/FormalConjectures/ErdosProblems/85.lean
@@ -26,12 +26,12 @@ open SimpleGraph Finset Filter
 
 namespace Erdos85
 
-open Classical in
 /--
 Let $f(n)$ be the smallest integer for which every graph on $n$ vertices with minimal degree $\geq
 f(n)$ contains a $C_4$.
 -/
 noncomputable def f (n : ℕ) : ℕ :=
+  open scoped Classical in
   sInf {k : ℕ | ∀ (G : SimpleGraph (Fin n)), G.minDegree ≥ k → (cycleGraph 4) ⊑ G}
 
 /--

--- a/FormalConjectures/ErdosProblems/85.lean
+++ b/FormalConjectures/ErdosProblems/85.lean
@@ -26,6 +26,7 @@ open SimpleGraph Finset Filter
 
 namespace Erdos85
 
+open Classical in
 /--
 Let $f(n)$ be the smallest integer for which every graph on $n$ vertices with minimal degree $\geq
 f(n)$ contains a $C_4$.

--- a/FormalConjectures/ErdosProblems/85.lean
+++ b/FormalConjectures/ErdosProblems/85.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/85](https://www.erdosproblems.com/85)
 -/
 
-open Classical SimpleGraph Finset Filter
+open SimpleGraph Finset Filter
 
 namespace Erdos85
 

--- a/FormalConjectures/ErdosProblems/872.lean
+++ b/FormalConjectures/ErdosProblems/872.lean
@@ -60,9 +60,9 @@ structure GamePos (n : ℕ) where
   claimed : Finset ℕ
   pool : Finset ℕ
 
-open scoped Classical in
 /-- The legal moves from a position: unclaimed elements whose insertion preserves primitiveness. -/
 def legalMoves {n : ℕ} (p : GamePos n) : Finset ℕ :=
+  open scoped Classical in
   p.pool.filter fun x => IsPrimitive n (insert x p.claimed)
 
 /-- Membership in `legalMoves`: a legal move is a pool element whose insertion preserves

--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
   theory. Number theory (Eger, 1996) (1998), 169-180.
 -/
 
-open Classical Filter
+open Filter
 
 namespace Erdos888
 

--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -43,6 +43,7 @@ exists.
 -/
 def p (n : ℕ) (k : ℕ) : Prop := ∃ A : Finset ℕ, RequiredCondition A n ∧ A.card = k
 
+open Classical in
 /--
 What is the size of the largest $A\subseteq \{1,\ldots,n\}$ such that if
 $a\leq b\leq c\leq d\in A$ are such that $abcd$ is a square then $ad=bc$?
@@ -55,6 +56,7 @@ theorem erdos_888 :
       (fun n : ℕ ↦ (n : ℝ) * Real.log (Real.log n) / Real.log n) := by
   sorry
 
+open Classical in
 /--
 Erdős claims that Sárközy proved that $\lvert A\rvert =o(n)$ (a proof of this
 bound is provided by Tao in the comments).
@@ -64,6 +66,7 @@ theorem erdos_888.variants.sarkozy :
     (fun n ↦ (Nat.findGreatest (p n) n : ℝ)) =o[atTop] (Nat.cast : ℕ → ℝ) := by
   sorry
 
+open Classical in
 /--
 The primes show that $\lvert A\rvert \gg n/\log n$ is possible.
 -/
@@ -72,6 +75,7 @@ theorem erdos_888.variants.primes :
     (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ)) ≫ (fun n : ℕ ↦ (n : ℝ) / Real.log n) := by
   sorry
 
+open Classical in
 /--
 Cambie and Weisenberg have noted in the comments that the set of semiprimes
 also works, showing $(1+o(1))\frac{\log\log n}{\log n}n \leq \lvert A\rvert$ is achievable.

--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -43,7 +43,7 @@ exists.
 -/
 def p (n : ℕ) (k : ℕ) : Prop := ∃ A : Finset ℕ, RequiredCondition A n ∧ A.card = k
 
-open Classical in
+open scoped Classical in
 /--
 What is the size of the largest $A\subseteq \{1,\ldots,n\}$ such that if
 $a\leq b\leq c\leq d\in A$ are such that $abcd$ is a square then $ad=bc$?
@@ -56,7 +56,7 @@ theorem erdos_888 :
       (fun n : ℕ ↦ (n : ℝ) * Real.log (Real.log n) / Real.log n) := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Erdős claims that Sárközy proved that $\lvert A\rvert =o(n)$ (a proof of this
 bound is provided by Tao in the comments).
@@ -66,7 +66,7 @@ theorem erdos_888.variants.sarkozy :
     (fun n ↦ (Nat.findGreatest (p n) n : ℝ)) =o[atTop] (Nat.cast : ℕ → ℝ) := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 The primes show that $\lvert A\rvert \gg n/\log n$ is possible.
 -/
@@ -75,7 +75,7 @@ theorem erdos_888.variants.primes :
     (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ)) ≫ (fun n : ℕ ↦ (n : ℝ) / Real.log n) := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Cambie and Weisenberg have noted in the comments that the set of semiprimes
 also works, showing $(1+o(1))\frac{\log\log n}{\log n}n \leq \lvert A\rvert$ is achievable.

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -57,12 +57,12 @@ theorem erdos_961.variants.well_defined (k : ℕ) (hk : 0 < k): ∃ n, Erdos961P
   use k
   exact erdos_961.sylvester_schur k hk
 
-open Classical in
 /--
 For $k$, let $f(k)$ be the minimal $n$ such that every set of $n$ consecutive integers $>k$ contains
 an integer divisible by a prime $>k$, i.e. not $(k+1)$-smooth.
 -/
 noncomputable def f (k : ℕ) : ℕ :=
+  open scoped Classical in
   if hk : 0 < k then Nat.find (erdos_961.variants.well_defined k hk) else 0
 
 /--

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -57,6 +57,7 @@ theorem erdos_961.variants.well_defined (k : ℕ) (hk : 0 < k): ∃ n, Erdos961P
   use k
   exact erdos_961.sylvester_schur k hk
 
+open Classical in
 /--
 For $k$, let $f(k)$ be the minimal $n$ such that every set of $n$ consecutive integers $>k$ contains
 an integer divisible by a prime $>k$, i.e. not $(k+1)$-smooth.

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -24,7 +24,7 @@ import FormalConjecturesUtil
 - [RaSh73](https://eudml.org/doc/urn:eudml:doc:205214) Ramachandra, K. and Shorey, T. N., On gaps between numbers with a large prime factor. Acta Arith. (1973), 99--111.
 -/
 
-open Classical Filter Real
+open Filter Real
 
 namespace Erdos961
 

--- a/FormalConjectures/ErdosProblems/962.lean
+++ b/FormalConjectures/ErdosProblems/962.lean
@@ -38,6 +38,7 @@ def Erdos962Prop (n k : ℕ) : Prop :=
   ∃ m ≤ n, ∀ i ∈ Set.Icc 1 k,
     ∃ p : ℕ, Nat.Prime p ∧ k < p ∧ p ∣ (m + i)
 
+open Classical in
 /--
 Let $k(n)$ be the maximal $k$ such that there exists $m \le n$ with
 $m+1, \ldots, m+k$ each divisible by a prime $> k$.

--- a/FormalConjectures/ErdosProblems/962.lean
+++ b/FormalConjectures/ErdosProblems/962.lean
@@ -26,7 +26,7 @@ import FormalConjecturesUtil
 - [Tao](https://www.erdosproblems.com/forum/thread/962)
 -/
 
-open Classical Filter Real
+open Filter Real
 
 namespace Erdos962
 

--- a/FormalConjectures/ErdosProblems/962.lean
+++ b/FormalConjectures/ErdosProblems/962.lean
@@ -38,12 +38,12 @@ def Erdos962Prop (n k : ℕ) : Prop :=
   ∃ m ≤ n, ∀ i ∈ Set.Icc 1 k,
     ∃ p : ℕ, Nat.Prime p ∧ k < p ∧ p ∣ (m + i)
 
-open Classical in
 /--
 Let $k(n)$ be the maximal $k$ such that there exists $m \le n$ with
 $m+1, \ldots, m+k$ each divisible by a prime $> k$.
 -/
 noncomputable def k (n : ℕ) : ℕ :=
+  open scoped Classical in
   Nat.findGreatest (fun k => Erdos962Prop n k) n
 
 /--

--- a/FormalConjectures/GreensOpenProblems/19.lean
+++ b/FormalConjectures/GreensOpenProblems/19.lean
@@ -29,7 +29,7 @@ import FormalConjecturesUtil
   Dynamical Systems 31.3 (2011): 771-792.
 -/
 
-open Finset Real Classical
+open Finset Real
 
 namespace Green19
 
@@ -47,6 +47,7 @@ From [FSS20]: given $A \subseteq G \times G$ and $d \in G$, let
 $$S_d(A) = \lbrace (x, y) \in G \times G : (x, y), (x + d, y), (x, y + d) \in A \rbrace$$
 -/
 noncomputable def S (d : G) (A : Finset (G × G)) : Finset (G × G) :=
+  open scoped Classical in
   univ.filter (fun p => IsCorner A p.1 p.2 d)
 
 end GroupDefs

--- a/FormalConjectures/GreensOpenProblems/36.lean
+++ b/FormalConjectures/GreensOpenProblems/36.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
   Matrix Multiplication" (Problem 4.7)
 -/
 
-open Classical Filter
+open Filter
 open scoped Pointwise
 
 namespace Green36

--- a/FormalConjectures/GreensOpenProblems/36.lean
+++ b/FormalConjectures/GreensOpenProblems/36.lean
@@ -30,17 +30,17 @@ open scoped Pointwise
 
 namespace Green36
 
-open Classical in
 /-- The simultaneous double product property [CKS05, 4.1]. -/
 def SimultaneousDoubleProduct {ι H : Type*} [AddCommGroup H]
     (A B : ι → Finset H) : Prop :=
+  open scoped Classical in
   (∀ i, (A i + B i).card = (A i).card * (B i).card) ∧
   (∀ i j k, i ≠ k → Disjoint (A i + B j) (A j + B k))
 
-open Classical in
 /-- A variant of the simultaneous double product property, as stated in [Gr24, Problem 36]. -/
 def Green36Property {ι H : Type*} [AddCommGroup H]
     (A B : ι → Finset H) : Prop :=
+  open scoped Classical in
   (∀ i, (A i + B i).card = (A i).card * (B i).card) ∧
   (∀ i j k, j ≠ k → Disjoint (A i + B i) (A j + B k))
 

--- a/FormalConjectures/GreensOpenProblems/36.lean
+++ b/FormalConjectures/GreensOpenProblems/36.lean
@@ -30,12 +30,14 @@ open scoped Pointwise
 
 namespace Green36
 
+open Classical in
 /-- The simultaneous double product property [CKS05, 4.1]. -/
 def SimultaneousDoubleProduct {ι H : Type*} [AddCommGroup H]
     (A B : ι → Finset H) : Prop :=
   (∀ i, (A i + B i).card = (A i).card * (B i).card) ∧
   (∀ i j k, i ≠ k → Disjoint (A i + B j) (A j + B k))
 
+open Classical in
 /-- A variant of the simultaneous double product property, as stated in [Gr24, Problem 36]. -/
 def Green36Property {ι H : Type*} [AddCommGroup H]
     (A B : ι → Finset H) : Prop :=

--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -38,6 +38,7 @@ namespace SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
+open Classical in
 /-- The number of vertices of `G` having degree `d`. -/
 noncomputable def degreeFreq (G : SimpleGraph α) (d : ℕ) : ℕ :=
   #{v | G.degree v = d}
@@ -200,6 +201,7 @@ lemma lemma3 (n : ℕ) (hn : 0 < n) :
       G.IsBipartite ∧ G.minDegree = n + 1 ∧ degreeSequenceMultiplicity G = 3 := by
   sorry
 
+open Classical in
 /-- **Lemma 4.** Let `G` be a triangle-free graph with `n` vertices and let `v` be a vertex of `G`.
 There exists a triangle-free graph `H` containing `G` as an induced subgraph such that:
 (i) the degree of `v` in `H` is one more than its degree in `G`;

--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -23,7 +23,6 @@ Published in Discrete Mathematics 92 (1991) 85–88.
 -/
 
 open BigOperators
-open Classical
 open scoped Finset
 
 namespace DegreeSequencesTriangleFree

--- a/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
+++ b/FormalConjectures/Paper/DegreeSequencesTriangleFree.lean
@@ -38,9 +38,9 @@ namespace SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-open Classical in
 /-- The number of vertices of `G` having degree `d`. -/
 noncomputable def degreeFreq (G : SimpleGraph α) (d : ℕ) : ℕ :=
+  open scoped Classical in
   #{v | G.degree v = d}
 
 end SimpleGraph
@@ -201,7 +201,7 @@ lemma lemma3 (n : ℕ) (hn : 0 < n) :
       G.IsBipartite ∧ G.minDegree = n + 1 ∧ degreeSequenceMultiplicity G = 3 := by
   sorry
 
-open Classical in
+open scoped Classical in
 /-- **Lemma 4.** Let `G` be a triangle-free graph with `n` vertices and let `v` be a vertex of `G`.
 There exists a triangle-free graph `H` containing `G` as an induced subgraph such that:
 (i) the degree of `v` in `H` is one more than its degree in `G`;

--- a/FormalConjectures/Paper/ReedOmegaDeltaChi.lean
+++ b/FormalConjectures/Paper/ReedOmegaDeltaChi.lean
@@ -25,7 +25,6 @@ import FormalConjecturesUtil
 - [mathoverflow/37923](https://mathoverflow.net/questions/37923) asked by user [Andrew D. King](https://mathoverflow.net/users/4580/andrew-d-king)
 -/
 
-open Classical
 open scoped Finset
 
 namespace ReedOmegaDeltaChi

--- a/FormalConjectures/Paper/StrongSensitivityConjecture.lean
+++ b/FormalConjectures/Paper/StrongSensitivityConjecture.lean
@@ -48,7 +48,7 @@ known gap, due to Ambainis and Sun (https://arxiv.org/abs/1108.3494), is
 
 namespace StrongSensitivityConjecture
 
-open Finset Function Classical
+open Finset Function
 
 section Sensitivity
 
@@ -80,6 +80,7 @@ def IsValidBlockConfig (f : (Fin n → Bool) → Bool) (x : Fin n → Bool)
 /-- Local block sensitivity bs(f,x),
 maximum size of a collection of sensitive, disjoint blocks for `f` at `x`. -/
 noncomputable def blockSensitivityAt (f : (Fin n → Bool) → Bool) (x : Fin n → Bool) : ℕ :=
+  open scoped Classical in
   Finset.sup {cB | IsValidBlockConfig f x cB} card
 
 /-- Global block sensitivity of `f`,

--- a/FormalConjectures/Wikipedia/AgohGiuga.lean
+++ b/FormalConjectures/Wikipedia/AgohGiuga.lean
@@ -249,7 +249,7 @@ theorem agoh_giuga.variants._13000_le_digits_length_of_isStrongGiuga
     (a : ℕ) (ha : IsStrongGiuga a) : 13000 ≤ (Nat.digits 10 a).length := by
   sorry
 
-open Classical in
+open scoped Classical in
 /--
 Let `G(X)` denote the number of exceptions `n ≤ X` to Giuga’s conjecture.
 Then for `X` larger than an absolute constant which can be made

--- a/FormalConjectures/Wikipedia/HardyLittlewood.lean
+++ b/FormalConjectures/Wikipedia/HardyLittlewood.lean
@@ -24,7 +24,7 @@ import FormalConjecturesUtil
 
 open Filter
 
-open scoped Nat.Prime Classical
+open scoped Nat.Prime
 
 /-  ## First Hardy-Littlewood Conjecture -/
 
@@ -55,6 +55,7 @@ For a given tuple $(m_1, \dots, m_k)$, this counts number of admissible
 prime constellations $(p, p + m_1, \dots, p + m_k)$ where $p \leq n$.
 -/
 noncomputable def Nat.primeTupleCounting {k : ℕ} (m : Fin k.succ → ℕ) (n : ℕ) : ℕ :=
+  open scoped Classical in
   Nat.count (IsAdmissiblePrimeConstellation m) n.succ
 
 def FirstHardyLittlewoodConjectureFor {k : ℕ} (m : Fin k.succ → ℕ) : Prop :=

--- a/FormalConjectures/Wikipedia/JacobianConjecture.lean
+++ b/FormalConjectures/Wikipedia/JacobianConjecture.lean
@@ -92,7 +92,6 @@ noncomputable abbrev G [CommRing k] : RegularFunction k (Fin 3) (Fin 3) :=
     Y + 3 * X * (1 + 2 * X * Y) ^ 2 * Z + 12 * X * Y ^ 2 * (2 + 3 * (X * Y)),
     -X + 3 * X ^ 2 * Y + X ^ 3 * Z]
 
-open Classical
 
 @[category API, AMS 14]
 lemma det_jacobian_F [CommRing k] : (F k).Jacobian.det = -2 := by

--- a/FormalConjectures/Wikipedia/Koethe.lean
+++ b/FormalConjectures/Wikipedia/Koethe.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/K%C3%B6the_conjecture)
 -/
 
-open Ideal TwoSidedIdeal Classical Polynomial
+open Ideal TwoSidedIdeal Polynomial
 
 open Matrix
 
@@ -56,6 +56,7 @@ theorem KotherConjecture.variants.le_KotherRadical {I : Ideal R} (hI : IsNil I) 
     (I : Set R) ⊆ KotheRadical R := by
   sorry
 
+open scoped Classical in
 /-- The **Köthe conjecture**: for any nil ideal `I` of `R`, the matrix ideal `M_n(I)` is a nil ideal
 of the matrix ring `M_n(R)`. -/
 @[category research open, AMS 16]
@@ -70,6 +71,7 @@ theorem KotherConjecture.variants.two_by_two_matrix {I : TwoSidedIdeal R} (hI : 
     IsNil (matrix (Fin 2) I) := by
   sorry
 
+open scoped Classical in
 /-- The **Köthe conjecture**: for any positive integer `n`, the Köthe radical of `R` is the matrix ideal `M_2(Nil*(R))`. -/
 @[category research open, AMS 16]
 theorem KotherConjecture.variants.matrixOver_KotherRadical

--- a/FormalConjectures/Wikipedia/LeinsterGroup.lean
+++ b/FormalConjectures/Wikipedia/LeinsterGroup.lean
@@ -37,8 +37,6 @@ TODO: The following properties from the Wikipedia article can also be formalized
 
 namespace LeinsterGroup
 
-open scoped Classical
-
 /--
 A finite group `G` is a **Leinster group** if the sum of the orders of all its normal subgroups
 equals twice the group's order.

--- a/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
+++ b/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
@@ -30,7 +30,7 @@ import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.HomDensity
   *Trans. Amer. Math. Soc.* 370, pp. 8515--8552.
 -/
 
-open Classical Finset SimpleGraph
+open Finset SimpleGraph
 
 namespace SidorenkoConjecture
 

--- a/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
+++ b/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
@@ -86,6 +86,7 @@ theorem sidorenko_K2 {W : Type} [Fintype W] [DecidableEq W]
 
 /- ## Sidorenko for `K_{2,2}`: auxiliary lemmas -/
 
+open Classical in
 /-- `edgeCount` of `K_{2,2}` (complete bipartite graph on `Fin 2 + Fin 2`) is `4`.
 
 The four edges are `{inl 0, inr 0}`, `{inl 0, inr 1}`, `{inl 1, inr 0}`, `{inl 1, inr 1}`. -/
@@ -169,6 +170,7 @@ lemma homCount_completeGraph_fin_two_eq_two_mul_card_edgeFinset
         cases d
         rfl }
 
+open Classical in
 /-- **The `Hom(K_{2,2}, G)` decomposition.** The number of homomorphisms from
 `K_{2,2}` to `G` equals `∑_{(a, b) ∈ W × W} |N(a) ∩ N(b)|^2`, where `N(v)` is the
 neighbourhood of `v` in `G`. Equivalently, summing over *ordered* pairs
@@ -334,6 +336,7 @@ lemma sum_inter_card_eq_sum_degree_sq
   simp only [Nat.cast_sum, Nat.cast_pow] at this
   exact this
 
+open Classical in
 /--
 **Case `H = K_{2,2}` (four-cycle, also called `C_4`): Sidorenko's conjecture holds, by
 Cauchy–Schwarz.**
@@ -467,6 +470,7 @@ theorem sidorenko_K22 {W : Type} [Fintype W] [DecidableEq W]
   -- hmul : N^4 * n^4 ≤ (M * n^4) * n^4
   nlinarith [hmul, sq_nonneg ((n : ℝ))]
 
+open Classical in
 /-- Consequence of `homDensity_le_one`: both sides of the Sidorenko K_{2,2}
 inequality are bounded above by 1. This is a trivial consequence, recorded
 as a sanity check on the helper infrastructure in

--- a/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
+++ b/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
@@ -86,7 +86,7 @@ theorem sidorenko_K2 {W : Type} [Fintype W] [DecidableEq W]
 
 /- ## Sidorenko for `K_{2,2}`: auxiliary lemmas -/
 
-open Classical in
+open scoped Classical in
 /-- `edgeCount` of `K_{2,2}` (complete bipartite graph on `Fin 2 + Fin 2`) is `4`.
 
 The four edges are `{inl 0, inr 0}`, `{inl 0, inr 1}`, `{inl 1, inr 0}`, `{inl 1, inr 1}`. -/
@@ -170,7 +170,7 @@ lemma homCount_completeGraph_fin_two_eq_two_mul_card_edgeFinset
         cases d
         rfl }
 
-open Classical in
+open scoped Classical in
 /-- **The `Hom(K_{2,2}, G)` decomposition.** The number of homomorphisms from
 `K_{2,2}` to `G` equals `∑_{(a, b) ∈ W × W} |N(a) ∩ N(b)|^2`, where `N(v)` is the
 neighbourhood of `v` in `G`. Equivalently, summing over *ordered* pairs
@@ -336,7 +336,7 @@ lemma sum_inter_card_eq_sum_degree_sq
   simp only [Nat.cast_sum, Nat.cast_pow] at this
   exact this
 
-open Classical in
+open scoped Classical in
 /--
 **Case `H = K_{2,2}` (four-cycle, also called `C_4`): Sidorenko's conjecture holds, by
 Cauchy–Schwarz.**
@@ -470,7 +470,7 @@ theorem sidorenko_K22 {W : Type} [Fintype W] [DecidableEq W]
   -- hmul : N^4 * n^4 ≤ (M * n^4) * n^4
   nlinarith [hmul, sq_nonneg ((n : ℝ))]
 
-open Classical in
+open scoped Classical in
 /-- Consequence of `homDensity_le_one`: both sides of the Sidorenko K_{2,2}
 inequality are bounded above by 1. This is a trivial consequence, recorded
 as a sanity check on the helper infrastructure in

--- a/FormalConjectures/WrittenOnTheWallII/160.lean
+++ b/FormalConjectures/WrittenOnTheWallII/160.lean
@@ -51,6 +51,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 noncomputable def maxTrianglesAtVertex (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
   (Finset.univ.image (numTrianglesAtVertex G)).max' (Finset.image_nonempty.mpr Finset.univ_nonempty)
 
+open Classical in
 /--
 WOWII [Conjecture 160](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/160.lean
+++ b/FormalConjectures/WrittenOnTheWallII/160.lean
@@ -43,7 +43,7 @@ conjecture instead uses this binary $C_4$-free indicator.
 
 namespace WrittenOnTheWallII.GraphConjecture160
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/160.lean
+++ b/FormalConjectures/WrittenOnTheWallII/160.lean
@@ -51,7 +51,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 noncomputable def maxTrianglesAtVertex (G : SimpleGraph α) [DecidableRel G.Adj] : ℕ :=
   (Finset.univ.image (numTrianglesAtVertex G)).max' (Finset.image_nonempty.mpr Finset.univ_nonempty)
 
-open Classical in
+open scoped Classical in
 /--
 WOWII [Conjecture 160](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture100.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture100.lean
@@ -51,7 +51,7 @@ so the inequality is genuinely about a finite `length(Ḡ) = diam(Gᶜ)`.
 
 namespace WrittenOnTheWallII.GraphConjecture100
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture101.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture101.lean
@@ -34,7 +34,7 @@ These vertices are also called "critical vertices for independence."
 
 namespace WrittenOnTheWallII.GraphConjecture101
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture103.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture103.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture103
 
-open Classical SimpleGraph
+open SimpleGraph
 
 /-- The 11-vertex counterexample: a triangle with four leaves on each of two vertices. -/
 abbrev wowii103Counterexample : SimpleGraph (Fin 11) :=

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture109.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture109
 
-open Classical SimpleGraph
+open SimpleGraph
 /--
 WOWII [Conjecture 109](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture13.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture13.lean
@@ -26,7 +26,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture13
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture133.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture133.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture133
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture141.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture141.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture141
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture142.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture142
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture143.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture143.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture143
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture144.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture144.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture144
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture145.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture145.lean
@@ -49,7 +49,7 @@ $\overline{G}$.
 
 namespace WrittenOnTheWallII.GraphConjecture145
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture146.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture146.lean
@@ -34,7 +34,7 @@ $$\mathrm{rad}(G^2) = \min_{v \in V} \max_{u \in V} \mathrm{dist}_{G^2}(u, v).$$
 
 namespace WrittenOnTheWallII.GraphConjecture146
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture16.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture16.lean
@@ -26,7 +26,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture16
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture17.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture17.lean
@@ -26,7 +26,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture17
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture18.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture18.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture18
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture19.lean
@@ -24,7 +24,6 @@ import FormalConjecturesUtil
 -/
 
 
-open Classical
 
 namespace WrittenOnTheWallII.GraphConjecture19
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture194.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture194.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture194
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture198a.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture198a.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture198a
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
@@ -26,7 +26,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture2
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
@@ -30,6 +30,7 @@ open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
+open Classical in
 /--
 WOWII [Conjecture 2](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture2.lean
@@ -30,7 +30,7 @@ open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
-open Classical in
+open scoped Classical in
 /--
 WOWII [Conjecture 2](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture20.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture20.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture20
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture200.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture200.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture200
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture217.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture217.lean
@@ -33,7 +33,7 @@ Per the WOWII definitions popup linked from this conjecture:
 
 namespace WrittenOnTheWallII.GraphConjecture217
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture23
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
@@ -51,7 +51,7 @@ the minimum triangle count.
 
 namespace WrittenOnTheWallII.GraphConjecture291
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture31.lean
@@ -34,7 +34,7 @@ $\mathrm{rad}(G)$ is the graph radius.
 
 namespace WrittenOnTheWallII.GraphConjecture31
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture314.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture314.lean
@@ -23,7 +23,6 @@ import FormalConjecturesUtil
 [E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 -/
 
-open Classical
 
 namespace WrittenOnTheWallII.GraphConjecture314
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture315.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture315.lean
@@ -29,7 +29,6 @@ The notions `IsTotalDominatingSet`, `IsMinimalTotalDominatingSet`,
 `FormalConjecturesForMathlib.Combinatorics.SimpleGraph.GraphConjectures.WellTotallyDominated`.
 -/
 
-open Classical
 
 namespace WrittenOnTheWallII.GraphConjecture315
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture32.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture32.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture32
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture322.lean
@@ -23,7 +23,6 @@ import FormalConjecturesUtil
 [E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 -/
 
-open Classical
 
 namespace WrittenOnTheWallII.GraphConjecture322
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture33.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture33.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture33
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture34
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
@@ -27,10 +27,10 @@ namespace WrittenOnTheWallII.GraphConjecture36
 
 open SimpleGraph
 
-open Classical in
 /-- `dp G` is the number of diametrical pairs of `G`: the number of unordered
 pairs `{u, v}` of vertices at distance `diam(G)`.  -/
 noncomputable def dp {α : Type*} [Fintype α] (G : SimpleGraph α) : ℕ :=
+  open scoped Classical in
   (Finset.univ.filter
     (fun p : Sym2 α => p.lift ⟨fun u v => G.dist u v = G.diam ∧ u ≠ v,
       fun u v => by simp [SimpleGraph.dist_comm, ne_comm]⟩)).card

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture36
 
-open Classical SimpleGraph
+open SimpleGraph
 
 /-- `dp G` is the number of diametrical pairs of `G`: the number of unordered
 pairs `{u, v}` of vertices at distance `diam(G)`.  -/

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture36.lean
@@ -27,6 +27,7 @@ namespace WrittenOnTheWallII.GraphConjecture36
 
 open SimpleGraph
 
+open Classical in
 /-- `dp G` is the number of diametrical pairs of `G`: the number of unordered
 pairs `{u, v}` of vertices at distance `diam(G)`.  -/
 noncomputable def dp {α : Type*} [Fintype α] (G : SimpleGraph α) : ℕ :=

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
@@ -31,6 +31,7 @@ open SimpleGraph
 variable {V : Type*} [Fintype V] [DecidableEq V] [Nontrivial V]
 
 
+open Classical in
 /--
 WOWII [Conjecture 5](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
@@ -31,7 +31,7 @@ open SimpleGraph
 variable {V : Type*} [Fintype V] [DecidableEq V] [Nontrivial V]
 
 
-open Classical in
+open scoped Classical in
 /--
 WOWII [Conjecture 5](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture5.lean
@@ -30,7 +30,6 @@ open SimpleGraph
 
 variable {V : Type*} [Fintype V] [DecidableEq V] [Nontrivial V]
 
-open Classical
 
 /--
 WOWII [Conjecture 5](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture59.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture59.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture59
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture61.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture61.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture61
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture65.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture65
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture7.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture7.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 
 namespace WrittenOnTheWallII.GraphConjecture7
 
-open Classical SimpleGraph
+open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -140,9 +140,9 @@ theorem house_max_deg : HouseGraph.maxDegree = 3 := by
 theorem house_avg_deg : averageDegree HouseGraph = 12/5 := by
   unfold averageDegree; simp [Fintype.card_fin]; decide +native
 
-open Classical in
 @[category test, AMS 5]
 theorem house_matching : matchingNumber HouseGraph = 2 := by
+  classical
   have hbdd : BddAbove (Set.image (fun M : Subgraph HouseGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
     refine ⟨(Fintype.card (Fin 5) : ℝ), ?_⟩
     rintro x ⟨M, hM, rfl⟩
@@ -243,9 +243,9 @@ theorem K4_max_deg : K4.maxDegree = 3 := by
 theorem K4_avg_deg : averageDegree K4 = 3 := by
   unfold averageDegree; simp [Fintype.card_fin]
 
-open Classical in
 @[category test, AMS 5]
 theorem K4_matching : matchingNumber K4 = 2 := by
+  classical
   have hbdd : BddAbove (Set.image (fun M : Subgraph K4 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
     refine ⟨(Fintype.card (Fin 4) : ℝ), ?_⟩
     rintro x ⟨M, hM, rfl⟩
@@ -337,9 +337,9 @@ theorem petersen_max_deg : PetersenGraph.maxDegree = 3 := by
 theorem petersen_avg_deg : averageDegree PetersenGraph = 3 := by
   unfold averageDegree; simp [Fintype.card_fin]; decide +native
 
-open Classical in
 @[category test, AMS 5]
 theorem petersen_matching : matchingNumber PetersenGraph = 5 := by
+  classical
   have hbdd : BddAbove (Set.image (fun M : Subgraph PetersenGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
     refine ⟨(Fintype.card (Fin 10) : ℝ), ?_⟩
     rintro x ⟨M, hM, rfl⟩
@@ -443,9 +443,9 @@ theorem C6_max_deg : C6.maxDegree = 2 := by
 theorem C6_avg_deg : averageDegree C6 = 2 := by
   unfold averageDegree; simp [Fintype.card_fin]; decide +native
 
-open Classical in
 @[category test, AMS 5]
 theorem C6_matching : matchingNumber C6 = 3 := by
+  classical
   have hbdd : BddAbove (Set.image (fun M : Subgraph C6 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
     refine ⟨(Fintype.card (Fin 6) : ℝ), ?_⟩
     rintro x ⟨M, hM, rfl⟩
@@ -565,9 +565,9 @@ theorem Star5_max_deg : Star5.maxDegree = 5 := by
 theorem Star5_avg_deg : averageDegree Star5 = 5/3 := by
   unfold averageDegree; simp [Fintype.card_sum, Fintype.card_fin]; decide +native
 
-open Classical in
 @[category test, AMS 5]
 theorem Star5_matching : matchingNumber Star5 = 1 := by
+  classical
   have hle : ∀ M : Subgraph Star5, M.IsMatching → M.edgeSet.toFinset.card ≤ 1 := by
     intro M hM
     have hcenter : ∀ e ∈ M.edgeSet, (Sum.inl 0 : Fin 1 ⊕ Fin 5) ∈ e := by

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -36,7 +36,6 @@ open SimpleGraph
 
 namespace WrittenOnTheWallII.Test
 
-open Classical
 
 -- Bridge theorems for Sym2/edist-based invariants:
 -- All 6 (indep_num, dom_num, dist, wiener, avg_dist, szeged) are proved in

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -140,6 +140,7 @@ theorem house_max_deg : HouseGraph.maxDegree = 3 := by
 theorem house_avg_deg : averageDegree HouseGraph = 12/5 := by
   unfold averageDegree; simp [Fintype.card_fin]; decide +native
 
+open Classical in
 @[category test, AMS 5]
 theorem house_matching : matchingNumber HouseGraph = 2 := by
   have hbdd : BddAbove (Set.image (fun M : Subgraph HouseGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
@@ -242,6 +243,7 @@ theorem K4_max_deg : K4.maxDegree = 3 := by
 theorem K4_avg_deg : averageDegree K4 = 3 := by
   unfold averageDegree; simp [Fintype.card_fin]
 
+open Classical in
 @[category test, AMS 5]
 theorem K4_matching : matchingNumber K4 = 2 := by
   have hbdd : BddAbove (Set.image (fun M : Subgraph K4 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
@@ -335,6 +337,7 @@ theorem petersen_max_deg : PetersenGraph.maxDegree = 3 := by
 theorem petersen_avg_deg : averageDegree PetersenGraph = 3 := by
   unfold averageDegree; simp [Fintype.card_fin]; decide +native
 
+open Classical in
 @[category test, AMS 5]
 theorem petersen_matching : matchingNumber PetersenGraph = 5 := by
   have hbdd : BddAbove (Set.image (fun M : Subgraph PetersenGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
@@ -440,6 +443,7 @@ theorem C6_max_deg : C6.maxDegree = 2 := by
 theorem C6_avg_deg : averageDegree C6 = 2 := by
   unfold averageDegree; simp [Fintype.card_fin]; decide +native
 
+open Classical in
 @[category test, AMS 5]
 theorem C6_matching : matchingNumber C6 = 3 := by
   have hbdd : BddAbove (Set.image (fun M : Subgraph C6 => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
@@ -561,6 +565,7 @@ theorem Star5_max_deg : Star5.maxDegree = 5 := by
 theorem Star5_avg_deg : averageDegree Star5 = 5/3 := by
   unfold averageDegree; simp [Fintype.card_sum, Fintype.card_fin]; decide +native
 
+open Classical in
 @[category test, AMS 5]
 theorem Star5_matching : matchingNumber Star5 = 1 := by
   have hle : ∀ M : Subgraph Star5, M.IsMatching → M.edgeSet.toFinset.card ≤ 1 := by

--- a/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/AP/Basic.lean
@@ -22,8 +22,6 @@ import Mathlib.Tactic.IntervalCases
 
 @[expose] public section
 
-open scoped Classical
-
 /-! # Arithmetic Progressions
 
 Main definitions:
@@ -253,4 +251,5 @@ Define the largest possible size of a subset of a finset `s` that does not conta
 any non-trivial `k`-term arithmetic progression.
 -/
 noncomputable def Finset.maxAPFreeCard (k : ℕ) (s : Finset α) : ℕ :=
+  open scoped Classical in
   (s.powerset.filter fun t : Finset α ↦ (t : Set α).IsAPOfLengthFree k).sup Finset.card

--- a/FormalConjecturesForMathlib/Combinatorics/Additive/Convolution.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/Additive/Convolution.lean
@@ -41,7 +41,7 @@ This file defines the sum (`∗`) convolution of functions `ℕ → R`.
 
 namespace AdditiveCombinatorics
 
-open Finset Classical Set
+open Finset Set
 
 variable {R : Type*} [Semiring R]
 
@@ -55,7 +55,7 @@ infixl:70 " ∗ " => sumConv
 function with itself: $1_A\ast 1_A(n)$. -/
 noncomputable def sumRep (A : Set ℕ) : ℕ → ℕ := (𝟙_A ∗ 𝟙_A)
 
-
+open scoped Classical in
 @[simp]
 lemma sumRep_def (A : Set ℕ) (n : ℕ) :
     sumRep A n = ((antidiagonal n).filter (fun (p : ℕ × ℕ) ↦ p.1 ∈ A ∧ p.2 ∈ A)).card := by

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/AnnihilationNumber.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/AnnihilationNumber.lean
@@ -23,7 +23,6 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Degrees
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Circumference.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Circumference.lean
@@ -21,7 +21,6 @@ public import Mathlib.Data.Nat.Lattice
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -24,7 +24,7 @@ public import Mathlib.Order.CompletePartialOrder
 namespace SimpleGraph
 variable {V : Type*} {G : SimpleGraph V}
 
-open Classical Finset List
+open Finset List
 
 @[inherit_doc] scoped notation "α(" G ")" => indepNum G
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -22,7 +22,7 @@ public import Mathlib.Combinatorics.SimpleGraph.Paths
 namespace SimpleGraph
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-open Classical Finset List
+open Finset List
 
 /--
 Two walks are internally disjoint if they share no vertices other than their endpoints.

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Cvetkovic.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Cvetkovic.lean
@@ -23,7 +23,6 @@ public import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CycleRank.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/CycleRank.lean
@@ -20,7 +20,6 @@ public import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Degrees.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Degrees.lean
@@ -27,7 +27,6 @@ public import Mathlib.Order.CompletePartialOrder
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
@@ -74,6 +73,7 @@ noncomputable def NG (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ :=
   else
     (Fintype.card α : ℝ)
 
+open Classical in
 noncomputable def S (G : SimpleGraph α) : ℝ :=
   let card := Fintype.card α
   if card < 2 then 0 else

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Degrees.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Degrees.lean
@@ -73,8 +73,8 @@ noncomputable def NG (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ :=
   else
     (Fintype.card α : ℝ)
 
-open Classical in
 noncomputable def S (G : SimpleGraph α) : ℝ :=
+  open scoped Classical in
   let card := Fintype.card α
   if card < 2 then 0 else
     let degrees := Multiset.ofList (List.map (fun v => G.degree v) Finset.univ.toList)

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Eccentricity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Eccentricity.lean
@@ -22,7 +22,6 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.VertexDistan
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/FractionalAlpha.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/FractionalAlpha.lean
@@ -22,7 +22,6 @@ public import Mathlib.Data.Real.Archimedean
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Independence.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Independence.lean
@@ -21,7 +21,7 @@ public import Mathlib.Data.Real.Basic
 @[expose] public section
 
 namespace SimpleGraph
-open Classical Finset
+open Finset
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Induced.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Induced.lean
@@ -21,7 +21,6 @@ public import Mathlib.Data.Real.Basic
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/LovaszTheta.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/LovaszTheta.lean
@@ -22,7 +22,6 @@ public import FormalConjecturesForMathlib.Analysis.Matrix.Spectrum
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 /--

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -23,8 +23,9 @@ public import Mathlib.Data.Real.Archimedean
 namespace SimpleGraph
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-open Classical Finset List
+open Finset List
 
+open Classical in
 /-- `matchingNumber G` is the size of a maximum matching of `G`. -/
 noncomputable def matchingNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ :=
   let matchings := { M : Subgraph G | M.IsMatching }

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -25,7 +25,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 
 open Finset List
 
-open Classical in
+open scoped Classical in
 /-- `matchingNumber G` is the size of a maximum matching of `G`. -/
 noncomputable def matchingNumber (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ :=
   let matchings := { M : Subgraph G | M.IsMatching }

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/PathCover.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/PathCover.lean
@@ -22,7 +22,6 @@ public import Mathlib.Data.Real.Basic
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Residue.lean
@@ -21,7 +21,6 @@ public import Mathlib.Data.Finset.Sort
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SpanningTree.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SpanningTree.lean
@@ -23,8 +23,9 @@ public import Mathlib.Data.Real.Archimedean
 namespace SimpleGraph
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-open Classical Finset List
+open Finset List
 
+open Classical in
 /-- `Ls G` is the maximum number of leaves over all spanning trees of `G`.
 It is defined to be `0` when `G` is not connected. -/
 noncomputable def Ls (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ :=

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SpanningTree.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SpanningTree.lean
@@ -25,10 +25,10 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 
 open Finset List
 
-open Classical in
 /-- `Ls G` is the maximum number of leaves over all spanning trees of `G`.
 It is defined to be `0` when `G` is not connected. -/
 noncomputable def Ls (G : SimpleGraph α) [DecidableRel G.Adj] : ℝ :=
+  open scoped Classical in
   letI spanningTrees := { T : Subgraph G | T.IsSpanning ∧ IsTree T.coe }
   letI leaves (T : Subgraph G) := T.verts.toFinset.filter (fun v => T.degree v = 1)
   letI num_leaves (T : Subgraph G) := (leaves T).card

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SzegedIndex.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SzegedIndex.lean
@@ -23,7 +23,6 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.VertexDistan
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Temperature.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Temperature.lean
@@ -21,7 +21,6 @@ public import Mathlib.Data.Real.Basic
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/UnitDistancePlaneGraph.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/UnitDistancePlaneGraph.lean
@@ -23,7 +23,7 @@ public import Mathlib.Combinatorics.SimpleGraph.Basic
 namespace SimpleGraph
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-open Classical Finset List
+open Finset List
 
 /-- A unit distance graph in ℝ²:
 A graph where the vertices V are a collection of points in ℝ² and there is

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
@@ -23,10 +23,10 @@ public import Mathlib.Tactic.IntervalCases
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
+open Classical in
 /-- Distance from a vertex to a finite set. -/
 noncomputable def distToSet (G : SimpleGraph α) (v : α) (S : Set α) : ℕ :=
   if h : S.toFinset.Nonempty then
@@ -45,12 +45,14 @@ noncomputable def averageDistance (G : SimpleGraph α) : ℝ :=
 def isInducedPath (G : SimpleGraph α) (l : List α) : Prop :=
   l.Nodup ∧ ∀ i j : Fin l.length, G.Adj (l.get i) (l.get j) ↔ i.val + 1 = j.val ∨ j.val + 1 = i.val
 
+open Classical in
 /-- The path number of a graph: The number of vertices of a largest induced path of the graph. -/
 noncomputable def path (G : SimpleGraph α) : ℕ :=
   let induced_paths := Finset.univ.filter (fun s : Finset α =>
     ∃ l : List α, l.toFinset = s ∧ isInducedPath G l)
   (induced_paths.image Finset.card).max.getD 0
 
+open Classical in
 /-- Auxiliary quantity `ecc` used in conjecture 34. -/
 noncomputable def ecc (G : SimpleGraph α) (S : Set α) : ℕ :=
   let s_comp := Finset.univ.filter (fun v => v ∉ S)
@@ -58,6 +60,7 @@ noncomputable def ecc (G : SimpleGraph α) (S : Set α) : ℕ :=
     (s_comp.image (fun v => distToSet G v S)).max' (Finset.Nonempty.image h _)
   else 0
 
+open Classical in
 /-- The minimum, over all vertices $v \notin S$, of the distance from $v$ to the set $S$:
 $\min_{v \notin S} \operatorname{dist}(v, S)$. Returns `0` when $S = \mathrm{univ}$ (no
 vertex outside $S$).

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
@@ -26,9 +26,9 @@ namespace SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-open Classical in
 /-- Distance from a vertex to a finite set. -/
 noncomputable def distToSet (G : SimpleGraph α) (v : α) (S : Set α) : ℕ :=
+  open scoped Classical in
   if h : S.toFinset.Nonempty then
     (S.toFinset.image (fun s => G.dist v s)).min' (Finset.Nonempty.image h _)
   else 0
@@ -45,22 +45,21 @@ noncomputable def averageDistance (G : SimpleGraph α) : ℝ :=
 def isInducedPath (G : SimpleGraph α) (l : List α) : Prop :=
   l.Nodup ∧ ∀ i j : Fin l.length, G.Adj (l.get i) (l.get j) ↔ i.val + 1 = j.val ∨ j.val + 1 = i.val
 
-open Classical in
 /-- The path number of a graph: The number of vertices of a largest induced path of the graph. -/
 noncomputable def path (G : SimpleGraph α) : ℕ :=
+  open scoped Classical in
   let induced_paths := Finset.univ.filter (fun s : Finset α =>
     ∃ l : List α, l.toFinset = s ∧ isInducedPath G l)
   (induced_paths.image Finset.card).max.getD 0
 
-open Classical in
 /-- Auxiliary quantity `ecc` used in conjecture 34. -/
 noncomputable def ecc (G : SimpleGraph α) (S : Set α) : ℕ :=
+  open scoped Classical in
   let s_comp := Finset.univ.filter (fun v => v ∉ S)
   if h : s_comp.Nonempty then
     (s_comp.image (fun v => distToSet G v S)).max' (Finset.Nonempty.image h _)
   else 0
 
-open Classical in
 /-- The minimum, over all vertices $v \notin S$, of the distance from $v$ to the set $S$:
 $\min_{v \notin S} \operatorname{dist}(v, S)$. Returns `0` when $S = \mathrm{univ}$ (no
 vertex outside $S$).
@@ -68,6 +67,7 @@ vertex outside $S$).
 Counterpart to `ecc`: the outer minimum (instead of maximum) of the
 distance-to-set function, restricted to vertices outside $S$. -/
 noncomputable def distMin (G : SimpleGraph α) (S : Set α) : ℕ :=
+  open scoped Classical in
   let outside := Finset.univ.filter (fun v : α => v ∉ S)
   if h : outside.Nonempty then
     (outside.image (fun v => distToSet G v S)).min' (Finset.Nonempty.image h _)

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/WienerIndex.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/WienerIndex.lean
@@ -20,7 +20,6 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.VertexDistan
 @[expose] public section
 
 namespace SimpleGraph
-open Classical
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/FormalConjecturesForMathlib/Data/Set/Density.lean
+++ b/FormalConjecturesForMathlib/Data/Set/Density.lean
@@ -101,12 +101,12 @@ def HasPosDensity {β : Type*} [Preorder β] [LocallyFiniteOrderBot β]
     (S : Set β) (A : Set β := Set.univ) : Prop :=
   ∃ α > 0, S.HasDensity α A
 
-open Classical in
 /--
 The two-sided partial natural density of a set of integers, counted inside the interval
 `[-N, N]`.
 -/
 noncomputable def intPartialDensity (S : Set ℤ) (N : ℕ) : ℝ :=
+  open scoped Classical in
   (((Finset.Icc (-(N : ℤ)) (N : ℤ)).filter (fun m => m ∈ S)).card : ℝ) /
     (2 * (N : ℝ) + 1)
 
@@ -214,7 +214,7 @@ end Nat
 
 section LogarithmicDensity
 
-open Finset Real Classical
+open Finset Real
 
 /--
 A set `A` of natural numbers has logarithmic density `d` if the sequence
@@ -224,6 +224,7 @@ then it also has logarithmic density `d` (see `Set.HasDensity.hasLogDensity`), b
 is false.
 -/
 def Set.HasLogDensity (A : Set ℕ) (d : ℝ) : Prop :=
+  open scoped Classical in
   Tendsto (fun n : ℕ => (∑ k ≤ n with k ∈ A, (k : ℝ)⁻¹ / .log n : ℝ)) atTop (𝓝 d)
 
 /-- If a set has natural density `d`, then it also has logarithmic density `d`. -/

--- a/FormalConjecturesForMathlib/NumberTheory/AdditivelyComplete.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/AdditivelyComplete.lean
@@ -71,7 +71,7 @@ theorem IsAddStronglyCompleteNatSeq.isAddComplete {A : ℕ → M}
     (hA : IsAddStronglyCompleteNatSeq A) :
     IsAddComplete (Set.range A) := by simpa using hA 0
 
-open Classical in
+open scoped Classical in
 /-- If the range of a sequence `A` is strongly complete, then `A` is strongly complete. -/
 theorem IsAddStronglyCompleteNatSeq.of_isAddStronglyComplete {A : ℕ → M}
     (h : IsAddStronglyComplete (.range A)) : IsAddStronglyCompleteNatSeq A :=

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -23,6 +23,8 @@ relaxedAutoImplicit = false
 # our own linters which we don't want to force upon downstream packages
 weak.linter.style.copyright.formalConjectures = true
 weak.linter.style.namespace = true
+# Don't open Classical globally
+weak.linter.style.openClassical = true
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
Until now, formal conjectures deals with classical reasoning very liberally, in particular many files open the Classical namespace globally, which is unfortunate; in mathlib this is linted against, since by doing this a theorem might accidentally use classical results, even though it does not need to.

This PR removes all global `open Classical` and turns on the linter against it (the linter says very clearly what one ought to do instead, so i dont think that should pose a problem).
Furthermore, it also optimises `open Classical in`: Prefer `open scoped Classical` (or `classical`) and move it into the proof term whenever possible

(I have made a series on PRs about this topic in mathlib a few weeks ago, i.e. [this](https://github.com/leanprover-community/mathlib4/pull/41414))