### PR TITLE
fix(ErdosProblems): state Romanoff's theorem with primes

### DIFF
--- a/FormalConjectures/ErdosProblems/851.lean
+++ b/FormalConjectures/ErdosProblems/851.lean
@@ -32,14 +32,14 @@ prime divisors.
 -/
 def TwoPowAddSet (r : ℕ) := {(2 ^ k + n) | (k : ℕ) (n : ℕ) (_ : n.primeFactors.card ≤ r)}
 
+/-- The set of integers of the form `2^k+p`, where `k ≥ 0` and `p` is prime. -/
+def twoPowAddPrimeSet : Set ℕ := {(2 ^ k + p) | (k : ℕ) (p : ℕ) (_ : p.Prime)}
+
 /--
 The set of integers of the form `2^k+p` (where `p` is prime) has positive lower density.
-
-Formalisation note: here we also allow `p = 1` since this simplifies the code and is equivalent
-to the original statement.
 -/
 @[category research solved, AMS 11]
-theorem erdos_851.variants.romanoff : 0 < Set.lowerDensity (TwoPowAddSet 1) := by
+theorem erdos_851.variants.romanoff : 0 < Set.lowerDensity twoPowAddPrimeSet := by
   sorry
 
 /--


### PR DESCRIPTION
The set used for Romanoff's theorem was defined by `primeFactors.card ≤ 1`. That also admits 1 and prime powers, while the theorem is specifically about integers of the form prime plus a power of two.

This states the set directly using a prime `p` and an exponent `k`, matching the cited theorem.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
