### PR TITLE
ErdosProblems/337: use the asymptotic additive basis predicate

### DIFF
--- a/FormalConjectures/ErdosProblems/337.lean
+++ b/FormalConjectures/ErdosProblems/337.lean
@@ -48,10 +48,14 @@ $$
 The answer is no, and a counterexample was provided by Turjányi [Tu84]. This was generalised (to
 the replacement of $A+A$ by the $h$-fold sumset $hA$ for any $h\geq 2$) by Ruzsa and Turjányi
 [RT85].
+
+"Additive basis" is `Set.IsAsymptoticAddBasis`: some finite $h$ has $hA$ containing every
+sufficiently large integer. The exact notion `Set.IsAddBasis`, which asks that $hA$ be all of
+$\mathbb{N}$, would force $0, 1 \in A$ and is not the class these results are about.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_337 : answer(False) ↔
-    ∀ A : Set ℕ, A.IsAddBasis →
+    ∀ A : Set ℕ, A.IsAsymptoticAddBasis →
       (fun N : ℕ ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =o[atTop] (fun N : ℕ ↦ (N : ℝ)) →
       Tendsto (fun N : ℕ ↦ (((A + A) ∩ Icc 1 N).ncard : ℝ) / ((A ∩ Icc 1 N).ncard : ℝ))
         atTop atTop := by
@@ -63,7 +67,7 @@ by Ruzsa and Turjányi [RT85].
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_337.variants.h_fold : ∀ h : ℕ, 2 ≤ h →
-    ∃ A : Set ℕ, A.IsAddBasis ∧
+    ∃ A : Set ℕ, A.IsAsymptoticAddBasis ∧
       (fun N : ℕ ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =o[atTop] (fun N : ℕ ↦ (N : ℝ)) ∧
       ¬ Tendsto (fun N : ℕ ↦
           ((h • A ∩ Icc 1 N).ncard : ℝ) / ((A ∩ Icc 1 N).ncard : ℝ))
@@ -79,7 +83,7 @@ $$
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_337.variants.three_fold :
-    ∀ A : Set ℕ, A.IsAddBasis →
+    ∀ A : Set ℕ, A.IsAsymptoticAddBasis →
       (fun N : ℕ ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =o[atTop] (fun N : ℕ ↦ (N : ℝ)) →
       Tendsto (fun N : ℕ ↦
           (((A + A + A) ∩ Icc 1 (3 * N)).ncard : ℝ) / ((A ∩ Icc 1 N).ncard : ℝ))
@@ -96,7 +100,7 @@ and conjecture that the same should be true with $(A+A)\cap \{1,\ldots,2N\}$ in 
 -/
 @[category research open, AMS 5 11]
 theorem erdos_337.variants.ruzsa_turjanyi :
-    ∀ A : Set ℕ, A.IsAddBasis →
+    ∀ A : Set ℕ, A.IsAsymptoticAddBasis →
       (fun N : ℕ ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =o[atTop] (fun N : ℕ ↦ (N : ℝ)) →
       Tendsto (fun N : ℕ ↦
           (((A + A) ∩ Icc 1 (2 * N)).ncard : ℝ) / ((A ∩ Icc 1 N).ncard : ℝ))

--- a/FormalConjectures/ErdosProblems/337.lean
+++ b/FormalConjectures/ErdosProblems/337.lean
@@ -52,8 +52,12 @@ the replacement of $A+A$ by the $h$-fold sumset $hA$ for any $h\geq 2$) by Ruzsa
 "Additive basis" is `Set.IsAsymptoticAddBasis`: some finite $h$ has $hA$ containing every
 sufficiently large integer. The exact notion `Set.IsAddBasis`, which asks that $hA$ be all of
 $\mathbb{N}$, would force $0, 1 \in A$ and is not the class these results are about.
+
+The linked file states the basis hypothesis as `∃ N₀, Set.Ici N₀ ⊆ iterated_sumset A k` and
+indexes both counting functions by a real $x$ through $\lfloor x\rfloor$, where the counting
+functions here are indexed by $N : \mathbb{N}$.
 -/
-@[category research solved, AMS 5 11]
+@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos337.lean"]
 theorem erdos_337 : answer(False) ↔
     ∀ A : Set ℕ, A.IsAsymptoticAddBasis →
       (fun N : ℕ ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =o[atTop] (fun N : ℕ ↦ (N : ℝ)) →


### PR DESCRIPTION
Fixes #4721.

All four theorems in 337 used `Set.IsAddBasis`, which is the exact notion:

```lean
def IsAddBasisOfOrder (A : Set M) (n : ℕ) : Prop := ∀ a, a ∈ n • A
```

On `ℕ` that forces `0` and `1` into `A` — `0` is a sum of `n` naturals only if all of them are `0`, and `1` only if one is `1` and the rest `0`. So the statement was quantifying over sets that all contain `0` and `1`, and in particular satisfy `A ⊆ A + A`. The counting function in the same statement is `(A ∩ Icc 1 N).ncard`, counting from `1`, which is a sign the exact reading was not what was wanted.

Turjányi [Tu84] and Ruzsa and Turjányi [RT85] work with asymptotic bases: some finite `h` has `hA` containing every sufficiently large integer. This switches all four theorems to `Set.IsAsymptoticAddBasis`, which lives in the same ForMathlib file and is already what 330, 868 and 881 use.

The class only shrinks under the old reading, so the effect differed by theorem: `erdos_337`, `variants.three_fold` and `variants.ruzsa_turjanyi` are `∀` over the class and said less than intended (`three_fold` understated Ruzsa–Turjányi), while `variants.h_fold` is `∃` and asked for more. `erdos_337` keeps `answer(False)` either way, since Turjányi's counterexample survives being patched to `A ∪ {0, 1}`.

I also added two sentences to the headline docstring saying which notion is meant, so the next reader does not have to unfold it.

`lake build --wfail FormalConjectures` passes.

The `formal_proof` link is now in on `erdos_337`. `Erdos337.not_erdos_337` in [plby/lean-proofs](https://github.com/plby/lean-proofs/blob/68da20b96673899166e94638f5a7fffeb7231d35/src/latest/ErdosProblems/Erdos337.lean) refutes the same proposition: its basis hypothesis is `∃ N₀, Set.Ici N₀ ⊆ iterated_sumset A k`, which is our `IsAsymptoticAddBasis` written out, and `#print axioms` gives `[propext, Classical.choice, Quot.sound]`. It indexes both counting functions by a real `x` through `⌊x⌋₊` where we index by `N : ℕ`, so the transfer needs a reindexing step in the little-o and in the `Tendsto`. I noted that in the docstring rather than leaving it implicit.

I did not link the variants. `not_erdos_337a` there covers `h = 2` only (its `ratio_fun A 3` is the two-fold sumset), so it does not give `variants.h_fold` for general `h`, and the three-fold and Ruzsa–Turjányi variants are not in that file at all.

`scripts/check_erdos_status.py` no longer reports 337.
