### PR TITLE
fix(ErdosProblems): restore the ratio in 417

### DIFF
--- a/FormalConjectures/ErdosProblems/417.lean
+++ b/FormalConjectures/ErdosProblems/417.lean
@@ -33,15 +33,12 @@ namespace Erdos417
 /--
 Let$$V'(x)=\#\{\phi(m) : 1\leq m\leq x\}$$and$$V(x)=\#\{\phi(m) \leq x : 1\leq m\}.$$
 Does $\lim V(x)/V'(x)$ exist?
-
-Formalization note: We formalize the limit of the inverse fraction V'(x)/V(x)
-to ensure the limit is finite (bounded between 0 and 1).
 -/
 @[category research open, AMS 11]
 theorem erdos_417.parts.i :
-    answer(sorry) ↔ ∃ L : ℝ, Tendsto (fun x ↦
-      ((totient '' { m | 1 ≤ m ∧ (m : ℝ) ≤ x }).ncard : ℝ) /
-      ({ k | k ∈ range totient ∧ (k : ℝ) ≤ x }.ncard : ℝ))
+    answer(sorry) ↔ ∃ L : ENNReal, Tendsto (fun x ↦
+      ({ k | k ∈ range totient ∧ (k : ℝ) ≤ x }.ncard : ENNReal) /
+      ((totient '' { m | 1 ≤ m ∧ (m : ℝ) ≤ x }).ncard : ENNReal))
       atTop (𝓝 L) := by
   sorry
 
@@ -50,9 +47,9 @@ Is it $>1$?
 -/
 @[category research open, AMS 11]
 theorem erdos_417.parts.ii :
-    answer(sorry) ↔ ∃ L < 1, Tendsto (fun x ↦
-      ((totient '' { m | 1 ≤ m ∧ (m : ℝ) ≤ x }).ncard : ℝ) /
-      ({ k | k ∈ range totient ∧ (k : ℝ) ≤ x }.ncard : ℝ))
+    answer(sorry) ↔ ∃ L > (1 : ENNReal), Tendsto (fun x ↦
+      ({ k | k ∈ range totient ∧ (k : ℝ) ≤ x }.ncard : ENNReal) /
+      ((totient '' { m | 1 ≤ m ∧ (m : ℝ) ≤ x }).ncard : ENNReal))
       atTop (𝓝 L) := by
   sorry
 


### PR DESCRIPTION
The Lean statement inverted the volume ratio from Erdős Problem 417. Taking the reciprocal changes both parts of the conjecture and is especially problematic when a volume is infinite.

This restores the numerator and denominator used by the source and states the ratio in `ENNReal`, where infinite volume is represented correctly.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
