### PR TITLE
docs: make agent workflow focused and proportional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,37 @@ The same applies to a proof you cite with `formal_proof`. Read the file for `sor
 are claiming. A repository saying it proves a conjecture may prove something weaker, and the
 statement is often the same theorem under a different name.
 
+## Checking your own work
+
+Each of these has produced a wrong claim in this repository, and each is cheap to avoid.
+
+**Read what matched, not how many.** Searching the site for `coprime` returned four results,
+which looked like the search covering statement text. All four matched the theorem *name*.
+A count tells you nothing about why something matched.
+
+**`grep sorry` hits prose.** A file whose only two `sorry` matches were inside a comment
+describing a plan was nearly written off as incomplete. Use `#print axioms` to decide, and
+grep only to find where to look.
+
+**Check the data before describing it.** "The statements are already in `conjectures.json`"
+was wrong: `extract_names` is run with `--exclude=statement`, so they are not. Open the file.
+
+**Measure at the right moment.** An environment probe run from a later command says nothing
+about what an attribute saw while elaborating, because the declaration is rewound in between.
+If a claim is about when something happens, instrument that point.
+
+**A no-op edit looks like a successful one.** A `str.replace` whose pattern no longer matches
+changes nothing and reports nothing; so does a `PATCH` that writes back identical content.
+Assert that the edit landed, and re-read the file rather than the exit code.
+
+**Shell quoting eats Lean source silently.** An unquoted heredoc expanded `` `A` `` and `$K_n`
+in docstrings to nothing. The file still compiled, so only a reader noticed. Quote the
+delimiter, and reread any docstring a script wrote.
+
+**Dry-run anything that closes or deletes.** A comparison between an `int` and a set of
+strings matched nothing, which would have closed 34 of 35 issues rather than the 6 intended.
+Print what a destructive step would do, against real data, before letting it do it.
+
 ## Statement fidelity
 
 The docstring quotes the source, and the Lean says exactly that. When they can differ, the
@@ -96,6 +127,7 @@ left `sorry` exercises nothing.
 - [ ] `#print axioms` on anything claimed to be proved
 - [ ] no `sorry` under `FormalConjecturesForMathlib/`
 - [ ] `git status` before `git add`: generated files and `__pycache__` sweep in easily
+- [ ] any file a script edited has been reread, not just rebuilt
 - [ ] `Fixes #1, fixes #2` in the description, with the keyword repeated. `Fixes #1, #2`
       closes only the first
 - [ ] formalisation choices and caveats in the pull request description, not in the Lean file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Quote it. The guillemets in a numbered file are part of the module name.
 ```bash
 lake --wfail build FormalConjecturesForMathlib   # if you changed a shared definition
 lake --wfail test                                # if you changed anything under FormalConjecturesUtil
-lake --wfail build                               # over an hour; leave it to CI
+lake --wfail build                               # ~25 min warm; leave it to CI
 ```
 
 `--wfail` turns warnings into failures, which is how CI runs. Two that catch people out:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,140 +1,149 @@
 # Agent guidelines
 
-Formal Conjectures states open mathematical problems in Lean 4. It is a statement
-repository, not a proof repository: the value is in the statement saying what the source
-says, and almost every problem is `sorry`.
+Formal Conjectures states open mathematical problems in Lean 4. This is a repository of
+statements, not a repository of proofs. Each statement must say what its source says. Almost
+every problem contains `sorry`.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and the
-attributes. This file is what an agent needs on top of it.
+[CONTRIBUTING.md](CONTRIBUTING.md) gives the conventions, the directories and the attributes.
+This file adds only what CONTRIBUTING does not tell you.
 
-For the shape of a file, copy one rather than a template. *File structure conventions* in
-CONTRIBUTING gives the skeleton, and
-[`FormalConjectures/ErdosProblems/13.lean`](FormalConjectures/ErdosProblems/13.lean) is 62
-lines showing the rest: a definition with its docstring, a `research solved` headline citing
-its source, and a `research open` variant using `answer(sorry)`. A file in the repository
-cannot drift away from the repository.
+Copy an existing file. Do not copy a template. *File structure conventions* in CONTRIBUTING
+gives the skeleton.
+[`FormalConjectures/ErdosProblems/13.lean`](FormalConjectures/ErdosProblems/13.lean) gives the
+remainder in 62 lines: a definition with its docstring, a `research solved` statement with its
+source, and a `research open` variant with `answer(sorry)`. A template can become incorrect. A
+file in the repository cannot, because the build compiles it.
 
 ## Commands
 
-Build the module you touched, not the project:
+Build only the module that you changed. Do not build the project.
 
 ```bash
 lake --wfail build 'FormalConjectures.ErdosProblems.«361»'
 ```
 
-Quote it. The guillemets in a numbered file are part of the module name.
+Put the module name in quotation marks. The guillemets in a numbered file are part of the
+module name.
 
 ```bash
 lake --wfail build FormalConjecturesForMathlib   # if you changed a shared definition
-lake --wfail test                                # if you changed anything under FormalConjecturesUtil
-lake --wfail build                               # ~25 min warm; leave it to CI
+lake --wfail test                                # if you changed FormalConjecturesUtil
+lake --wfail build                               # 25 minutes when warm. Let CI do this.
 ```
 
-`--wfail` turns warnings into failures, which is how CI runs. Two that catch people out:
+`--wfail` makes each warning into a failure. CI uses the same option. Two warnings cause most
+of these failures:
 
-- `open Classical` trips `linter.style.openClassical`. Use `open scoped Classical in` on the
-  declaration that needs it, or a `Decidable` instance.
-- AMS tags must be ascending: `AMS 15 51`, not `AMS 51 15`.
+- `open Classical` causes the `linter.style.openClassical` warning. Write
+  `open scoped Classical in` before the declaration that needs it. As an alternative, supply
+  a `Decidable` instance.
+- The AMS tags must be in ascending order. Write `AMS 15 51`. Do not write `AMS 51 15`.
 
-## Where a statement goes
+## Where to put a statement
 
