### PR TITLE
ErdosProblems/330: ask for positive upper density, not an existing density

### DIFF
--- a/FormalConjectures/ErdosProblems/330.lean
+++ b/FormalConjectures/ErdosProblems/330.lean
@@ -45,11 +45,16 @@ def MinAsymptoticAddBasisOfOrder (A : Set ℕ) (h : ℕ) : Prop :=
 Does there exist a minimal basis $A \subset \mathbb{N}$ with positive density
 such that, for any $n \in A$, the (upper) density of integers which
 cannot be represented without using $n$ is positive?
+
+The unrepresentable set is not asked to have a density, only to have positive upper density,
+so `Set.upperDensity` is used for it rather than `Set.HasPosDensity`. A set of integers that
+cannot be represented without $n$ has no reason to have a natural density, and requiring one
+would ask a strictly harder question than the one posed.
 -/
 @[category research open, AMS 5 11]
 theorem erdos_330_statement :
     answer(sorry) ↔ ∃ (A : Set ℕ), ∃ h, MinAsymptoticAddBasisOfOrder A h ∧ A.HasPosDensity ∧
-    ∀ n ∈ A, Set.HasPosDensity (UnrepWithout A n h) := by
+    ∀ n ∈ A, 0 < (UnrepWithout A n h).upperDensity := by
   sorry
 
 end Erdos330


### PR DESCRIPTION
Fixes #4730.

`erdos_330_statement` asked the unrepresentable set to have a density and for that density to be positive:

```lean
∀ n ∈ A, Set.HasPosDensity (UnrepWithout A n h)
```

`Set.HasPosDensity S` is `∃ α > 0, S.HasDensity α`, so it carries the existence of the limit. `UnrepWithout A n h` is the set of integers not representable as a sum of at most `h` elements of `A \ {n}`, which has no reason to have a natural density. Asking for one is a strictly harder question than the one posed, and both the file's own docstring and #491, the issue this problem came from, say "the **(upper)** density".

Changed to:

```lean
∀ n ∈ A, 0 < (UnrepWithout A n h).upperDensity
```

and added a docstring sentence saying why, so the next reader does not switch it back.

I left `A.HasPosDensity` alone for the set `A` itself. The source says "minimal basis with positive density" there with no parenthetical, and the natural-density reading is defensible for a basis, so that is a judgement call rather than a clear error. Flagged in the issue for a second opinion.

The statement is `research open` with `answer(sorry)`, so nothing that was being claimed changes; what changes is which question is being asked.

`lake build --wfail FormalConjectures` passes.
