### PR TITLE
ErdosProblems/330: fix representability, density, and a typo

### DIFF
--- a/FormalConjectures/ErdosProblems/330.lean
+++ b/FormalConjectures/ErdosProblems/330.lean
@@ -25,15 +25,25 @@ import FormalConjecturesUtil
 namespace Erdos330
 
 open Set
-open scoped BigOperators
+open scoped BigOperators Pointwise
 
-/-- `Rep A m h` means `m` is a sum of at most `h` elements of `A`x. -/
-def Rep (A : Set ℕ) (m h : ℕ) : Prop :=
-  ∃ k : ℕ, k ≤ h ∧ ∃ f : Fin k → ℕ, (∀ i, f i ∈ A) ∧ (∑ i : Fin k, f i) = m
+/-- `Rep A m h` means `m` is a sum of exactly `h` elements of `A`, which is `m ∈ h • A`.
 
-/-- Integers **not** representable as a finite sum of elements with at most `h` terms of `A`
+Exactly `h` rather than at most `h`, for two reasons. It is the notion Erdős states the problem
+with, via `f_2(m)`, the number of solutions of `m = a_i + a_j` [Er80]. And it is the notion
+`IsAsymptoticAddBasisOfOrder` uses below, so the statement is not switching between two meanings
+of "representable" partway through.
+
+Allowing fewer than `h` summands also breaks the statement outright: taking one summand makes
+every element of `A` count as represented, so `UnrepWithout A n h` would contain no element of
+`A` besides possibly `n`. Those are exactly the integers the problem is about. If `a ∈ A` with
+`a ≠ n` is only expressible as `a = n + b`, it cannot be represented without `n` and belongs in
+the set, but the one-element sum `a` itself would have excluded it. -/
+def Rep (A : Set ℕ) (m h : ℕ) : Prop := m ∈ h • A
+
+/-- Integers **not** representable as a sum of exactly `h` elements of `A`
 **while avoiding** `n`. -/
-def UnrepWithout (A : Set ℕ) (n h: ℕ) : Set ℕ :=
+def UnrepWithout (A : Set ℕ) (n h : ℕ) : Set ℕ :=
   {m | ¬ Rep (A \ {n}) m h}
 
 /-- An asymptotic additive basis of order `h` is minimal when one cannot obtain an asymptotic
@@ -46,15 +56,17 @@ Does there exist a minimal basis $A \subset \mathbb{N}$ with positive density
 such that, for any $n \in A$, the (upper) density of integers which
 cannot be represented without using $n$ is positive?
 
-The unrepresentable set is not asked to have a density, only to have positive upper density,
-so `Set.upperDensity` is used for it rather than `Set.HasPosDensity`. A set of integers that
-cannot be represented without $n$ has no reason to have a natural density, and requiring one
-would ask a strictly harder question than the one posed.
+Neither set is asked to have a density, only to have positive upper density, so
+`Set.upperDensity` is used for both rather than `Set.HasPosDensity`. As with many of Erdős'
+questions "positive density" here most likely means positive upper density, and in [Er80] he
+considers either the lower or the upper density for the integers not representable without a
+fixed `n`. Requiring the density to exist would ask a strictly harder question than the one
+posed. See #3979.
 -/
 @[category research open, AMS 5 11]
 theorem erdos_330_statement :
-    answer(sorry) ↔ ∃ (A : Set ℕ), ∃ h, MinAsymptoticAddBasisOfOrder A h ∧ A.HasPosDensity ∧
-    ∀ n ∈ A, 0 < (UnrepWithout A n h).upperDensity := by
+    answer(sorry) ↔ ∃ (A : Set ℕ), ∃ h, MinAsymptoticAddBasisOfOrder A h ∧
+    0 < A.upperDensity ∧ ∀ n ∈ A, 0 < (UnrepWithout A n h).upperDensity := by
   sorry
 
 end Erdos330


### PR DESCRIPTION
Fixes the four points @Jayyhk raised in https://github.com/google-deepmind/formal-conjectures/issues/3998#issuecomment-5187540855. I checked each against the source before changing anything; all four hold.

### `Rep` counted the wrong thing, twice

`Rep A m h` allowed *at most* `h` summands:

```lean
def Rep (A : Set ℕ) (m h : ℕ) : Prop :=
  ∃ k : ℕ, k ≤ h ∧ ∃ f : Fin k → ℕ, (∀ i, f i ∈ A) ∧ (∑ i : Fin k, f i) = m
```

Taking `k = 1` makes every element of `A` count as represented, so `UnrepWithout A n h` contained no element of `A` except possibly `n`. Those are exactly the integers the problem is about: if `a ∈ A` with `a ≠ n` is only expressible as `a = n + b`, it cannot be represented without `n` and belongs in the set, but the one-element sum `a` itself excluded it. Confirmed in Lean:

```lean
example (A : Set ℕ) (m h : ℕ) (hm : m ∈ A) (hh : 1 ≤ h) : Rep A m h :=
  ⟨1, hh, fun _ => m, fun _ => hm, by simp⟩
```

Separately, `Rep` used at most `h` while `MinAsymptoticAddBasisOfOrder` uses `IsAsymptoticAddBasisOfOrder`, which is `∀ᶠ a in cofinite, a ∈ h • A`, exactly `h`. The statement switched meaning of "representable" partway through. Erdős states the problem with `f_2(m)`, the number of solutions of `m = a_i + a_j`, which is exactly two.

Both are fixed by `Rep A m h := m ∈ h • A`, which is definitionally what the basis condition uses:

```lean
example (A : Set ℕ) (m h : ℕ) : Rep A m h ↔ m ∈ h • A := Iff.rfl
example (A : Set ℕ) (h : ℕ) :
    Set.IsAsymptoticAddBasisOfOrder A h ↔ ∀ᶠ a in Filter.cofinite, a ∈ h • A := Iff.rfl
```

One thing worth flagging for review, since it is silent if wrong: `h • A` for `h : ℕ` and `A : Set ℕ` could plausibly elaborate to scalar multiplication, `{h * a | a ∈ A}`. It does not; `pp.explicit` shows `@Set.NSMul`, the `h`-fold sumset, the same instance the basis predicate reaches through `to_additive`. I checked rather than assumed.

### Density

`A.HasPosDensity` becomes `0 < A.upperDensity`. #3979 asks for exactly this and notes the proof recorded as settling the problem establishes only positive upper density. #4731 made the same change for the unrepresentable set and deliberately left this half, which is now closed.

### Typo

`elements of `A`x`.

`lake build --wfail FormalConjectures` passes.
