### PR TITLE
feat(Arxiv): add the Barker-sequence conjecture

### DIFF
--- a/FormalConjectures/Arxiv/2104.00502/BarkerSequence.lean
+++ b/FormalConjectures/Arxiv/2104.00502/BarkerSequence.lean
@@ -25,16 +25,19 @@ has length greater than $13$.
 
 *References:*
 * J. Willms, [A note on Barker sequences of even length](https://arxiv.org/abs/2104.00502)
+* [Barker code](https://en.wikipedia.org/wiki/Barker_code)
 * [OEIS A091704](https://oeis.org/A091704)
 -/
 
-namespace BarkerSequence
+namespace Arxiv.«2104.00502»
 
 /-- The aperiodic autocorrelation $C_k(a)=\sum_i a_i a_{i+k}$. -/
 def aperiodicAutocorrelation (a : List ℤ) (k : ℕ) : ℤ :=
   (List.zipWith (· * ·) a (a.drop k)).sum
 
-/-- A Barker sequence has $\pm 1$ entries and nontrivial autocorrelations of magnitude at most one. -/
+/--
+A Barker sequence has $\pm 1$ entries and nontrivial autocorrelations of magnitude at most one.
+-/
 def IsBarkerSequence (a : List ℤ) : Prop :=
   (∀ x ∈ a, x = 1 ∨ x = -1) ∧
     ∀ k : ℕ, 0 < k → k < a.length → |aperiodicAutocorrelation a k| ≤ 1
@@ -43,6 +46,19 @@ def IsBarkerSequence (a : List ℤ) : Prop :=
 @[category research open, AMS 5 11 94]
 theorem barker_conjecture (a : List ℤ) (ha : IsBarkerSequence a) : a.length ≤ 13 := by
   sorry
+
+/--
+The known sequence $(1,1,1,1,1,-1,-1,1,1,-1,1,-1,1)$ of length $13$ is a Barker sequence.
+-/
+@[category test, AMS 5 11 94]
+theorem isBarkerSequence_length_thirteen :
+    IsBarkerSequence [1, 1, 1, 1, 1, -1, -1, 1, 1, -1, 1, -1, 1] := by
+  constructor
+  · simp
+  · intro k hkpos hklen
+    norm_num at hklen
+    interval_cases k <;>
+      norm_num [aperiodicAutocorrelation] at hkpos ⊢
 
 /-- The sequence $(1,1,1,-1)$ is a Barker sequence. -/
 @[category test, AMS 5 11 94]
@@ -61,4 +77,4 @@ theorem not_isBarkerSequence_constant_four : ¬ IsBarkerSequence [1, 1, 1, 1] :=
   have h := ha.2 1 (by norm_num) (by norm_num)
   norm_num [aperiodicAutocorrelation] at h
 
-end BarkerSequence
+end Arxiv.«2104.00502»

--- a/FormalConjectures/Arxiv/2104.00502/BarkerSequence.lean
+++ b/FormalConjectures/Arxiv/2104.00502/BarkerSequence.lean
@@ -1,0 +1,64 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Barker sequences
+
+A Barker sequence is a finite sequence of $\pm 1$ values whose nontrivial aperiodic
+autocorrelations all have magnitude at most one. The Barker conjecture says that no such sequence
+has length greater than $13$.
+
+*References:*
+* J. Willms, [A note on Barker sequences of even length](https://arxiv.org/abs/2104.00502)
+* [OEIS A091704](https://oeis.org/A091704)
+-/
+
+namespace BarkerSequence
+
+/-- The aperiodic autocorrelation $C_k(a)=\sum_i a_i a_{i+k}$. -/
+def aperiodicAutocorrelation (a : List ℤ) (k : ℕ) : ℤ :=
+  (List.zipWith (· * ·) a (a.drop k)).sum
+
+/-- A Barker sequence has $\pm 1$ entries and nontrivial autocorrelations of magnitude at most one. -/
+def IsBarkerSequence (a : List ℤ) : Prop :=
+  (∀ x ∈ a, x = 1 ∨ x = -1) ∧
+    ∀ k : ℕ, 0 < k → k < a.length → |aperiodicAutocorrelation a k| ≤ 1
+
+/-- Every Barker sequence has length at most $13$. -/
+@[category research open, AMS 5 11 94]
+theorem barker_conjecture (a : List ℤ) (ha : IsBarkerSequence a) : a.length ≤ 13 := by
+  sorry
+
+/-- The sequence $(1,1,1,-1)$ is a Barker sequence. -/
+@[category test, AMS 5 11 94]
+theorem isBarkerSequence_length_four : IsBarkerSequence [1, 1, 1, -1] := by
+  constructor
+  · simp
+  · intro k hkpos hklen
+    norm_num at hklen
+    interval_cases k <;>
+      norm_num [aperiodicAutocorrelation] at hkpos ⊢
+
+/-- The constant sequence $(1,1,1,1)$ is not a Barker sequence. -/
+@[category test, AMS 5 11 94]
+theorem not_isBarkerSequence_constant_four : ¬ IsBarkerSequence [1, 1, 1, 1] := by
+  intro ha
+  have h := ha.2 1 (by norm_num) (by norm_num)
+  norm_num [aperiodicAutocorrelation] at h
+
+end BarkerSequence


### PR DESCRIPTION
Closes #4787

## Summary

This PR formalizes the conjecture that every Barker sequence has length at most $13$. It represents
a sequence as a list of integers, defines its aperiodic autocorrelation at a shift, and requires
every entry to be $1$ or $-1$ and every nontrivial autocorrelation to have magnitude at most $1$.

Completed tests prove that the known length-$13$ sequence and $(1,1,1,-1)$ are Barker sequences,
while $(1,1,1,1)$ is not. The length-bound theorem has the single intentional `sorry` because it
remains open.

## Formalization choices

`List ℤ` makes the finite sequence and signed products direct. At shift `k`, `zipWith` pairs the
original list with `a.drop k`; because it stops at the shorter list, the resulting sum is exactly
the aperiodic autocorrelation. The predicate checks shifts satisfying $0<k<a.length$, excluding
the trivial zero shift and empty overlaps. No extra helper API or `FormalConjecturesForMathlib`
change is needed.

The declarations use the source-derived namespace `Arxiv.«2104.00502»`. The arXiv paper explicitly
states the conjecture and therefore governs the file placement; the Wikipedia Barker-code page is
included as a secondary reference.

## Verification

The review update was rebased onto upstream base
`942fb149e782a56c2719c543ab58e093f733acb4` and verified at exact head
`5cae6dc5c031ae8f9f34fea2a1389c0e8005bb66`.

- Passed: `env LEAN_NUM_THREADS=2 lake env lean FormalConjectures/Arxiv/2104.00502/BarkerSequence.lean`
  with only the intentional open-conjecture warning.
- Passed: `env LEAN_NUM_THREADS=2 lake --wfail build FormalConjectures.Arxiv.«2104.00502».BarkerSequence`
  (`8054` jobs).
- Passed: exact-head whitespace, proof-gap, banned-construct, line-length, and metadata checks.
- Passed: `git diff --check origin/main...HEAD`; the range contains exactly
  `FormalConjectures/Arxiv/2104.00502/BarkerSequence.lean`.
- No `native_decide`; exactly one intentional `sorry`.

The repository-wide build was delegated to PR CI. At the exact head, `Build project`, `Test
scripts`, `check-copyright`, `check-changes`, `scan-pr`, `labeler`, and `cla/google` passed;
`deploy` and the `zizmor-*` jobs were skipped. No candidate-specific CI failure was observed.

## AI use

AI assistance was used extensively to research this submission, draft and refine the Lean
formalization and tests, prepare the issue and PR text, and help run local verification. I reviewed
the formalization walkthrough and understand the problem, the formal statement, its modeling
choices, the completed examples, and the role of the intentional `sorry`. I take responsibility
for the submitted content.
