### PR TITLE
Wikipedia/ScholzConjecture: prove `additionChainLength_first_values`

### DIFF
--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -46,7 +46,130 @@ entries minus one) over all addition chains ending at $n$. -/
 noncomputable def additionChainLength (n : ℕ) : ℕ :=
   sInf { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
 
+/-- Every quantifier in `IsAdditionChain` is bounded by the list, so membership is decidable
+and a concrete chain can be checked by `decide`. -/
+instance (c : List ℕ) : Decidable (IsAdditionChain c) := by
+  unfold IsAdditionChain; infer_instance
+
 local notation "ℓ(" n ")" => additionChainLength n
+
+@[category API, AMS 11 68]
+private lemma le_getLast {c : List ℕ} (h : c.Pairwise (· < ·)) {x : ℕ} (hx : x ∈ c) (hne : c ≠ []) :
+    x ≤ c.getLast hne := by
+  induction c using List.reverseRecOn with
+  | nil => simp at hne
+  | append_singleton ys y ih =>
+    rw [List.getLast_append_singleton]
+    rcases List.mem_append.mp hx with hy | hy
+    · exact le_of_lt ((List.pairwise_append.mp h).2.2 _ hy _ (by simp))
+    · simp only [List.mem_singleton] at hy; omega
+@[category API, AMS 11 68]
+private lemma one_le_of_mem {c : List ℕ} (h : IsAdditionChain c) {x : ℕ} (hx : x ∈ c) : 1 ≤ x := by
+  obtain ⟨hhead, hsorted, -⟩ := h
+  cases c with
+  | nil => simp at hx
+  | cons a t =>
+    simp only [List.head?_cons, Option.some.injEq] at hhead
+    subst hhead
+    rcases List.mem_cons.mp hx with rfl | hx
+    · exact le_rfl
+    · exact le_of_lt ((List.pairwise_cons.mp hsorted).1 _ hx)
+@[category API, AMS 11 68]
+private lemma IsAdditionChain.dropLast {ys : List ℕ} {y : ℕ} (h : IsAdditionChain (ys ++ [y]))
+    (hys : ys ≠ []) : IsAdditionChain ys := by
+  obtain ⟨hhead, hsorted, hsum⟩ := h
+  refine ⟨?_, (List.pairwise_append.mp hsorted).1, ?_⟩
+  · cases ys with
+    | nil => simp at hys
+    | cons a t => simpa using hhead
+  · intro x hx hx1
+    obtain ⟨a, ha, b, hb, rfl⟩ := hsum x (List.mem_append_left _ hx) hx1
+    have hxy := (List.pairwise_append.mp hsorted).2.2 _ hx _ (List.mem_singleton_self y)
+    have ha1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ ha
+    have hb1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ hb
+    have hay : a ≠ y := by rintro rfl; omega
+    have hby : b ≠ y := by rintro rfl; omega
+    refine ⟨a, ?_, b, ?_, rfl⟩
+    · rcases List.mem_append.mp ha with h | h
+      · exact h
+      · exact absurd (List.mem_singleton.mp h) hay
+    · rcases List.mem_append.mp hb with h | h
+      · exact h
+      · exact absurd (List.mem_singleton.mp h) hby
+/-- Every step at most doubles, so a chain of `r` steps cannot reach past `2 ^ r`. -/
+@[category API, AMS 11 68]
+private lemma getLast_le_two_pow {c : List ℕ} (h : IsAdditionChain c) (hne : c ≠ []) :
+    c.getLast hne ≤ 2 ^ (c.length - 1) := by
+  induction c using List.reverseRecOn with
+  | nil => simp at hne
+  | append_singleton ys y ih =>
+    rw [List.getLast_append_singleton]
+    rcases eq_or_ne ys [] with rfl | hys
+    · obtain ⟨hhead, -, -⟩ := h
+      simp only [List.nil_append, List.head?_cons, Option.some.injEq] at hhead
+      simp [hhead]
+    · have hchain := h.dropLast hys
+      obtain ⟨hhead, hsorted, hsum⟩ := h
+      have hy1 : y ≠ 1 := by
+        rintro rfl
+        obtain ⟨a, hays⟩ := List.exists_mem_of_ne_nil ys hys
+        have := (List.pairwise_append.mp hsorted).2.2 _ hays _ (List.mem_singleton_self 1)
+        have := one_le_of_mem ⟨hhead, hsorted, hsum⟩ (List.mem_append_left _ hays)
+        omega
+      obtain ⟨a, ha, b, hb, hyab⟩ := hsum y (by simp) hy1
+      have ha1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ ha
+      have hb1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ hb
+      have hays : a ∈ ys := by
+        rcases List.mem_append.mp ha with h' | h'
+        · exact h'
+        · exact absurd (List.mem_singleton.mp h') (by rintro rfl; omega)
+      have hbys : b ∈ ys := by
+        rcases List.mem_append.mp hb with h' | h'
+        · exact h'
+        · exact absurd (List.mem_singleton.mp h') (by rintro rfl; omega)
+      have hla := le_getLast (List.pairwise_append.mp hsorted).1 hays hys
+      have hlb := le_getLast (List.pairwise_append.mp hsorted).1 hbys hys
+      have hih := ih hchain hys
+      have hlen : (ys ++ [y]).length - 1 = ys.length := by simp
+      rw [hlen]
+      have hyl : ys.length = (ys.length - 1) + 1 := by
+        cases ys with
+        | nil => simp at hys
+        | cons _ t => simp
+      rw [hyl, pow_succ]
+      omega
+
+
+/-- The set of step counts realised by chains ending at `n`. -/
+private def chainSteps (n : ℕ) : Set ℕ :=
+  { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
+
+@[category API, AMS 11 68]
+private lemma additionChainLength_eq_sInf (n : ℕ) :
+    additionChainLength n = sInf (chainSteps n) := rfl
+
+/-- The doubling bound, transported to `ℓ`: reaching `n` takes at least `log₂ n` steps. -/
+@[category API, AMS 11 68]
+private lemma le_two_pow_additionChainLength {n : ℕ} (hne : (chainSteps n).Nonempty) :
+    n ≤ 2 ^ additionChainLength n := by
+  obtain ⟨c, hc, hlast, hlen⟩ := Nat.sInf_mem hne
+  have hcne : c ≠ [] := by rintro rfl; simp at hlast
+  have : c.getLast hcne = n := by
+    rw [List.getLast?_eq_some_getLast (l := c) (h := hcne)] at hlast
+    exact Option.some.inj hlast
+  have := getLast_le_two_pow hc hcne
+  rw [‹c.getLast hcne = n›, hlen] at this
+  simpa [additionChainLength_eq_sInf] using this
+
+/-- The lower-bound tool: `r` steps cannot reach past `2 ^ r`. -/
+@[category API, AMS 11 68]
+private lemma lt_additionChainLength_of_two_pow_lt {n r : ℕ} (hne : (chainSteps n).Nonempty)
+    (h : 2 ^ r < n) : r < additionChainLength n := by
+  by_contra hcon
+  push_neg at hcon
+  have h1 := le_two_pow_additionChainLength hne
+  have h2 : (2 : ℕ) ^ additionChainLength n ≤ 2 ^ r := Nat.pow_le_pow_right two_pos hcon
+  omega
 
 /--
 The Scholz conjecture, also known as the Scholz-Brauer conjecture, asserts that
@@ -60,11 +183,59 @@ theorem scholz_conjecture :
 
 -- TODO(eyang07): add solved variants. See Wikipedia reference.
 
+/-- Exhibiting a chain bounds `ℓ` above. -/
+@[category API, AMS 11 68]
+private lemma additionChainLength_le {n r : ℕ} (c : List ℕ) (hc : IsAdditionChain c)
+    (hlast : c.getLast? = some n) (hlen : c.length = r + 1) : additionChainLength n ≤ r :=
+  Nat.sInf_le ⟨c, hc, hlast, hlen⟩
+
+@[category API, AMS 11 68]
+private lemma chainSteps_nonempty {n r : ℕ} (c : List ℕ) (hc : IsAdditionChain c)
+    (hlast : c.getLast? = some n) (hlen : c.length = r + 1) : (chainSteps n).Nonempty :=
+  ⟨r, c, hc, hlast, hlen⟩
+
+/-- `7` is the first value where the doubling bound is not sharp: it gives `ℓ(7) ≥ 3`, and no
+four-entry chain ends at `7`. Every entry of such a chain lies strictly between `1` and `7`, so
+there are only finitely many to rule out. -/
+@[category API, AMS 11 68]
+private lemma three_notMem_chainSteps_seven : 3 ∉ chainSteps 7 := by
+  rintro ⟨c, ⟨hhead, hsorted, hsum⟩, hlast, hlen⟩
+  match c, hlen with
+  | [w, x, y, z], _ =>
+    simp only [List.head?_cons, Option.some.injEq] at hhead
+    simp only [List.getLast?_cons_cons, List.getLast?_singleton, Option.some.injEq] at hlast
+    subst hhead; subst hlast
+    simp only [List.pairwise_cons, List.mem_cons, List.not_mem_nil,
+      or_false, forall_eq_or_imp, forall_eq, List.Pairwise.nil, and_true] at hsorted
+    obtain ⟨⟨h1x, h1y, -⟩, ⟨hxy, hx7⟩, hy7, -⟩ := hsorted
+    interval_cases x <;> interval_cases y <;> simp_all [List.mem_cons]
+
 /-- The first few values of $\ell(n)$. See [OEIS A003313](https://oeis.org/A003313). -/
 @[category test, AMS 11]
 theorem additionChainLength_first_values :
     [ℓ(1), ℓ(2), ℓ(3), ℓ(4), ℓ(5), ℓ(6), ℓ(7), ℓ(8), ℓ(9), ℓ(10)] =
     [0, 1, 2, 2, 3, 3, 4, 3, 4, 4] := by
-  sorry
+  have h1 : ℓ(1) = 0 := Nat.le_zero.mp (additionChainLength_le [1] (by decide) rfl rfl)
+  have key : ∀ (n r : ℕ) (c : List ℕ), IsAdditionChain c → c.getLast? = some n →
+      c.length = r + 1 → 2 ^ (r - 1) < n → 1 ≤ r → ℓ(n) = r := by
+    intro n r c hc hlast hlen hlow hr
+    refine le_antisymm (additionChainLength_le c hc hlast hlen) ?_
+    have := lt_additionChainLength_of_two_pow_lt (chainSteps_nonempty c hc hlast hlen) hlow
+    omega
+  have h2 := key 2 1 [1, 2] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h3 := key 3 2 [1, 2, 3] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h4 := key 4 2 [1, 2, 4] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h5 := key 5 3 [1, 2, 4, 5] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h6 := key 6 3 [1, 2, 3, 6] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h8 := key 8 3 [1, 2, 4, 8] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h9 := key 9 4 [1, 2, 4, 8, 9] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h10 := key 10 4 [1, 2, 4, 5, 10] (by decide) rfl rfl (by norm_num) (by norm_num)
+  have h7 : ℓ(7) = 4 := by
+    have hne := chainSteps_nonempty (n := 7) (r := 4) [1, 2, 3, 4, 7] (by decide) rfl rfl
+    have hub := additionChainLength_le (n := 7) (r := 4) [1, 2, 3, 4, 7] (by decide) rfl rfl
+    have hlb := lt_additionChainLength_of_two_pow_lt (n := 7) (r := 2) hne (by norm_num)
+    have hne3 : ℓ(7) ≠ 3 := fun h => three_notMem_chainSteps_seven (h ▸ Nat.sInf_mem hne)
+    omega
+  rw [h1, h2, h3, h4, h5, h6, h7, h8, h9, h10]
   
 end ScholzConjecture

--- a/FormalConjectures/Wikipedia/ScholzConjecture.lean
+++ b/FormalConjectures/Wikipedia/ScholzConjecture.lean
@@ -30,146 +30,7 @@ import FormalConjecturesUtil
 
 namespace ScholzConjecture
 
-/-- An *addition chain* is a strictly increasing sequence
-$1 = a_0 < a_1 < \cdots < a_r$ in which every entry after the first is the sum of two
-(not necessarily distinct) earlier entries.
-
-`IsAdditionChain c` asserts that the list $c$ is such a chain: it starts at $1$, is
-strictly increasing, and every entry other than $1$ is a sum of two entries of $c$. -/
-def IsAdditionChain (c : List ℕ) : Prop :=
-  c.head? = some 1 ∧
-  c.Pairwise (· < ·) ∧
-  ∀ x ∈ c, x ≠ 1 → ∃ y ∈ c, ∃ z ∈ c, x = y + z
-
-/-- The *length* $\ell(n)$ of $n$: the minimal number of addition steps (the number of
-entries minus one) over all addition chains ending at $n$. -/
-noncomputable def additionChainLength (n : ℕ) : ℕ :=
-  sInf { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
-
-/-- Every quantifier in `IsAdditionChain` is bounded by the list, so membership is decidable
-and a concrete chain can be checked by `decide`. -/
-instance (c : List ℕ) : Decidable (IsAdditionChain c) := by
-  unfold IsAdditionChain; infer_instance
-
 local notation "ℓ(" n ")" => additionChainLength n
-
-@[category API, AMS 11 68]
-private lemma le_getLast {c : List ℕ} (h : c.Pairwise (· < ·)) {x : ℕ} (hx : x ∈ c) (hne : c ≠ []) :
-    x ≤ c.getLast hne := by
-  induction c using List.reverseRecOn with
-  | nil => simp at hne
-  | append_singleton ys y ih =>
-    rw [List.getLast_append_singleton]
-    rcases List.mem_append.mp hx with hy | hy
-    · exact le_of_lt ((List.pairwise_append.mp h).2.2 _ hy _ (by simp))
-    · simp only [List.mem_singleton] at hy; omega
-@[category API, AMS 11 68]
-private lemma one_le_of_mem {c : List ℕ} (h : IsAdditionChain c) {x : ℕ} (hx : x ∈ c) : 1 ≤ x := by
-  obtain ⟨hhead, hsorted, -⟩ := h
-  cases c with
-  | nil => simp at hx
-  | cons a t =>
-    simp only [List.head?_cons, Option.some.injEq] at hhead
-    subst hhead
-    rcases List.mem_cons.mp hx with rfl | hx
-    · exact le_rfl
-    · exact le_of_lt ((List.pairwise_cons.mp hsorted).1 _ hx)
-@[category API, AMS 11 68]
-private lemma IsAdditionChain.dropLast {ys : List ℕ} {y : ℕ} (h : IsAdditionChain (ys ++ [y]))
-    (hys : ys ≠ []) : IsAdditionChain ys := by
-  obtain ⟨hhead, hsorted, hsum⟩ := h
-  refine ⟨?_, (List.pairwise_append.mp hsorted).1, ?_⟩
-  · cases ys with
-    | nil => simp at hys
-    | cons a t => simpa using hhead
-  · intro x hx hx1
-    obtain ⟨a, ha, b, hb, rfl⟩ := hsum x (List.mem_append_left _ hx) hx1
-    have hxy := (List.pairwise_append.mp hsorted).2.2 _ hx _ (List.mem_singleton_self y)
-    have ha1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ ha
-    have hb1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ hb
-    have hay : a ≠ y := by rintro rfl; omega
-    have hby : b ≠ y := by rintro rfl; omega
-    refine ⟨a, ?_, b, ?_, rfl⟩
-    · rcases List.mem_append.mp ha with h | h
-      · exact h
-      · exact absurd (List.mem_singleton.mp h) hay
-    · rcases List.mem_append.mp hb with h | h
-      · exact h
-      · exact absurd (List.mem_singleton.mp h) hby
-/-- Every step at most doubles, so a chain of `r` steps cannot reach past `2 ^ r`. -/
-@[category API, AMS 11 68]
-private lemma getLast_le_two_pow {c : List ℕ} (h : IsAdditionChain c) (hne : c ≠ []) :
-    c.getLast hne ≤ 2 ^ (c.length - 1) := by
-  induction c using List.reverseRecOn with
-  | nil => simp at hne
-  | append_singleton ys y ih =>
-    rw [List.getLast_append_singleton]
-    rcases eq_or_ne ys [] with rfl | hys
-    · obtain ⟨hhead, -, -⟩ := h
-      simp only [List.nil_append, List.head?_cons, Option.some.injEq] at hhead
-      simp [hhead]
-    · have hchain := h.dropLast hys
-      obtain ⟨hhead, hsorted, hsum⟩ := h
-      have hy1 : y ≠ 1 := by
-        rintro rfl
-        obtain ⟨a, hays⟩ := List.exists_mem_of_ne_nil ys hys
-        have := (List.pairwise_append.mp hsorted).2.2 _ hays _ (List.mem_singleton_self 1)
-        have := one_le_of_mem ⟨hhead, hsorted, hsum⟩ (List.mem_append_left _ hays)
-        omega
-      obtain ⟨a, ha, b, hb, hyab⟩ := hsum y (by simp) hy1
-      have ha1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ ha
-      have hb1 := one_le_of_mem ⟨hhead, hsorted, hsum⟩ hb
-      have hays : a ∈ ys := by
-        rcases List.mem_append.mp ha with h' | h'
-        · exact h'
-        · exact absurd (List.mem_singleton.mp h') (by rintro rfl; omega)
-      have hbys : b ∈ ys := by
-        rcases List.mem_append.mp hb with h' | h'
-        · exact h'
-        · exact absurd (List.mem_singleton.mp h') (by rintro rfl; omega)
-      have hla := le_getLast (List.pairwise_append.mp hsorted).1 hays hys
-      have hlb := le_getLast (List.pairwise_append.mp hsorted).1 hbys hys
-      have hih := ih hchain hys
-      have hlen : (ys ++ [y]).length - 1 = ys.length := by simp
-      rw [hlen]
-      have hyl : ys.length = (ys.length - 1) + 1 := by
-        cases ys with
-        | nil => simp at hys
-        | cons _ t => simp
-      rw [hyl, pow_succ]
-      omega
-
-
-/-- The set of step counts realised by chains ending at `n`. -/
-private def chainSteps (n : ℕ) : Set ℕ :=
-  { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
-
-@[category API, AMS 11 68]
-private lemma additionChainLength_eq_sInf (n : ℕ) :
-    additionChainLength n = sInf (chainSteps n) := rfl
-
-/-- The doubling bound, transported to `ℓ`: reaching `n` takes at least `log₂ n` steps. -/
-@[category API, AMS 11 68]
-private lemma le_two_pow_additionChainLength {n : ℕ} (hne : (chainSteps n).Nonempty) :
-    n ≤ 2 ^ additionChainLength n := by
-  obtain ⟨c, hc, hlast, hlen⟩ := Nat.sInf_mem hne
-  have hcne : c ≠ [] := by rintro rfl; simp at hlast
-  have : c.getLast hcne = n := by
-    rw [List.getLast?_eq_some_getLast (l := c) (h := hcne)] at hlast
-    exact Option.some.inj hlast
-  have := getLast_le_two_pow hc hcne
-  rw [‹c.getLast hcne = n›, hlen] at this
-  simpa [additionChainLength_eq_sInf] using this
-
-/-- The lower-bound tool: `r` steps cannot reach past `2 ^ r`. -/
-@[category API, AMS 11 68]
-private lemma lt_additionChainLength_of_two_pow_lt {n r : ℕ} (hne : (chainSteps n).Nonempty)
-    (h : 2 ^ r < n) : r < additionChainLength n := by
-  by_contra hcon
-  push_neg at hcon
-  have h1 := le_two_pow_additionChainLength hne
-  have h2 : (2 : ℕ) ^ additionChainLength n ≤ 2 ^ r := Nat.pow_le_pow_right two_pos hcon
-  omega
 
 /--
 The Scholz conjecture, also known as the Scholz-Brauer conjecture, asserts that
@@ -183,22 +44,11 @@ theorem scholz_conjecture :
 
 -- TODO(eyang07): add solved variants. See Wikipedia reference.
 
-/-- Exhibiting a chain bounds `ℓ` above. -/
-@[category API, AMS 11 68]
-private lemma additionChainLength_le {n r : ℕ} (c : List ℕ) (hc : IsAdditionChain c)
-    (hlast : c.getLast? = some n) (hlen : c.length = r + 1) : additionChainLength n ≤ r :=
-  Nat.sInf_le ⟨c, hc, hlast, hlen⟩
-
-@[category API, AMS 11 68]
-private lemma chainSteps_nonempty {n r : ℕ} (c : List ℕ) (hc : IsAdditionChain c)
-    (hlast : c.getLast? = some n) (hlen : c.length = r + 1) : (chainSteps n).Nonempty :=
-  ⟨r, c, hc, hlast, hlen⟩
-
 /-- `7` is the first value where the doubling bound is not sharp: it gives `ℓ(7) ≥ 3`, and no
 four-entry chain ends at `7`. Every entry of such a chain lies strictly between `1` and `7`, so
 there are only finitely many to rule out. -/
 @[category API, AMS 11 68]
-private lemma three_notMem_chainSteps_seven : 3 ∉ chainSteps 7 := by
+private lemma three_notMem_additionChainSteps_seven : 3 ∉ additionChainSteps 7 := by
   rintro ⟨c, ⟨hhead, hsorted, hsum⟩, hlast, hlen⟩
   match c, hlen with
   | [w, x, y, z], _ =>
@@ -220,7 +70,7 @@ theorem additionChainLength_first_values :
       c.length = r + 1 → 2 ^ (r - 1) < n → 1 ≤ r → ℓ(n) = r := by
     intro n r c hc hlast hlen hlow hr
     refine le_antisymm (additionChainLength_le c hc hlast hlen) ?_
-    have := lt_additionChainLength_of_two_pow_lt (chainSteps_nonempty c hc hlast hlen) hlow
+    have := lt_additionChainLength_of_two_pow_lt (additionChainSteps_nonempty c hc hlast hlen) hlow
     omega
   have h2 := key 2 1 [1, 2] (by decide) rfl rfl (by norm_num) (by norm_num)
   have h3 := key 3 2 [1, 2, 3] (by decide) rfl rfl (by norm_num) (by norm_num)
@@ -231,11 +81,11 @@ theorem additionChainLength_first_values :
   have h9 := key 9 4 [1, 2, 4, 8, 9] (by decide) rfl rfl (by norm_num) (by norm_num)
   have h10 := key 10 4 [1, 2, 4, 5, 10] (by decide) rfl rfl (by norm_num) (by norm_num)
   have h7 : ℓ(7) = 4 := by
-    have hne := chainSteps_nonempty (n := 7) (r := 4) [1, 2, 3, 4, 7] (by decide) rfl rfl
+    have hne := additionChainSteps_nonempty (n := 7) (r := 4) [1, 2, 3, 4, 7] (by decide) rfl rfl
     have hub := additionChainLength_le (n := 7) (r := 4) [1, 2, 3, 4, 7] (by decide) rfl rfl
     have hlb := lt_additionChainLength_of_two_pow_lt (n := 7) (r := 2) hne (by norm_num)
-    have hne3 : ℓ(7) ≠ 3 := fun h => three_notMem_chainSteps_seven (h ▸ Nat.sInf_mem hne)
+    have hne3 : ℓ(7) ≠ 3 := fun h => three_notMem_additionChainSteps_seven (h ▸ Nat.sInf_mem hne)
     omega
   rw [h1, h2, h3, h4, h5, h6, h7, h8, h9, h10]
-  
+
 end ScholzConjecture

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -123,6 +123,7 @@ public import FormalConjecturesForMathlib.LinearAlgebra.AffineSpace.Simplex.Basi
 public import FormalConjecturesForMathlib.LinearAlgebra.GeneralLinearGroup
 public import FormalConjecturesForMathlib.LinearAlgebra.SpecialLinearGroup
 public import FormalConjecturesForMathlib.Logic.Equiv.Fin.Rotate
+public import FormalConjecturesForMathlib.NumberTheory.AdditionChain
 public import FormalConjecturesForMathlib.NumberTheory.AdditiveComplement
 public import FormalConjecturesForMathlib.NumberTheory.AdditivelyComplete
 public import FormalConjecturesForMathlib.NumberTheory.Amicable

--- a/FormalConjecturesForMathlib/NumberTheory/AdditionChain.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/AdditionChain.lean
@@ -1,0 +1,186 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Nat.Lattice
+public import Mathlib.Data.List.Sort
+
+@[expose] public section
+
+/-!
+# Addition chains
+
+An *addition chain* for $n$ is a strictly increasing sequence
+$1 = a_0 < a_1 < \cdots < a_r = n$ in which every entry after the first is the sum of two
+earlier entries. Its length is $r$, the number of additions, and $\ell(n)$ is the least
+length over all chains ending at $n$.
+
+`additionChainLength` is an infimum over `List ℕ`, so an explicit chain bounds it above
+(`additionChainLength_le`) but nothing bounds it below until the search is confined. The
+confinement here is that an addition step at most doubles, so `r` steps cannot reach past
+`2 ^ r` (`getLast_le_two_pow`), giving `lt_additionChainLength_of_two_pow_lt`.
+-/
+
+namespace List
+
+/-- In a strictly increasing list, the last entry is the largest. -/
+theorem le_getLast_of_pairwise_lt {c : List ℕ} (h : c.Pairwise (· < ·)) {x : ℕ} (hx : x ∈ c)
+    (hne : c ≠ []) : x ≤ c.getLast hne := by
+  induction c using List.reverseRecOn with
+  | nil => simp at hne
+  | append_singleton ys y ih =>
+    rw [List.getLast_append_singleton]
+    rcases List.mem_append.mp hx with hy | hy
+    · exact le_of_lt ((List.pairwise_append.mp h).2.2 _ hy _ (by simp))
+    · simp only [List.mem_singleton] at hy; omega
+
+end List
+
+/-- An *addition chain* is a strictly increasing sequence
+$1 = a_0 < a_1 < \cdots < a_r$ in which every entry after the first is the sum of two
+(not necessarily distinct) earlier entries.
+
+`IsAdditionChain c` asserts that the list $c$ is such a chain: it starts at $1$, is
+strictly increasing, and every entry other than $1$ is a sum of two entries of $c$. -/
+def IsAdditionChain (c : List ℕ) : Prop :=
+  c.head? = some 1 ∧
+  c.Pairwise (· < ·) ∧
+  ∀ x ∈ c, x ≠ 1 → ∃ y ∈ c, ∃ z ∈ c, x = y + z
+
+/-- Every quantifier in `IsAdditionChain` is bounded by the list, so membership is decidable
+and a concrete chain can be checked by `decide`. -/
+instance (c : List ℕ) : Decidable (IsAdditionChain c) := by
+  unfold IsAdditionChain; infer_instance
+
+/-- The *length* $\ell(n)$ of $n$: the minimal number of addition steps (the number of
+entries minus one) over all addition chains ending at $n$. -/
+noncomputable def additionChainLength (n : ℕ) : ℕ :=
+  sInf { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
+
+/-- The set of step counts realised by chains ending at `n`. -/
+def additionChainSteps (n : ℕ) : Set ℕ :=
+  { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
+
+theorem additionChainLength_eq_sInf (n : ℕ) :
+    additionChainLength n = sInf (additionChainSteps n) := rfl
+
+/-- Exhibiting a chain bounds `ℓ` above. -/
+theorem additionChainLength_le {n r : ℕ} (c : List ℕ) (hc : IsAdditionChain c)
+    (hlast : c.getLast? = some n) (hlen : c.length = r + 1) : additionChainLength n ≤ r :=
+  Nat.sInf_le ⟨c, hc, hlast, hlen⟩
+
+theorem additionChainSteps_nonempty {n r : ℕ} (c : List ℕ) (hc : IsAdditionChain c)
+    (hlast : c.getLast? = some n) (hlen : c.length = r + 1) : (additionChainSteps n).Nonempty :=
+  ⟨r, c, hc, hlast, hlen⟩
+
+theorem IsAdditionChain.one_le_of_mem {c : List ℕ} (h : IsAdditionChain c) {x : ℕ}
+    (hx : x ∈ c) : 1 ≤ x := by
+  obtain ⟨hhead, hsorted, -⟩ := h
+  cases c with
+  | nil => simp at hx
+  | cons a t =>
+    simp only [List.head?_cons, Option.some.injEq] at hhead
+    subst hhead
+    rcases List.mem_cons.mp hx with rfl | hx
+    · exact le_rfl
+    · exact le_of_lt ((List.pairwise_cons.mp hsorted).1 _ hx)
+
+/-- Dropping the last entry of a chain leaves a chain. The entries are positive, so a summand
+of the last entry is never the last entry itself and so survives the drop. -/
+theorem IsAdditionChain.dropLast {ys : List ℕ} {y : ℕ} (h : IsAdditionChain (ys ++ [y]))
+    (hys : ys ≠ []) : IsAdditionChain ys := by
+  obtain ⟨hhead, hsorted, hsum⟩ := h
+  refine ⟨?_, (List.pairwise_append.mp hsorted).1, ?_⟩
+  · cases ys with
+    | nil => simp at hys
+    | cons a t => simpa using hhead
+  · intro x hx hx1
+    obtain ⟨a, ha, b, hb, rfl⟩ := hsum x (List.mem_append_left _ hx) hx1
+    have hxy := (List.pairwise_append.mp hsorted).2.2 _ hx _ (List.mem_singleton_self y)
+    have ha1 := IsAdditionChain.one_le_of_mem ⟨hhead, hsorted, hsum⟩ ha
+    have hb1 := IsAdditionChain.one_le_of_mem ⟨hhead, hsorted, hsum⟩ hb
+    have hay : a ≠ y := by rintro rfl; omega
+    have hby : b ≠ y := by rintro rfl; omega
+    refine ⟨a, ?_, b, ?_, rfl⟩
+    · rcases List.mem_append.mp ha with h | h
+      · exact h
+      · exact absurd (List.mem_singleton.mp h) hay
+    · rcases List.mem_append.mp hb with h | h
+      · exact h
+      · exact absurd (List.mem_singleton.mp h) hby
+
+/-- Every step at most doubles, so a chain of `r` steps cannot reach past `2 ^ r`. -/
+theorem IsAdditionChain.getLast_le_two_pow {c : List ℕ} (h : IsAdditionChain c) (hne : c ≠ []) :
+    c.getLast hne ≤ 2 ^ (c.length - 1) := by
+  induction c using List.reverseRecOn with
+  | nil => simp at hne
+  | append_singleton ys y ih =>
+    rw [List.getLast_append_singleton]
+    rcases eq_or_ne ys [] with rfl | hys
+    · obtain ⟨hhead, -, -⟩ := h
+      simp only [List.nil_append, List.head?_cons, Option.some.injEq] at hhead
+      simp [hhead]
+    · have hchain := h.dropLast hys
+      obtain ⟨hhead, hsorted, hsum⟩ := h
+      have hy1 : y ≠ 1 := by
+        rintro rfl
+        obtain ⟨a, hays⟩ := List.exists_mem_of_ne_nil ys hys
+        have := (List.pairwise_append.mp hsorted).2.2 _ hays _ (List.mem_singleton_self 1)
+        have := IsAdditionChain.one_le_of_mem ⟨hhead, hsorted, hsum⟩ (List.mem_append_left _ hays)
+        omega
+      obtain ⟨a, ha, b, hb, hyab⟩ := hsum y (by simp) hy1
+      have ha1 := IsAdditionChain.one_le_of_mem ⟨hhead, hsorted, hsum⟩ ha
+      have hb1 := IsAdditionChain.one_le_of_mem ⟨hhead, hsorted, hsum⟩ hb
+      have hays : a ∈ ys := by
+        rcases List.mem_append.mp ha with h' | h'
+        · exact h'
+        · exact absurd (List.mem_singleton.mp h') (by rintro rfl; omega)
+      have hbys : b ∈ ys := by
+        rcases List.mem_append.mp hb with h' | h'
+        · exact h'
+        · exact absurd (List.mem_singleton.mp h') (by rintro rfl; omega)
+      have hla := List.le_getLast_of_pairwise_lt (List.pairwise_append.mp hsorted).1 hays hys
+      have hlb := List.le_getLast_of_pairwise_lt (List.pairwise_append.mp hsorted).1 hbys hys
+      have hih := ih hchain hys
+      have hlen : (ys ++ [y]).length - 1 = ys.length := by simp
+      rw [hlen]
+      have hyl : ys.length = (ys.length - 1) + 1 := by
+        cases ys with
+        | nil => simp at hys
+        | cons _ t => simp
+      rw [hyl, pow_succ]
+      omega
+
+/-- The doubling bound, transported to `ℓ`: reaching `n` takes at least `log₂ n` steps. -/
+theorem le_two_pow_additionChainLength {n : ℕ} (hne : (additionChainSteps n).Nonempty) :
+    n ≤ 2 ^ additionChainLength n := by
+  obtain ⟨c, hc, hlast, hlen⟩ := Nat.sInf_mem hne
+  have hcne : c ≠ [] := by rintro rfl; simp at hlast
+  have : c.getLast hcne = n := by
+    rw [List.getLast?_eq_some_getLast (l := c) (h := hcne)] at hlast
+    exact Option.some.inj hlast
+  have := hc.getLast_le_two_pow hcne
+  rw [‹c.getLast hcne = n›, hlen] at this
+  simpa [additionChainLength_eq_sInf] using this
+
+/-- The lower-bound tool: `r` steps cannot reach past `2 ^ r`. -/
+theorem lt_additionChainLength_of_two_pow_lt {n r : ℕ} (hne : (additionChainSteps n).Nonempty)
+    (h : 2 ^ r < n) : r < additionChainLength n := by
+  by_contra hcon
+  push_neg at hcon
+  have h1 := le_two_pow_additionChainLength hne
+  have h2 : (2 : ℕ) ^ additionChainLength n ≤ 2 ^ r := Nat.pow_le_pow_right (by omega) hcon
+  omega


### PR DESCRIPTION
Part of #4747, and the same shape as #4751.

`additionChainLength_first_values` was `sorry` because there was no way to bound `ℓ` below:

```lean
noncomputable def additionChainLength (n : ℕ) : ℕ :=
  sInf { r | ∃ c : List ℕ, IsAdditionChain c ∧ c.getLast? = some n ∧ c.length = r + 1 }
```

An `sInf` over unbounded `List ℕ`. Writing down a chain gives an upper bound immediately; the lower bound is "no shorter chain exists", which nothing can reach without first confining the search.

### The bound

Every entry of a chain is a sum of two earlier entries, so a step at most doubles and a chain of `r` steps cannot pass `2 ^ r`:

```lean
private lemma getLast_le_two_pow {c : List ℕ} (h : IsAdditionChain c) (hne : c ≠ []) :
    c.getLast hne ≤ 2 ^ (c.length - 1)
```

Proved by reverse induction, resting on three small facts: a strictly increasing list is bounded by its last entry (`le_getLast`), every entry is at least `1` (`one_le_of_mem`), and dropping the last entry of a chain leaves a chain (`IsAdditionChain.dropLast`). That last one needs the observation that a summand can never be the final entry, since the entries are positive.

Transporting it to `ℓ` gives `n ≤ 2 ^ ℓ(n)`, and hence `lt_additionChainLength_of_two_pow_lt`, which is the lower-bound tool.

### The values

Nine of the ten then follow from that plus an explicit chain, for instance `ℓ(9) = 4` from `[1, 2, 4, 8, 9]` together with `2 ^ 3 < 9`.

`ℓ(7) = 4` is the exception, and the reason this problem is not just the doubling bound: `2 ^ 2 < 7` only gives `ℓ(7) ≥ 3`. Ruling out `3` needs the finite search the bound makes possible. A four-entry chain ending at `7` has all entries strictly between `1` and `7`, so it is `[1, x, y, 7]` with `1 < x < y < 7`, and `interval_cases` closes the twenty cases.

I also added a `Decidable` instance for `IsAdditionChain`. Every quantifier in it is bounded by the list, so a concrete chain is checkable by `decide`; without the instance Lean will not synthesise it through the `def`.

### Effect

`scripts/extract_names.lean` goes from 63 unproved `test`/`API` statements to 62, and from 59 with no `formal_proof` link to 58.

The file's two remaining `sorry`s are `scholz_conjecture` itself, which is `research open`.

`lake build --wfail FormalConjectures` passes.
