### PR TITLE
Fix two dead `formal_proof` links

### DIFF
--- a/FormalConjectures/ErdosProblems/331.lean
+++ b/FormalConjectures/ErdosProblems/331.lean
@@ -41,7 +41,7 @@ any $n\geq 1$ there is exactly one solution to $n=a+b$ with $a\in A$ and $b\in B
 
 This was formalized in Lean by van Doorn using Aristotle.
 -/
-@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Woett/Lean-files/blob/main/ErdosProblem%23331.lean"]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Woett/Lean-files/blob/d30552f64c55686d40b928a0a3b8e2396357a4ee/ErdosProblem331.lean"]
 theorem erdos_331 :
     answer(False) ↔
       ∀ A B : Set ℕ,

--- a/FormalConjectures/ErdosProblems/392.lean
+++ b/FormalConjectures/ErdosProblems/392.lean
@@ -38,7 +38,7 @@ $$
   A(n) = \frac{n}{2} - \frac{n}{2\log n} + o\left(\frac{n}{\log n}\right).
 $$
 -/
-@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/main/PrimeNumberTheoremAnd/Erdos392.lean"]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/d82a35ecc798ada27f82a88b559f25b753f63a73/PrimeNumberTheoremAnd/IEANTN/Erdos392.lean"]
 theorem erdos_392 (A : ℕ → ℕ) (h : ∀ n > 0,
     IsLeast { t + 1 | (t) (_ : ∃ a : Fin (t + 1) → ℕ, (n)! = ∏ i, a i ∧
       Monotone a ∧ a (Fin.last t) ≤ n ^ 2) } (A n)) :


### PR DESCRIPTION
Two `formal_proof` links are dead. Both were unpinned `main` links, which is how they got that way.

| Problem | Was | Now |
| --- | --- | --- |
| 331 | `Woett/Lean-files/blob/main/ErdosProblem%23331.lean` | the file is `ErdosProblem331.lean`, no `#` |
| 392 | `.../blob/main/PrimeNumberTheoremAnd/Erdos392.lean` | moved upstream to `PrimeNumberTheoremAnd/IEANTN/Erdos392.lean` |

Both are pinned to a commit now rather than `main`, so an upstream rename cannot break them again.

I found these by checking every `formal_proof` link in the repo, 244 of them, against a `curl`. These two were the only ones that did not return 200, so the rest are healthy. Worth knowing that fork-hosted links are not the fragile ones: 61 of the 79 `formal_conjectures`-kind links point off `google-deepmind` and every one of them resolves. What rots is an unpinned path, wherever it is hosted.

That suggests a periodic link check would earn its keep, since nothing currently notices when one of these goes stale. Happy to add one as a scheduled workflow if that is wanted, though it is a separate change from this.

`lake build --wfail FormalConjectures` passes.