-`FormalConjectures/<Source>/` for problems, one file per problem, named for it. Reusable
-mathematics goes in `FormalConjecturesForMathlib/`, which must be `sorry`-free. `sorry` is
-expected in `FormalConjectures/` and nowhere else.
+Put a problem in `FormalConjectures/<Source>/`. Use one file for each problem. Give the file
+the name of the problem. Put reusable mathematics in `FormalConjecturesForMathlib/`. That
+directory must not contain `sorry`. Only `FormalConjectures/` can contain `sorry`.
 
-Search before you define. Much of what a problem needs is already in Mathlib, in
-`FormalConjecturesForMathlib/`, or in a neighbouring problem file, under a name you would not
-guess: `trianglesContaining`, `InGeneralPosition`, `NonTrilinear`, `distinctDistances`.
+Search before you write a definition. Mathlib, `FormalConjecturesForMathlib/` and the adjacent
+problem files already contain much of what a problem needs. The names are difficult to guess.
+Examples: `trianglesContaining`, `InGeneralPosition`, `NonTrilinear`, `distinctDistances`.
 
 ## Check the degenerate cases
 
-The usual way a formalisation is wrong is not a typo. It is a statement that is vacuous,
-trivially true, or false on an input nobody pictured, and Lean's junk values hide it because
-the file still compiles and still reads well. Try the smallest and emptiest inputs:
+Most incorrect formalisations are not typographical errors. They are statements that are
+vacuous, or trivially true, or false on an input that the author did not think about. Lean
+gives a junk value in these cases. Thus the file compiles, and the statement continues to read
+correctly. Test the smallest inputs and the empty inputs:
 
 | | |
 |---|---|
-| empty type or set | `∑ i, f i = 0`, and `X → ℝ` is a subsingleton, so contradictory-looking conditions can both hold |
-| `ZMod 0` | it is `ℤ`, not a finite modulus |
-| `x / 0` | it is `0`, so `∃ m : ℤ, q = m` counts a pole as an integer. Say `a ∣ b` instead |
-| `sInf ∅` | it is `0`, so a "least such `n`" is `0` when nothing qualifies |
-| `Nat` subtraction | it truncates at zero |
+| empty type or set | `∑ i, f i = 0`. Also, `X → ℝ` is a subsingleton. Thus two conditions that look contradictory can both hold |
+| `ZMod 0` | This type is `ℤ`. It is not a finite modulus |
+| `x / 0` | The result is `0`. Thus `∃ m : ℤ, q = m` accepts a pole as an integer. Write `a ∣ b` |
+| `sInf ∅` | The result is `0`. Thus the least such `n` is `0` when no `n` qualifies |
+| `Nat` subtraction | The result truncates to zero |
 
-If a hypothesis such as `0 < N`, `[Nonempty X]` or `2 ≤ n` is what keeps the statement
-honest, say so in a sentence in the docstring. A reviewer cannot otherwise tell a
-load-bearing hypothesis from a decorative one.
+Some statements are correct only because of a hypothesis such as `0 < N`, `[Nonempty X]` or
+`2 ≤ n`. Write one sentence in the docstring for each such hypothesis. A reviewer cannot
+otherwise know which hypotheses are necessary.
 
-## Compiling is not proving
+## Compilation is not proof
 
-A file containing `sorry` compiles. If you claim something is proved, check:
+A file that contains `sorry` compiles. Run this command before you write that a theorem is
+proved:
 
 ```lean
 #print axioms my_theorem
 -- [propext, Classical.choice, Quot.sound]
 ```
 
-Anything else, `sorryAx` above all, means it is not proved.
+Any other axiom shows that the theorem is not proved. `sorryAx` is the most important example.
 
-The same applies to a proof you cite with `formal_proof`. Read the file for `sorry`, run
-`#print axioms` on the theorem you are citing, and check that its statement is the one you
-are claiming. A repository saying it proves a conjecture may prove something weaker, and the
-statement is often the same theorem under a different name.
+Do the same for a proof that you cite with `formal_proof`. Read the file and look for `sorry`.
+Run `#print axioms` on the theorem that you cite. Then make sure that this theorem states what
+you claim. A repository can claim a proof of a conjecture and prove a weaker result. The
+correct theorem frequently has a different name.
 
-## Checking your own work
+## Check your own work
 
-Each of these has produced a wrong claim in this repository, and each is cheap to avoid.
+Each item below caused an incorrect claim in this repository. Each check is quick.
 
-**Read what matched, not how many.** Searching the site for `coprime` returned four results,
-which looked like the search covering statement text. All four matched the theorem *name*.
-A count tells you nothing about why something matched.
+**Read the matches. Do not count them.** A site search for `coprime` gave four results. This
+looked like a search of the statement text. All four results matched the theorem *name*. A
+count does not tell you why a search matched.
 
-**`grep sorry` hits prose.** A file whose only two `sorry` matches were inside a comment
-describing a plan was nearly written off as incomplete. Use `#print axioms` to decide, and
-grep only to find where to look.
+**`grep sorry` also matches prose.** One file had two matches for `sorry`, both in a comment
+that described a plan. The file was almost recorded as incomplete. Use `#print axioms` to
+decide. Use grep only to find the location.
 
-**Check the data before describing it.** "The statements are already in `conjectures.json`"
-was wrong: `extract_names` is run with `--exclude=statement`, so they are not. Open the file.
+**Look at the data before you describe it.** The claim "the statements are already in
+`conjectures.json`" was incorrect. `extract_names` uses the `--exclude=statement` option, and
+does not write them. Open the file.
 
-**Measure at the right moment.** An environment probe run from a later command says nothing
-about what an attribute saw while elaborating, because the declaration is rewound in between.
-If a claim is about when something happens, instrument that point.
+**Measure at the correct time.** An environment probe in a later command does not show what an
+attribute saw during elaboration. Lean rewinds the declaration between the two points. Add the
+instrument at the point that your claim is about.
 
-**A no-op edit looks like a successful one.** A `str.replace` whose pattern no longer matches
-changes nothing and reports nothing; so does a `PATCH` that writes back identical content.
-Assert that the edit landed, and re-read the file rather than the exit code.
+**An edit that does nothing looks like an edit that works.** A `str.replace` whose pattern no
+longer matches changes nothing and reports nothing. A `PATCH` that writes identical content
+does the same. Make sure that the edit occurred. Read the file again. Do not use the exit
+code.
 
