### PR TITLE
fix(Books): record Borwein series convergence

### DIFF
--- a/FormalConjectures/Books/BorweinSineSeries.lean
+++ b/FormalConjectures/Books/BorweinSineSeries.lean
@@ -46,7 +46,7 @@ conditional on such an irrationality measure of pi (cf https://arxiv.org/abs/191
 -/
 @[category research solved, formal_proof using lean4 at "https://github.com/AxiomMath/gdm-formal-conjectures/blob/main/BorweinSineSeries/solution.lean",  AMS 26 40]
 theorem borwein_sine_series :
-    answer(sorry) ↔
+    answer(True) ↔
       Summable fun n : ℕ+ ↦ ((2 / 3 + 1 / 3 * Real.sin (n : ℝ)) ^ (n : ℕ)) / (n : ℝ) := by
   sorry
 


### PR DESCRIPTION
The file cites and states the result that the Borwein sine series converges, but its headline theorem still left the yes-or-no answer unknown.

This replaces `answer(sorry)` with `answer(True)` so the statement records the known affirmative answer.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
