### PR TITLE
ErdosProblems: link Jayyhk/erdos-lean proofs for 512 and 865

### DIFF
--- a/FormalConjectures/ErdosProblems/512.lean
+++ b/FormalConjectures/ErdosProblems/512.lean
@@ -41,7 +41,7 @@ where $e(x)=e^{2\pi ix }$?
 Littlewood's conjecture, proved independently by Konyagin [Ko81] and McGehee, Pigno, and
 Smith [MPS81].
 -/
-@[category research solved, AMS 11 42]
+@[category research solved, AMS 11 42, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/f8a51976fd2e66a52b4928c109fb9ae877a1a507/problems/512/Erdos512.lean"]
 theorem erdos_512 : answer(True) ↔
     ∃ c > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℤ), A.card = N →
       c * Real.log N ≤ ∫ θ in (0 : ℝ)..1, ‖∑ n ∈ A, e (n * θ)‖ := by

--- a/FormalConjectures/ErdosProblems/865.lean
+++ b/FormalConjectures/ErdosProblems/865.lean
@@ -36,8 +36,13 @@ size at least $\frac{5}{8}N+C$ then there are distinct $a,b,c\in A$ such that $a
 
 A problem of Erdős and Sós (also earlier considered by Choi, Erdős, and Szemerédi [CES75], but Erdős
 had forgotten this).
+
+This is true. The linked proof gives it in the contrapositive and with the constant cleared:
+every triple-free $A\subseteq\{1,\ldots,N\}$ satisfies $8\lvert A\rvert\leq 5N+C$ for a fixed
+$C$, for every $N$ rather than only for large $N$. It also shows the threshold is sharp, by
+exhibiting triple-free sets of size $(5N+16)/8$ for every $N$ divisible by $8$.
 -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/f8a51976fd2e66a52b4928c109fb9ae877a1a507/problems/865/Erdos865.lean"]
 theorem erdos_865 :
     ∃ C > 0, ∀ᶠ (N : ℕ) in atTop,
       ∀ A ⊆ Icc 1 N, A.card ≥ (5 / 8 : ℝ) * N + C →


### PR DESCRIPTION
Closes #4536, closes #4373.

Two more of the status-sync backlog, from a source we do not link yet: [Jayyhk/erdos-lean](https://github.com/Jayyhk/erdos-lean), pinned to `f8a5197`. Each proof there is a single self-contained file whose only import is `Mathlib`, with its own pinned toolchain and Mathlib revision.

| Problem | Before | After |
| --- | --- | --- |
| 512 | `research solved` | + link |
| 865 | `research open` | `research solved`, + link |

### 512

Direct match. Ours is `∃ c > 0, ∀ N A, A.card = N → c * log N ≤ ∫ …`; theirs is `∃ K, 0 < K ∧ ∀ A, K * log A.card ≤ ∫ …`, which is the same statement with `N` inlined. Their integrand is `Complex.exp (2 * π * I * n * θ)` against our `e (n * θ)`, and `e` unfolds to `Complex.exp ((2 * π * x : ℝ) * I)`, so the two agree up to commuting the factors.

### 865

This one was `research open` and is now solved. Their statement is the contrapositive with the constant cleared and no largeness condition:

```lean
∃ C : ℕ, ∀ (N : ℕ) (A : Finset ℕ), A ⊆ Finset.Icc 1 N →
    IsTripleFree A → 8 * A.card ≤ 5 * N + C
```

`IsTripleFree A` is `¬ HasTriple A`, and `HasTriple` is our inner condition written out identically, down to the three distinctness hypotheses and the three sum memberships. Taking `C' = (C + 1) / 8` gives ours: `|A| ≥ (5/8)N + C'` forces `8|A| > 5N + C`, hence a triple. Their `∀ N` covers our `∀ᶠ N`.

The same file also proves sharpness, exhibiting triple-free sets of size `(5N + 16)/8` for every `N` divisible by `8`. I mentioned that in the docstring since it is what makes `5/8` the right constant, but did not add a separate statement for it.

### Checks

Both files: no `sorry`, no declared `axiom`, no `native_decide`, and the headline theorem takes no hypotheses. `#print axioms` in each gives `[propext, Classical.choice, Quot.sound]`.

`lake build --wfail FormalConjectures` passes and `scripts/check_erdos_status.py` no longer reports either problem.
