### PR TITLE
Decide category warnings from the JSON, not the stderr

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -31,6 +31,23 @@ permissions:
   contents: read
 
 jobs:
+  # The category check is a policy gate, so it has tests of its own. They need
+  # no Lean build, so they run alongside it rather than after it.
+  scripts:
+    runs-on: ubuntu-latest
+    name: Test scripts
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12.9'
+
+      - name: Run script tests
+        run: python3 -m unittest discover -s scripts -p 'test_*.py' -v
+
   build:
     runs-on: ubuntu-latest
     name: Build project
@@ -157,15 +174,15 @@ jobs:
         run: |
           mkdir -p site/data
           lake exe extract_names --exclude=statement,docstring,moduleDocstrings \
-            > site/data/conjectures.json 2> extract_names.warnings || true
+            > site/data/conjectures.json
 
-      # `extract_names` notices `research open` problems with a sorry-free proof, and
-      # `test`/`API` statements without one. Those warnings went to stderr behind the
-      # `|| true` above, so nothing ever read them. The first is a contradiction and
-      # fails; the other two are reported to the run summary without blocking.
+      # `extract_names` notices `research open` problems with a sorry-free proof,
+      # and `test`/`API` statements without one, all decidable from the JSON just
+      # written. The first is a contradiction and fails; the other two are counted
+      # in the run summary without blocking.
       - name: Check category warnings
         if: steps.mode.outputs.website_only != 'true'
-        run: python3 scripts/check_category_warnings.py extract_names.warnings
+        run: python3 scripts/check_category_warnings.py site/data/conjectures.json
 
       - name: Extract Verso fragments for website
         if: steps.mode.outputs.website_only != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ site/data/conjectures.json
 # Generated all-imports file
 FormalConjectures.lean
 FormalConjectures/All.lean
+
+# Python bytecode from the scripts in `scripts/`.
+__pycache__/

--- a/scripts/check_category_warnings.py
+++ b/scripts/check_category_warnings.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Surface the category warnings that `extract_names` already produces.
+"""Report the category diagnostics that `extract_names` metadata implies.
 
 `scripts/extract_names.lean` notices three things: a `research open` problem
 with a sorry-free proof, and `test` or `API` statements without one. It writes
-them to stderr, and the workflow step that runs it ends in `|| true`, so they
-land in the middle of a build log unread.
+them to stderr as prose, but every field it decides them from is already in
+`site/data/conjectures.json`, so this script classifies the JSON directly
+rather than parsing warning text.
 
 The three are not equally serious:
 
@@ -12,79 +13,179 @@ The three are not equally serious:
   repository and fails the build.
 * A `test` or `API` statement without a proof is worth seeing but not worth
   blocking on. Adding the statement is better than not adding it, and someone
-  else often supplies the proof shortly after. Those are reported, and written
-  to the workflow run summary so they are visible without opening a log.
+  else often supplies the proof shortly after. Those counts go to the workflow
+  run summary so they are visible without opening a log.
 
 Usage:
-  lake exe extract_names ... 2> warnings.txt
-  python check_category_warnings.py warnings.txt
+  lake exe extract_names ... > site/data/conjectures.json
+  python3 check_category_warnings.py site/data/conjectures.json
 """
 
+import argparse
+import json
 import os
 import pathlib
-import re
 import sys
 
-ROOT = pathlib.Path(__file__).resolve().parent.parent
+BLOCKING = "research_open_with_proof"
 
-BLOCKING = ("research_open_with_proof",
-            re.compile(r"categorised as `research open` but has a sorry-free proof"))
+# In report order, with the sentence `extract_names` uses for each.
+CODES = {
+    "research_open_with_proof":
+        "is categorised as `research open` but has a sorry-free proof",
+    "test_without_proof":
+        "is categorised as `test` but has no sorry-free proof",
+    "api_without_proof":
+        "is categorised as `API` but has no sorry-free proof",
+}
 
