### PR TITLE
feat(Erdős 982): add the concyclic solved variant

### DIFF
--- a/FormalConjectures/ErdosProblems/982.lean
+++ b/FormalConjectures/ErdosProblems/982.lean
@@ -35,4 +35,16 @@ theorem erdos_982 (n : ℕ) (hn : 3 ≤ n) (p : Fin n → ℝ²) (hp : Function.
     ∃ (i : Fin n), { d : ℝ | ∃ j : Fin n, j ≠ i ∧ d = dist (p i) (p j) }.ncard ≥ n / 2 := by
   sorry
 
+/--
+For distinct points on a common circle, every vertex has at least
+$\lfloor\frac{n}{2}\rfloor$ different distances to the other vertices.
+This does not require convexity or the assumption $3 \leq n$.
+-/
+@[category research solved, AMS 52,
+  formal_proof using lean4 at "https://github.com/arex1337/formal-conjectures-proofs/blob/3b7d581c75fd00e482deabfb20675cf3ccfaf49f/Erdos982/GeneralCircle.lean"]
+theorem erdos_982.variants.concyclic {n : ℕ} (p : Fin n → ℝ²) (hp : Function.Injective p)
+    (c : ℝ²) (R : ℝ) (hR : ∀ j, dist (p j) c = R) (i : Fin n) :
+    { d : ℝ | ∃ j : Fin n, j ≠ i ∧ d = dist (p i) (p j) }.ncard ≥ n / 2 := by
+  sorry
+
 end Erdos982


### PR DESCRIPTION
## What changed

Added `erdos_982.variants.concyclic`: for distinct points on one circle, every
chosen vertex determines at least `n / 2` distinct distances to the other
points. The statement needs neither convexity nor `3 ≤ n`.

## Proof

The linked Lean proof handles radius zero separately. For positive radius it
normalizes the points to the unit circle, proves that multiplication by the
radius preserves the number of distinct distances, and applies the
unit-circle chord-counting theorem.

The proof repository builds with Lean 4.32.2 and Mathlib v4.32.2, contains no
`sorry`, `admit`, or custom axioms, and includes an axiom report and reasoning
trace.

Closes #4691.

## Checks

- `lake --wfail build` on this exact PR head
- clean build of `arex1337/formal-conjectures-proofs` at
  `3b7d581c75fd00e482deabfb20675cf3ccfaf49f`
- `#print axioms Erdos982.ncard_distinct_distances_onCircle`: `propext`,
  `Classical.choice`, `Quot.sound`
- anonymous resolution of the immutable proof URL

Disclosure: the Lean proof and analysis were AI-generated under human
direction; this exposition was human-prepared, and Lean’s kernel
machine-checked the proof.