### PR TITLE
Consolidated into #4828: proof-link checking

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -267,7 +267,7 @@ jobs:
         if: steps.mode.outputs.website_only != 'true'
         run: |
           mkdir -p site/data
-          lake exe extract_names --exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified \
+          lake exe extract_names --exclude=fileFirstAdded,fileLastModified \
             > site/data/conjectures.json
 
       # `extract_names` notices `research open` problems with a sorry-free proof,

--- a/.github/workflows/check_proof_links.yml
+++ b/.github/workflows/check_proof_links.yml
@@ -1,0 +1,31 @@
+# `formal_proof` links rot quietly: nothing builds them and nothing reads
+# them. The Python extracts the URLs; lychee, which owns link checking the
+# way comparator owns proof checking, does the HTTP.
+name: Check formal_proof links
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"   # weekly; link rot is slow
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Extract formal_proof links
+        run: python3 scripts/check_proof_links.py > proof-links.txt
+
+      - name: Check them
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --no-progress --max-retries 3 --timeout 30
+            --user-agent formal-conjectures-link-check
+            proof-links.txt
+          fail: true

--- a/.github/workflows/check_proof_links.yml
+++ b/.github/workflows/check_proof_links.yml
@@ -1,0 +1,70 @@
+# Copyright 2026 The Formal Conjectures Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check formal_proof links
+
+# `formal_proof` links are never built and never read by CI, so an upstream
+# rename leaves a dead link that nobody notices. On a pull request only the
+# links in changed files are checked, which keeps it quick and catches a bad
+# link while it is still being reviewed. The weekly run covers the rest.
+on:
+  schedule:
+    - cron: '17 6 * * 1' # Mondays, 06:17 UTC
+  pull_request:
+    paths:
+      - 'FormalConjectures/**/*.lean'
+      - 'scripts/check_proof_links.py'
+      - '.github/workflows/check_proof_links.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    # Scheduled runs on forks would check the same links again to no purpose.
+    if: >-
+      github.event_name != 'schedule' ||
+      github.repository == 'google-deepmind/formal-conjectures'
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # `git diff` against the base needs the history, not just the tip.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Check the links in changed files
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Only added and modified files; a deleted file has no links to check.
+          # Filtering on the extension here rather than with a git pathspec,
+          # because git globs do not treat `**` the way a shell does.
+          git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD -- FormalConjectures \
+            | grep '\.lean$' > changed.txt || true
+          if [[ ! -s changed.txt ]]; then
+            echo "No problem files changed."
+            exit 0
+          fi
+          echo "Changed files:"; cat changed.txt
+          xargs python3 scripts/check_proof_links.py < changed.txt
+
+      - name: Check every link
+        if: github.event_name != 'pull_request'
+        run: python3 scripts/check_proof_links.py

--- a/FormalConjecturesTest/Util/Metadata.lean
+++ b/FormalConjecturesTest/Util/Metadata.lean
@@ -1,0 +1,55 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import FormalConjecturesTest.Util.MetadataFixture
+public meta import FormalConjecturesUtil.ProblemMetadata
+
+meta section
+
+open Lean FormalConjectures.Metadata
+
+private unsafe def checkMetadata : CoreM Unit := do
+  let problems ← extractProblems #[`FormalConjecturesTest.Util.MetadataFixture]
+  unless problems.length == 3 do
+    throwError m!"expected three named problems: {problems.map (·.theorem)}"
+  let some conditional := problems.find? (·.theorem == "MetadataFixture.«quoted name»")
+    | throwError "quoted declaration missing"
+  unless conditional.formalProofs.map (·.conditions) == [["MetadataFixture.assumption"]] &&
+      conditional.hasSorryFreeProof do
+    throwError "conditional proof metadata changed"
+  let some problem := problems.find? (·.theorem == "MetadataFixture.problem")
+    | throwError "primary declaration missing"
+  unless problem.answerKinds == ["Prop"] && !problem.hasSorryFreeProof do
+    throwError "proposition answer hole lost"
+  let some variant := problems.find? (·.theorem == "MetadataFixture.problem.variant")
+    | throwError "variant missing"
+  unless variant.answerKinds == ["non-Prop"] do
+    throwError "value answer hole lost"
+  let again ← extractProblems #[`FormalConjecturesTest.Util.MetadataFixture]
+  unless (problems.map (·.toFilteredJson)) == (again.map (·.toFilteredJson)) do
+    throwError "metadata extraction is not deterministic"
+  if ((problem.toFilteredJson).getObjValAs? (List Json) "formalProofs").toOption.isSome then
+    throwError "empty formalProofs must remain omitted in schema 2"
+
+private unsafe def testMetadata : IO Unit := do
+  initSearchPath (← getBuildDir)
+  enableInitializersExecution
+  let env ← importModules #[{ module := `FormalConjecturesTest.Util.MetadataFixture }]
+    {} (trustLevel := 1024) (loadExts := true)
+  let _ ← Core.CoreM.toIO checkMetadata { fileName := "", fileMap := default } { env := env }
+
+#eval testMetadata