-ADVISORY = [
-    ("test_without_proof",
-     re.compile(r"categorised as `test` but has no sorry-free proof")),
-    ("api_without_proof",
-     re.compile(r"categorised as `API` but has no sorry-free proof")),
-]
+REQUIRED_FIELDS = (
+    ("theorem", str),
+    ("module", str),
+    ("category", str),
+    ("hasSorryFreeProof", bool),
+)
 
 
-def names(text, pattern):
-    """Declaration names on the lines matching `pattern`."""
-    out = []
-    for line in text.splitlines():
-        if pattern.search(line):
-            m = re.search(r"Theorem (\S+)", line)
-            if m:
-                out.append(m.group(1))
-    return sorted(out)
+class DataError(Exception):
+    """Input that cannot be classified, as opposed to a diagnostic finding."""
+
+
+def diagnostic_for(problem):
+    """The diagnostic code a problem earns, or `None`."""
+    category = problem["category"]
+    has_proof = problem["hasSorryFreeProof"]
+    if category == "research open" and has_proof:
+        return "research_open_with_proof"
+    if category == "test" and not has_proof:
+        return "test_without_proof"
+    if category == "API" and not has_proof:
+        return "api_without_proof"
+    return None
+
+
+def split_module(module):
+    """The components of a Lean module name, with any `«...»` quoting removed.
+
+    Splitting on `.` alone is wrong: `FormalConjectures.Arxiv.«1609.08688»`
+    has three components, not four.
+    """
+    parts = []
+    current = []
+    depth = 0
+    for ch in module:
+        if ch == "«":
+            depth += 1
+        elif ch == "»":
+            depth -= 1
+        elif ch == "." and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    parts.append("".join(current))
+    return parts
+
+
+def module_to_path(module):
+    """The source file a module name came from, for workflow annotations."""
+    return "/".join(split_module(module)) + ".lean"
+
+
+def classify(problems, source):
+    """The set of `(code, theorem, module)` triples the problems imply."""
+    found = set()
+    for index, problem in enumerate(problems):
+        if not isinstance(problem, dict):
+            raise DataError(f"{source}: entry {index} is not an object")
+        for field, kind in REQUIRED_FIELDS:
+            if field not in problem:
+                raise DataError(f"{source}: entry {index} has no `{field}`")
+            if not isinstance(problem[field], kind):
+                raise DataError(
+                    f"{source}: entry {index} has a `{field}` that is not "
+                    f"{kind.__name__}")
+        code = diagnostic_for(problem)
+        if code:
+            found.add((code, problem["theorem"], problem["module"]))
+    return found
+
+
+def load_extraction(path):
+    """Classify the `extract_names` output at `path`."""
+    try:
+        text = pathlib.Path(path).read_text(encoding="utf-8")
+    except OSError as error:
+        raise DataError(f"cannot read {path}: {error}")
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise DataError(f"{path} is not valid JSON: {error}")
+    if not isinstance(raw, dict):
+        raise DataError(f"{path} is not a JSON object")
+    problems = raw.get("problems")
+    if not isinstance(problems, list):
+        raise DataError(f"{path} has no `problems` list")
+    return classify(problems, path)
+
+
+def annotate(level, code, theorem, module):
+    """A workflow annotation, which GitHub attaches to the file it names."""
+    print(f"::{level} file={module_to_path(module)},title={code}::"
+          f"{theorem} {CODES[code]}")
 
 
 def summarise(lines):
-    """Append to the workflow run summary, when running under Actions."""
+    """Append to the workflow run summary, or to stdout when run by hand."""
+    text = "\n".join(lines) + "\n"
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
+        print(text, end="")
         return
-    with open(path, "a", encoding="utf-8") as f:
-        f.write("\n".join(lines) + "\n")
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(text)
 
 
-def main(argv):
-    if not argv:
-        print("usage: check_category_warnings.py <extract_names stderr>")
+def report(found):
+    lines = ["### Category diagnostics", ""]
+    lines.append("| Diagnostic | Total |")
+    lines.append("| --- | ---: |")
+    for code in CODES:
+        total = sum(1 for d in found if d[0] == code)
+        lines.append(f"| `{code}` | {total} |")
+    lines.append("")
+    lines.append("The advisory two are not failures. A `test` or `API` "
+                 "statement without a proof is still better than no "
+                 "statement, and the proof often follows later.")
+    return lines
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("extraction",
+                        help="the JSON written by `lake exe extract_names`")
+    args = parser.parse_args(argv)
+
+    try:
+        found = load_extraction(args.extraction)
+    except DataError as error:
+        print(f"::error::{error}")
         return 2
 
