### PR TITLE
fix(ErdosProblems): record the answer to 1071(ii)

### DIFF
--- a/FormalConjectures/ErdosProblems/1071.lean
+++ b/FormalConjectures/ErdosProblems/1071.lean
@@ -55,7 +55,7 @@ This was formalized in Lean by Alexeev using Aristotle and ChatGPT.
 -/
 @[category research solved, AMS 52, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.24.0/ErdosProblems/Erdos1071b.lean"]
 theorem erdos_1071.parts.ii :
-    answer(sorry) ↔ ∃ (R : Set ℝ²) (S : Set (ℝ² × ℝ²)),
+    answer(True) ↔ ∃ (R : Set ℝ²) (S : Set (ℝ² × ℝ²)),
       IsOpen R ∧ IsConnected R ∧ S.Countable ∧ S.Infinite ∧
       Maximal (fun T : Set (ℝ² × ℝ²) =>
         (∀ seg ∈ T, dist seg.1 seg.2 = 1 ∧ seg.1 ∈ R ∧ seg.2 ∈ R) ∧


### PR DESCRIPTION
Part (ii) of Erdős Problem 1071 is marked solved and links a formal proof, but its theorem still used `answer(sorry)`.

This changes the answer to `True`, matching the cited affirmative solution.

Validation: `lake --wfail build`

AI assistance disclosure: This was assisted by GPT 5.6 Sol via Codex.
