### PR TITLE
ci: pin actions to commit SHAs and fix a template injection

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -50,9 +50,12 @@ jobs:
       #   - Manual workflow_dispatch with website_only=true
       - name: Detect build mode
         id: mode
+        env:
+          WEBSITE_ONLY: ${{ inputs.website_only }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ inputs.website_only }}" == "true" ]] || \
-             [[ "${{ github.ref_name }}" == *-webtest ]]; then
+          if [[ "$WEBSITE_ONLY" == "true" ]] || \
+             [[ "$REF_NAME" == *-webtest ]]; then
             echo "website_only=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Website-only build: skipping Lean compilation, downloading data from live site."
           else
@@ -69,7 +72,7 @@ jobs:
 
       - name: Restore ~/.cache/mathlib
         if: steps.mode.outputs.website_only != 'true'
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache/mathlib
           key: oleans-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.lean') }}
@@ -124,14 +127,14 @@ jobs:
 
       - name: Save ~/.cache/mathlib
         if: steps.mode.outputs.website_only != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache
           key: oleans-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.lean') }}
 
       - name: Set up Python
         if: steps.mode.outputs.website_only != 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12.9'
 
@@ -148,7 +151,7 @@ jobs:
           python site/plot_growth.py
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18'
 
@@ -228,7 +231,7 @@ jobs:
 
       - name: Upload deploy artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: _deploy
 
@@ -246,4 +249,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -27,11 +27,8 @@ on:
         type: boolean
         default: false
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -246,6 +243,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    # Only the deployment job needs write access to Pages and the OIDC token.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/check_copyright_header.yml
+++ b/.github/workflows/check_copyright_header.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     - name: Run copyright check script
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           const script = require('./scripts/check_copyright_header.js')

--- a/.github/workflows/check_copyright_header.yml
+++ b/.github/workflows/check_copyright_header.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   check-copyright:
     runs-on: ubuntu-latest
+    # The check only reads the working tree; it makes no API calls.
+    permissions:
+      contents: read
     steps:
     - name: Check out repository code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/check_erdos_status.yml
+++ b/.github/workflows/check_erdos_status.yml
@@ -12,9 +12,9 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6

--- a/.github/workflows/update_erdosproblems.yml
+++ b/.github/workflows/update_erdosproblems.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'google-deepmind/formal-conjectures'
     steps:
       - name: Send repository dispatch event
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           # A Fine-grained personal access token with `Repository access` set to
           # "Only select repositories", namely "teorth/erdosproblems" and `permissions`

--- a/.github/workflows/update_erdosproblems.yml
+++ b/.github/workflows/update_erdosproblems.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     # Not running on forks
     if: github.repository == 'google-deepmind/formal-conjectures'
+    # The dispatch authenticates with REPO_DISPATCH_PAT, so GITHUB_TOKEN needs nothing.
+    permissions: {}
     steps:
       - name: Send repository dispatch event
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3


### PR DESCRIPTION
The org-level Actions scan wants actions pinned by hash and rejects expanding attacker-controllable values into shell, so any PR touching a workflow currently fails. #4368 is red for this, on findings unrelated to its own diff.

- Pinned all 11 unpinned action references across five workflows, `@<sha> # <tag>` as in `welcome_pull_request.yml`. Each SHA resolves to the tag it's commented with.
- Routed `inputs.website_only` and `github.ref_name` through `env` in "Detect build mode" rather than into the shell. A branch name can break out of the `[[ ]]`.
- Moved `pages: write` and `id-token: write` off the workflow and onto the `deploy` job, which is the only one that uses them.
- Added `permissions:` blocks to `check_copyright_header.yml` and `update_erdosproblems.yml`, which had none and inherited the repo default. The copyright script only reads the working tree; the erdosproblems dispatch authenticates with `REPO_DISPATCH_PAT` rather than `GITHUB_TOKEN`, so it gets `permissions: {}`.

The last two came out of fixing the first two, since each round of findings hid the next. All eight workflows now set permissions explicitly and zizmor passes.

The scan only looks at files a PR changes, so none of this showed up until #4368 happened to touch a workflow. #4700 is the same kind of thing.