-    text = pathlib.Path(argv[0]).read_text(encoding="utf-8", errors="replace")
+    summarise(report(found))
+    for code in CODES:
+        print(f"{code}: {sum(1 for d in found if d[0] == code)}")
 
-    kind, pattern = BLOCKING
-    blocking = names(text, pattern)
-
-    advisory = [(k, names(text, p)) for k, p in ADVISORY]
-    summary = ["### Category warnings", ""]
-    for k, found in advisory:
-        print(f"{k}: {len(found)}")
-        summary.append(f"- `{k}`: {len(found)}")
-    summary.append("")
-    summary.append("These are advisory. A `test` or `API` statement without a proof is "
-                   "still better than no statement, and the proof often follows later.")
-    summarise(summary)
-
+    blocking = sorted(d for d in found if d[0] == BLOCKING)
+    for code, theorem, module in blocking:
+        annotate("error", code, theorem, module)
     if blocking:
-        print(f"\n{kind}: {len(blocking)}")
-        for n in blocking:
-            print(f"  {n}")
-        print("\nA problem categorised as `research open` should not have a sorry-free "
-              "proof. Either the proof settles it, in which case the category should be "
-              "`research solved`, or the proof is of something weaker than the statement.")
+        print("\nA problem categorised as `research open` should not have a "
+              "sorry-free proof. Either the proof settles it, in which case "
+              "the category should be `research solved`, or the proof is of "
+              "something weaker than the statement.")
+        for _, theorem, _ in blocking:
+            print(f"  {theorem}")
         summarise(["", f"**Failing**: {len(blocking)} `research open` "
                        "problem(s) with a sorry-free proof."])
         return 1
