### PR TITLE
ErdosProblems: link Jayyhk/erdos-lean proofs for 328, 403, 884

### DIFF
--- a/FormalConjectures/ErdosProblems/328.lean
+++ b/FormalConjectures/ErdosProblems/328.lean
@@ -48,8 +48,14 @@ Erdős [Er80e] had previously shown the answer is no for $C=3,4$ and infinitely 
 values of $C$.
 
 See also [774].
+
+The linked proof writes the representation function as
+`Set.ncard {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 + p.2 = n}`, which counts the same ordered
+pairs as `sumRep`, and states the partition condition as a named definition with the same two
+conjuncts used below. Its `∃ t` additionally carries `1 ≤ t`, which costs nothing: `t = 0`
+forces `A = ∅`, and `A = {1}` has all representation counts at most `C` for `C ≥ 1`.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/f8a51976fd2e66a52b4928c109fb9ae877a1a507/problems/328/Erdos328.lean"]
 theorem erdos_328 : answer(False) ↔
     ∀ C : ℕ, 0 < C →
       ∃ t : ℕ, ∀ A : Set ℕ, (∀ n, sumRep A n ≤ C) →

--- a/FormalConjectures/ErdosProblems/403.lean
+++ b/FormalConjectures/ErdosProblems/403.lean
@@ -46,8 +46,12 @@ See also [404].
 A solution is encoded below as a pair $(m, s)$ where $s$ is the finite set
 $\{a_1 < a_2 < \cdots < a_k\}$ of positive integers, so the distinctness of the $a_i$ is
 given by set membership. The empty set contributes no solutions since $2^m \geq 1 > 0$.
+
+The linked proof gives more than finiteness: it classifies the solutions outright, as
+$(0,\{1\})$, $(1,\{2\})$, $(3,\{2,3\})$, $(5,\{2,3,4\})$ and $(7,\{2,3,5\})$, so the set below
+has exactly five elements.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/f8a51976fd2e66a52b4928c109fb9ae877a1a507/problems/403/Erdos403.lean"]
 theorem erdos_403 : answer(True) ↔
     {p : ℕ × Finset ℕ | (∀ a ∈ p.2, 0 < a) ∧
       2 ^ p.1 = ∑ a ∈ p.2, a.factorial}.Finite := by

--- a/FormalConjectures/ErdosProblems/884.lean
+++ b/FormalConjectures/ErdosProblems/884.lean
@@ -80,7 +80,7 @@ This conjecture has been **disproved**:
 
 *Reference:* [erdosproblems.com/884](https://www.erdosproblems.com/884)
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/f8a51976fd2e66a52b4928c109fb9ae877a1a507/problems/884/Erdos884.lean"]
 theorem erdos_884 :
     answer(False) ↔ Erdos884Prop := by
   sorry


### PR DESCRIPTION
Closes #4531, closes #4533, closes #4452.

Three more from [Jayyhk/erdos-lean](https://github.com/Jayyhk/erdos-lean), pinned to `f8a5197`, following #4723.

### 884

A literal match, and the one I would have bet against. The linked file defines

```lean
noncomputable abbrev sumDivisorInvPairwiseDifference (n : ℕ) : ℝ :=
    ∑ j : Fin n.divisors.card, ∑ i : Fin j,
    (1 : ℚ) / (Nat.nth (· ∣ n) j - Nat.nth (· ∣ n) i)
```

which is our definition byte for byte apart from two stray spaces, and likewise for `sumDivisorInvConsecutiveDifference`. Its theorem is `¬ (sumDivisorInvPairwiseDifference =O[atTop] (1 + sumDivisorInvConsecutiveDifference))`, and `≪` unfolds to `=O[atTop]`, so that is `¬ Erdos884Prop`, which is what `answer(False)` asserts.

It has no hypotheses and `#print axioms` is clean, so it is Larsen's unconditional disproof rather than Tao's conditional one. `erdos_884_false_of_hardy_littlewood` is a different statement and keeps its `sorry`.

### 328

Two small gaps, both noted in the docstring.

The linked file counts representations as `Set.ncard {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 + p.2 = n}`, where `sumRep` is the card of the antidiagonal filtered by the same condition. Same ordered pairs. Its partition predicate is a named definition whose body is our two inline conjuncts, `(⋃ i, P i) = A ∧ Set.PairwiseDisjoint univ P`.

Its `∃ t` also carries `1 ≤ t`, which ours does not. That costs nothing, since `t = 0` forces `A = ∅` and `A = {1}` has all representation counts at most `C` for `C ≥ 1`, so no witness for our version can have `t = 0` either.

### 403

The linked file proves more than we ask. Rather than finiteness it classifies the solutions outright, as `(0,{1})`, `(1,{2})`, `(3,{2,3})`, `(5,{2,3,4})` and `(7,{2,3,5})`, so our set has exactly five elements. Its `IsErdos403Solution` additionally requires `s.Nonempty`, which does not change the set: the empty sum is `0` and never equals `2 ^ m`. Noted in the docstring.

### Checks

All three files: no `sorry`, no declared `axiom`, no `native_decide`, and the headline theorem takes no hypotheses.

`lake build --wfail FormalConjectures` passes and `scripts/check_erdos_status.py` no longer reports any of the three.

### What I did not link

Jayyhk hosts eleven of the problems in this backlog that we did not link. Five are now linked, here and in #4723. The remaining six are open for reasons that are not "the proof is bad":

- **90** — `axiomatic` in their catalog, assuming two published theorems as axioms
- **209** — models the plane as `ℂ`, we use `ℝ²`; transferring needs the isomorphism carried through the whole statement
- **330** — no declaration names in common with our file, so the two statements have to be compared directly
- **353** — proves a four-part conjunction of which ours is part one; needs their `Koizumi.IsoTrapArea1` matched against our `IsIsoscelesTrapezoid` plus the area condition
- **464** — assumes lacunarity for all `k` where `IsLacunary` only asks eventually, and concludes `0 ∉ closure …` where we ask `¬ Dense …`; two transfer steps rather than one
- **71** — bundles the arithmetic progression as a structure and adds `[Nonempty V]`