-**Shell quoting eats Lean source silently.** An unquoted heredoc expanded `` `A` `` and `$K_n`
-in docstrings to nothing. The file still compiled, so only a reader noticed. Quote the
-delimiter, and reread any docstring a script wrote.
+**The shell can remove Lean source silently.** An unquoted heredoc expanded `` `A` `` and
+`$K_n` in docstrings to nothing. The file compiled, thus only a reader found the error. Put
+the delimiter in quotation marks. Read again each docstring that a script wrote.
 
-**Dry-run anything that closes or deletes.** A comparison between an `int` and a set of
-strings matched nothing, which would have closed 34 of 35 issues rather than the 6 intended.
-Print what a destructive step would do, against real data, before letting it do it.
+**Do a dry run of each step that closes or deletes.** A comparison between an `int` and a set
+of strings matched nothing. This would have closed 34 of the 35 issues. The correct number was
+6. Print the effect of a destructive step on the real data first.
 
 ## Statement fidelity
 
-The docstring quotes the source, and the Lean says exactly that. When they can differ, the
-Lean is wrong. Things to reread before submitting:
+The docstring quotes the source. The Lean must agree with the docstring. If they disagree, the
+Lean is incorrect. Read these again before you submit:
 
-- quantifier order and scope
-- `≤` against `<`, `∀ᶠ` against `∀`, asymptotic equivalence against same order
-- a hypothesis the prose states and the Lean drops
-- `∃ x, P x → Q`, which is almost always meant as `∃ x, P x ∧ Q` and is trivially true as
-  written. There is a linter for it
+- the order and the scope of the quantifiers
+- `≤` against `<`, `∀ᶠ` against `∀`, asymptotic equivalence against the same order
+- a hypothesis that the prose gives and the Lean omits
+- `∃ x, P x → Q`. The intended statement is almost always `∃ x, P x ∧ Q`. As written, the
+  statement is trivially true. A linter finds this
 
-Prove the `test` and `API` statements you add. They exist to exercise a definition, and one
-left `sorry` exercises nothing.
+Prove each `test` statement and each `API` statement that you add. These statements must test
+a definition. A statement that contains `sorry` tests nothing.
 
-## Before opening a pull request
+## Before you open a pull request
 
-- [ ] `lake --wfail build <module>` passes for what you touched
-- [ ] docstring quotes the source, with a reference in the module docstring
-- [ ] every theorem has `category` and at least one `AMS` tag, in ascending order
-- [ ] degenerate inputs tried: empty, zero, division
-- [ ] `#print axioms` on anything claimed to be proved
-- [ ] no `sorry` under `FormalConjecturesForMathlib/`
-- [ ] `git status` before `git add`: generated files and `__pycache__` sweep in easily
-- [ ] any file a script edited has been reread, not just rebuilt
-- [ ] `Fixes #1, fixes #2` in the description, with the keyword repeated. `Fixes #1, #2`
-      closes only the first
-- [ ] formalisation choices and caveats in the pull request description, not in the Lean file
+- [ ] `lake --wfail build <module>` passes for each module that you changed
+- [ ] the docstring quotes the source, and the module docstring gives a reference
+- [ ] each theorem has a `category` and at least one `AMS` tag, in ascending order
+- [ ] you tested the degenerate inputs: empty, zero, division
+- [ ] you ran `#print axioms` on each theorem that you claim is proved
+- [ ] `FormalConjecturesForMathlib/` contains no `sorry`
+- [ ] you ran `git status` before `git add`. Generated files and `__pycache__` are easy to add
+      by mistake
+- [ ] you read again each file that a script changed. A build that passes is not sufficient
+- [ ] the description contains `Fixes #1, fixes #2`. Repeat the keyword. `Fixes #1, #2` closes
+      only the first issue
+- [ ] the description gives the formalisation decisions and the limitations. Do not put them
+      in the Lean file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,12 @@ proved:
 -- [propext, Classical.choice, Quot.sound]
 ```
 
-Any other axiom shows that the theorem is not proved. `sorryAx` is the most important example.
+`sorryAx` shows that the theorem is not proved.
+
+The three axioms above are the bar for a `research solved` statement. A `test` statement can
+use `native_decide`, which adds `Lean.ofReduceBool` and `Lean.trustCompiler`. These two move
+the proof out of the kernel, so name them in the pull request when a statement depends on
+them.
 
 Do the same for a proof that you cite with `formal_proof`. Read the file and look for `sorry`.
 Run `#print axioms` on the theorem that you cite. Then make sure that this theorem states what
@@ -104,19 +109,6 @@ does not write them. Open the file.
 **Measure at the correct time.** An environment probe in a later command does not show what an
 attribute saw during elaboration. Lean rewinds the declaration between the two points. Add the
 instrument at the point that your claim is about.
-
-**An edit that does nothing looks like an edit that works.** A `str.replace` whose pattern no
-longer matches changes nothing and reports nothing. A `PATCH` that writes identical content
-does the same. Make sure that the edit occurred. Read the file again. Do not use the exit
-code.
-
-**The shell can remove Lean source silently.** An unquoted heredoc expanded `` `A` `` and
-`$K_n` in docstrings to nothing. The file compiled, thus only a reader found the error. Put
-the delimiter in quotation marks. Read again each docstring that a script wrote.
-
-**Do a dry run of each step that closes or deletes.** A comparison between an `int` and a set
-of strings matched nothing. This would have closed 34 of the 35 issues. The correct number was
-6. Print the effect of a destructive step on the real data first.
 
 ## Statement fidelity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Agent guidelines
 