@@ -93,4 +194,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/scripts/test_check_category_warnings.py
+++ b/scripts/test_check_category_warnings.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for `check_category_warnings.py`.
+
+Run with `python3 -m unittest discover -s scripts -p 'test_*.py'`.
+No dependencies beyond the standard library.
+"""
+
+import contextlib
+import io
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+import unittest.mock
+
+import check_category_warnings as cw
+
+
+def problem(theorem, category, has_proof, module="FormalConjectures.Example"):
+    return {
+        "theorem": theorem,
+        "module": module,
+        "category": category,
+        "hasSorryFreeProof": has_proof,
+    }
+
+
+class ClassifyTest(unittest.TestCase):
+
+    def test_each_code(self):
+        found = cw.classify([
+            problem("A", "research open", True),
+            problem("B", "test", False),
+            problem("C", "API", False),
+        ], "test")
+        self.assertEqual({d[0] for d in found}, set(cw.CODES))
+
+    def test_healthy_combinations_are_silent(self):
+        found = cw.classify([
+            problem("A", "research open", False),
+            problem("B", "research solved", True),
+            problem("C", "test", True),
+            problem("D", "API", True),
+            problem("E", "textbook", False),
+            problem("F", "textbook", True),
+        ], "test")
+        self.assertEqual(found, set())
+
+    def test_duplicate_records_collapse(self):
+        found = cw.classify([problem("A", "test", False)] * 3, "test")
+        self.assertEqual(len(found), 1)
+
+    def test_same_name_in_two_modules_stays_distinct(self):
+        found = cw.classify([
+            problem("M_two", "test", False, "FormalConjectures.ErdosProblems.«36»"),
+            problem("M_two", "test", False, "FormalConjectures.Wikipedia.Dedekind"),
+        ], "test")
+        self.assertEqual(len(found), 2)
+
+    def test_unicode_names_survive(self):
+        name = "Arxiv.«1609.08688».erdős_problem"
+        found = cw.classify([problem(name, "test", False)], "test")
+        self.assertEqual({d[1] for d in found}, {name})
+
+    def test_missing_field(self):
+        entry = problem("A", "test", False)
+        del entry["hasSorryFreeProof"]
+        with self.assertRaisesRegex(cw.DataError, "hasSorryFreeProof"):
+            cw.classify([entry], "test")
+
+    def test_wrong_field_type(self):
+        entry = problem("A", "test", False)
+        entry["hasSorryFreeProof"] = "false"
+        with self.assertRaisesRegex(cw.DataError, "hasSorryFreeProof"):
+            cw.classify([entry], "test")
+
+    def test_entry_not_an_object(self):
+        with self.assertRaisesRegex(cw.DataError, "not an object"):
+            cw.classify(["A"], "test")
+
+
+class ModulePathTest(unittest.TestCase):
+
+    def test_plain(self):
+        self.assertEqual(
+            cw.module_to_path("FormalConjectures.Wikipedia.ScholzConjecture"),
+            "FormalConjectures/Wikipedia/ScholzConjecture.lean")
+
+    def test_quoted_numeral(self):
+        self.assertEqual(
+            cw.module_to_path("FormalConjectures.ErdosProblems.«36»"),
+            "FormalConjectures/ErdosProblems/36.lean")
+
+    def test_dot_inside_quotes_is_not_a_separator(self):
+        self.assertEqual(
+            cw.module_to_path("FormalConjectures.Arxiv.«1609.08688»"),
+            "FormalConjectures/Arxiv/1609.08688.lean")
+
+
+class MainTest(unittest.TestCase):
+    """End to end, including exit codes and the run summary."""
+
+    def setUp(self):
+        self.dir = pathlib.Path(
+            self.enterContext(tempfile.TemporaryDirectory()))
+        self.summary = self.dir / "summary.md"
+        self.enterContext(unittest.mock.patch.dict(
+            os.environ, {"GITHUB_STEP_SUMMARY": str(self.summary)}))
+
+    def extraction(self, problems):
+        path = self.dir / "conjectures.json"
+        path.write_text(json.dumps({"problems": problems}), encoding="utf-8")
+        return str(path)
+
+    def run_main(self, argv):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            code = cw.main(argv)
+        summary = (self.summary.read_text(encoding="utf-8")
+                   if self.summary.exists() else "")
+        return code, out.getvalue(), summary
+
+    def test_research_open_with_proof_fails(self):
+        path = self.extraction([problem("A", "research open", True)])
+        code, out, summary = self.run_main([path])
+        self.assertEqual(code, 1)
+        self.assertIn("::error file=FormalConjectures/Example.lean", out)
+        self.assertIn("**Failing**", summary)
+
+    def test_advisory_only_succeeds(self):
+        path = self.extraction([problem("A", "test", False)])
+        code, out, summary = self.run_main([path])
+        self.assertEqual(code, 0)
+        self.assertIn("| `test_without_proof` | 1 |", summary)
+        self.assertNotIn("::error", out)
+
+    def test_clean_input_succeeds_quietly(self):
+        path = self.extraction([problem("A", "research solved", True)])
+        code, out, summary = self.run_main([path])
+        self.assertEqual(code, 0)
+        self.assertIn("| `test_without_proof` | 0 |", summary)
+        self.assertNotIn("::", out)
+
+    def test_malformed_extraction_fails_loudly(self):
+        path = self.dir / "conjectures.json"
+        path.write_text("{not json", encoding="utf-8")
+        code, out, _ = self.run_main([str(path)])
+        self.assertEqual(code, 2)
+        self.assertIn("::error::", out)
+
+    def test_missing_file_fails_loudly(self):
+        code, out, _ = self.run_main([str(self.dir / "absent.json")])
+        self.assertEqual(code, 2)
+        self.assertIn("::error::", out)
+
+    def test_missing_problems_list_fails(self):
+        path = self.dir / "conjectures.json"
+        path.write_text(json.dumps({"moduleDocstrings": {}}), encoding="utf-8")
+        code, _, _ = self.run_main([str(path)])
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #4761. The check reads `conjectures.json` now instead of parsing `extract_names` stderr:

```python
if category == "research open" and has_proof:  return "research_open_with_proof"
if category == "test" and not has_proof:       return "test_without_proof"
if category == "API" and not has_proof:        return "api_without_proof"
```

`category` and `hasSorryFreeProof` were all it ever needed, and rewording a warning can't quietly disable it any more.

That also lets `|| true` come off the extraction step. `IO.eprintln` doesn't set an exit code, so it wasn't tolerating warnings, just hiding crashes, and the old check would then see no warning text and pass.

Policy is the same as before: `research_open_with_proof` fails, `test`/`API` get counted in the run summary. Tests are stdlib-only, in a job that doesn't need the Lean build.

The "which warnings are new in this PR" part from #4761 isn't here. Notes on that are in #4394.