### PR TITLE
ErdosProblems: link plby proofs for 206, 426, 469, 621, 639, 648

### DIFF
--- a/FormalConjectures/ErdosProblems/206.lean
+++ b/FormalConjectures/ErdosProblems/206.lean
@@ -90,7 +90,7 @@ Kovač [Ko24b] has proved that this is false - in fact as false as possible: the
 $x\in (0,\infty)$ for which the best underapproximations are eventually 'greedy' has Lebesgue
 measure zero.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos206.lean"]
 theorem erdos_206 : answer(False) ↔
     ∀ᵐ x ∂(volume.restrict (Set.Ioi (0 : ℝ))), EventuallyGreedy x := by
   sorry

--- a/FormalConjectures/ErdosProblems/426.lean
+++ b/FormalConjectures/ErdosProblems/426.lean
@@ -58,8 +58,13 @@ $$f(n) = o\left(\frac{2^{\binom{n}{2}}}{n!}\right).$$
 The $\gg$ below is read as: some constant $c>0$ works for arbitrarily large $n$. The negation
 of the proposition on the right is then exactly $f(n) = o(2^{\binom{n}{2}}/n!)$, the form in
 which Bradač and Christoph [BrCh24] resolved the problem.
+
+The linked file states the resolution in that negated form, as
+`Tendsto fSeq atTop (nhds 0)`. It counts the isomorphism classes occurring as unique subgraphs,
+whereas `uniqueSubgraphCount` counts their representatives $G\leq H$; uniqueness forces exactly
+one representative per class, so the two counts agree.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos426.lean"]
 theorem erdos_426 : answer(False) ↔
     ∃ c : ℝ, 0 < c ∧ ∃ᶠ (n : ℕ) in atTop, ∃ H : SimpleGraph (Fin n),
       c * ((2 : ℝ) ^ n.choose 2 / n.factorial) ≤ (uniqueSubgraphCount H : ℝ) := by

--- a/FormalConjectures/ErdosProblems/469.lean
+++ b/FormalConjectures/ErdosProblems/469.lean
@@ -19,7 +19,10 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 469
 
