### PR TITLE
ErdosProblems/330: link Jayyhk's proof of the minimal-basis question

### DIFF
--- a/FormalConjectures/ErdosProblems/330.lean
+++ b/FormalConjectures/ErdosProblems/330.lean
@@ -62,10 +62,13 @@ questions "positive density" here most likely means positive upper density, and 
 considers either the lower or the upper density for the integers not representable without a
 fixed `n`. Requiring the density to exist would ask a strictly harder question than the one
 posed. See #3979.
+
+Such a set exists, so the answer is yes. The linked proof gives one of order `2`.
 -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11, formal_proof using lean4 at
+  "https://github.com/Jayyhk/erdos-lean/blob/a5ffc87b3d684fc00ea906b9e746c283740da900/problems/330/Erdos330.lean"]
 theorem erdos_330_statement :
-    answer(sorry) ↔ ∃ (A : Set ℕ), ∃ h, MinAsymptoticAddBasisOfOrder A h ∧
+    answer(True) ↔ ∃ (A : Set ℕ), ∃ h, MinAsymptoticAddBasisOfOrder A h ∧
     0 < A.upperDensity ∧ ∀ n ∈ A, 0 < (UnrepWithout A n h).upperDensity := by
   sorry
 


### PR DESCRIPTION
Closes #4047.

[Jayyhk](https://github.com/Jayyhk/erdos-lean/blob/a5ffc87b3d684fc00ea906b9e746c283740da900/problems/330/Erdos330.lean) restated his proof against the statement #4762 landed. The last theorem in that file is ours, not a paraphrase:

```lean
theorem erdos_330 :
    ∃ (A : Set ℕ), ∃ h, MinAsymptoticAddBasisOfOrderFC A h ∧
      0 < Set.upperDensity A ∧
      ∀ n ∈ A, 0 < Set.upperDensity (UnrepWithoutFC A n h) := by
```

The four definitions under it match ours: `IsAsymptoticAddBasisOfOrderFC` and `MinAsymptoticAddBasisOfOrderFC` have the same bodies as `Set.IsAsymptoticAddBasisOfOrder` and `MinAsymptoticAddBasisOfOrder`, `UnrepWithoutFC A n h = {m | m ∉ h • (A \ {n})}` is `UnrepWithout` with `Rep` unfolded, and `partialDensity`/`upperDensity` are vendored verbatim from `Data/Set/Density.lean`.

No `sorry` in the file, and `#print axioms erdos_330` gives `[propext, Classical.choice, Quot.sound]`. Pinned to `a5ffc87`.
