### PR TITLE
ErdosProblems: add 146, 180, 183 with openai/ten-proofs formal_proof links

### DIFF
--- a/FormalConjectures/ErdosProblems/146.lean
+++ b/FormalConjectures/ErdosProblems/146.lean
@@ -1,0 +1,70 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 146
+
+*References:*
+- [erdosproblems.com/146](https://www.erdosproblems.com/146)
+- [ErSi84] Erdős, P. and Simonovits, M., *Cube-supersaturated graphs and related problems*.
+  Progress in graph theory (1984), 203-218.
+- [OpenAI26] OpenAI, *Ten advances in mathematics and theoretical computer science*. (2026).
+-/
+
+open Filter SimpleGraph
+
+namespace Erdos146
+
+open scoped Classical in
+/-- `H` is `r`-degenerate when every induced subgraph has a vertex of degree at most `r`, that is,
+every nonempty vertex set contains a vertex with at most `r` neighbours inside it. -/
+def IsDegenerate {V : Type*} (H : SimpleGraph V) (r : ℕ) : Prop :=
+  ∀ s : Finset V, s.Nonempty → ∃ v ∈ s, (s.filter (H.Adj v)).card ≤ r
+
+/--
+If $H$ is bipartite and is $r$-degenerate, that is, every induced subgraph of $H$ has minimum
+degree $\leq r$, then
+$$\mathrm{ex}(n;H) \ll n^{2-1/r}.$$
+
+The answer is no. OpenAI [OpenAI26] give a connected bipartite `2`-degenerate `H` and constants
+`c, ε > 0` with $\mathrm{ex}(n;H)\geq cn^{3/2+\epsilon}$ for all large `n`, which exceeds the
+conjectured $n^{2-1/2}=n^{3/2}$. See `erdos_146.variants.two_degenerate_counterexample`.
+-/
+@[category research solved, AMS 5]
+theorem erdos_146 : answer(False) ↔
+    ∀ (r : ℕ) (V : Type) (H : SimpleGraph V),
+      0 < r → H.IsBipartite → IsDegenerate H r →
+        ∃ C : ℝ, ∀ᶠ n : ℕ in atTop,
+          (extremalNumber n H : ℝ) ≤ C * (n : ℝ) ^ (2 - 1 / (r : ℝ)) := by
+  sorry
+
+/--
+The counterexample: a connected bipartite `2`-degenerate `H` whose extremal number exceeds
+$n^{3/2+\epsilon}$ infinitely often, so the `r = 2` case of `erdos_146` fails.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at
+  "https://github.com/openai/ten-proofs/blob/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6/CompactnessAndDegeneracy.lean"]
+theorem erdos_146.variants.two_degenerate_counterexample :
+    ∃ (q : ℕ) (H : SimpleGraph (Fin q)),
+      H.Connected ∧ H.IsBipartite ∧ IsDegenerate H 2 ∧
+      ∃ c ε : ℝ, 0 < c ∧ 0 < ε ∧
+        ∀ᶠ n : ℕ in atTop,
+          c * (n : ℝ) ^ ((3 : ℝ) / 2 + ε) ≤ (extremalNumber n H : ℝ) := by
+  sorry
+
+end Erdos146

--- a/FormalConjectures/ErdosProblems/146.lean
+++ b/FormalConjectures/ErdosProblems/146.lean
@@ -31,10 +31,14 @@ open Filter SimpleGraph
 namespace Erdos146
 
 open scoped Classical in
+/-- The neighbours of `v` lying inside `s`. -/
+noncomputable def neighborsWithin {V : Type*} (H : SimpleGraph V) (s : Finset V) (v : V) :
+    Finset V := s.filter (H.Adj v)
+
 /-- `H` is `r`-degenerate when every induced subgraph has a vertex of degree at most `r`, that is,
 every nonempty vertex set contains a vertex with at most `r` neighbours inside it. -/
-def IsDegenerate {V : Type*} (H : SimpleGraph V) (r : ℕ) : Prop :=
-  ∀ s : Finset V, s.Nonempty → ∃ v ∈ s, (s.filter (H.Adj v)).card ≤ r
+def IsDegenerate {V : Type*} (r : ℕ) (H : SimpleGraph V) : Prop :=
+  ∀ s : Finset V, s.Nonempty → ∃ v ∈ s, (neighborsWithin H s v).card ≤ r
 
 /--
 If $H$ is bipartite and is $r$-degenerate, that is, every induced subgraph of $H$ has minimum
