### PR TITLE
ErdosProblems: link Jayyhk proofs for 71, 209, 353 and 464

### DIFF
--- a/FormalConjectures/ErdosProblems/209.lean
+++ b/FormalConjectures/ErdosProblems/209.lean
@@ -62,7 +62,7 @@ each of these intersection points only intersects two lines from $A$?
 Füredi and Palásti [FuPa84] showed this is false when $d\geq 4$ is not divisible by $9$.
 Escudero [Es16] showed this is false for all $d\geq 4$.
 -/
-@[category research solved, AMS 52]
+@[category research solved, AMS 52, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/209/Erdos209.lean"]
 theorem erdos_209 : answer(False) ↔
     ∀ d : ℕ, 4 ≤ d → ∀ A : Finset (AffineSubspace ℝ ℝ²), A.card = d →
       (∀ L ∈ A, IsLine L) →

--- a/FormalConjectures/ErdosProblems/353.lean
+++ b/FormalConjectures/ErdosProblems/353.lean
@@ -50,7 +50,7 @@ This statement formalizes the leading question, for isosceles trapezoids; the re
 configurations are given as variants below. The area of a polygon is taken to be the Lebesgue
 measure of the convex hull of its vertices.
 -/
-@[category research solved, AMS 28 51]
+@[category research solved, AMS 28 51, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/353/Erdos353.lean"]
 theorem erdos_353 : answer(True) ↔
     ∀ A : Set ℝ², MeasurableSet A → volume A = ⊤ →
       ∃ a ∈ A, ∃ b ∈ A, ∃ c ∈ A, ∃ d ∈ A,
@@ -69,7 +69,7 @@ triangle, all of area $1$.
 Note the area condition forces `a`, `b`, `c` to be affinely independent, so no separate
 non-degeneracy hypothesis is needed.
 -/
-@[category research solved, AMS 28 51]
+@[category research solved, AMS 28 51, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/353/Erdos353.lean"]
 theorem erdos_353.variants.isosceles_triangle :
     ∀ A : Set ℝ², MeasurableSet A → volume A = ⊤ →
       ∃ a ∈ A, ∃ b ∈ A, ∃ c ∈ A,
@@ -88,7 +88,7 @@ triangle, all of area $1$.
 Note the area condition forces `a`, `b`, `c` to be affinely independent, so no separate
 non-degeneracy hypothesis is needed.
 -/
-@[category research solved, AMS 28 51]
+@[category research solved, AMS 28 51, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/353/Erdos353.lean"]
 theorem erdos_353.variants.right_angled_triangle :
     ∀ A : Set ℝ², MeasurableSet A → volume A = ⊤ →
       ∃ a ∈ A, ∃ b ∈ A, ∃ c ∈ A,
@@ -105,7 +105,7 @@ is, every set with infinite measure contains four distinct points on a circle su
 quadrilateral determined by these four points has area $1$. The quadrilateral determined by
 four distinct concyclic points is their convex hull.
 -/
-@[category research solved, AMS 28 51]
+@[category research solved, AMS 28 51, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/353/Erdos353.lean"]
 theorem erdos_353.variants.cyclic_quadrilateral :
     ∀ A : Set ℝ², MeasurableSet A → volume A = ⊤ →
       ∃ Q : Set ℝ², Q ⊆ A ∧ Q.ncard = 4 ∧ Cospherical Q ∧
@@ -117,7 +117,7 @@ The answer is negative for convex polygons with congruent sides: Kovač and Pred
 [KoPr24] prove that there exists a set of infinite measure such that every convex polygon
 with congruent sides and all vertices in the set has area $<1$.
 -/
-@[category research solved, AMS 28 51]
+@[category research solved, AMS 28 51, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/353/Erdos353.lean"]
 theorem erdos_353.variants.congruent_sides :
     ∃ A : Set ℝ², MeasurableSet A ∧ volume A = ⊤ ∧
       ∀ (n : ℕ) (v : Fin (n + 3) → ℝ²),

--- a/FormalConjectures/ErdosProblems/464.lean
+++ b/FormalConjectures/ErdosProblems/464.lean
@@ -77,7 +77,7 @@ This problem has consequences for [894](https://www.erdosproblems.com/894).
 The conclusion "$\{\|\theta n_k\|\}$ is not dense in $[0,1]$" is formalized as the sequence
 $(\theta n_k)$ not being dense modulo one; see the formalization notes above.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/464/Erdos464.lean"]
 theorem erdos_464 : answer(True) ↔
     ∀ n : ℕ → ℕ, StrictMono n → (∀ k, 0 < n k) → IsLacunary n →
       ∃ θ : ℝ, Irrational θ ∧

--- a/FormalConjectures/ErdosProblems/71.lean
+++ b/FormalConjectures/ErdosProblems/71.lean
@@ -46,7 +46,7 @@ as the existence of an even element. The average degree of a finite simple graph
 `SimpleGraph.averageDegree`, i.e. $(\sum_v \deg v)/|V| \in \mathbb{Q}$, and a cycle whose
 length is in $P$ is a cycle walk `w` with `w.length ∈ P`.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/110d489ed5c07e5b216453e092e9113127c98c9a/problems/71/Erdos71.lean"]
 theorem erdos_71 : answer(True) ↔
     ∀ P : Set ℕ, P.IsAPOfLength ⊤ → (∃ n ∈ P, Even n) →
       ∃ c : ℚ, ∀ (V : Type) [Fintype V] [DecidableEq V] (G : SimpleGraph V)


### PR DESCRIPTION
On #3998 I listed why these four could not be linked. @Jayyhk rewrote them against the FC statements, so they can now. Pinned to `110d489`.

| Problem | What changed |
| --- | --- |
| 71 | now FC's right-hand side character for character |
| 464 | same |
| 209 | was over `ℂ`; now carries `PlaneR`, `IsLineR`, `pointMultiplicityR` and `HasGallaiTriangleR` matching FC's, and transfers the `ℂ` development across a `planeREquivComplex` |
| 353 | all five parts restated in FC's shape |

### 209

The obstruction was that the development modelled the plane as `ℂ` while FC uses `ℝ²`, and I said transferring would mean carrying an isomorphism through the whole statement. That is what the update does. `PlaneR` is `EuclideanSpace ℝ (Fin 2)`, and the four definitions are FC's verbatim, down to `pointMultiplicityR A p = {L ∈ ↑A | p ∈ L}.ncard`.

### 353

Two things I had flagged are both addressed. The areas were coordinate formulas where FC uses `volume (convexHull ℝ …)`; they are now the measure. And `IsoTrapArea1` had no convexity condition where FC's `IsIsoscelesTrapezoid` requires `IsCcwConvexPolygon`; `IsIsoscelesTrapezoidFC` now has it, and `IsCcwConvexPolygonFC` is FC's definition verbatim.

The theorem is a five-part conjunction matching FC's five statements one to one, including `MeasurableSet A` in the congruent-sides part, which the earlier version was missing. So the link goes on `erdos_353` and all four variants.

### Checks

All four files: no `sorry`, no declared `axiom`, `#print axioms` clean, and the headline theorem takes no hypotheses. `lake build --wfail FormalConjectures` passes, and `scripts/check_erdos_status.py` no longer reports any of the four; the repo total drops from 25 to 21.

90 stays unlinked. It is `axiomatic` in that catalog, assuming two published theorems, and Jayyhk says an axiom-free version is in progress.