-Formal Conjectures states open mathematical problems in Lean 4. This is a repository of
-statements, not a repository of proofs. Each statement must say what its source says. Almost
-every problem contains `sorry`.
+Formal Conjectures states open mathematical problems in Lean 4. It is a statement
+repository, not a proof repository: almost every problem is `sorry`. Each statement must say
+what its source says.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) gives the conventions, the directories and the attributes.
-This file adds only what CONTRIBUTING does not tell you.
+[CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and the
+attributes. This file adds only what CONTRIBUTING does not tell you.
 
 Copy an existing file. Do not copy a template. *File structure conventions* in CONTRIBUTING
 gives the skeleton.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,13 @@ says, and almost every problem is `sorry`.
 [CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and the
 attributes. This file is what an agent needs on top of it.
 
+For the shape of a file, copy one rather than a template. *File structure conventions* in
+CONTRIBUTING gives the skeleton, and
+[`FormalConjectures/ErdosProblems/13.lean`](FormalConjectures/ErdosProblems/13.lean) is 62
+lines showing the rest: a definition with its docstring, a `research solved` headline citing
+its source, and a `research open` variant using `answer(sorry)`. A file in the repository
+cannot drift away from the repository.
+
 ## Commands
 
 Build the module you touched, not the project:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,564 +1,101 @@
-# Agent Guidelines for Formal Conjectures
+# Agent guidelines
 
-This document provides guidelines for AI agents working on the Formal Conjectures repository.
+Formal Conjectures states open mathematical problems in Lean 4. It is a statement
+repository, not a proof repository: the value is in the statement saying what the source
+says, and almost every problem is `sorry`.
 
-## Repository Structure
+[CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and the
+attributes. This file is what an agent needs on top of it.
 
-### Main Directories
+## Commands
 
-- **`FormalConjectures/`**: Contains formalisations of conjectures, organized by source:
-  - `ErdosProblems/` - Problems from [erdosproblems.com](https://www.erdosproblems.com/)
-  - `Paper/` - Problems from research papers
-  - `Arxiv/` - Problems from arXiv papers (organized by arXiv ID)
-  - `Books/` - Problems from mathematics books
-  - `Wikipedia/` - Problems from Wikipedia
-  - `OptimizationConstants/` - Problems from [Tao's Optimization Constants](https://teorth.github.io/optimizationproblems/)
-  - Other sources as appropriate
+Build the module you touched, not the project:
 
-  **IMPORTANT**: Some subdirectories contain their own `README.md` with more specific conventions
-  (e.g. naming, docstring, and reference rules). Always check for and follow a subdirectory's
-  `README.md` before applying the general guidelines below. For example,
-  `FormalConjectures/ErdosProblems/README.md` defines naming patterns for multi-part questions,
-  estimate questions, and variants that supplement the general conventions in this file.
-
-- **`FormalConjecturesUtil/`**: Repository infrastructure and utilities:
-  - `Attributes/` - Defines the `category` and `AMS` attributes
-  - `Answer.lean` - Implements the `answer()` elaborator for problems requiring answers
-  - `Linters/` - Custom linters for the repository
-  - `ProblemImports.lean` - Standard imports for problem files
-
-- **`FormalConjecturesForMathlib/`**: Definitions, lemmas, and basic API suitable for upstreaming to Mathlib:
-  - **IMPORTANT**: No `sorry` is allowed in this directory
-  - Follows Mathlib's directory structure (e.g., `Topology/`, `Algebra/`, `NumberTheory/`)
-  - Contains supporting definitions and lemmas needed for problem statements
-  - Code here should be of Mathlib quality and eventually PR-able to Mathlib
-
-## Formalisation Conventions
-
-### Namespaces
-
-Each problem file should define its content in a dedicated namespace:
-
-```lean
-namespace Erdos10
-
--- definitions, theorems, variants here
-
-end Erdos10
+```bash
+lake --wfail build 'FormalConjectures.ErdosProblems.«361»'
 ```
 
-For variants of a problem, use dotted notation within the same namespace:
+Quote it. The guillemets in a numbered file are part of the module name.
 
-```lean
-theorem main_conjecture : ... := by
-  sorry
-
-theorem main_conjecture.variants.special_case : ... := by
-  sorry
+```bash
+lake --wfail build FormalConjecturesForMathlib   # if you changed a shared definition
+lake --wfail test                                # if you changed anything under FormalConjecturesUtil
+lake --wfail build                               # over an hour; leave it to CI
 ```
 
-### The `category` Attribute
+`--wfail` turns warnings into failures, which is how CI runs. Two that catch people out:
 
-Every theorem/lemma should have exactly one `category` attribute indicating its type:
+- `open Classical` trips `linter.style.openClassical`. Use `open scoped Classical in` on the
+  declaration that needs it, or a `Decidable` instance.
+- AMS tags must be ascending: `AMS 15 51`, not `AMS 51 15`.
 
-**Values:**
+## Where a statement goes
 
-- `@[category textbook]` - Textbook level math problem (high school, undergraduate, or graduate)
-- `@[category research open]` - Open research problem (no accepted solution exists)
-- `@[category research solved]` - Solved research problem (informal proof widely accepted)
-- `@[category test]` - Sanity check or unit test for definitions
-- `@[category API]` - Basic theory around a new definition
+`FormalConjectures/<Source>/` for problems, one file per problem, named for it. Reusable
+mathematics goes in `FormalConjecturesForMathlib/`, which must be `sorry`-free. `sorry` is
+expected in `FormalConjectures/` and nowhere else.
 
-**Examples:**
+Search before you define. Much of what a problem needs is already in Mathlib, in
+`FormalConjecturesForMathlib/`, or in a neighbouring problem file, under a name you would not
+guess: `trianglesContaining`, `InGeneralPosition`, `NonTrilinear`, `distinctDistances`.
 
-```lean
-@[category research open, AMS 11]
-theorem riemann_hypothesis : ... := by
-  sorry
+## Check the degenerate cases
 
-@[category test, AMS 11]
-theorem sanity_check : ¬ SomeBadProperty := by
-  sorry
+The usual way a formalisation is wrong is not a typo. It is a statement that is vacuous,
+trivially true, or false on an input nobody pictured, and Lean's junk values hide it because
+the file still compiles and still reads well. Try the smallest and emptiest inputs:
 
-@[category API]
-lemma basic_property_of_new_definition : ... := by exact ...
-```
+| | |
+|---|---|
+| empty type or set | `∑ i, f i = 0`, and `X → ℝ` is a subsingleton, so contradictory-looking conditions can both hold |
+| `ZMod 0` | it is `ℤ`, not a finite modulus |
+| `x / 0` | it is `0`, so `∃ m : ℤ, q = m` counts a pole as an integer. Say `a ∣ b` instead |
+| `sInf ∅` | it is `0`, so a "least such `n`" is `0` when nothing qualifies |
+| `Nat` subtraction | it truncates at zero |
 
-### The `formal_proof` Attribute
+If a hypothesis such as `0 < N`, `[Nonempty X]` or `2 ≤ n` is what keeps the statement
+honest, say so in a sentence in the docstring. A reviewer cannot otherwise tell a
+load-bearing hypothesis from a decorative one.
 
-The `formal_proof` attribute records the existence and location of a formal proof.
-It is independent of the `category` attribute and can be used with any category.
+## Compiling is not proving
 
-**Values:**
-
-- `@[formal_proof using formal_conjectures at "link"]` - Formally proved in this repository
-- `@[formal_proof using lean4 at "link"]` - Formally proved in Lean 4 elsewhere
-- `@[formal_proof using other_system at "link"]` - Formally proved in another system
-  (Roqc, Isabelle, Lean 3, HOL, etc.)
-
-**Examples:**
+A file containing `sorry` compiles. If you claim something is proved, check:
 
 ```lean
-@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/example"]
-theorem some_solved_problem : ... := by
-  sorry
-
-@[category textbook, AMS 11, formal_proof using formal_conjectures at "https://..."]
-theorem a_textbook_problem_with_proof : ... := by
-  sorry
+#print axioms my_theorem
+-- [propext, Classical.choice, Quot.sound]
 ```
 
-**Note:** A `formal_proof` annotation on a `research open` problem will trigger a lint warning,
-since open problems should not have proofs.
-
-### The `AMS` Attribute
-
-Every problem should have at least one AMS subject classification number from the [AMS MSC2020](https://mathscinet.ams.org/mathscinet/msc/pdfs/classifications2020.pdf).
-
-**Common subjects:**
-
-- `3` - Mathematical logic and foundations
-- `5` - Combinatorics
-- `11` - Number theory
-- `14` - Algebraic geometry
-- `54` - General topology
-- `60` - Probability theory
-
-Multiple subjects can be specified:
-
-```lean
-@[AMS 5 11]  -- Both combinatorics and number theory
-theorem erdos_problem : ... := by
-  sorry
-```
-
-**In VS Code:** Use `#AMS` command to list all available subjects and their numbers. Hover over a number to see its description.
-
-Full list of AMS subjects
-
-| Code | Name | Keywords |
-|------|------|----------|
-| 00 | General and overarching topics | general |
-| 03 | Mathematical logic and foundations | logic, set theory, model theory |
-| 05 | Combinatorics | combinatorics, graph theory, enumeration |
-| 06 | Order | order, lattice, poset, partial order |
-| 08 | General algebraic systems | universal algebra, algebraic system |
-| 11 | Number theory | number theory, prime, arithmetic, diophantine |
-| 12 | Field theory and polynomials | field, polynomial, galois |
-| 13 | Commutative algebra | commutative, ring, ideal, module |
-| 14 | Algebraic geometry | algebraic geometry, variety, scheme |
-| 15 | Linear algebra | linear algebra, matrix, vector |
-| 16 | Associative rings and algebras | associative, ring, algebra |
-| 17 | Nonassociative rings and algebras | lie algebra, jordan |
-| 18 | Category theory; homological algebra | category, functor, homological |
-| 19 | K-theory | k-theory |
-| 20 | Group theory and generalizations | group, finite group, representation |
-| 22 | Topological groups + Lie groups | topological group, lie group |
-| 26 | Real functions | real analysis, real function, derivative |
-| 28 | Measure and integration | measure, integration, lebesgue |
-| 30 | Functions of a complex variable | complex analysis, holomorphic, analytic |
-| 31 | Potential theory | potential, harmonic function, subharmonic |
-| 32 | Complex analysis | several complex variables, complex manifold |
-| 33 | Special functions | special function, gamma, zeta, bessel |
-| 34 | Ordinary differential equations | ode, differential equation |
-| 35 | Partial differential equations | pde, partial differential |
-| 37 | Dynamical systems and ergodic theory | dynamical, ergodic, chaos |
-| 39 | Difference and functional equations | difference equation, functional equation |
-| 40 | Sequences + series + summability | sequence, series, convergence |
-| 41 | Approximations and expansions | approximation, expansion, interpolation |
-| 42 | Harmonic analysis on Euclidean spaces | harmonic analysis, fourier |
-| 43 | Abstract harmonic analysis | abstract harmonic |
-| 44 | Integral transforms + operational calculus | integral transform, laplace |
-| 45 | Integral equations | integral equation |
-| 46 | Functional analysis | functional analysis, banach, hilbert |
-| 47 | Operator theory | operator, spectral |
-| 49 | Calc. of vars. and opt. ctrl.; optimiz. | calculus of variations, optimal control |
-| 51 | Geometry | geometry, euclidean, projective |
-| 52 | Convex and discrete geometry | convex, polytope, discrete geometry |
-| 53 | Differential geometry | differential geometry, manifold, riemannian |
-| 54 | General topology | topology, topological space, compact |
-| 55 | Algebraic topology | algebraic topology, homotopy, homology |
-| 57 | Manifolds and cell complexes | manifold, cell complex |
-| 58 | Global analysis + analysis on manifolds | global analysis |
-| 60 | Probability theory | probability, stochastic, random |
-| 62 | Statistics | statistics, estimation, hypothesis |
-| 65 | Numerical analysis | numerical, approximation, algorithm |
-| 68 | Computer science | computer science, complexity, algorithm |
-| 70 | Mechanics of particles and systems | mechanics, particle, celestial |
-| 74 | Mechanics of deformable solids | elasticity, solid mechanics |
-| 76 | Fluid mechanics | fluid, navier-stokes |
-| 78 | Optics + electromagnetic theory | optics, electromagnetic |
-| 80 | Classical thermodynamics + heat transfer | thermodynamics, heat |
-| 81 | Quantum theory | quantum, quantum mechanics |
-| 82 | Statistical mechanics | statistical mechanics |
-| 83 | Relativity and gravitational theory | relativity, gravity, einstein |
-| 85 | Astronomy and astrophysics | astronomy, astrophysics |
-| 86 | Geophysics | geophysics |
-| 90 | Mathematical programming | optimization, linear programming |
-| 91 | Game theory | game theory, economics |
-| 92 | Biology and other natural sciences | biology, mathematical biology |
-| 93 | Systems theory; control | control theory, systems theory |
-| 94 | Information and communication + circuits | information theory, coding theory |
-| 97 | Mathematics education | education |
-
-### The `answer()` Elaborator
-
-For problems that ask questions requiring specific answers (not just yes/no), use `answer(sorry)`:
-
-```lean
-/-- Does $P$ hold? -/
-@[category research open]
-theorem problem_name : answer(sorry) ↔ SomeProperty := by
-  sorry
-```
-
-Note that if the statement of the theorem depends on some variables, then the quantification should
-happen _after_ the `answer(sorry)`, i.e.
-
-```lean
-/-- Does $P(n)$ hold for all $n$? -/
-@[category research open]
-theorem problem_name : answer(sorry) ↔ ∀ n, P n := by
-  sorry
-```
-
-rather than
-
-```lean
-/-- Does $P(n)$ hold for all $n$? -/
-@[category research open]
-theorem problem_name (n) : answer(sorry) ↔ P n := by
-  sorry
-```
-
-When the problem is solved:
-
-- Replace `answer(sorry)` with `answer(True)` or `answer(False)` as appropriate
-- Update the category to `research solved`
-- If a formal proof exists, add `formal_proof using <kind> at "<link>"`
-
-**Note:** Providing a term inside `answer()` does NOT automatically mean the problem is mathematically solved - trivial or tautological answers don't count as solutions.
-
-### File Organization
-
-1. **One problem per file** (with flexibility for closely related variants)
-2. **Copyright header required** (see template in README.md, use year 2026)
-3. **Module docstring** with references:
-
-   ```lean
-   /-!
-   # Problem Name
-
-   *References:*
-   - [Title](URL) by *Author Name*, Journal (Year)
-   - [Title](URL)
-
-   Brief description if needed.
-   -/
-   ```
-
-   For a single reference, `*Reference:*` (singular) is also acceptable.
-
-4. **Import structure**:
-   - Problem files: Import `FormalConjecturesUtil`
-   - ForMathlib files: Import only necessary Mathlib modules
-5. If a problem fits in several directories then it should stated in one directory rather than copied
-   accross several. In other directories, one can simply add a file with a declaration pointing
-   to the original, e.g.
-
-   ```lean
-   @[category research open, AMS 11]
-   theorem pointer_to_original : type_of% my_original_theorem := by
-     sorry
-   ```
-
-   See for example `FormalConjectures/GreensOpenProblems/81.lean`.
-
-### Variants and Related Results
-
-Variants should be in the same file as the main conjecture:
-
-```lean
-@[category research open, AMS 11]
-theorem main_conjecture : MainStatement := by
-  sorry
-
-@[category research solved, AMS 11]
-theorem main_conjecture.variants.weaker_version : WeakerStatement := by
-  sorry
-
-@[category test, AMS 11]
-theorem main_conjecture.variants.small_cases : MainStatement with (n < 100) := by
-  interval_cases n <;> decide
-```
-
-## Lean and Mathlib Style Guidelines
-
-### Naming Conventions
-
-Follow [Mathlib's naming conventions](https://leanprover-community.github.io/contribute/naming.html). Unlike Lean 3, Lean 4 uses a combination of `snake_case`, `lowerCamelCase`, and `UpperCamelCase`:
-
-#### Capitalization Rules
-
-1. **Terms of Props** (proofs, theorem names) use `snake_case`:
-
-   ```lean
-   theorem fermat_last_theorem : FermatLastTheorem := by sorry
-   lemma add_comm (a b : ℕ) : a + b = b + a := by sorry
-   ```
-
-2. **Props and Types** (inductive types, structures, classes) use `UpperCamelCase`:
-
-   ```lean
-   class HasGδSingletons (X : Type*) [TopologicalSpace X] : Prop
-   structure MyStructure where
-     field1 : ℕ
-     field2 : String
-   inductive Color where
-     | Red | Green | Blue
-   ```
-
-3. **Functions** are named the same way as their return values:
-   - A function `A → B → C` is named as though it's a term of type `C`.
-   - A function `A → B → Prop` or `A → B → Type _` should be named in `UpperCamelCase`.
-   - A function `A → B → C` where `C : Type _` and `C` isn't itself `Type _` should be named in
-    `lowerCamelCase`.
-   - A function `A → B → C` where `C : Prop` should be named in `snake_case`.
-
-4. **All other terms of Types** use `lowerCamelCase`:
-
-   ```lean
-   def leftFactorial (n : ℕ) : ℕ := ∑ i in Finset.range n, i!
-   def myFunction (x : ℕ) : ℕ := x + 1
-   ```
-
-5. **UpperCamelCase in snake_case contexts**: When something named with `UpperCamelCase` is part of something named with `snake_case`, it is referenced in `lowerCamelCase`:
-
-   ```lean
-   theorem fermat_last_theorem : FermatLastTheorem := by sorry
-   theorem nat_factorial_pos (n : ℕ) : 0 < n! := by sorry
-   ```
-
-6. **Acronyms**: Written as a group in upper-/lowercase depending on the first character:
-   - `LE`, `LT`, `GE`, `GT` (when in `UpperCamelCase` context)
-   - `le`, `lt`, `ge`, `gt` (when in `lowerCamelCase` context)
-
-7. **Structure fields and constructors**: Follow the same rules (1-6) as top-level declarations
-
-#### Common Naming Patterns
-
-- `add_comm`, `mul_assoc` - operation + property
-- `Nat.factorial_pos` - namespace + definition + property
-- `foo_of_bar` - derive `foo` from hypothesis `bar`
-- `bar_iff_foo` - equivalence between `bar` and `foo`
-- `foo_le_bar` - inequality statement
-
-#### Exceptions
-
-Some rare exceptions exist for consistency:
-
-- `Ne` (not `NE`) follows `Eq`
-- Intervals: `Set.Icc`, `Set.Iic` (capital `I` despite convention)
-- Some legacy structure fields may be lowercase
-
-**Note**: In this repository, most declarations are theorems (terms of Props), so you'll primarily use `snake_case`.
-
-### Code Quality
-
-- **Use Unicode math symbols** where appropriate: `∀`, `∃`, `∈`, `⊆`, `∧`, `∨`, `¬`, etc.
-- **Format code properly**: Use consistent indentation (2 spaces)
-- **Add docstrings** with the math written in LaTeX for definitions and main theorems. Note that docstrings should generally use LaTeX markdown (e.g., `$P$` instead of `` `P` ``) to represent mathematical expressions, except for the `FormalConjecturesForMathlib` parts and for definitions that are very much on the Lean/Mathlib API side, where backticks are preferred:
-
-  ```lean
-  /--
-  The left factorial of $n$, defined as $0! + 1! + 2! + ... + (n-1)!$
-  -/
-  def left_factorial (n : ℕ) := ...
-  ```
-
-- **`research open`, `research solved` and `textbook` docstrings MUST include** a concise description of the
-  problem:
-
-  ```lean
-  /--
-  Can every even integer greater than 2 be written as the sum of two primes?
-  -/
-  @[category research open, AMS 11]
-  theorem goldbach :
-      answer(sorry) ↔ ∀ n : ℕ, 2 < n → Even n → ∃ p q, Prime p ∧ Prime q ∧ n = p + q := by
-    sorry
-  ```
-
-- **Use `local notation`** for problem-specific notation within namespaces
-- **Avoid unnecessary type annotations** when Lean can infer them
-- **Use `by` tactic mode** for sorries: `by sorry` (not just `sorry`)
-- **Do not try to add a suggested informal proof for an open research problem**
-- **Avoid using tactics like `native_decide` in proofs**. These are completely banned in `FormalConjecturesForMathlib`
-  and may be considered on a case by case basis for in `category test` statements in problem files
-  when the goal is a large computation.
-
-### Imports
-
-- Be specific with imports - don't import more than needed
-- In FormalConjecturesForMathlib, import only from Mathlib
-- In problem files, import only `FormalConjecturesUtil`, unless you are adding a
-  pointer to another problem or need to state an implication.
-
-## Agent-Specific Requirements
-
-### Before Submitting
-
-**CRITICAL REQUIREMENTS:**
-
-1. **`lake --wfail build` MUST pass** without errors before submitting for review
-   - Run `lake --wfail build` in the repository root
-   - Fix all compilation errors
-   - Fix all linter warnings (fail for warning option is set by `--wfail`)
-   - Ensure all dependencies are properly imported
-
-2. **`sorry` usage restrictions**:
-   - ✅ **ALLOWED**: In `FormalConjectures/` for benchmark problem statements
-
-     ```lean
-     @[category research open]
-     theorem open_conjecture : Statement := by sorry
-     ```
-
-   - ❌ **NOT ALLOWED**: In `FormalConjecturesForMathlib/`
-
-     ```lean
-     -- WRONG - will be rejected
-     def helper_function : Type := sorry
-     lemma helper_lemma : P := by sorry
-     ```
-
-   - Exception: `answer(sorry)` is allowed as a placeholder for unknown answers
-
-3. **Completeness**:
-   - No placeholder definitions (e.g., `def foo : Type := sorry`)
-   - No incomplete type annotations or holes
-   - All referenced definitions must exist
-   - All imports must be correct
-
-4. **Clean code**:
-   - Remove commented-out code
-   - Remove debug statements
-   - No unused imports
-   - No unnecessary intermediate definitions
-
-### Quality Checklist
-
-Before considering your work complete, verify:
-
-- [ ] File has correct copyright header (current year)
-- [ ] Module docstring with reference links present
-- [ ] Namespace properly opened and closed
-- [ ] All theorems have `category` attribute
-- [ ] All theorems have at least one `AMS` subject
-- [ ] Names follow snake_case convention
-- [ ] `lake build` succeeds
-- [ ] No `sorry` in FormalConjecturesForMathlib/
-- [ ] Docstrings present for main definitions
-- [ ] `research open`, `textbook` and `research solved` docstrings include a concise description
-- [ ] Code properly formatted and readable
-- [ ] Searched mathlib and `FormalConjecturesForMathlib` and neighboring files for existing definitions, API, and notation before adding new ones
-- [ ] Notes to reviewers (formalization choices, caveats, AI support used) are in the PR description, not the Lean file
-
-### Testing Definitions
-
-When adding new definitions to FormalConjecturesForMathlib/, include basic sanity checks:
-
-```lean
--- In FormalConjecturesForMathlib/Topology/MyDefinition.lean
-class MyNewClass (X : Type*) : Prop where
-  property : SomeProperty X
-
--- In FormalConjectures/Paper/ProblemUsingMyDefinition.lean
-@[category test]
-theorem myNewClass_sanity_check :
-    MyNewClass SomeConcreteType := by
-  constructor
-  exact proof_of_property
-```
-
-### Common Pitfalls to Avoid
-
-❌ **DON'T:**
-
-- Use `sorry` outside of problem statement proofs
-- Create files without copyright headers
-- Forget to add `category` and `AMS` attributes
-- Submit code that doesn't compile
-- Add large proofs (this is a benchmark repository, not a proof repository)
-- Use camelCase for theorem names
-- Create placeholder definitions in FormalConjecturesForMathlib/
-- Redefine notation or API that already exists in mathlib, `FormalConjecturesForMathlib` or a neighboring problem file
-- Put meta-commentary or notes-to-reviewers in Lean files (they belong in the PR description)
-
-✅ **DO:**
-
-- Follow existing file patterns in the repository
-- Keep formalisations clean and minimal
-- Add references to sources. These should all appear in the module docstring reference list, and
-  each `textbook`, `research open` and `research solved` theorem docstring MUST have a reference and a
-  concise description of the problem.
-- Use namespaces appropriately
-- Test that `lake build` works
-- Add variants in the same file as the main problem
-- Include basic API for new definitions
-
-## Getting Help
-
-- Check existing files for examples: `FormalConjectures/ErdosProblems/10.lean`, `FormalConjectures/Paper/Kurepa.lean`
-- Use `#AMS` command in VS Code to see available subject classifications
-- Refer to [Mathlib naming conventions](https://leanprover-community.github.io/contribute/naming.html)
-- See [main README.md](./README.md) for contribution workflow
-- See [CONTRIBUTING.md](./CONTRIBUTING.md) for CLA requirements
-
-## Example Template
-
-```lean
-/-
-Copyright YYYY The Formal Conjectures Authors.
-    (Replace YYYY with the current year, e.g., 2026 for work done in 2026)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--/
-
-import FormalConjecturesUtil
-
-/-!
-# Problem Name
-
-*Reference:* [Source Title](https://source-url.com)
-
-Brief description if helpful.
--/
-
-namespace ProblemName
-
-/-- Main definition if needed -/
-def myDefinition (x : ℕ) : ℕ := x + 1
-
-/-- The main conjecture -/
-@[category research open, AMS 11]
-theorem main_conjecture : SomeStatement := by
-  sorry
-
-/-- A variant or special case -/
-@[category research solved, AMS 11]
-theorem main_conjecture.variants.special_case : WeakerStatement := by
-  sorry
-
-end ProblemName
-```
+Anything else, `sorryAx` above all, means it is not proved.
+
+The same applies to a proof you cite with `formal_proof`. Read the file for `sorry`, run
+`#print axioms` on the theorem you are citing, and check that its statement is the one you
+are claiming. A repository saying it proves a conjecture may prove something weaker, and the
+statement is often the same theorem under a different name.
+
+## Statement fidelity
+
+The docstring quotes the source, and the Lean says exactly that. When they can differ, the
+Lean is wrong. Things to reread before submitting:
+
+- quantifier order and scope
+- `≤` against `<`, `∀ᶠ` against `∀`, asymptotic equivalence against same order
+- a hypothesis the prose states and the Lean drops
+- `∃ x, P x → Q`, which is almost always meant as `∃ x, P x ∧ Q` and is trivially true as
+  written. There is a linter for it
+
+Prove the `test` and `API` statements you add. They exist to exercise a definition, and one
+left `sorry` exercises nothing.
+
+## Before opening a pull request
+
+- [ ] `lake --wfail build <module>` passes for what you touched
+- [ ] docstring quotes the source, with a reference in the module docstring
+- [ ] every theorem has `category` and at least one `AMS` tag, in ascending order
+- [ ] degenerate inputs tried: empty, zero, division
+- [ ] `#print axioms` on anything claimed to be proved
+- [ ] no `sorry` under `FormalConjecturesForMathlib/`
+- [ ] `git status` before `git add`: generated files and `__pycache__` sweep in easily
+- [ ] `Fixes #1, fixes #2` in the description, with the keyword repeated. `Fixes #1, #2`
+      closes only the first
+- [ ] formalisation choices and caveats in the pull request description, not in the Lean file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,28 +7,23 @@ what its source says.
 [CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and the
 attributes. This file adds only what CONTRIBUTING does not tell you.
 
-Copy an existing file. Do not copy a template. *File structure conventions* in CONTRIBUTING
-gives the skeleton.
-[`FormalConjectures/ErdosProblems/13.lean`](FormalConjectures/ErdosProblems/13.lean) gives the
-remainder in 62 lines: a definition with its docstring, a `research solved` statement with its
-source, and a `research open` variant with `answer(sorry)`. A template can become incorrect. A
-file in the repository cannot, because the build compiles it.
+Follow the style of an existing file. Start by copying one from the same directory. *File
+structure conventions* in CONTRIBUTING gives the skeleton, and a neighbouring file gives the
+rest: a definition with its docstring, a statement with its source, and a variant. A template
+can become incorrect. A file in the repository cannot, because the build compiles it.
 
 ## Commands
 
-Build only the module that you changed. Do not build the project.
+Build only the modules that you changed. Do not build the project.
 
 ```bash
 lake --wfail build 'FormalConjectures.ErdosProblems.«361»'
 ```
 
-Put the module name in quotation marks. The guillemets in a numbered file are part of the
-module name.
-
 ```bash
 lake --wfail build FormalConjecturesForMathlib   # if you changed a shared definition
 lake --wfail test                                # if you changed FormalConjecturesUtil
-lake --wfail build                               # 25 minutes when warm. Let CI do this.
+lake --wfail build                               # the whole project. Let CI do this.
 ```
 
 `--wfail` makes each warning into a failure. CI uses the same option. Two warnings cause most
@@ -47,7 +42,9 @@ directory must not contain `sorry`. Only `FormalConjectures/` can contain `sorry
 
 Search before you write a definition. Mathlib, `FormalConjecturesForMathlib/` and the adjacent
 problem files already contain much of what a problem needs. The names are difficult to guess.
-Examples: `trianglesContaining`, `InGeneralPosition`, `NonTrilinear`, `distinctDistances`.
+Examples: `trianglesContaining`, `InGeneralPosition`, `NonTrilinear`, `distinctDistances`. The
+notation is also easy to miss: `ℝ²` for `EuclideanSpace ℝ (Fin 2)`, and `≪` for `IsBigO` at
+`atTop`.
 
 ## Check the degenerate cases
 
@@ -81,9 +78,10 @@ proved:
 `sorryAx` shows that the theorem is not proved.
 
 The three axioms above are the bar for a `research solved` statement. A `test` statement can
-use `native_decide`, which adds `Lean.ofReduceBool` and `Lean.trustCompiler`. These two move
-the proof out of the kernel, so name them in the pull request when a statement depends on
-them.
+use `decide +native`, which the repository prefers to `native_decide`. It adds at least
+`Lean.ofReduceBool` and `Lean.trustCompiler`, and the exact set depends on the proof. These
+axioms move the work out of the kernel, so run `#print axioms` and name the result in the pull
+request. `decide +kernel` stays within the three axioms above, where it is fast enough.
 
 Do the same for a proof that you cite with `formal_proof`. Read the file and look for `sorry`.
 Run `#print axioms` on the theorem that you cite. Then make sure that this theorem states what


### PR DESCRIPTION
Reduced to ~150 lines. Most of it restated [CONTRIBUTING.md](CONTRIBUTING.md), so it now links there and keeps what an agent can't infer.

A few points:

- **Commands.** The old headline requirement was a full `lake --wfail build`, ~25 min warm, so nobody runs it. Now it's the module you touched, with the guillemet quoting numbered files need. Plus the two `--wfail` traps, `open Classical` and AMS tag order.
- **Degenerate cases**, where formalisations break and the old file said nothing. `ZMod 0` is `ℤ`, `x / 0` is `0`, `sInf ∅` is `0`. Four statements of mine this week were wrong or nearly wrong on one of those.
- **`#print axioms`.** A file with `sorry` still compiles. Same check for a proof cited with `formal_proof`.

On the size, the general convention is ~150 lines, Codex truncates past 32 KiB, and shorter files measurably do better.