@@ -47,10 +51,11 @@ conjectured $n^{2-1/2}=n^{3/2}$. See `erdos_146.variants.two_degenerate_countere
 -/
 @[category research solved, AMS 5]
 theorem erdos_146 : answer(False) ↔
-    ∀ (r : ℕ) (V : Type) (H : SimpleGraph V),
-      0 < r → H.IsBipartite → IsDegenerate H r →
-        ∃ C : ℝ, ∀ᶠ n : ℕ in atTop,
-          (extremalNumber n H : ℝ) ≤ C * (n : ℝ) ^ (2 - 1 / (r : ℝ)) := by
+    ∀ (r q : ℕ) (H : SimpleGraph (Fin q)),
+      0 < r → H.IsBipartite → IsDegenerate r H →
+        Asymptotics.IsBigO atTop
+          (fun n : ℕ => (extremalNumber n H : ℝ))
+          (fun n : ℕ => (n : ℝ) ^ ((2 : ℝ) - 1 / (r : ℝ))) := by
   sorry
 
 /--
@@ -61,7 +66,7 @@ $n^{3/2+\epsilon}$ infinitely often, so the `r = 2` case of `erdos_146` fails.
   "https://github.com/openai/ten-proofs/blob/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6/CompactnessAndDegeneracy.lean"]
 theorem erdos_146.variants.two_degenerate_counterexample :
     ∃ (q : ℕ) (H : SimpleGraph (Fin q)),
-      H.Connected ∧ H.IsBipartite ∧ IsDegenerate H 2 ∧
+      H.Connected ∧ H.IsBipartite ∧ IsDegenerate 2 H ∧
       ∃ c ε : ℝ, 0 < c ∧ 0 < ε ∧
         ∀ᶠ n : ℕ in atTop,
           c * (n : ℝ) ^ ((3 : ℝ) / 2 + ε) ≤ (extremalNumber n H : ℝ) := by

--- a/FormalConjectures/ErdosProblems/180.lean
+++ b/FormalConjectures/ErdosProblems/180.lean
@@ -1,0 +1,78 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 180
+
+*References:*
+- [erdosproblems.com/180](https://www.erdosproblems.com/180)
+- [ErSi82] Erdős, P. and Simonovits, M., *Compactness results in extremal graph theory*.
+  Combinatorica (1982), 275-288.
+- [OpenAI26] OpenAI, *Ten advances in mathematics and theoretical computer science*. (2026).
+-/
+
+open Filter SimpleGraph
+
+namespace Erdos180
+
+variable {V : Type*}
+
+/-- A graph on `Fin n` is `F`-free when it contains no member of the family `F` as a subgraph. -/
+def FamilyFree {q : ℕ} (F : Finset (SimpleGraph (Fin q))) {n : ℕ} (G : SimpleGraph (Fin n)) :
+    Prop :=
+  ∀ H ∈ F, H.Free G
+
+/-- $\mathrm{ex}(n;\mathcal{F})$, the greatest number of edges of a graph on `n` vertices
+containing no member of `F`. -/
+noncomputable def familyExtremalNumber {q : ℕ} (F : Finset (SimpleGraph (Fin q))) (n : ℕ) : ℕ :=
+  sSup {m : ℕ | ∃ G : SimpleGraph (Fin n), FamilyFree F G ∧ G.edgeFinset.card = m}
+
+/--
+If $\mathcal{F}$ is a finite set of finite graphs then $\mathrm{ex}(n;\mathcal{F})$ is the maximum
+number of edges a graph on $n$ vertices can have without containing any subgraphs from
+$\mathcal{F}$. Note that it is trivial that $\mathrm{ex}(n;\mathcal{F})\leq \mathrm{ex}(n;G)$ for
+every $G\in\mathcal{F}$. Is it true that, for every $\mathcal{F}$, there exists $G\in\mathcal{F}$
+such that
+$$\mathrm{ex}(n;G)\ll_{\mathcal{F}}\mathrm{ex}(n;\mathcal{F})?$$
+
+This is the Erdős–Simonovits compactness conjecture. The answer is no: OpenAI [OpenAI26] give a
+family of connected bipartite graphs, none of them acyclic, for which no single member controls
+the family extremal number. See `erdos_180.variants.counterexample`.
+-/
+@[category research solved, AMS 5]
+theorem erdos_180 : answer(False) ↔
+    ∀ (q : ℕ) (F : Finset (SimpleGraph (Fin q))), F.Nonempty →
+      ∃ H ∈ F, ∃ C : ℝ, ∀ᶠ n : ℕ in atTop,
+        (extremalNumber n H : ℝ) ≤ C * (familyExtremalNumber F n : ℝ) := by
+  sorry
+
+/--
+The counterexample: a nonempty family of connected bipartite graphs, none acyclic, that is not
+compact in the sense of `erdos_180`.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at
+  "https://github.com/openai/ten-proofs/blob/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6/CompactnessAndDegeneracy.lean"]
+theorem erdos_180.variants.counterexample :
+    ∃ (q : ℕ) (F : Finset (SimpleGraph (Fin q))),
+      F.Nonempty ∧
+      (∀ H ∈ F, H.Connected ∧ H.IsBipartite ∧ ¬ H.IsAcyclic) ∧
+      ¬ ∃ H ∈ F, ∃ C : ℝ, ∀ᶠ n : ℕ in atTop,
+        (extremalNumber n H : ℝ) ≤ C * (familyExtremalNumber F n : ℝ) := by
+  sorry
+
+end Erdos180

--- a/FormalConjectures/ErdosProblems/180.lean
+++ b/FormalConjectures/ErdosProblems/180.lean
@@ -30,17 +30,31 @@ open Filter SimpleGraph
 
 namespace Erdos180
 
-variable {V : Type*}
+/-- A finite graph, bundled with its vertex count, so that a family may mix orders. -/
+structure FiniteGraph where
+  order : ℕ
+  graph : SimpleGraph (Fin order)
 
-/-- A graph on `Fin n` is `F`-free when it contains no member of the family `F` as a subgraph. -/
-def FamilyFree {q : ℕ} (F : Finset (SimpleGraph (Fin q))) {n : ℕ} (G : SimpleGraph (Fin n)) :
-    Prop :=
-  ∀ H ∈ F, H.Free G
+/-- A host graph is `family`-free when it contains no member of `family` as a subgraph. -/
+def FamilyFree (family : Finset FiniteGraph) {n : ℕ} (host : SimpleGraph (Fin n)) : Prop :=
+  ∀ forbidden ∈ family, forbidden.graph.Free host
 
+open scoped Classical in
 /-- $\mathrm{ex}(n;\mathcal{F})$, the greatest number of edges of a graph on `n` vertices
-containing no member of `F`. -/
-noncomputable def familyExtremalNumber {q : ℕ} (F : Finset (SimpleGraph (Fin q))) (n : ℕ) : ℕ :=
-  sSup {m : ℕ | ∃ G : SimpleGraph (Fin n), FamilyFree F G ∧ G.edgeFinset.card = m}
+containing no member of `family`. -/
+noncomputable def familyExtremal (family : Finset FiniteGraph) (n : ℕ) : ℕ :=
+  (Finset.univ.filter (FamilyFree family)).sup
+    fun host : SimpleGraph (Fin n) => host.edgeFinset.card
+
+/-- No member of the family is acyclic. -/
+def IsCyclicFamily (family : Finset FiniteGraph) : Prop :=
+  ∀ forbidden ∈ family, ¬ forbidden.graph.IsAcyclic
+
+/-- The family is *compact*: some single member already controls the family extremal number. -/
+def IsCompactFamily (family : Finset FiniteGraph) : Prop :=
+  ∃ forbidden ∈ family, ∃ C : ℝ, 0 < C ∧
+    ∀ᶠ n : ℕ in atTop,
+      (extremalNumber n forbidden.graph : ℝ) ≤ C * (familyExtremal family n : ℝ)
 
 /--
 If $\mathcal{F}$ is a finite set of finite graphs then $\mathrm{ex}(n;\mathcal{F})$ is the maximum
@@ -56,23 +70,23 @@ the family extremal number. See `erdos_180.variants.counterexample`.
 -/
 @[category research solved, AMS 5]
 theorem erdos_180 : answer(False) ↔
-    ∀ (q : ℕ) (F : Finset (SimpleGraph (Fin q))), F.Nonempty →
-      ∃ H ∈ F, ∃ C : ℝ, ∀ᶠ n : ℕ in atTop,
-        (extremalNumber n H : ℝ) ≤ C * (familyExtremalNumber F n : ℝ) := by
+    ∀ family : Finset FiniteGraph,
+      family.Nonempty → IsCyclicFamily family → IsCompactFamily family := by
   sorry
 
 /--
 The counterexample: a nonempty family of connected bipartite graphs, none acyclic, that is not
-compact in the sense of `erdos_180`.
+compact.
 -/
 @[category research solved, AMS 5, formal_proof using lean4 at
   "https://github.com/openai/ten-proofs/blob/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6/CompactnessAndDegeneracy.lean"]
 theorem erdos_180.variants.counterexample :
-    ∃ (q : ℕ) (F : Finset (SimpleGraph (Fin q))),
-      F.Nonempty ∧
-      (∀ H ∈ F, H.Connected ∧ H.IsBipartite ∧ ¬ H.IsAcyclic) ∧
-      ¬ ∃ H ∈ F, ∃ C : ℝ, ∀ᶠ n : ℕ in atTop,
-        (extremalNumber n H : ℝ) ≤ C * (familyExtremalNumber F n : ℝ) := by
+    ∃ family : Finset FiniteGraph,
+      family.Nonempty ∧
+      (∀ forbidden ∈ family,
+        forbidden.graph.Connected ∧ forbidden.graph.IsBipartite ∧
+          ¬ forbidden.graph.IsAcyclic) ∧
+      ¬ IsCompactFamily family := by
   sorry
 
 end Erdos180

--- a/FormalConjectures/ErdosProblems/183.lean
+++ b/FormalConjectures/ErdosProblems/183.lean
@@ -1,0 +1,73 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 183
+
+*References:*
+- [erdosproblems.com/183](https://www.erdosproblems.com/183)
+- [Er61] Erdős, P., *Graph theory and probability. II*. Canad. J. Math. (1961), 346-352.
+- [OpenAI26] OpenAI, *Ten advances in mathematics and theoretical computer science*. (2026).
+-/
+
+open Filter
+
+open scoped Topology
+
+namespace Erdos183
+
+/-- A `k`-colouring of the edges of `K_n` forces a monochromatic triangle when every colouring
+admits three distinct vertices whose three edges share a colour. -/
+def ForcesMonochromaticTriangle (n k : ℕ) : Prop :=
+  ∀ c : Sym2 (Fin n) → Fin k, ∃ x y z : Fin n, x ≠ y ∧ x ≠ z ∧ y ≠ z ∧
+    c s(x, y) = c s(x, z) ∧ c s(x, y) = c s(y, z)
+
+/-- $R(3;k)$, the minimal `n` such that every `k`-colouring of the edges of `K_n` contains a
+monochromatic triangle. -/
+noncomputable def multicolourTriangleRamsey (k : ℕ) : ℕ :=
+  sInf {n : ℕ | ForcesMonochromaticTriangle n k}
+
+/--
+Let $R(3;k)$ be the minimal $n$ such that if the edges of $K_n$ are coloured with $k$ colours
+then there must exist a monochromatic triangle. Determine
+$$\lim_{k\to \infty}R(3;k)^{1/k}.$$
+
+There is no finite limit: $R(3;k)^{1/k}\to\infty$. This was established by OpenAI [OpenAI26]
+along with the explicit superexponential lower bound in
+`erdos_183.variants.explicit_lower_bound`.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at
+  "https://github.com/openai/ten-proofs/blob/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6/MulticolorTriangleRamsey.lean"]
+theorem erdos_183 :
+    Tendsto (fun k : ℕ => (multicolourTriangleRamsey k : ℝ) ^ ((1 : ℝ) / (k : ℝ)))
+      atTop atTop := by
+  sorry
+
+/--
+The explicit bound behind `erdos_183`: for every $k\geq 2$,
+$$R(3;k)\geq \left(\frac{k^{1/3}}{6e^{38}\log k}\right)^k.$$
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at
+  "https://github.com/openai/ten-proofs/blob/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6/MulticolorTriangleRamsey.lean"]
+theorem erdos_183.variants.explicit_lower_bound :
+    ∀ k : ℕ, 2 ≤ k →
+      (((1 : ℝ) / (6 * Real.exp 38)) * (k : ℝ) ^ ((1 : ℝ) / 3) / Real.log (k : ℝ)) ^ k ≤
+        (multicolourTriangleRamsey k : ℝ) := by
+  sorry
+
+end Erdos183

--- a/FormalConjectures/ErdosProblems/183.lean
+++ b/FormalConjectures/ErdosProblems/183.lean
@@ -31,15 +31,10 @@ open scoped Topology
 
 namespace Erdos183
 
-/-- A `k`-colouring of the edges of `K_n` is triangle-free when no colour class contains a
-triangle. -/
-def TriangleFree {n k : ℕ} (C : SimpleGraph.TopEdgeLabeling (Fin n) (Fin k)) : Prop :=
-  ∀ colour : Fin k, (C.labelGraph colour).CliqueFree 3
-
-/-- `n` forces a monochromatic triangle on `k` colours when no `k`-colouring of the edges of
-`K_n` is triangle-free. -/
+/-- `n` forces a monochromatic triangle on `k` colours when every `k`-colouring of the edges
+of `K_n` has a colour class containing a triangle. -/
 def ForcesMonochromaticTriangle (n k : ℕ) : Prop :=
-  ∀ C : SimpleGraph.TopEdgeLabeling (Fin n) (Fin k), ¬ TriangleFree C
+  ∀ C : SimpleGraph.TopEdgeLabeling (Fin n) (Fin k), ¬ C.CliqueFree 3
 
 /-- $R(3;k)$, the minimal `n` such that every `k`-colouring of the edges of `K_n` contains a
 monochromatic triangle. -/

--- a/FormalConjectures/ErdosProblems/183.lean
+++ b/FormalConjectures/ErdosProblems/183.lean
@@ -31,11 +31,15 @@ open scoped Topology
 
 namespace Erdos183
 
-/-- A `k`-colouring of the edges of `K_n` forces a monochromatic triangle when every colouring
-admits three distinct vertices whose three edges share a colour. -/
+/-- A `k`-colouring of the edges of `K_n` is triangle-free when no colour class contains a
+triangle. -/
+def TriangleFree {n k : ℕ} (C : SimpleGraph.TopEdgeLabeling (Fin n) (Fin k)) : Prop :=
+  ∀ colour : Fin k, (C.labelGraph colour).CliqueFree 3
+
+/-- `n` forces a monochromatic triangle on `k` colours when no `k`-colouring of the edges of
+`K_n` is triangle-free. -/
 def ForcesMonochromaticTriangle (n k : ℕ) : Prop :=
-  ∀ c : Sym2 (Fin n) → Fin k, ∃ x y z : Fin n, x ≠ y ∧ x ≠ z ∧ y ≠ z ∧
-    c s(x, y) = c s(x, z) ∧ c s(x, y) = c s(y, z)
+  ∀ C : SimpleGraph.TopEdgeLabeling (Fin n) (Fin k), ¬ TriangleFree C
 
 /-- $R(3;k)$, the minimal `n` such that every `k`-colouring of the edges of `K_n` contains a
 monochromatic triangle. -/

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/EdgeColouring.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/EdgeColouring.lean
@@ -16,6 +16,8 @@ limitations under the License.
 module
 
 public import Mathlib.Combinatorics.SimpleGraph.Basic
+public import Mathlib.Combinatorics.SimpleGraph.Clique
+public import Mathlib.Combinatorics.SimpleGraph.EdgeLabeling
 
 @[expose] public section
 
@@ -29,6 +31,10 @@ the edges of `H` into colour classes indexed by `ι`. The classes must (1) cover
 This unifies the previous local `IsNEdgeColouring` (`ι = Fin n`) and `IsCountableEdgeColouring`
 (`ι = ℕ`) shapes used in `FormalConjectures/ErdosProblems/596.lean`. The two are now special
 cases of `IsEdgeColouring` parameterised by the index type.
+
+`SimpleGraph.TopEdgeLabeling.CliqueFree` is the Ramsey-theoretic condition on the other
+edge-colouring shape Mathlib provides, a labelling of the edges of the complete graph: no
+colour class contains a clique of the given size.
 -/
 
 namespace SimpleGraph
@@ -37,5 +43,10 @@ namespace SimpleGraph
 of `H`: the colour classes cover `H` (`H = ⨆ i, c i`) and are pairwise disjoint. -/
 def IsEdgeColouring {V ι : Type*} (H : SimpleGraph V) (c : ι → SimpleGraph V) : Prop :=
   H = ⨆ i, c i ∧ ∀ i j, i ≠ j → Disjoint (c i) (c j)
+
+/-- A labelling of the edges of the complete graph on `V` by `ι` is `n`-clique-free when no
+colour class contains an `n`-clique, that is, when it admits no monochromatic `n`-clique. -/
+def TopEdgeLabeling.CliqueFree {V ι : Type*} (C : TopEdgeLabeling V ι) (n : ℕ) : Prop :=
+  ∀ i : ι, (C.labelGraph i).CliqueFree n
 
 end SimpleGraph


### PR DESCRIPTION
fixes #382, fixes #407 fixes #409 

Adds statements and `formal_proof` links for three Erdős problems resolved in [openai/ten-proofs](https://github.com/openai/ten-proofs), pinned to `94bc0fe`. Not my work.

| Problem | What the proof gives |
|--:|---|
| 146 | a connected bipartite 2-degenerate `H` with `ex(n;H) ≥ c·n^(3/2+ε)`, so the conjectured `ex(n;H) ≪ n^(2-1/r)` fails at `r = 2` |
| 180 | a family with no single member controlling its extremal number, so the Erdős–Simonovits compactness conjecture is false |
| 183 | `R(3;k)^(1/k) → ∞`, plus an explicit superexponential lower bound |

FC had no file for any of the three, so the statements are new rather than links onto existing ones.

## Why these three

`problems.yaml` upstream already records `formal_status: Lean` for 146, 180 and 183, each pointing at this exact commit, with `formalized: no`. So these are gaps erdosproblems has flagged and already accepted the formalization for.

The repo is Apache-2.0, its `formalization.yaml` reports `sorry_count: 0` with axioms exactly `[propext, Classical.choice, Quot.sound]`, and it ships with a paper.

ten-proofs contains twelve results in total; the other nine are not Erdős problems and would need FC statements in areas the repo does not currently cover (sphere packing, metric codes, sofic groups, Connes rigidity, Ehrhart, quantum parallel repetition, closest-vector hardness, permanent lower bounds). Those want domain review rather than transcription, so they are left out here.

## Statements

Each FC statement mirrors the linked theorem's own definitions, so the correspondence is an
unfolding rather than an argument.

- **183** — `TriangleFree` and `ForcesMonochromaticTriangle` are stated over Mathlib's
  `TopEdgeLabeling`, as the proof does, and `multicolourTriangleRamsey` is the same `sInf`. The
  headline is the divergence; `erdos_183.variants.explicit_lower_bound` carries the explicit bound.
- **146** — `IsDegenerate` and `neighborsWithin` match the proof's, and the headline uses the same
  `IsBigO` phrasing over `SimpleGraph (Fin q)`. Headline is `answer(False)`; the 2-degenerate
  counterexample is the linked variant.
- **180** — `FiniteGraph`, `FamilyFree`, `familyExtremal`, `IsCyclicFamily` and `IsCompactFamily`
  all mirror the proof's, and the headline is its `CompactnessConjectureStatement`. Headline is
  `answer(False)`; the counterexample is the linked variant.

An earlier version of this PR wrote the statements independently and got 180 wrong: the family was
`Finset (SimpleGraph (Fin q))`, which forces every member onto a common vertex count, where the
problem is about a finite set of finite graphs of any orders. It also dropped the `IsCyclicFamily`
hypothesis. Both are fixed.

## What I have not done

I have not rebuilt the proofs. They pin Lean 4.32 against their own Mathlib, so the `sorry_count: 0`
and axiom claims are from the repo's own `formalization.yaml` and its CI rather than something
rerun here.
