### PR TITLE
feat(Wikipedia): add the Wilson-prime conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/WilsonPrime.lean
+++ b/FormalConjectures/Wikipedia/WilsonPrime.lean
@@ -49,6 +49,11 @@ theorem isWilsonPrime_five : IsWilsonPrime 5 := by
 theorem isWilsonPrime_thirteen : IsWilsonPrime 13 := by
   norm_num [IsWilsonPrime, Nat.factorial]
 
+/-- The primality condition excludes $1$, which satisfies the divisibility condition alone. -/
+@[category test, AMS 11]
+theorem not_isWilsonPrime_one : ¬ IsWilsonPrime 1 := by
+  norm_num [IsWilsonPrime]
+
 /-- The prime $7$ is not a Wilson prime. -/
 @[category test, AMS 11]
 theorem not_isWilsonPrime_seven : ¬ IsWilsonPrime 7 := by

--- a/FormalConjectures/Wikipedia/WilsonPrime.lean
+++ b/FormalConjectures/Wikipedia/WilsonPrime.lean
@@ -23,6 +23,7 @@ A Wilson prime is a prime $p$ for which $p^2$ divides $(p-1)!+1$. The only known
 $5$, $13$, and $563$. It is conjectured that infinitely many Wilson primes exist.
 
 *References:*
+* [Wikipedia, Wilson prime](https://en.wikipedia.org/wiki/Wilson_prime)
 * [OEIS A007540](https://oeis.org/A007540)
 * E. Costa, R. Gerbicz, and D. Harvey,
   [A search for Wilson primes](https://arxiv.org/abs/1209.3436)

--- a/FormalConjectures/Wikipedia/WilsonPrime.lean
+++ b/FormalConjectures/Wikipedia/WilsonPrime.lean
@@ -1,0 +1,57 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Wilson primes
+
+A Wilson prime is a prime $p$ for which $p^2$ divides $(p-1)!+1$. The only known examples are
+$5$, $13$, and $563$. It is conjectured that infinitely many Wilson primes exist.
+
+*References:*
+* [OEIS A007540](https://oeis.org/A007540)
+* E. Costa, R. Gerbicz, and D. Harvey,
+  [A search for Wilson primes](https://arxiv.org/abs/1209.3436)
+-/
+
+namespace WilsonPrime
+
+/-- A Wilson prime is a prime $p$ such that $p^2 \mid (p-1)!+1$. -/
+def IsWilsonPrime (p : ℕ) : Prop :=
+  p.Prime ∧ p ^ 2 ∣ (p - 1).factorial + 1
+
+/-- There are infinitely many Wilson primes. -/
+@[category research open, AMS 11]
+theorem infinitely_many_wilson_primes : Set.Infinite {p : ℕ | IsWilsonPrime p} := by
+  sorry
+
+/-- The prime $5$ is a Wilson prime. -/
+@[category test, AMS 11]
+theorem isWilsonPrime_five : IsWilsonPrime 5 := by
+  norm_num [IsWilsonPrime, Nat.factorial]
+
+/-- The prime $13$ is a Wilson prime. -/
+@[category test, AMS 11]
+theorem isWilsonPrime_thirteen : IsWilsonPrime 13 := by
+  norm_num [IsWilsonPrime, Nat.factorial]
+
+/-- The prime $7$ is not a Wilson prime. -/
+@[category test, AMS 11]
+theorem not_isWilsonPrime_seven : ¬ IsWilsonPrime 7 := by
+  norm_num [IsWilsonPrime, Nat.factorial]
+
+end WilsonPrime


### PR DESCRIPTION
Closes #4783

## Summary

This PR formalizes the conjecture that infinitely many Wilson primes exist. A
Wilson prime is a prime $p$ satisfying $p^2 \mid (p-1)!+1$. The new file defines
that predicate directly, states the open infinitude theorem, and checks that
$5$ and $13$ satisfy it while $7$ does not. The theorem contains the single
intentional `sorry` because the infinitude claim is still open.

## Formalization choices

`IsWilsonPrime` combines primality with the defining divisibility condition.
The expression uses natural-number subtraction, which is harmless here because
the primality hypothesis forces $p\geq2$. The conjecture is expressed as the
set of numbers satisfying this predicate being infinite. All definitions are
local to the new Wikipedia file, so no `FormalConjecturesForMathlib` change is
needed.

## Verification

- Passed: `env LEAN_NUM_THREADS=3 lake env lean FormalConjectures/Wikipedia/WilsonPrime.lean`
- Passed: `git diff --check origin/main...HEAD`
- Confirmed: the diff adds only `FormalConjectures/Wikipedia/WilsonPrime.lean`
- Full-project verification is delegated to this draft PR's CI checks
- Final source, issue, and PR collision searches completed against the current base
- No `native_decide`; exactly one intentional `sorry`

## AI use

AI assistance was used extensively to research this submission, draft and
refine the Lean formalization and tests, prepare the issue and PR text, and help
run local verification. I reviewed the formalization walkthrough and understand
the problem, the formal statement, its modeling choices, the completed examples,
and the role of the intentional `sorry`. I take responsibility for the submitted
content.
