### PR TITLE
ErdosProblems 318, 413, 418: record why `HasPosDensity` is right

### DIFF
--- a/FormalConjectures/ErdosProblems/318.lean
+++ b/FormalConjectures/ErdosProblems/318.lean
@@ -107,7 +107,13 @@ theorem erdos_318.variants.contain_single_even {A : Set ℕ} (hA : {n | n ∈ A 
   sorry
 
 /-- There exists a set `A` with positive density that does not have property `P₁`.
-#TODO: prove this lemma by assuming `erdos_318.contain_single_even`. -/
+#TODO: prove this lemma by assuming `erdos_318.contain_single_even`.
+
+The density sits in an existential, so `HasPosDensity` is the *stronger* reading here and
+weakening it to positive lower density would claim less, which is the opposite of the usual
+situation for Erdős' "positive density". It also costs nothing: by
+`erdos_318.variants.contain_single_even` a witness only needs exactly one even element, and the
+odd numbers together with one even number have density `1 / 2` on the nose. -/
 @[category research solved, AMS 11]
 theorem erdos_318.parts.i : ∃ A : Set ℕ, HasPosDensity A ∧ ¬ P₁ A := by
   sorry

--- a/FormalConjectures/ErdosProblems/413.lean
+++ b/FormalConjectures/ErdosProblems/413.lean
@@ -49,7 +49,17 @@ theorem erdos_413.parts.i :
 def expProd (n : ℕ) : ℕ :=
   n.factorization.prod fun _ e => e
 
-/-- Erdős proved that the barrier set for `expProd` is infinite and even has positive density. -/
+/-- Erdős proved that the barrier set for `expProd` is infinite and even has positive density.
+
+`HasPosDensity` is the right reading rather than positive lower density. In [Er79d] this is
+Theorem 1, "the density of integers satisfying (2) is positive", where `d₀(n) = ∏ αᵢ` is
+`expProd`. The averaging argument there bounds the density below, but Erdős states the existence
+separately on the last page: "With a little more trouble, I can prove that the density of
+integers `n` for which `n` is a barrier for `d₀(n)` exists." He goes further, that if `αᵢ` is the
+density of `n` with `max_{m<n} (m + d₀(m)) = n + i`, then every `αᵢ` exists and they sum to `1`.
+
+[Er79d] Erdős, P., *Some unconventional problems in number theory*.
+Acta Math. Acad. Sci. Hungar. (1979), 71-80. -/
 @[category research solved, AMS 11]
 theorem erdos_413.variants.hasPosDensity_barrier_expProd :
     { n | IsBarrier (fun m => expProd m) n }.HasPosDensity := by

--- a/FormalConjectures/ErdosProblems/418.lean
+++ b/FormalConjectures/ErdosProblems/418.lean
@@ -86,6 +86,12 @@ theorem erdos_418.variants.conditional
 /--
 Erdős [Er73b] has shown that a positive density set of natural numbers cannot be written as
 $\sigma(n)-n$ (numbers not of this form are called nonaliquot, or sometimes untouchable).
+
+The density sits in an existential, so `HasPosDensity` is the *stronger* reading: the witness
+`S` is ours to choose, and weakening it to positive lower density would claim less rather than
+more. That is the opposite of the usual situation for Erdős' "positive density", where the
+density is a hypothesis or a claim about a fixed set. Whether the nonaliquot numbers themselves
+have a density is a separate question and is not what this states.
 -/
 @[category research solved, AMS 11]
 theorem erdos_418.variants.sigma :


### PR DESCRIPTION
Part of #4553, following #4758 and #4759. No statement changes; this records why three more should not be changed.

I had 318, 413 and 418 on a list of files to switch from `Set.HasPosDensity` to positive lower density. All three should stay. The reasons differ, and both are worth writing down where the next sweep will see them.

### 318 and 418: the density is inside an existential

```lean
theorem erdos_318.parts.i : ∃ A : Set ℕ, HasPosDensity A ∧ ¬ P₁ A
theorem erdos_418.variants.sigma : ∃ (S : Set ℕ) (hS : S.HasPosDensity), S ⊆ { (σ 1 n - n : ℕ) | n }ᶜ
```

The witness is ours to choose, so `HasPosDensity` is the *stronger* statement and weakening it to positive lower density would claim less rather than more. That inverts the usual situation, where "positive density" is a hypothesis or a claim about a fixed set, and it is the mistake my earlier list made.

For 318 the stronger form is also cheap: by `erdos_318.variants.contain_single_even` a witness only needs exactly one even element, and the odd numbers together with one even number have density `1 / 2` exactly.

### 413: the paper says the density exists

This one needed reading. [Er79d] is Erdős, *Some unconventional problems in number theory*, Acta Math. Acad. Sci. Hungar. 33 (1979), 71-80. Theorem 1 on page 71:

> For `n = ∏ pᵢ^{αᵢ}` set `d₀(n) = ∏ αᵢ`. Then `d₀(n)` has infinitely many barriers … In fact, the density of integers satisfying (2) is positive.

`d₀` is `expProd`. The averaging proof on pages 79-80 gives a lower bound, but Erdős states existence separately at the end:

> With a little more trouble, I can prove that the density of integers `n` for which `n` is a barrier for `d₀(n)` exists. More generally let `αᵢ` be the density of integers `n` for which `max_{m<n} (m + d₀(m)) = n + i`. Then `αᵢ` exists for every `i` and `∑ αᵢ = 1`.

So the reference is added to the file too, since it only had the problem page and an OEIS link before.

`lake build --wfail FormalConjectures` passes.
