### PR TITLE
fix(Wikipedia): make Frobenius traces integer-valued

### DIFF
--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -64,9 +64,9 @@ instance apFintype (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ+) :
   apply Subtype.fintype _
 
 /-- Note that normally this is written as `p + 1 - #E(𝔽ₚ)`, but since we don't have a point at
-infinity on this affine curve we only have `p` -/
-noncomputable def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : ℕ :=
-  p - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
+infinity on this affine curve we only have `p`. The trace is integer-valued and can be negative. -/
+noncomputable def WeierstrassCurve.ap (E : WeierstrassCurve ℚ) [E.IsElliptic] (p : ℕ) : ℤ :=
+  (p : ℤ) - Cardinal.toNat (Cardinal.mk (setOfPointsModN E p))
 
 /-- Since we don't have Hecke operators yet, we define this via the q-expansion coefficients. See
  Proposition 5.8.5 of [diamondshurman2005]. -/


### PR DESCRIPTION
For an elliptic curve, the Frobenius trace `a_p = p + 1 - #E(F_p)` can be negative. Representing it as a natural number truncates those negative values and changes the modularity statement.

This changes the trace to an integer-valued function, so the equation states the intended quantity.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
