### PR TITLE
ErdosProblems/470: record why `HasPosDensity` is the right reading

### DIFF
--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -51,6 +51,13 @@ theorem erdos_470.parts.ii : answer(sorry) ↔ Set.Infinite PrimitiveWeird := by
 /--
 Benkoski and Erdős [BeEr74](https://mathscinet.ams.org/mathscinet/relay-station?mr=347726) proved
 that the set of weird numbers has positive density.
+
+`HasPosDensity` is the right reading here, rather than the positive *lower* density that Erdős'
+"positive density" usually abbreviates. Their Theorem 5 is stated as "the density of weird
+numbers is positive", and they first establish that the density exists at all: "It is clear that
+the weird numbers have a density since both the abundant numbers and the pseudoperfect numbers
+have a density. (A weird number is abundant and not pseudoperfect.)" The work in the paper goes
+into showing that density is not `0`.
 -/
 @[category research solved, AMS 11]
 theorem erdos_470.variants.weird_pos_density : {n : ℕ | n.Weird}.HasPosDensity := by


### PR DESCRIPTION
Part of #4553. No change to any statement; this records why one should not be changed.

I had 470 on a list of files to switch from `Set.HasPosDensity` to positive lower density, on the general principle that Erdős' "positive density" usually means the lower one. Reading [BeEr74] settles it the other way.

Page 622, immediately before their Theorem 5:

> It is clear that the weird numbers have a density since both the abundant numbers and the pseudoperfect numbers have a density. (A weird number is abundant and not pseudoperfect.) Hence, we need only show that the density of weird numbers cannot be 0.
>
> **Theorem 5.** *The density of weird numbers is positive.*

So the density exists for an easy reason, and the paper says so: it is the density of the abundant numbers minus that of the pseudoperfect numbers, both of which exist. The work goes into showing the difference is not `0`. `HasPosDensity`, which is `∃ α > 0, HasDensity α`, is exactly that.

The same paper is careful about the distinction elsewhere, which is what made me check: on page 617 it says Erdős proved "the density of integers having property P **exists and is positive**", and on page 620 that "the density of the pseudoperfect numbers **exists**". The wording tracks a real difference rather than being loose.

I put this in the docstring rather than leaving it in a comment thread, since the next person to sweep for `HasPosDensity` will otherwise reach the same wrong conclusion I did.

`lake build --wfail FormalConjectures` passes.

