### PR TITLE
Mark Erdős Problem 279 as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/279.lean
+++ b/FormalConjectures/ErdosProblems/279.lean
@@ -27,9 +27,12 @@ namespace Erdos279
 Let $k\geq 3$. Is there a choice of congruence classes $a_p\pmod{p}$ for every prime $p$
 such that all sufficiently large integers can be written as $a_p+tp$ for some prime $p$
 and integer $t\geq k$?
+
+This was formally proved in Lean by Wanfang Chen.
 -/
-@[category research open, AMS 11]
-theorem erdos_279 :  answer(sorry) ↔ ∀ k : Nat, k ≥ 3 →
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/WanfangChen/Erdos/blob/585b714d5146fc12926dbff54bc0afd765452481/Erdos279/DeepMindBridge.lean"]
+theorem erdos_279 : answer(True) ↔ ∀ k : Nat, k ≥ 3 →
     ∃ a : Nat → Nat, ∃ N : Nat, (∀ p : Nat, p.Prime → a p < p) ∧
     ∀ n ≥ N, ∃ p : Nat, ∃ t ≥ k, p.Prime ∧ n = a p + t * p := by
   sorry


### PR DESCRIPTION
## Summary

- mark Erdős Problem 279 as affirmatively solved;
- replace `answer(sorry)` with `answer(True)`;
- link the external Lean 4 formal proof with the `formal_proof` attribute;
- credit Wanfang Chen for the formal proof.

## Statement alignment

The external project reproduces the exact affirmative right-hand side of this theorem as `Erdos279.DeepMindErdos279Affirmative` and proves

```lean
theorem Erdos279.globalAffirmative_iff_deepMindErdos279Affirmative :
    Erdos279.GlobalAffirmative ↔ Erdos279.DeepMindErdos279Affirmative
```

It then derives `Erdos279.deepMindErdos279Affirmative` from the unconditional final theorem.

## Verification

- `lake build` passed (3551 jobs);
- `lake env lean Erdos279/Audit.lean` passed;
- GitHub Actions independently passed build, compiled-environment replay, unfinished-placeholder rejection, and final axiom auditing;
- the final proof and equivalence use only `propext`, `Classical.choice`, and `Quot.sound`.

Proof permalink:
https://github.com/WanfangChen/Erdos/blob/585b714d5146fc12926dbff54bc0afd765452481/Erdos279/DeepMindBridge.lean

Verification run:
https://github.com/WanfangChen/Erdos/actions/runs/30605062079