### PR TITLE
fix(Wikipedia): record the moving sofa answer

### DIFF
--- a/FormalConjectures/Wikipedia/MovingSofa.lean
+++ b/FormalConjectures/Wikipedia/MovingSofa.lean
@@ -207,7 +207,7 @@ theorem one_le_sofaConstant : 1 ≤ sofaConstant := by
 
 /-- What is the sofa constant? -/
 @[category research solved, AMS 49]
-theorem sofaConstant_eq : sofaConstant = answer(sorry) := by
+theorem sofaConstant_eq : sofaConstant = answer(volume gerversSofa) := by
   sorry
 
 /-- Gerver's sofa attains the sofa constant, conjectured by [Ge92] and claimed by [Ba24]. -/


### PR DESCRIPTION
The theorem asks which member of the stated sofa family has the greatest area, but leaves that answer unknown even though the following result identifies Gerver's sofa as the maximizer.

This records the volume of Gerver's sofa as the answer to the question.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
