### PR TITLE
fix(ErdosProblems): record the answer to 1044

### DIFF
--- a/FormalConjectures/ErdosProblems/1044.lean
+++ b/FormalConjectures/ErdosProblems/1044.lean
@@ -61,9 +61,9 @@ A problem of Erdős, Herzog, and Piranian [EHP58].
 This has been resolved by Tang, who proved that the infimum of $\Lambda(f)$ over all such $f$
 is $2$.
 -/
-@[category research solved, AMS 30]
+@[category research solved, AMS 30, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1044.lean"]
 theorem erdos_1044 :
-    IsGLB {L : ℝ≥0∞ | ∃ f : ℂ[X], IsAdmissible f ∧ maxBoundaryLength f = L} answer(sorry) := by
+    IsGLB {L : ℝ≥0∞ | ∃ f : ℂ[X], IsAdmissible f ∧ maxBoundaryLength f = L} answer(2) := by
   sorry
 
 /--


### PR DESCRIPTION
Erdős Problem 1044 has known infimum 2, and the file already included that value in a solved variant, but the main theorem still used `answer(sorry)`.

This records 2 directly as the answer to the headline question.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
