### PR TITLE
fix(Erdős 124): correct the BEGL96 special case and link Lean proof

### DIFF
--- a/FormalConjectures/ErdosProblems/124.lean
+++ b/FormalConjectures/ErdosProblems/124.lean
@@ -61,15 +61,16 @@ lemma erdos124.ne_zero : answer(sorry) ↔
   sorry
 
 /--
-All sufficiently large integers can be written as $a + b + c$ where $a$ has only the digits $0, 1$
-in base $3$, $b$ only the digits $0, 1$ in base $4$, $c$ only the digits $0, 1$ in base $7$.
+All sufficiently large integers can be written as $a + b + c$, where $a$, $b$, and $c$ are
+divisible by $3$, $4$, and $7$ respectively, and after division by that base have only the
+digits $0, 1$ in that base.
 
-Provee by Burr, Erdős, Graham, and Li [BEGL96]
+Proved by Burr, Erdős, Graham, and Li [BEGL96]
 -/
 @[category research solved, AMS 11]
-lemma erdos124.ne_zero_three_four_seven {k : ℕ} (hk : k ≠ 0) :
+lemma erdos124.ne_zero_three_four_seven :
     ∀ᶠ n in atTop,
-      n ∈ sumsOfDistinctPowers 3 k + sumsOfDistinctPowers 4 k + sumsOfDistinctPowers 7 k :=
+      n ∈ sumsOfDistinctPowers 3 1 + sumsOfDistinctPowers 4 1 + sumsOfDistinctPowers 7 1 :=
   sorry
 
 /--
@@ -80,7 +81,8 @@ $$\sum_{1 \le i \le r}\frac 1{d_i - 1} \ge 1.$$
 
 Reported by Burr, Erdős, Graham, and Li [BEGL96] as an observation of Pomerance
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/arex1337/formal-conjectures-proofs/blob/3b7d581c75fd00e482deabfb20675cf3ccfaf49f/Erdos124/Converse.lean"]
 lemma erdos124.converse {D : Finset ℕ} (hD₃ : ∀ d ∈ D, 3 ≤ d)
     (h : ∀ᶠ n in atTop, n ∈ ∑ d ∈ D, sumsOfDistinctPowers d 0) : 1 ≤ ∑ d ∈ D, (d - 1 : ℚ)⁻¹ :=
   sorry


### PR DESCRIPTION
## What changed

- corrected `erdos124.ne_zero_three_four_seven` from arbitrary `k ≠ 0` to
  the cited BEGL96 special case `k = 1`;
- corrected “Provee” to “Proved”;
- linked a complete Lean 4 proof of `erdos124.converse`.

## Why

BEGL96 establishes the `{3,4,7}` result for `k = 1`. The former declaration
also claimed every `k ≥ 2`, which are special cases of the still-open
`erdos124.ne_zero` conjecture.

The linked proof repository builds with Lean 4.32.2 and Mathlib v4.32.2,
contains no `sorry`, `admit`, or custom axioms, and includes an axiom report
and reasoning trace.

Closes #4690.

## Checks

- `lake --wfail build` on this exact PR head
- clean build of `arex1337/formal-conjectures-proofs` at
  `3b7d581c75fd00e482deabfb20675cf3ccfaf49f`
- `#print axioms Erdos124.converse`: `propext`, `Classical.choice`,
  `Quot.sound`
- anonymous resolution of the immutable proof URL

Disclosure: the Lean proof and analysis were AI-generated under human
direction; this exposition was human-prepared, and Lean’s kernel
machine-checked the proof.