--- a/FormalConjecturesTest/Util/MetadataFixture.lean
+++ b/FormalConjecturesTest/Util/MetadataFixture.lean
@@ -1,0 +1,46 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import FormalConjecturesUtil.Attributes.Basic
+public import FormalConjecturesUtil.Answer
+
+public section
+set_option google.answer "postpone"
+
+namespace MetadataFixture
+
+/-- An assumption retained on an individual proof. -/
+theorem assumption : True := by sorry
+
+/-- A quoted declaration with a conditional external proof. -/
+@[category research solved, AMS 11,
+  conditional formal_proof using lean4 at "https://example.org/conditional"
+    assuming assumption]
+theorem «quoted name» : True := by trivial
+
+/-- The proposition requested by an open problem. -/
+@[category research open, AMS 11]
+theorem problem : answer(sorry) ↔ True := by sorry
+
+/-- A variant with a value-valued answer. -/
+@[category research solved, AMS 11]
+theorem problem.variant : (answer(sorry) : Nat) = 1 := by sorry
+
+@[category test, AMS 11]
+example : True := by trivial
+
+end MetadataFixture

--- a/FormalConjecturesUtil/Metadata.lean
+++ b/FormalConjecturesUtil/Metadata.lean
@@ -26,13 +26,11 @@ this repository's declarations, and each has been re-deriving them. This
 module is where the shared representation lives, so that one semantic fact is
 interpreted once.
 
-It starts deliberately small: `FormalProofInfo` is the schema
-`extract_names` exports as `formalProofs` (`schemaVersion` 2), moved here so
-its next consumer imports it rather than restating it. A `ProblemSpec`
-bundling declaration, module, category, subjects, answer holes and source
-range belongs here too, and arrives when `extract_names`' internal
-`TheoremInfo` migrates; growing it ahead of its consumers would be schema
-fiction.
+`FormalProofInfo` is the schema-2 `formalProofs` record. The shared
+`ProblemSpec` and environment extractor live in
+`FormalConjecturesUtil.ProblemMetadata`, which imports the attribute and
+answer elaborators. Consumers that need only proof records can import this
+smaller module.
 -/
 
 public section

