### PR TITLE
Formalize Green's Open Problem 88

### DIFF
--- a/FormalConjectures/GreensOpenProblems/88.lean
+++ b/FormalConjectures/GreensOpenProblems/88.lean
@@ -1,0 +1,47 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+import FormalConjectures.Arxiv.«1609.08688».sIncreasingrTuples
+
+/-!
+# Ben Green's Open Problem 88
+
+*References:*
+- [Gr24] [Ben Green's Open Problem
+  88](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.88)
+- [GoLo21] [The length of an $s$-increasing sequence of
+  $r$-tuples](https://arxiv.org/abs/1609.08688)
+  by W. T. Gowers and J. Long
+-/
+
+open Arxiv.«1609.08688»
+
+namespace Green88
+
+/--
+[Gr24, Problem 88]: Is there an absolute constant $\delta > 0$ such that every pairwise
+$2$-comparable set $S \subseteq [N]^3$ satisfies $|S| \leq N^{2 - \delta}$?
+-/
+@[category research open, AMS 5 52]
+theorem green_88 :
+    answer(sorry) ↔
+      ∃ δ > (0 : ℝ), ∀ (N : ℕ) (S : Finset (Fin 3 → Fin N)),
+        (S : Set (Fin 3 → Fin N)).Pairwise IsComparable₂ →
+          (S.card : ℝ) ≤ (N : ℝ) ^ (2 - δ) := by
+  sorry
+
+end Green88


### PR DESCRIPTION
## Summary

- add a formalization of Ben Green's Open Problem 88
- model $[N]^3$ as `Fin 3 → Fin N`
- reuse the Gowers--Long `IsComparable₂` relation and `Set.Pairwise` for pairwise comparability
- state the conjectured uniform polynomial saving $|S| \leq N^{2-\delta}$

Closes #1744.

## Formalization choices

`Fin N` is order-isomorphic to $\{1, \ldots, N\}$, so shifting to zero-based coordinates does not
change the strict-comparison relation. The existing `IsComparable₂` predicate expresses strict
ordering in at least two coordinates; applying `Set.Pairwise` supplies the distinct-pair
quantification required by the source.

## Validation

- `lake --wfail build 'FormalConjectures.GreensOpenProblems.«88»'`
- `git diff --check`

A full `lake --wfail build` was also started. The local checkout had roughly 250 unrelated uncached
conjecture modules, so the repo-wide warm-up was stopped after confirming steady progress; the
focused warning-as-error target and all of its dependencies completed successfully.

## AI assistance

OpenAI GPT-5.6 Sol was used to locate the existing comparison API, propose and independently review
the theorem statement, run validation, and prepare this draft pull request. The PR is left as a
draft for the contributor's review; the contributor will be responsible for understanding and
justifying the final formalization before marking it ready.
