### PR TITLE
feat(Wikipedia): add the Pierpont-prime conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/PierpontPrime.lean
+++ b/FormalConjectures/Wikipedia/PierpontPrime.lean
@@ -29,7 +29,7 @@ nonnegative integers. Marc Gleason conjectured that there are infinitely many.
 
 namespace PierpontPrime
 
-/-- A Pierpont prime is a prime of the form `2 ^ a * 3 ^ b + 1`. -/
+/-- A Pierpont prime is a prime of the form $2^a3^b + 1$. -/
 def IsPierpontPrime (p : ℕ) : Prop :=
   p.Prime ∧ ∃ a b : ℕ, p = 2 ^ a * 3 ^ b + 1
 

--- a/FormalConjectures/Wikipedia/PierpontPrime.lean
+++ b/FormalConjectures/Wikipedia/PierpontPrime.lean
@@ -1,0 +1,50 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Pierpont primes
+
+A Pierpont prime is a prime of the form $2^a 3^b + 1$, where $a$ and $b$ are
+nonnegative integers. Marc Gleason conjectured that there are infinitely many.
+
+*Reference:* [Wikipedia, Pierpont prime](https://en.wikipedia.org/wiki/Pierpont_prime)
+-/
+
+namespace PierpontPrime
+
+/-- A Pierpont prime is a prime of the form `2 ^ a * 3 ^ b + 1`. -/
+def IsPierpontPrime (p : ℕ) : Prop :=
+  p.Prime ∧ ∃ a b : ℕ, p = 2 ^ a * 3 ^ b + 1
+
+@[category test, AMS 11]
+theorem two_isPierpontPrime : IsPierpontPrime 2 := by
+  refine ⟨by norm_num, 0, 0, ?_⟩
+  norm_num
+
+@[category test, AMS 11]
+theorem thirtySeven_isPierpontPrime : IsPierpontPrime 37 := by
+  refine ⟨by norm_num, 2, 2, ?_⟩
+  norm_num
+
+/-- There are infinitely many Pierpont primes. -/
+@[category research open, AMS 11]
+theorem infinitely_many_pierpont_primes :
+    Set.Infinite {p : ℕ | IsPierpontPrime p} := by
+  sorry
+
+end PierpontPrime

--- a/FormalConjectures/Wikipedia/PierpontPrime.lean
+++ b/FormalConjectures/Wikipedia/PierpontPrime.lean
@@ -22,7 +22,9 @@ import FormalConjecturesUtil
 A Pierpont prime is a prime of the form $2^a 3^b + 1$, where $a$ and $b$ are
 nonnegative integers. Marc Gleason conjectured that there are infinitely many.
 
-*Reference:* [Wikipedia, Pierpont prime](https://en.wikipedia.org/wiki/Pierpont_prime)
+*References:*
+- [Wikipedia, Pierpont prime](https://en.wikipedia.org/wiki/Pierpont_prime)
+- [OEIS A005109](https://oeis.org/A005109)
 -/
 
 namespace PierpontPrime


### PR DESCRIPTION
Closes #4753

## Summary

This PR defines a Pierpont prime as a natural prime of the form
`2^a * 3^b + 1`, where both exponents are natural numbers. It includes proved
tests for the boundary example `2 = 2^0 * 3^0 + 1` and the nontrivial example
`37 = 2^2 * 3^2 + 1`, then states the open conjecture that the set of Pierpont
primes is infinite. The research statement is tagged AMS 11.

## Formalization choices

Using `a b : ℕ` directly captures the source's nonnegative-exponent
convention, including zero. Primality remains an explicit part of
`IsPierpontPrime`, since having the required algebraic form alone does not make
a number prime. Mathlib's existing natural-number and set APIs are sufficient,
so no shared helper API is added.

## Verification

- `lake env lean FormalConjectures/Wikipedia/PierpontPrime.lean`
- `lake --wfail build FormalConjectures/Wikipedia/PierpontPrime.lean`
- Rebased onto current `origin/main`; PR CI supplies the authoritative clean full-project build
- Wikipedia and OEIS A005109 links and current source/issue/PR collision searches checked
- No `native_decide`; only the intended open-conjecture `sorry` remains

## AI use

AI was used extensively on this effort: specifically, OpenAI Codex using GPT-5.6 Sol with ultra reasoning effort. My intent at the onset of this project was to learn Lean, and thus sought a problem that might be particularly well-suited for a beginner. I used AI to comb open issues and search for a problem relating to prime numbers. I used AI in deciding how to structure the problem, and for some additional exploratory work on what a proof/disproof of this conjecture might look like (separate and not included in this statement-only PR). AI helped me stage the issue and PR, and although I have used my own words throughout as required, AI proofread everything for me just in case. I have personally reviewed and understand the submitted file, including the nonnegative-exponent convention, the examples 2 and 37, and the `Set.Infinite` statement. I understand that the only `sorry` is the open infinitude conjecture.