--- a/FormalConjecturesUtil/ProblemMetadata.lean
+++ b/FormalConjecturesUtil/ProblemMetadata.lean
@@ -1,0 +1,224 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Lean
+public meta import FormalConjecturesUtil.Metadata
+public import FormalConjecturesUtil.Attributes.Basic
+public import FormalConjecturesUtil.Answer
+
+/-!
+# Shared declaration metadata
+
+Extract semantic facts from Lean's environment once for catalog consumers.
+The website wire format remains schema 2. Git timestamps are supplied by the
+caller and are not used to interpret declarations. Internal and anonymous
+examples remain excluded; this module does not assign persistent identities.
+-/
+
+@[expose] public meta section
+
+namespace FormalConjectures.Metadata
+open Lean ProblemAttributes Google
+
+-- Helper to format Category as string
+def categoryToString : Category → String
+  | .textbook => "textbook"
+  | .research .open => "research open"
+  | .research .solved => "research solved"
+  | .test => "test"
+  | .API => "API"
+
+-- Helper to format FormalProofKind as string
+def formalProofKindToString : FormalProofKind → String
+  | .formalConjecturesProof => "formal_conjectures"
+  | .lean4 => "lean4"
+  | .otherSystem => "other_system"
+
+def nameAny (n : Name) (p : String → Bool) : Bool :=
+  match n with
+  | .anonymous => false
+  | .str p' s => p s || nameAny p' p
+  | .num p' _ => nameAny p' p
+
+def isInternal (n : Name) : Bool :=
+  nameAny n (fun s => s.startsWith "_" || s.startsWith "match_" || s.startsWith "proof_")
+
+/-- Determine the `answerKinds` for a theorem's type expression.
+
+For each `answer(...)` occurrence found in the type,
+returns `"Prop"` or `"non-Prop"` depending on the type
+of the annotated subexpression. -/
+def getAnswerKinds (type : Expr) : MetaM (List String) := do
+  let ansExprs := findAnswerExprs type
+  ansExprs.toList.mapM fun ansExpr => do
+    if ← Meta.isProp ansExpr then
+      return "Prop"
+    else
+      return "non-Prop"
+
+structure ProblemSpec where
+  «theorem» : String
+  module : String
+  category : String
+  subjects : List String
+  statement : String
+  docstring : Option String
+  formalProofs : List FormalProofInfo
+  hasSorryFreeProof : Bool
+  subsets : List String
+  answerKinds : List String
+  fileFirstAdded : Option String
+  fileLastModified : Option String
+
+
+/-- Serialize `ProblemSpec` to JSON, omitting fields whose keys are in `exclude`. -/
+def ProblemSpec.toFilteredJson (info : ProblemSpec) (exclude : Std.HashSet String := {}) : Json :=
+  let fields : List (String × Json) :=
+    [("theorem", toJson info.theorem),
+     ("module", toJson info.module),
+     ("category", toJson info.category)]
+    ++ (if exclude.contains "subjects" then [] else [("subjects", toJson info.subjects)])
+    ++ (if exclude.contains "statement" then [] else [("statement", toJson info.statement)])
+    ++ (if exclude.contains "docstring" then [] else [("docstring", toJson info.docstring)])
+    ++ (if exclude.contains "formalProofs" || info.formalProofs.isEmpty then [] else
+        [("formalProofs", Json.arr (info.formalProofs.map FormalProofInfo.toJson).toArray)])
+    ++ (if exclude.contains "hasSorryFreeProof" then [] else
+        [("hasSorryFreeProof", toJson info.hasSorryFreeProof)])
+    ++ (if info.subsets.isEmpty then [] else [("subsets", toJson info.subsets)])
+    ++ (if exclude.contains "answerKinds" then [] else
+        [("answerKinds", toJson info.answerKinds)])
+    ++ (if exclude.contains "fileFirstAdded" then [] else
+        [("fileFirstAdded", toJson info.fileFirstAdded)])
+    ++ (if exclude.contains "fileLastModified" then [] else
+        [("fileLastModified", toJson info.fileLastModified)])
+  Json.mkObj fields
+
+instance : ToJson ProblemSpec where
+  toJson info := info.toFilteredJson
+
+/-- Extract the named, categorized theorem declarations from the requested modules.
+
+This observes a declaration's own proof term for `hasSorryFreeProof`; it does
+not establish that its transitive assumptions are acceptable. -/
+unsafe def extractProblems (moduleNames : Array Name)
+    (fileTimestamps : Std.HashMap Name (Option String × Option String) := {}) :
+    CoreM (List ProblemSpec) := do
+  let env ← getEnv
+  let tags ← getTags
+  let subjectTags ← getSubjectTags
+  let formalProofTags ← getFormalProofTags
+
+  -- Create maps for quick lookup
+  let mut categoryMap : Std.HashMap Name (List String) := {}
+  let mut categoryFullMap : Std.HashMap Name CategoryTag := {}
+  for tag in tags do
+    categoryMap := categoryMap.insert tag.declName (categoryToString tag.category :: categoryMap.getD tag.declName [])
+    categoryFullMap := categoryFullMap.insert tag.declName tag
+
+  -- Create formal proof map. A declaration may carry several `formal_proof` annotations,
+  -- so collect them all rather than keeping whichever arrives last.
+  let mut formalProofMap : Std.HashMap Name (List FormalProofTag) := {}
+  for tag in formalProofTags do
+    formalProofMap :=
+      formalProofMap.insert tag.declName (tag :: formalProofMap.getD tag.declName [])
+
+  let mut subjectMap : Std.HashMap Name (List String) := {}
+  for tag in subjectTags do
+    let subjects := tag.subjects.map (fun (s : AMS) => s!"{s.toNat?.get!}")
+    subjectMap := subjectMap.insert tag.declName (subjects ++ subjectMap.getD tag.declName [])
+
+  let mut theoremToSubsets : Std.HashMap Name (List String) := {}
+
+  for (declName, _) in env.constants do
+    if let .str (.str grandparent subsetName) "problems" := declName then
+      if grandparent.toString == "Subsets" then
+        let info ← getConstInfo declName
+        if let some val := info.value? then
+          try
+            let problemsList ← Lean.Meta.MetaM.run' <|
+              unsafe Lean.Meta.evalExpr (List Name) (mkApp (mkConst ``List [.zero]) (mkConst ``Name)) val
+            for p in problemsList do
+              theoremToSubsets := theoremToSubsets.insert p (subsetName :: theoremToSubsets.getD p [])
+          catch e =>
+            let msg ← e.toMessageData.toString
+            IO.eprintln s!"WARNING: Failed to evaluate problems list for {declName}: {msg}"
+
+  let mut allResults : List ProblemSpec := []
+  for modName in moduleNames do
+    let some modIdx := env.header.moduleNames.findIdx? (· == modName)
+      | continue
+    let modData := env.header.moduleData[modIdx]!
+    for info in modData.constants do
+      let name := info.name
+      match info with
+      | ConstantInfo.thmInfo .. =>
+        if !isInternal name then
+          let cats := categoryMap.getD name []
+          let subjs := subjectMap.getD name []
+          if !cats.isEmpty || !subjs.isEmpty then
+            if cats.length ≠ 1 then
+              throwError m!"Theorem {name} must have exactly one category, found {cats.length}."
+            let statement := toString (← Meta.MetaM.run' (Meta.ppExpr info.type))
+            let docstring ← findDocString? env name
+            if docstring.isNone then
+              IO.eprintln s!"WARNING: Theorem {name} (category: {cats.head!}) is missing a docstring"
+            -- Extract formal proof info from the separate formal_proof attributes. Each
+            -- carries its own `conditions`, since one proof can be conditional while
+            -- another of the same statement is not.
+            let formalProofs :=
+              ((formalProofMap.getD name []).map fun tag =>
+                { kind := formalProofKindToString tag.proofKind,
+                  link := tag.proofLink,
+                  conditions := tag.conditions.map Name.toString : FormalProofInfo })
+              |>.toArray.qsort (fun a b => a.sortKey < b.sortKey) |>.toList
+            -- Check whether the proof term is sorry-free
+            let hasSorryFreeProof :=
+              info.value? (allowOpaque := true) |>.any (!·.hasSorry)
+            -- Warn about suspicious category / sorry combinations
+            if let some catTag := categoryFullMap.get? name then
+              match catTag.category, hasSorryFreeProof with
+              | .research .open, true =>
+                IO.eprintln s!"WARNING: Theorem {name} is categorised as `research open` but has a sorry-free proof"
+              | .test, false =>
+                IO.eprintln s!"WARNING: Theorem {name} is categorised as `test` but has no sorry-free proof"
+              | .API, false =>
+                IO.eprintln s!"WARNING: Theorem {name} is categorised as `API` but has no sorry-free proof"
+              | _, _ => pure ()
+            let subsets := (theoremToSubsets.getD name []).toArray.qsort (· < ·) |>.toList
+            -- Determine answerKinds from the elaborated type
+            let answerKinds ← Meta.MetaM.run'
+              (getAnswerKinds info.type)
+            let (fileFirstAdded, fileLastModified) :=
+              fileTimestamps.getD modName (none, none)
+            allResults := {
+              «theorem» := name.toString,
+              module := modName.toString,
+              category := cats.head!,
+              subjects := subjs,
+              statement := statement,
+              docstring := docstring,
+              formalProofs := formalProofs,
+              hasSorryFreeProof := hasSorryFreeProof,
+              subsets := subsets
+              answerKinds := answerKinds
+              fileFirstAdded := fileFirstAdded
+              fileLastModified := fileLastModified
+            } :: allResults
+      | _ => pure ()
+  return allResults.reverse
+
+end FormalConjectures.Metadata

--- a/scripts/check_proof_links.py
+++ b/scripts/check_proof_links.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Check that every `formal_proof` link in the repo still resolves.
+
+These links rot quietly. Nothing builds them and nothing reads them, so an
+upstream rename or a typo in the path sits there until somebody clicks it. Two
+were already dead when this script was written, both of them unpinned links to
+a `main` branch that had since moved the file.
+
+The links are read straight out of the `.lean` sources rather than from
+`lake exe extract_names`, so this needs no Lean toolchain and no Mathlib build.
+
+Usage:
+  python check_proof_links.py                 # check every link
+  python check_proof_links.py FILE [FILE ...] # check only these files
+"""
+
+import concurrent.futures
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# `formal_proof using <kind> at "<link>"`, with the attribute free to wrap
+# across lines the way it does in the problem files.
+LINK = re.compile(
+    r'formal_proof\s+using\s+\w+\s+at\s*\n?\s*"([^"]*)"',
+    re.MULTILINE,
+)
+
+TIMEOUT = 30
+ATTEMPTS = 3
+# GitHub serves 403 to unadorned scripted requests often enough to matter.
+HEADERS = {"User-Agent": "formal-conjectures-link-check"}
+
+
+def display(path):
+    """Path relative to the repo root, whichever form it arrived in."""
+    try:
+        return path.resolve().relative_to(ROOT)
+    except ValueError:
+        return path
+
+
+def links_in(path):
+    """Yield (path, line number, link) for each `formal_proof` link in `path`."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for match in LINK.finditer(text):
+        line = text.count("\n", 0, match.start()) + 1
+        yield path, line, match.group(1)
+
+
+def collect(paths):
+    out = []
+    for path in paths:
+        if path.suffix == ".lean" and path.is_file():
+            out.extend(links_in(path))
+    return out
+
+
+def check(link):
+    """Return None if the link resolves, else a short reason.
+
+    An empty link is not this script's business. It is allowed for the
+    `formal_conjectures` kind, where the proof is this statement and there is
+    nothing to point at, and the attribute itself already warns about an empty
+    or malformed link for the kinds where one is required.
+    """
+    if not link or not link.startswith(("http://", "https://")):
+        return None
+    # A `#L79` fragment is for the reader; the server never sees it.
+    url = link.split("#", 1)[0]
+    last = "unknown error"
+    for _ in range(ATTEMPTS):
+        try:
+            request = urllib.request.Request(url, headers=HEADERS)
+            with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+                if response.status == 200:
+                    return None
+                last = f"HTTP {response.status}"
+        except urllib.error.HTTPError as error:
+            # A 4xx is the link's fault and will not improve on a retry.
+            if 400 <= error.code < 500:
+                return f"HTTP {error.code}"
+            last = f"HTTP {error.code}"
+        except Exception as error:  # network flake, DNS, timeout
+            last = type(error).__name__
+    return last
+
+
+def main(argv):
+    if argv:
+        paths = [pathlib.Path(a) for a in argv]
+    else:
+        paths = sorted(ROOT.glob("FormalConjectures/**/*.lean"))
+
+    found = collect(paths)
+    if not found:
+        print("no formal_proof links found")
+        return 0
+
+    broken = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = pool.map(lambda entry: check(entry[2]), found)
+        for (path, line, link), reason in zip(found, results):
+            if reason is not None:
+                broken.append((path, line, link, reason))
+
+    print(f"checked {len(found)} formal_proof links, {len(broken)} broken")
+    for path, line, link, reason in broken:
+        print(f"\n{display(path)}:{line}: {reason}\n  {link}")
+
+    if broken:
+        print(
+            "\nA link that has rotted usually means the file moved upstream. "
+            "Prefer pinning to a commit rather than a branch."
+        )
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_proof_links.py
+++ b/scripts/check_proof_links.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Enumerate formalProofs from native metadata; Lychee checks HTTP reachability only."""
+import argparse
+import json
+from pathlib import Path
+import urllib.request
+from problem_metadata import proof_links
+URL = "https://google-deepmind.github.io/formal-conjectures/data/catalog.json"
+
+def unique_links(links):
+    return list(dict.fromkeys(link for link in links if link))
+
+def links_from_extract(path):
+    return proof_links(json.loads(Path(path).read_text()))
+
+def main(argv=None):
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--extract",type=Path,help="Use a local native schema-2 extract")
+    args=parser.parse_args(argv)
+    if args.extract:links=links_from_extract(args.extract)
+    else:
+        with urllib.request.urlopen(URL,timeout=30) as response:
+            links=proof_links(json.load(response))
+    for link in links:print(link)
+    return 0
+if __name__=="__main__":raise SystemExit(main())

--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -16,9 +16,7 @@ limitations under the License.
 module
 
 public import Lean
-public meta import FormalConjecturesUtil.Metadata
-public import FormalConjecturesUtil.Attributes.Basic
-public import FormalConjecturesUtil.Answer
+public meta import FormalConjecturesUtil.ProblemMetadata
 
 /-!
 # Extract Names
@@ -44,7 +42,7 @@ valued answers.
 
 @[expose] public meta section
 
-open Lean ProblemAttributes Google
+open Lean FormalConjectures.Metadata
 
 def getModuleNameFromFile (file : System.FilePath) : IO Name := do
   let components := file.withExtension "" |>.components
@@ -58,42 +56,6 @@ def getModuleNameFromFile (file : System.FilePath) : IO Name := do
   if moduleComponents.isEmpty then
     throw <| IO.userError s!"Could not determine module name for {file}. Is it under FormalConjectures/?"
   return moduleComponents.foldl (fun n s => Name.mkStr n s) Name.anonymous
-
--- Helper to format Category as string
-def categoryToString : Category → String
-  | .textbook => "textbook"
-  | .research .open => "research open"
-  | .research .solved => "research solved"
-  | .test => "test"
-  | .API => "API"
-
--- Helper to format FormalProofKind as string
-def formalProofKindToString : FormalProofKind → String
-  | .formalConjecturesProof => "formal_conjectures"
-  | .lean4 => "lean4"
-  | .otherSystem => "other_system"
-
-def nameAny (n : Name) (p : String → Bool) : Bool :=
-  match n with
-  | .anonymous => false
-  | .str p' s => p s || nameAny p' p
-  | .num p' _ => nameAny p' p
-
-def isInternal (n : Name) : Bool :=
-  nameAny n (fun s => s.startsWith "_" || s.startsWith "match_" || s.startsWith "proof_")
-
-/-- Determine the `answerKinds` for a theorem's type expression.
-
-For each `answer(...)` occurrence found in the type,
-returns `"Prop"` or `"non-Prop"` depending on the type
-of the annotated subexpression. -/
-def getAnswerKinds (type : Expr) : MetaM (List String) := do
-  let ansExprs := findAnswerExprs type
-  ansExprs.toList.mapM fun ansExpr => do
-    if ← Meta.isProp ansExpr then
-      return "Prop"
-    else
-      return "non-Prop"
 
 /-- Run a git command and return its stdout, trimmed. Returns `none` on failure. -/
 def gitOutput (args : Array String) : IO (Option String) := do
@@ -119,50 +81,6 @@ def validExcludeKeys : List String :=
   ["docstring", "statement", "subjects", "formalProofs",
    "hasSorryFreeProof", "moduleDocstrings", "answerKinds",
    "fileFirstAdded", "fileLastModified"]
-
--- `FormalProofInfo` and its ordering live in `FormalConjecturesUtil.Metadata`,
--- the shared home for facts more than one tool consumes.
-open FormalConjectures.Metadata
-
-structure TheoremInfo where
-  «theorem» : String
-  module : String
-  category : String
-  subjects : List String
-  statement : String
-  docstring : Option String
-  formalProofs : List FormalProofInfo
-  hasSorryFreeProof : Bool
-  subsets : List String
-  answerKinds : List String
-  fileFirstAdded : Option String
-  fileLastModified : Option String
-
-
-/-- Serialize `TheoremInfo` to JSON, omitting fields whose keys are in `exclude`. -/
-def TheoremInfo.toFilteredJson (info : TheoremInfo) (exclude : Std.HashSet String := {}) : Json :=
-  let fields : List (String × Json) :=
-    [("theorem", toJson info.theorem),
-     ("module", toJson info.module),
-     ("category", toJson info.category)]
-    ++ (if exclude.contains "subjects" then [] else [("subjects", toJson info.subjects)])
-    ++ (if exclude.contains "statement" then [] else [("statement", toJson info.statement)])
-    ++ (if exclude.contains "docstring" then [] else [("docstring", toJson info.docstring)])
-    ++ (if exclude.contains "formalProofs" || info.formalProofs.isEmpty then [] else
-        [("formalProofs", Json.arr (info.formalProofs.map FormalProofInfo.toJson).toArray)])
-    ++ (if exclude.contains "hasSorryFreeProof" then [] else
-        [("hasSorryFreeProof", toJson info.hasSorryFreeProof)])
-    ++ (if info.subsets.isEmpty then [] else [("subsets", toJson info.subsets)])
-    ++ (if exclude.contains "answerKinds" then [] else
-        [("answerKinds", toJson info.answerKinds)])
-    ++ (if exclude.contains "fileFirstAdded" then [] else
-        [("fileFirstAdded", toJson info.fileFirstAdded)])
-    ++ (if exclude.contains "fileLastModified" then [] else
-        [("fileLastModified", toJson info.fileLastModified)])
-  Json.mkObj fields
-
-instance : ToJson TheoremInfo where
-  toJson info := info.toFilteredJson
 
 unsafe def runWithImports {α : Type} (moduleNames : Array Name) (actionToRun : CoreM α) : IO α := do
   initSearchPath (← getBuildDir)
@@ -234,107 +152,7 @@ unsafe def main (args : List String) : IO Unit := do
 
   runWithImports moduleNames do
     let env ← getEnv
-    let tags ← getTags
-    let subjectTags ← getSubjectTags
-    let formalProofTags ← getFormalProofTags
-
-    -- Create maps for quick lookup
-    let mut categoryMap : Std.HashMap Name (List String) := {}
-    let mut categoryFullMap : Std.HashMap Name CategoryTag := {}
-    for tag in tags do
-      categoryMap := categoryMap.insert tag.declName (categoryToString tag.category :: categoryMap.getD tag.declName [])
-      categoryFullMap := categoryFullMap.insert tag.declName tag
-
-    -- Create formal proof map. A declaration may carry several `formal_proof` annotations,
-    -- so collect them all rather than keeping whichever arrives last.
-    let mut formalProofMap : Std.HashMap Name (List FormalProofTag) := {}
-    for tag in formalProofTags do
-      formalProofMap :=
-        formalProofMap.insert tag.declName (tag :: formalProofMap.getD tag.declName [])
-
-    let mut subjectMap : Std.HashMap Name (List String) := {}
-    for tag in subjectTags do
-      let subjects := tag.subjects.map (fun (s : AMS) => s!"{s.toNat?.get!}")
-      subjectMap := subjectMap.insert tag.declName (subjects ++ subjectMap.getD tag.declName [])
-
-    let mut theoremToSubsets : Std.HashMap Name (List String) := {}
-
-    for (declName, _) in env.constants do
-      if let .str (.str grandparent subsetName) "problems" := declName then
-        if grandparent.toString == "Subsets" then
-          let info ← getConstInfo declName
-          if let some val := info.value? then
-            try
-              let problemsList ← Lean.Meta.MetaM.run' <|
-                unsafe Lean.Meta.evalExpr (List Name) (mkApp (mkConst ``List [.zero]) (mkConst ``Name)) val
-              for p in problemsList do
-                theoremToSubsets := theoremToSubsets.insert p (subsetName :: theoremToSubsets.getD p [])
-            catch e =>
-              let msg ← e.toMessageData.toString
-              IO.eprintln s!"WARNING: Failed to evaluate problems list for {declName}: {msg}"
-
-    let mut allResults : List TheoremInfo := []
-    for modName in moduleNames do
-      let some modIdx := env.header.moduleNames.findIdx? (· == modName)
-        | continue
-      let modData := env.header.moduleData[modIdx]!
-      for info in modData.constants do
-        let name := info.name
-        match info with
-        | ConstantInfo.thmInfo .. =>
-          if !isInternal name then
-            let cats := categoryMap.getD name []
-            let subjs := subjectMap.getD name []
-            if !cats.isEmpty || !subjs.isEmpty then
-              if cats.length ≠ 1 then
-                throwError m!"Theorem {name} must have exactly one category, found {cats.length}."
-              let statement := toString (← Meta.MetaM.run' (Meta.ppExpr info.type))
-              let docstring ← findDocString? env name
-              if docstring.isNone then
-                IO.eprintln s!"WARNING: Theorem {name} (category: {cats.head!}) is missing a docstring"
-              -- Extract formal proof info from the separate formal_proof attributes. Each
-              -- carries its own `conditions`, since one proof can be conditional while
-              -- another of the same statement is not.
-              let formalProofs :=
-                ((formalProofMap.getD name []).map fun tag =>
-                  { kind := formalProofKindToString tag.proofKind,
-                    link := tag.proofLink,
-                    conditions := tag.conditions.map Name.toString : FormalProofInfo })
-                |>.toArray.qsort (fun a b => a.sortKey < b.sortKey) |>.toList
-              -- Check whether the proof term is sorry-free
-              let hasSorryFreeProof :=
-                info.value? (allowOpaque := true) |>.any (!·.hasSorry)
-              -- Warn about suspicious category / sorry combinations
-              if let some catTag := categoryFullMap.get? name then
-                match catTag.category, hasSorryFreeProof with
-                | .research .open, true =>
-                  IO.eprintln s!"WARNING: Theorem {name} is categorised as `research open` but has a sorry-free proof"
-                | .test, false =>
-                  IO.eprintln s!"WARNING: Theorem {name} is categorised as `test` but has no sorry-free proof"
-                | .API, false =>
-                  IO.eprintln s!"WARNING: Theorem {name} is categorised as `API` but has no sorry-free proof"
-                | _, _ => pure ()
-              let subsets := (theoremToSubsets.getD name []).toArray.qsort (· < ·) |>.toList
-              -- Determine answerKinds from the elaborated type
-              let answerKinds ← Meta.MetaM.run'
-                (getAnswerKinds info.type)
-              let (fileFirstAdded, fileLastModified) :=
-                fileTimestamps.getD modName (none, none)
-              allResults := {
-                «theorem» := name.toString,
-                module := modName.toString,
-                category := cats.head!,
-                subjects := subjs,
-                statement := statement,
-                docstring := docstring,
-                formalProofs := formalProofs,
-                hasSorryFreeProof := hasSorryFreeProof,
-                subsets := subsets
-                answerKinds := answerKinds
-                fileFirstAdded := fileFirstAdded
-                fileLastModified := fileLastModified
-              } :: allResults
-        | _ => pure ()
+    let allResults ← extractProblems moduleNames fileTimestamps
 
     -- Collect module docstrings via Lean's getModuleDoc? API
     let mut moduleDocstrings : List (String × String) := []
@@ -348,7 +166,7 @@ unsafe def main (args : List String) : IO Unit := do
             moduleDocstrings := (modName.toString, combined) :: moduleDocstrings
 
     -- Build structured output: { problems: [...], moduleDocstrings: {...} }
-    let problemsJson := toJson (allResults.reverse.map (·.toFilteredJson excludeSet))
+    let problemsJson := toJson (allResults.map (·.toFilteredJson excludeSet))
     -- Consumers should not have to guess whether they are reading the old
     -- `formalProofKind` shape or the `formalProofs` list; say so.
     let mut outputFields : List (String × Json) :=

--- a/scripts/problem_metadata.py
+++ b/scripts/problem_metadata.py
@@ -1,0 +1,5 @@
+"""Repository entry point for shared native metadata readers."""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]/'toolkit'))
+from conjectures.metadata import metadata_rows, unconditional_proof, proof_links

--- a/scripts/test_check_proof_links.py
+++ b/scripts/test_check_proof_links.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for native formal-proof link extraction."""
+
+import json
+import pathlib
+import tempfile
+import unittest
+
+from check_proof_links import links_from_extract, unique_links
+
+
+class ProofLinksTest(unittest.TestCase):
+
+    def write_extract(self, value):
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        self.addCleanup(pathlib.Path(tmp.name).unlink, missing_ok=True)
+        json.dump(value, tmp)
+        tmp.close()
+        return pathlib.Path(tmp.name)
+
+    def test_enumerates_every_nonempty_proof_link_once(self):
+        path = self.write_extract({
+            "schemaVersion": 2,
+            "conjectures": [
+                {"formalProofs": [
+                    {"kind": "lean4", "link": "https://example.com/a",
+                     "conditions": ["h"]},
+                    {"kind": "lean4", "link": "", "conditions": []},
+                ]},
+                {"formalProofs": [
+                    {"kind": "lean4", "link": "https://example.com/b",
+                     "conditions": []},
+                    {"kind": "lean4", "link": "https://example.com/a",
+                     "conditions": []},
+                ]},
+            ],
+        })
+        self.assertEqual(
+            links_from_extract(path),
+            ["https://example.com/a", "https://example.com/b"])
+
+    def test_rejects_legacy_extract_in_canonical_mode(self):
+        path = self.write_extract({"conjectures": []})
+        with self.assertRaisesRegex(ValueError, "schemaVersion 2"):
+            links_from_extract(path)
+
+    def test_omitted_empty_proof_list_is_valid_native_metadata(self):
+        path = self.write_extract({"schemaVersion": 2, "problems": [{}]})
+        self.assertEqual(links_from_extract(path), [])
+
+    def test_rejects_non_string_link(self):
+        path = self.write_extract({
+            "schemaVersion": 2,
+            "conjectures": [{"formalProofs": [{"kind":"lean4", "conditions":[], "link": None}]}],
+        })
+        with self.assertRaisesRegex(ValueError, "link must be a string"):
+            links_from_extract(path)
+
+    def test_source_mode_deduplication_stays_stable(self):
+        self.assertEqual(unique_links(["b", "", "a", "b"]), ["b", "a"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/README.md
+++ b/site/README.md
@@ -191,3 +191,8 @@ The GitHub Actions workflow in `.github/workflows/build-and-docs.yml` triggers o
 **Deployment** happens on pushes to `main`, and on `*-webtest` branches when on a fork.
 
 For GitHub Pages setup (including the environment rule needed for `*-webtest` branches), see [One-time fork setup](#one-time-fork-setup) above.
+
+The site also publishes `data/catalog.json`, preserving the native schema-2 extract
+for command-line consumers. The browser's `data/conjectures.json` projection is unchanged.
+Full CI extraction retains statements, docstrings, proof references, and answer kinds.
+A website-only rebuild from older live data cannot reconstruct omitted fields.

--- a/site/build.js
+++ b/site/build.js
@@ -808,6 +808,9 @@ async function main() {
     'site/data/conjectures.json',
     JSON.stringify({ conjectures, stats, advancedStats, amsSubjects: AMS_SUBJECTS, versoFragments, contributors }),
   );
+  // Retain the native extract for CLI, status, and link consumers. The existing
+  // browser projection and its field meanings remain unchanged.
+  fs.copyFileSync('data/conjectures.json', 'site/data/catalog.json');
   const whitePlotPath = path.join('data', 'file_counts_white.html');
   const darkPlotPath = path.join('data', 'file_counts_dark.html');
   if (fs.existsSync(whitePlotPath)) fs.copyFileSync(whitePlotPath, 'site/data/file_counts_white.html');

--- a/toolkit/conjectures/metadata.py
+++ b/toolkit/conjectures/metadata.py
@@ -1,0 +1,28 @@
+"""Read schema-2 native metadata without reinterpreting Lean declarations."""
+import json
+
+def metadata_rows(data):
+    if not isinstance(data,dict) or data.get('schemaVersion')!=2:
+        raise ValueError('Expected native schemaVersion 2')
+    rows=data.get('problems',data.get('conjectures'))
+    if not isinstance(rows,list):raise ValueError('Metadata rows must be a list')
+    for index,row in enumerate(rows):
+        if not isinstance(row,dict):raise ValueError(f'Row {index} must be an object')
+        if any(k in row for k in ('formalProofKind','formalProofLink','proofConditions')):
+            raise ValueError('Legacy proof fields are not valid in current metadata')
+        proofs=row.get('formalProofs',[])
+        if not isinstance(proofs,list):raise ValueError('formalProofs must be a list')
+        for proof in proofs:
+            if not isinstance(proof,dict):raise ValueError('Proof reference must be an object')
+            if proof.get('kind') not in ('formal_conjectures','lean4','other_system'):
+                raise ValueError('Unknown formal proof kind')
+            if not isinstance(proof.get('link'),str):raise ValueError('Proof link must be a string')
+            if not isinstance(proof.get('conditions'),list) or not all(isinstance(c,str) for c in proof['conditions']):
+                raise ValueError('Proof conditions must be a list of strings')
+    return rows
+
+def unconditional_proof(row):
+    return any(not proof['conditions'] for proof in row.get('formalProofs',[]))
+
+def proof_links(data):
+    return sorted({proof['link'] for row in metadata_rows(data) for proof in row.get('formalProofs',[]) if proof['link']})


### PR DESCRIPTION
**Consolidated into #4828 on 10 September 2026.**

The implementation and tests are retained in that PR's branch. This PR stays closed because its scope is now delivered together with status and proof-link metadata consumers; it is not a cancelled feature or a PR waiting to reopen.

Continue development and review in #4828. Existing commits and discussion here remain historical evidence. The authoritative delivery map is #4394.
