### PR TITLE
ErdosProblems/36: prove M_two through M_five

### DIFF
--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -129,6 +129,42 @@ private lemma M_eq_image (n : ℕ) :
     · rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hA, Int.card_Icc, hn]
       omega
 
+/-- A computable stand-in for `MaxOverlap`. `Overlap` is already computable; the only obstacle
+is the `iSup`, and `maxOverlap_eq_sup` says it agrees with this `Finset.sup`. -/
+private def maxOverlapC (A B : Finset ℤ) : ℕ :=
+  ((A ×ˢ B).image fun p => p.1 - p.2).sup (Overlap A B)
+
+@[category API, AMS 5 11]
+private lemma maxOverlap_eq_maxOverlapC (A B : Finset ℤ) :
+    MaxOverlap A B = maxOverlapC A B := maxOverlap_eq_sup A B
+
+/-- The `n`-element subsets of `{1, …, 2n}`. -/
+private def parts (n : ℕ) : Finset (Finset ℤ) :=
+  (Finset.Icc (1 : ℤ) (2 * n)).powerset.filter fun A => A.card = n
+
+@[category API, AMS 5 11]
+private lemma mem_parts {n : ℕ} {A : Finset ℤ} :
+    A ∈ parts n ↔ A ⊆ Finset.Icc (1 : ℤ) (2 * n) ∧ A.card = n := by
+  simp [parts, Finset.mem_filter, Finset.mem_powerset]
+
+@[category API, AMS 5 11]
+private lemma parts_nonempty (n : ℕ) : (parts n).Nonempty := by
+  refine ⟨Finset.Icc (1 : ℤ) n, mem_parts.mpr ⟨?_, ?_⟩⟩
+  · exact Finset.Icc_subset_Icc le_rfl (by omega)
+  · rw [Int.card_Icc]; omega
+
+/-- `M n` as the minimum of a `Finset` of naturals, which is what makes it evaluable. -/
+@[category API, AMS 5 11]
+private lemma M_eq_min' (n : ℕ) :
+    M n = ((parts n).image fun A => maxOverlapC A (Finset.Icc (1 : ℤ) (2 * n) \ A)).min'
+      ((parts_nonempty n).image _) := by
+  rw [M_eq_image, ← Finset.Nonempty.csInf_eq_min']
+  congr 1
+  rw [Finset.coe_image,
+    show ((parts n : Finset (Finset ℤ)) : Set (Finset ℤ))
+        = {A | A ⊆ Finset.Icc (1 : ℤ) (2 * n) ∧ A.card = n} from by ext A; simp [mem_parts]]
+  exact Set.image_congr fun A _ => maxOverlap_eq_maxOverlapC _ _
+
 /-- `MaxOverlap {1} {2} = 1`: the only nonzero overlap is at `k = -1`. -/
 @[category API, AMS 5 11]
 private lemma maxOverlap_singleton_one_two :
@@ -187,22 +223,30 @@ For $n = 2$, the set is $\{1, 2, 3, 4\}$. The balanced partition $A = \{1, 4\}, 
 has all four pairwise differences ($\pm 1, \pm 2$) distinct, so `MaxOverlap = 1`.
 Any balanced partition has both pieces nonempty, so `MaxOverlap \geq 1`.
 -/
-@[category test, AMS 5 11, formal_proof using formal_conjectures at
-"https://github.com/google-deepmind/formal-conjectures/pull/4153/commits/2ce2d6345d0fcf3b023fe35fde9a9a490b131a86"]
+@[category test, AMS 5 11]
 theorem M_two : M 2 = 1 := by
-  sorry
+  rw [M_eq_min']
+  decide
 
+/-- For `n = 3` the best splitting of `{1, …, 6}` has maximum overlap `2`. -/
 @[category test, AMS 5 11]
 theorem M_three : M 3 = 2 := by
-  sorry
+  rw [M_eq_min']
+  decide
 
+set_option maxRecDepth 8000 in
+/-- For `n = 4` the best splitting of `{1, …, 8}` still has maximum overlap `2`. -/
 @[category test, AMS 5 11]
 theorem M_four : M 4 = 2 := by
-  sorry
+  rw [M_eq_min']
+  decide
 
+set_option maxRecDepth 40000 in
+/-- For `n = 5` the best splitting of `{1, …, 10}` has maximum overlap `3`. -/
 @[category test, AMS 5 11]
 theorem M_five : M 5 = 3 := by
-  sorry
+  rw [M_eq_min']
+  decide
 
 /--
 The quotient of the minimum maximum overlap $M(N)$ by $N$. The central question of the

--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -58,6 +58,77 @@ private lemma one_le_overlap {A B : Finset ℤ} {a b : ℤ}
   Finset.card_pos.mpr ⟨(a, b), Finset.mem_filter.mpr
     ⟨Finset.mem_product.mpr ⟨ha, hb⟩, rfl⟩⟩
 
+/-- For a fixed difference `k`, the first coordinate determines the second, so an overlap is
+never larger than either side. This is what makes `MaxOverlap` a supremum of a bounded set. -/
+@[category API, AMS 5 11]
+private lemma overlap_le_card_left (A B : Finset ℤ) (k : ℤ) : Overlap A B k ≤ A.card := by
+  refine Finset.card_le_card_of_injOn Prod.fst (fun p hp => ?_) (fun p hp q hq h => ?_)
+  · exact (Finset.mem_product.mp (Finset.mem_filter.mp hp).1).1
+  · obtain ⟨-, hpk⟩ := Finset.mem_filter.mp hp
+    obtain ⟨-, hqk⟩ := Finset.mem_filter.mp hq
+    exact Prod.ext h (by omega)
+
+/-- The range of `Overlap A B` is bounded, so `MaxOverlap` is a genuine supremum rather than
+the junk value `sSup` returns on an unbounded set. -/
+@[category API, AMS 5 11]
+private lemma bddAbove_range_overlap (A B : Finset ℤ) :
+    BddAbove (Set.range (Overlap A B)) := by
+  refine ⟨A.card, ?_⟩
+  rintro x ⟨k, rfl⟩
+  exact overlap_le_card_left A B k
+
+@[category API, AMS 5 11]
+private lemma maxOverlap_le_card_left (A B : Finset ℤ) : MaxOverlap A B ≤ A.card :=
+  ciSup_le fun k => overlap_le_card_left A B k
+
+/-- An overlap can only be nonzero for a difference that is actually realised, which confines
+the search for `MaxOverlap` to a finite set. -/
+@[category API, AMS 5 11]
+private lemma overlap_eq_zero_of_notMem_sub (A B : Finset ℤ) {k : ℤ}
+    (hk : k ∉ (A ×ˢ B).image fun p => p.1 - p.2) : Overlap A B k = 0 := by
+  rw [Overlap, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  rintro ⟨a, b⟩ hab rfl
+  exact hk (Finset.mem_image.mpr ⟨(a, b), hab, rfl⟩)
+
+/-- `MaxOverlap` as a supremum over a finite set of differences. This is the form that makes it
+possible to evaluate: the `iSup` in the definition ranges over all of `ℤ`, but every difference
+outside `A - B` contributes `0`. -/
+@[category API, AMS 5 11]
+private lemma maxOverlap_eq_sup (A B : Finset ℤ) :
+    MaxOverlap A B = ((A ×ˢ B).image fun p => p.1 - p.2).sup (Overlap A B) := by
+  refine le_antisymm (ciSup_le fun k => ?_) (Finset.sup_le fun k _ => ?_)
+  · by_cases hk : k ∈ (A ×ˢ B).image fun p => p.1 - p.2
+    · exact Finset.le_sup hk
+    · simp [overlap_eq_zero_of_notMem_sub A B hk]
+  · exact le_ciSup (bddAbove_range_overlap A B) k
+
+/-- The pairs `M n` ranges over are exactly the `n`-element subsets of `{1, …, 2n}`, each paired
+with its complement. This turns the `sInf` over an unbounded family of `Finset ℤ` into an
+infimum over a `Finset`. -/
+@[category API, AMS 5 11]
+private lemma M_eq_image (n : ℕ) :
+    M n = sInf ((fun A : Finset ℤ => MaxOverlap A (Finset.Icc (1 : ℤ) (2 * n) \ A)) ''
+      {A | A ⊆ Finset.Icc (1 : ℤ) (2 * n) ∧ A.card = n}) := by
+  rw [M]
+  congr 1
+  ext m
+  constructor
+  · rintro ⟨A, B, hdisj, hunion, hcard, rfl⟩
+    have hA : A ⊆ Finset.Icc (1 : ℤ) (2 * n) := hunion ▸ Finset.subset_union_left
+    have hB : B = Finset.Icc (1 : ℤ) (2 * n) \ A := by
+      rw [← hunion, Finset.union_sdiff_cancel_left hdisj]
+    have hn : A.card = n := by
+      have := Finset.card_union_of_disjoint hdisj
+      rw [hunion] at this
+      simp only [Int.card_Icc] at this
+      omega
+    exact ⟨A, ⟨hA, hn⟩, by simp only [← hB]⟩
+  · rintro ⟨A, ⟨hA, hn⟩, rfl⟩
+    refine ⟨A, Finset.Icc (1 : ℤ) (2 * n) \ A, Finset.disjoint_sdiff, ?_, ?_, rfl⟩
+    · rw [Finset.union_sdiff_of_subset hA]
+    · rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hA, Int.card_Icc, hn]
+      omega
+
 /-- `MaxOverlap {1} {2} = 1`: the only nonzero overlap is at `k = -1`. -/
 @[category API, AMS 5 11]
 private lemma maxOverlap_singleton_one_two :


### PR DESCRIPTION
Part of #4747. Closes `M_two`, `M_three`, `M_four` and `M_five`.

Those four were `sorry` not because the values are unknown but because there was no way to get at them:

```lean
noncomputable def MaxOverlap (A B : Finset ℤ) : ℕ := iSup <| Overlap A B

noncomputable def M (n : ℕ) : ℕ :=
  sInf {MaxOverlap A B | (A : Finset ℤ) (B : Finset ℤ) (_ : Disjoint A B) ...}
```

An `iSup` over all of `ℤ` inside an `sInf` over an unbounded family of `Finset ℤ`. The blocker was the definition, not the statement.

### Confining both searches

| Lemma | What it gives |
| --- | --- |
| `overlap_le_card_left` | for a fixed `k` the first coordinate determines the second, so `Overlap A B k ≤ A.card` |
| `bddAbove_range_overlap` | hence the `iSup` is a genuine supremum, not the junk value `sSup` returns on an unbounded set |
| `maxOverlap_le_card_left` | the same bound for `MaxOverlap` |
| `overlap_eq_zero_of_notMem_sub` | an overlap vanishes off the differences actually realised |
| `maxOverlap_eq_sup` | `MaxOverlap A B = ((A ×ˢ B).image fun p => p.1 - p.2).sup (Overlap A B)` |
| `M_eq_image` | the pairs `M n` ranges over are exactly the `n`-element subsets of `{1, …, 2n}` with their complements |

### Making it compute

`Overlap` was already computable; only the two search operators were not. `maxOverlapC` is the `Finset.sup` form, `parts n` enumerates the subsets, and `M_eq_min'` rewrites `M n` as the minimum of a `Finset ℕ` via `Finset.Nonempty.csInf_eq_min'`. After that each value is `rw [M_eq_min']; decide`.

`M_five` searches the 252 five-element subsets of `{1, …, 10}` and needs `maxRecDepth 40000`, taking about 20 seconds. `M_four` needs `8000`. The other two are cheap.

### One judgement call

`M_two` carried a `formal_proof using formal_conjectures` link to a commit in #4153. That proof kind means the proof is at the other end of the link and the `sorry` here is expected. Since the `sorry` is now filled in place, I dropped the link rather than leaving it pointing at a commit that fills something already filled. Happy to put it back if the preference is to keep the provenance.

The three that had no docstring now have one, which `extract_names` was separately warning about.

### Effect

`scripts/extract_names.lean` goes from 63 unproved `test`/`API` statements to 59, and from 59 with no `formal_proof` link to 56.

`lake build --wfail FormalConjectures` passes.
