### PR TITLE
fix(ErdosProblems): use upper density in 298

### DIFF
--- a/FormalConjectures/ErdosProblems/298.lean
+++ b/FormalConjectures/ErdosProblems/298.lean
@@ -30,20 +30,25 @@ namespace Erdos298
 Does every set $A \subseteq \mathbb{N}$ of positive density contain some finite $S \subset A$ such that
 $\sum_{n \in S} \frac{1}{n} = 1$?
 
-The answer is yes, proved by Bloom [Bl21].
+The answer is yes, proved by Bloom [Bl21] (even if 'positive density' is interpreted as 'positive
+upper density', which is likely what Erdős intended).
+
+The theorem below uses the positive-upper-density interpretation; the literal natural-density
+interpretation is recorded separately.
 
 This was formalized in Lean 3 by Bloom and Mehta.
 -/
 @[category research solved, AMS 11, formal_proof using other_system at "https://github.com/b-mehta/unit-fractions/blob/master/src/final_results.lean"]
-theorem erdos_298 : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → A.HasPosDensity →
+theorem erdos_298 : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → 0 < A.upperDensity →
     ∃ (S : Finset ℕ), ↑S ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) := by
   sorry
 
 /--
-In [Bl21] it is proved under the weaker assumption that `A` only has positive upper density.
+The literal natural-density interpretation of Erdős Problem 298 follows from [Bl21].
 -/
 @[category research solved, AMS 11]
-theorem erdos_298.variants.upper_density : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A → 0 < A.upperDensity →
+theorem erdos_298.variants.natural_density : answer(True) ↔ (∀ (A : Set ℕ), 0 ∉ A →
+    A.HasPosDensity →
     ∃ (S : Finset ℕ), ↑S ⊆ A ∧ ∑ n ∈ S, (1 / n : ℚ) = 1) := by
   sorry
 


### PR DESCRIPTION
The source and cited result for Erdős Problem 298 concern positive upper density, but the main Lean theorem required an exact positive natural density. That stronger statement can fail when the density oscillates even though the upper density is positive.

This makes positive upper density the main statement and preserves the previous exact-density reading as an explicit variant.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