-*Reference:* [erdosproblems.com/469](https://www.erdosproblems.com/469)
+*References:*
+- [erdosproblems.com/469](https://www.erdosproblems.com/469)
+- [Le25] Lewis, Z. J., *On the convergence of the reciprocal sum of primitive pseudoperfect
+  numbers*. Preprint (2025).
 -/
 
 namespace Erdos469
@@ -37,11 +40,14 @@ $$
   \sum_{n ∈ A} \frac 1 n
 $$
 converge?
+
+Yes: the sum converges. This was proved by Lewis [Le25], whose proof has been formalized in
+Lean.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos469.lean"]
 theorem erdos_469 :
     letI A := {n : ℕ | 0 < n ∧ n.IsSumDivisors ∧ ∀ m < n, m ∣ n → ¬ m.IsSumDivisors}
-    answer(sorry) ↔ Summable fun n : A ↦ 1 / (n : ℝ) := by
+    answer(True) ↔ Summable fun n : A ↦ 1 / (n : ℝ) := by
   sorry
 
 end Erdos469

--- a/FormalConjectures/ErdosProblems/621.lean
+++ b/FormalConjectures/ErdosProblems/621.lean
@@ -51,8 +51,12 @@ edges that need to be removed to make the graph bipartite.
 
 Here $\alpha_1(G)$ and $\tau_1(G)$ are taken over subsets of the edge set of $G$, and the
 inequality is stated multiplied through by $4$ so that it lives in the natural numbers.
+
+The linked file states $\tau_1$ as the least number of edges whose deletion leaves $G$
+triangle-free, which is the same as meeting every triangle of $G$, and quantifies over an
+arbitrary `Fintype V` rather than `Fin n`.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos621.lean"]
 theorem erdos_621 : answer(True) ↔
     ∀ (n : ℕ) (G : SimpleGraph (Fin n)) (a t : ℕ),
       IsGreatest {k : ℕ | ∃ A ⊆ G.edgeFinset, A.card = k ∧

--- a/FormalConjectures/ErdosProblems/639.lean
+++ b/FormalConjectures/ErdosProblems/639.lean
@@ -50,8 +50,12 @@ sufficiently large $n$, every $2$-colouring of the edges of $K_n$ leaves at most
 not occurring in a monochromatic triangle. Edges of $K_n$ are the non-diagonal unordered pairs
 `Sym2 (Fin n)`; an edge $\{x, y\}$ occurs in a monochromatic triangle if and only if there is a
 third vertex $z$ with $C(\{x, z\}) = C(\{y, z\}) = C(\{x, y\})$.
+
+The linked file proves the bound for every finite vertex type with at least $10$ vertices, which
+gives the `atTop` reading below, and collects the uncovered edges as the edge set of a graph
+rather than as a set of pairs.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos639.lean"]
 theorem erdos_639 : answer(True) ↔
     ∀ᶠ (n : ℕ) in atTop, ∀ C : Sym2 (Fin n) → Fin 2,
       {e : Sym2 (Fin n) | ¬e.IsDiag ∧

--- a/FormalConjectures/ErdosProblems/648.lean
+++ b/FormalConjectures/ErdosProblems/648.lean
@@ -60,7 +60,7 @@ The sequence $a_1<a_2<\cdots<a_t$ is packaged as a strictly monotone map `a : Fi
 with $2\leq a_i<n$, the greatest prime factor $P$ is `Nat.maxPrimeFac`, and $g(n)$ is the
 supremum in `ℕ` of the achievable lengths $t$.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos648.lean"]
 theorem erdos_648 :
     (fun n => (g n : ℝ)) =Θ[atTop] fun n => Real.sqrt ((n : ℝ) / Real.log (n : ℝ)) := by
   sorry


### PR DESCRIPTION
Six problems flagged by the status sync have sorry-free Lean proofs in [plby/lean-proofs](https://github.com/plby/lean-proofs). This adds the `formal_proof using lean4` links, pinned to `68da20b96673899166e94638f5a7fffeb7231d35` rather than `main`.

Closes #4529, closes #4534, closes #4537, closes #4538, closes #4539, closes #4555.

### What changed

| Problem | Before | After |
| --- | --- | --- |
| 206 | `research solved` | + link |
| 426 | `research solved` | + link |
| 621 | `research solved` | + link |
| 639 | `research solved` | + link |
| 648 | `research solved` | + link |
| 469 | `research open`, `answer(sorry)` | `research solved`, `answer(True)`, + link |

469 is the odd one out: the linked file ends with a theorem named `erdos_469` stating our formulation verbatim, including the same `A` and the same `Summable fun n : A ↦ 1 / (n : ℝ)`. It is unconditional — earlier theorems in that file take `PNDContributionPackage` and `DecoratedContributionPackage` as hypotheses, but both are discharged (`unconditionalWeightedPNDSummable` and the canonical certificate construction). The underlying proof is Lewis's preprint; I added a reference for it.

### Correspondence checks

I read each linked theorem against ours rather than going by the upstream status. Where the two aren't literally the same statement I added a sentence to the docstring saying so.

- **206** — `EventuallyGreedy`, `IsBestNTerm`, `IsUnderapprox` and `egyptianSum` are the same definitions on both sides. The linked theorem gives `volume {x | EventuallyGreedy x} = 0`; since `volume (Set.Ioi 0) ≠ 0`, that refutes the `∀ᵐ` statement, which is `answer(False)`.
- **426** — the linked file proves `Tendsto fSeq atTop (nhds 0)`, i.e. the `o(2^C(n,2)/n!)` form, which is the negation our docstring already describes. It counts isomorphism classes where `uniqueSubgraphCount` counts representatives `G ≤ H`; uniqueness gives one representative per class, so the counts agree. Noted in the docstring.
- **621** — `alpha1` matches `IsGreatest` on the same set. `tau1` is stated as the least number of edges whose deletion leaves the graph triangle-free, which is the same as meeting every triangle. The linked theorem is over an arbitrary `Fintype V`, so it covers `Fin n`. Noted in the docstring.
- **639** — `NIMT` unfolds to the same condition as our set comprehension. The linked theorem holds for every finite vertex type with at least 10 vertices, which gives the `atTop` reading. Noted in the docstring.
- **648** — the divergences were already recorded in the comment block at the top of the file, so I left it alone. The linked `g` allows `0 < m ≤ n` where ours requires `2 ≤ a i < n`; the two differ by at most 2 uniformly, so `Θ(√(n / log n))` transfers.

`lake build --wfail FormalConjectures` passes, and `scripts/check_erdos_status.py` no longer reports any of the six.
