### PR TITLE
feat(Data/Nat): make maxPrimeFac computable

### DIFF
--- a/FormalConjectures/ErdosProblems/649.lean
+++ b/FormalConjectures/ErdosProblems/649.lean
@@ -52,16 +52,6 @@ solutions to $2^k\equiv -1\pmod{7}$, and hence this fails with $p=2$ and $q=7$.
 @[category textbook, AMS 11]
 theorem erdos_649.variants.no_solution_two_seven :
     ¬ ∃ n : ℕ, n.maxPrimeFac = 2 ∧ (n + 1).maxPrimeFac = 7 := by
-  -- `maxPrimeFac m` is the greatest element of the (bounded, nonempty) set of prime factors of `m`.
-  have hbdd : ∀ m : ℕ, 1 < m → BddAbove {p : ℕ | p.Prime ∧ p ∣ m} := fun m hm ↦
-    ⟨m, fun p ⟨_, hp⟩ ↦ Nat.le_of_dvd (by omega) hp⟩
-  have hne : ∀ m : ℕ, 1 < m → {p : ℕ | p.Prime ∧ p ∣ m}.Nonempty := by
-    intro m hm
-    simpa [Set.Nonempty, ← Nat.ne_one_iff_exists_prime_dvd] using by omega
-  have hdvd : ∀ m : ℕ, 1 < m → m.maxPrimeFac ∣ m := fun m hm ↦
-    (Nat.sSup_mem (hne m hm) (hbdd m hm)).2
-  have hle : ∀ m p : ℕ, 1 < m → p.Prime → p ∣ m → p ≤ m.maxPrimeFac := fun m p hm hp hpd ↦
-    le_csSup (hbdd m hm) ⟨hp, hpd⟩
   rintro ⟨n, hn, hn'⟩
   have h1n : 1 < n := by
     have := (Nat.one_lt_maxPrimeFac_iff n).mp (by omega)
@@ -69,9 +59,10 @@ theorem erdos_649.variants.no_solution_two_seven :
   -- Since `2` is the greatest prime factor of `n`, it is the only one, so `n` is a power of `2`.
   obtain ⟨k, hpow⟩ : ∃ k, n = 2 ^ k :=
     ⟨_, Nat.eq_prime_pow_of_unique_prime_dvd (by omega)
-      (fun {q} hq hqd ↦ le_antisymm (hn ▸ hle n q h1n hq hqd) hq.two_le)⟩
+      (fun {q} hq hqd ↦
+        le_antisymm (hn ▸ Nat.le_maxPrimeFac (by omega) hq hqd) hq.two_le)⟩
   -- On the other hand `7` divides `n + 1`, i.e. `2 ^ k ≡ -1 (mod 7)`.
-  have h7 : 7 ∣ n + 1 := hn' ▸ hdvd (n + 1) (by omega)
+  have h7 : 7 ∣ n + 1 := hn' ▸ Nat.maxPrimeFac_dvd
   -- This is impossible: `2 ^ k` is congruent to `1`, `2` or `4` modulo `7`, never to `6`.
   have hmod : 2 ^ k % 7 = 2 ^ (k % 3) % 7 := by
     conv_lhs => rw [← Nat.div_add_mod k 3, pow_add, pow_mul]

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -28,7 +28,7 @@ Takes the junk value `0` for `n = 0` and `1` for `n = 1`. -/
 def maxPrimeFac (n : ℕ) : ℕ := if n = 1 then 1 else n.primeFactorsList.getLastI
 
 example : maxPrimeFac 0 = 0 := by decide +kernel
-example : maxPrimeFac 1 = 1 := by decide
+example : maxPrimeFac 1 = 1 := rfl
 example : maxPrimeFac 12 = 3 := by decide +kernel
 example : maxPrimeFac 97 = 97 := by decide +kernel
 example : maxPrimeFac 125 = 5 := by decide +kernel
@@ -41,8 +41,7 @@ lemma maxPrimeFac_zero :
 
 @[simp]
 lemma maxPrimeFac_one :
-    maxPrimeFac 1 = 1 := by
-  simp [maxPrimeFac]
+    maxPrimeFac 1 = 1 := rfl
 
 lemma prime_maxPrimeFac_of_one_lt (n : ℕ) (h : 1 < n) :
     Prime (maxPrimeFac n) := by
@@ -53,21 +52,19 @@ lemma prime_maxPrimeFac_of_one_lt (n : ℕ) (h : 1 < n) :
     List.getLast?_eq_getLast_of_ne_nil hn] using hprime
 
 /-- The greatest prime factor of a natural number divides it. -/
-lemma maxPrimeFac_dvd {n : ℕ} :
-    maxPrimeFac n ∣ n := by
-  rcases lt_trichotomy n 1 with hn | rfl | hn
-  case inr.inr =>
-    have hlist : n.primeFactorsList ≠ [] := (primeFactorsList_ne_nil n).2 hn
-    have hmem : n.primeFactorsList.getLast hlist ∈ n.primeFactorsList :=
+lemma maxPrimeFac_dvd : ∀ {n : ℕ}, maxPrimeFac n ∣ n
+  | 0 => by simp
+  | 1 => by simp
+  | n + 2 => by
+    have hn : 1 < n + 2 := by omega
+    have hlist : (n + 2).primeFactorsList ≠ [] :=
+      (primeFactorsList_ne_nil (n + 2)).2 hn
+    have hmem : (n + 2).primeFactorsList.getLast hlist ∈ (n + 2).primeFactorsList :=
       List.getLast_mem hlist
-    have hdvd : n.primeFactorsList.getLast hlist ∣ n := dvd_of_mem_primeFactorsList hmem
+    have hdvd : (n + 2).primeFactorsList.getLast hlist ∣ n + 2 :=
+      dvd_of_mem_primeFactorsList hmem
     simpa [maxPrimeFac, hn.ne', List.getLastI_eq_getLast?_getD,
       List.getLast?_eq_getLast_of_ne_nil hlist] using hdvd
-  case inl =>
-    simp only [lt_one_iff] at hn
-    subst n
-    simp
-  case inr.inl => simp
 
 /-- Every prime factor of a nonzero natural number is at most its greatest prime factor. -/
 lemma le_maxPrimeFac
@@ -106,52 +103,84 @@ lemma maxPrimeFac_eq_self_iff {n : ℕ} :
     · obtain rfl | rfl := Nat.le_one_iff_eq_zero_or_eq_one.mp hn <;> simp
     · exact hn.maxPrimeFac_eq_self
 
-/-- The greatest prime factor of a nontrivial prime power is its prime base. -/
-lemma Prime.maxPrimeFac_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
-    Nat.maxPrimeFac (p ^ k) = p := by
-  rw [Nat.maxPrimeFac, hp.primeFactorsList_pow]
+/-- The greatest prime factor of a product of nonzero natural numbers is the maximum of their
+greatest prime factors. -/
+lemma maxPrimeFac_mul {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) :
+    maxPrimeFac (m * n) = max (maxPrimeFac m) (maxPrimeFac n) := by
+  by_cases hm_one : m = 1
+  · subst m
+    have hle : 1 ≤ maxPrimeFac n := by
+      by_cases hn_one : n = 1
+      · subst n
+        simp
+      · have hn_lt : 1 < n := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hn, hn_one⟩
+        exact (prime_maxPrimeFac_of_one_lt n hn_lt).one_lt.le
+    simp [hle]
+  by_cases hn_one : n = 1
+  · subst n
+    have hm_lt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm, hm_one⟩
+    have hle : 1 ≤ maxPrimeFac m := (prime_maxPrimeFac_of_one_lt m hm_lt).one_lt.le
+    simp [hle]
+  have hm_lt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm, hm_one⟩
+  have hn_lt : 1 < n := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hn, hn_one⟩
+  have hmn_lt : 1 < m * n := Nat.one_lt_mul_iff.mpr
+    ⟨zero_lt_of_lt hm_lt, zero_lt_of_lt hn_lt, Or.inl hm_lt⟩
+  apply le_antisymm
+  · have hp : Prime (maxPrimeFac (m * n)) := prime_maxPrimeFac_of_one_lt (m * n) hmn_lt
+    rcases hp.dvd_mul.mp maxPrimeFac_dvd with hpm | hpn
+    · exact (le_maxPrimeFac hm hp hpm).trans (le_max_left _ _)
+    · exact (le_maxPrimeFac hn hp hpn).trans (le_max_right _ _)
+  · apply max_le
+    · have hp : Prime (maxPrimeFac m) := prime_maxPrimeFac_of_one_lt m hm_lt
+      apply le_maxPrimeFac (mul_ne_zero hm hn) hp
+      exact dvd_mul_of_dvd_left maxPrimeFac_dvd n
+    · have hp : Prime (maxPrimeFac n) := prime_maxPrimeFac_of_one_lt n hn_lt
+      apply le_maxPrimeFac (mul_ne_zero hm hn) hp
+      exact dvd_mul_of_dvd_right maxPrimeFac_dvd m
+
+/-- The greatest prime factor of a nonzero power is the greatest prime factor of its base. -/
+@[simp]
+lemma maxPrimeFac_pow {k : ℕ} (hk : k ≠ 0) (n : ℕ) :
+    maxPrimeFac (n ^ k) = maxPrimeFac n := by
   obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk
-  have hrep : List.replicate (j + 1) p ≠ [] := by
+  clear hk
+  by_cases hn : n = 0
+  · subst n
     simp
-  simp [hp.ne_one, List.getLastI_eq_getLast?_getD,
-    List.getLast?_eq_getLast_of_ne_nil hrep]
+  induction j with
+  | zero => simp
+  | succ j ih =>
+      rw [pow_succ, maxPrimeFac_mul (pow_ne_zero _ hn) hn, ih]
+      simp
 
 /-- The greatest prime factor of a natural number is at most that number. -/
-lemma maxPrimeFac_le (n : ℕ) :
-    maxPrimeFac n ≤ n := by
-  rcases lt_trichotomy n 1 with hn | rfl | hn
-  case inr.inr =>
-    exact Nat.le_of_dvd (zero_lt_of_lt hn) maxPrimeFac_dvd
-  case inl =>
-    simp only [lt_one_iff] at hn
-    subst n
-    simp
-  case inr.inl => simp
+lemma maxPrimeFac_le : ∀ {n : ℕ}, maxPrimeFac n ≤ n
+  | 0 => by simp
+  | 1 => by simp
+  | n + 2 => Nat.le_of_dvd (by omega) maxPrimeFac_dvd
+
+/-- The greatest prime factor of a natural number greater than one is the least upper bound of
+its prime factors. -/
+lemma isLeast_maxPrimeFac {n : ℕ} (hn : 1 < n) :
+    IsLeast (upperBounds {p : ℕ | p.Prime ∧ p ∣ n}) (maxPrimeFac n) := by
+  constructor
+  · rintro p ⟨hp, h_dvd⟩
+    exact le_maxPrimeFac (zero_lt_of_lt hn).ne' hp h_dvd
+  · intro b hb
+    exact hb ⟨prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩
 
 /-- Away from `n = 1`, the computable greatest prime factor agrees with its supremum
 characterization. -/
 lemma maxPrimeFac_eq_sSup {n : ℕ} (hn_one : n ≠ 1) :
     maxPrimeFac n = sSup {p : ℕ | p.Prime ∧ p ∣ n} := by
-  rcases lt_trichotomy n 1 with hn | rfl | hn
-  case inr.inr =>
-    set s := {p : ℕ | p.Prime ∧ p ∣ n}
-    have hs₀ : s.Nonempty :=
-      ⟨maxPrimeFac n, prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩
-    have hs₁ : BddAbove s := by
-      refine ⟨n, ?_⟩
-      rintro p ⟨_, hp⟩
-      exact Nat.le_of_dvd (zero_lt_of_lt hn) hp
-    apply le_antisymm
-    · exact le_csSup hs₁
-        ⟨prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩
-    · apply csSup_le hs₀
-      rintro p ⟨hp, h_dvd⟩
-      exact le_maxPrimeFac (zero_lt_of_lt hn).ne' hp h_dvd
-  case inl =>
-    simp only [lt_one_iff] at hn
-    subst n
+  by_cases hn_zero : n = 0
+  · subst n
     simpa using (Set.Infinite.Nat.sSup_eq_zero infinite_setOf_prime).symm
-  case inr.inl => exact (hn_one rfl).elim
+  · have hn : 1 < n := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hn_zero, hn_one⟩
+    have h_lub : IsLUB {p : ℕ | p.Prime ∧ p ∣ n} (maxPrimeFac n) :=
+      isLeast_maxPrimeFac hn
+    exact (h_lub.csSup_eq
+      ⟨maxPrimeFac n, prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩).symm
 
 @[simp]
 lemma one_lt_maxPrimeFac_iff (n : ℕ) :

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -27,6 +27,10 @@ namespace Nat
 Takes the junk value `0` for `n = 0` and `n = 1`. -/
 def maxPrimeFac (n : ℕ) : ℕ := n.primeFactorsList.getLastI
 
+/-- The executable representation of the greatest prime factor. -/
+lemma maxPrimeFac_eq_getLastI (n : ℕ) :
+    maxPrimeFac n = n.primeFactorsList.getLastI := rfl
+
 @[simp]
 lemma maxPrimeFac_zero :
     maxPrimeFac 0 = 0 := by
@@ -68,6 +72,35 @@ lemma maxPrimeFac_eq_of_dvd_of_le
     (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) (h_le : maxPrimeFac n ≤ p) :
     maxPrimeFac n = p := by
   exact le_antisymm h_le (le_maxPrimeFac n p hn hp h_dvd)
+
+/-- The greatest prime factor of a prime is the prime itself. -/
+@[simp]
+lemma Prime.maxPrimeFac {p : ℕ} (hp : p.Prime) :
+    maxPrimeFac p = p := by
+  apply maxPrimeFac_eq_of_dvd_of_le p p hp.pos hp (dvd_refl p)
+  exact Nat.le_of_dvd hp.pos (maxPrimeFac_dvd p hp.one_lt)
+
+/-- The greatest prime factor of a nontrivial prime power is its prime base. -/
+lemma Prime.maxPrimeFac_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
+    Nat.maxPrimeFac (p ^ k) = p := by
+  rw [Nat.maxPrimeFac, hp.primeFactorsList_pow]
+  obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk
+  have hrep : List.replicate (j + 1) p ≠ [] := by
+    simp
+  simp [List.getLastI_eq_getLast?_getD,
+    List.getLast?_eq_getLast_of_ne_nil hrep]
+
+/-- The greatest prime factor of a natural number is at most that number. -/
+lemma maxPrimeFac_le (n : ℕ) :
+    maxPrimeFac n ≤ n := by
+  rcases lt_trichotomy n 1 with hn | rfl | hn
+  case inr.inr =>
+    exact Nat.le_of_dvd (zero_lt_of_lt hn) (maxPrimeFac_dvd n hn)
+  case inl =>
+    simp only [lt_one_iff] at hn
+    subst n
+    simp
+  case inr.inl => simp
 
 /-- The computable greatest prime factor agrees with its supremum characterization. -/
 lemma maxPrimeFac_eq_sSup (n : ℕ) :

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -24,15 +24,11 @@ namespace Nat
 
 /-- The greatest prime divisor of a natural number `n > 1`.
 
-Takes the junk value `0` for `n = 0` and `n = 1`. -/
-def maxPrimeFac (n : ℕ) : ℕ := n.primeFactorsList.getLastI
-
-/-- The executable representation of the greatest prime factor. -/
-lemma maxPrimeFac_eq_getLastI (n : ℕ) :
-    maxPrimeFac n = n.primeFactorsList.getLastI := rfl
+Takes the junk value `0` for `n = 0` and `1` for `n = 1`. -/
+def maxPrimeFac (n : ℕ) : ℕ := if n = 1 then 1 else n.primeFactorsList.getLastI
 
 example : maxPrimeFac 0 = 0 := by decide +kernel
-example : maxPrimeFac 1 = 0 := by decide +kernel
+example : maxPrimeFac 1 = 1 := by decide
 example : maxPrimeFac 12 = 3 := by decide +kernel
 example : maxPrimeFac 97 = 97 := by decide +kernel
 example : maxPrimeFac 125 = 5 := by decide +kernel
@@ -45,47 +41,57 @@ lemma maxPrimeFac_zero :
 
 @[simp]
 lemma maxPrimeFac_one :
-    maxPrimeFac 1 = 0 := by
-  simp [maxPrimeFac, List.getLastI]
+    maxPrimeFac 1 = 1 := by
+  simp [maxPrimeFac]
 
 lemma prime_maxPrimeFac_of_one_lt (n : ℕ) (h : 1 < n) :
     Prime (maxPrimeFac n) := by
   have hn : n.primeFactorsList ≠ [] := (primeFactorsList_ne_nil n).2 h
   have hmem : n.primeFactorsList.getLast hn ∈ n.primeFactorsList := List.getLast_mem hn
   have hprime : Prime (n.primeFactorsList.getLast hn) := prime_of_mem_primeFactorsList hmem
-  simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
+  simpa [maxPrimeFac, h.ne', List.getLastI_eq_getLast?_getD,
     List.getLast?_eq_getLast_of_ne_nil hn] using hprime
 
-/-- The greatest prime factor of `n > 1` divides `n`. -/
-lemma maxPrimeFac_dvd (n : ℕ) (h : 1 < n) :
+/-- The greatest prime factor of a natural number divides it. -/
+lemma maxPrimeFac_dvd {n : ℕ} :
     maxPrimeFac n ∣ n := by
-  have hn : n.primeFactorsList ≠ [] := (primeFactorsList_ne_nil n).2 h
-  have hmem : n.primeFactorsList.getLast hn ∈ n.primeFactorsList := List.getLast_mem hn
-  have hdvd : n.primeFactorsList.getLast hn ∣ n := dvd_of_mem_primeFactorsList hmem
-  simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
-    List.getLast?_eq_getLast_of_ne_nil hn] using hdvd
+  rcases lt_trichotomy n 1 with hn | rfl | hn
+  case inr.inr =>
+    have hlist : n.primeFactorsList ≠ [] := (primeFactorsList_ne_nil n).2 hn
+    have hmem : n.primeFactorsList.getLast hlist ∈ n.primeFactorsList :=
+      List.getLast_mem hlist
+    have hdvd : n.primeFactorsList.getLast hlist ∣ n := dvd_of_mem_primeFactorsList hmem
+    simpa [maxPrimeFac, hn.ne', List.getLastI_eq_getLast?_getD,
+      List.getLast?_eq_getLast_of_ne_nil hlist] using hdvd
+  case inl =>
+    simp only [lt_one_iff] at hn
+    subst n
+    simp
+  case inr.inl => simp
 
-/-- Every prime factor of a positive natural number is at most its greatest prime factor. -/
+/-- Every prime factor of a nonzero natural number is at most its greatest prime factor. -/
 lemma le_maxPrimeFac
-    (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) :
+    {n p : ℕ} (hn : n ≠ 0) (hp : p.Prime) (h_dvd : p ∣ n) :
     p ≤ maxPrimeFac n := by
-  have hmem : p ∈ n.primeFactorsList := (mem_primeFactorsList hn.ne').2 ⟨hp, h_dvd⟩
-  have hp_last : p ≤ n.primeFactorsList.getLast (List.ne_nil_of_mem hmem) :=
+  have hmem : p ∈ n.primeFactorsList := (mem_primeFactorsList hn).2 ⟨hp, h_dvd⟩
+  have hlist : n.primeFactorsList ≠ [] := List.ne_nil_of_mem hmem
+  have hn_one : n ≠ 1 := ((primeFactorsList_ne_nil n).1 hlist).ne'
+  have hp_last : p ≤ n.primeFactorsList.getLast hlist :=
     (primeFactorsList_sorted n).pairwise.rel_getLast hmem
-  simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
-    List.getLast?_eq_getLast_of_ne_nil (List.ne_nil_of_mem hmem)] using hp_last
+  simpa [maxPrimeFac, hn_one, List.getLastI_eq_getLast?_getD,
+    List.getLast?_eq_getLast_of_ne_nil hlist] using hp_last
 
 lemma maxPrimeFac_eq_of_dvd_of_le
     (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) (h_le : maxPrimeFac n ≤ p) :
     maxPrimeFac n = p := by
-  exact le_antisymm h_le (le_maxPrimeFac n p hn hp h_dvd)
+  exact le_antisymm h_le (le_maxPrimeFac hn.ne' hp h_dvd)
 
 /-- The greatest prime factor of a prime is the prime itself. -/
 @[simp]
-lemma Prime.maxPrimeFac {p : ℕ} (hp : p.Prime) :
+lemma Prime.maxPrimeFac_eq_self {p : ℕ} (hp : p.Prime) :
     maxPrimeFac p = p := by
   apply maxPrimeFac_eq_of_dvd_of_le p p hp.pos hp (dvd_refl p)
-  exact Nat.le_of_dvd hp.pos (maxPrimeFac_dvd p hp.one_lt)
+  exact Nat.le_of_dvd hp.pos maxPrimeFac_dvd
 
 /-- The greatest prime factor of a nontrivial prime power is its prime base. -/
 lemma Prime.maxPrimeFac_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
@@ -94,7 +100,7 @@ lemma Prime.maxPrimeFac_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
   obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk
   have hrep : List.replicate (j + 1) p ≠ [] := by
     simp
-  simp [List.getLastI_eq_getLast?_getD,
+  simp [hp.ne_one, List.getLastI_eq_getLast?_getD,
     List.getLast?_eq_getLast_of_ne_nil hrep]
 
 /-- The greatest prime factor of a natural number is at most that number. -/
@@ -102,44 +108,37 @@ lemma maxPrimeFac_le (n : ℕ) :
     maxPrimeFac n ≤ n := by
   rcases lt_trichotomy n 1 with hn | rfl | hn
   case inr.inr =>
-    exact Nat.le_of_dvd (zero_lt_of_lt hn) (maxPrimeFac_dvd n hn)
+    exact Nat.le_of_dvd (zero_lt_of_lt hn) maxPrimeFac_dvd
   case inl =>
     simp only [lt_one_iff] at hn
     subst n
     simp
   case inr.inl => simp
 
-/-- The computable greatest prime factor agrees with its supremum characterization. -/
-lemma maxPrimeFac_eq_sSup (n : ℕ) :
+/-- Away from `n = 1`, the computable greatest prime factor agrees with its supremum
+characterization. -/
+lemma maxPrimeFac_eq_sSup {n : ℕ} (hn_one : n ≠ 1) :
     maxPrimeFac n = sSup {p : ℕ | p.Prime ∧ p ∣ n} := by
   rcases lt_trichotomy n 1 with hn | rfl | hn
   case inr.inr =>
     set s := {p : ℕ | p.Prime ∧ p ∣ n}
     have hs₀ : s.Nonempty :=
-      ⟨maxPrimeFac n, prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd n hn⟩
+      ⟨maxPrimeFac n, prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩
     have hs₁ : BddAbove s := by
       refine ⟨n, ?_⟩
       rintro p ⟨_, hp⟩
       exact Nat.le_of_dvd (zero_lt_of_lt hn) hp
     apply le_antisymm
     · exact le_csSup hs₁
-        ⟨prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd n hn⟩
+        ⟨prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩
     · apply csSup_le hs₀
       rintro p ⟨hp, h_dvd⟩
-      exact le_maxPrimeFac n p (zero_lt_of_lt hn) hp h_dvd
+      exact le_maxPrimeFac (zero_lt_of_lt hn).ne' hp h_dvd
   case inl =>
     simp only [lt_one_iff] at hn
     subst n
     simpa using (Set.Infinite.Nat.sSup_eq_zero infinite_setOf_prime).symm
-  case inr.inl =>
-    suffices {p : ℕ | p.Prime ∧ p = 1} = ∅ by
-      have hset : {p : ℕ | p.Prime ∧ p ∣ 1} = ∅ := by
-        simpa using this
-      rw [hset]
-      simp
-    ext p
-    simp
-    exact fun hp => hp.ne_one
+  case inr.inl => exact (hn_one rfl).elim
 
 @[simp]
 lemma one_lt_maxPrimeFac_iff (n : ℕ) :

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -107,22 +107,15 @@ lemma maxPrimeFac_eq_self_iff {n : ℕ} :
 greatest prime factors. -/
 lemma maxPrimeFac_mul {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) :
     maxPrimeFac (m * n) = max (maxPrimeFac m) (maxPrimeFac n) := by
-  by_cases hm_one : m = 1
-  · subst m
-    have hle : 1 ≤ maxPrimeFac n := by
-      by_cases hn_one : n = 1
-      · subst n
-        simp
-      · have hn_lt : 1 < n := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hn, hn_one⟩
-        exact (prime_maxPrimeFac_of_one_lt n hn_lt).one_lt.le
+  obtain rfl | hm_lt : m = 1 ∨ 1 < m := by omega
+  · have hle : 1 ≤ maxPrimeFac n := by
+      obtain rfl | hn_lt : n = 1 ∨ 1 < n := by omega
+      · simp
+      · exact (prime_maxPrimeFac_of_one_lt n hn_lt).one_lt.le
     simp [hle]
-  by_cases hn_one : n = 1
-  · subst n
-    have hm_lt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm, hm_one⟩
-    have hle : 1 ≤ maxPrimeFac m := (prime_maxPrimeFac_of_one_lt m hm_lt).one_lt.le
+  obtain rfl | hn_lt : n = 1 ∨ 1 < n := by omega
+  · have hle : 1 ≤ maxPrimeFac m := (prime_maxPrimeFac_of_one_lt m hm_lt).one_lt.le
     simp [hle]
-  have hm_lt : 1 < m := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hm, hm_one⟩
-  have hn_lt : 1 < n := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hn, hn_one⟩
   have hmn_lt : 1 < m * n := Nat.one_lt_mul_iff.mpr
     ⟨zero_lt_of_lt hm_lt, zero_lt_of_lt hn_lt, Or.inl hm_lt⟩
   apply le_antisymm
@@ -141,17 +134,17 @@ lemma maxPrimeFac_mul {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) :
 /-- The greatest prime factor of a nonzero power is the greatest prime factor of its base. -/
 @[simp]
 lemma maxPrimeFac_pow {k : ℕ} (hk : k ≠ 0) (n : ℕ) :
-    maxPrimeFac (n ^ k) = maxPrimeFac n := by
-  obtain ⟨j, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hk
-  clear hk
-  by_cases hn : n = 0
-  · subst n
-    simp
-  induction j with
-  | zero => simp
-  | succ j ih =>
-      rw [pow_succ, maxPrimeFac_mul (pow_ne_zero _ hn) hn, ih]
+    maxPrimeFac (n ^ k) = maxPrimeFac n :=
+  match k, hk with
+  | k + 1, _ => by
+    by_cases hn : n = 0
+    · subst n
       simp
+    induction k with
+    | zero => simp
+    | succ k ih =>
+        rw [pow_succ, maxPrimeFac_mul (pow_ne_zero _ hn) hn, ih (by omega)]
+        simp
 
 /-- The greatest prime factor of a natural number is at most that number. -/
 lemma maxPrimeFac_le : ∀ {n : ℕ}, maxPrimeFac n ≤ n
@@ -173,11 +166,9 @@ lemma isLeast_maxPrimeFac {n : ℕ} (hn : 1 < n) :
 characterization. -/
 lemma maxPrimeFac_eq_sSup {n : ℕ} (hn_one : n ≠ 1) :
     maxPrimeFac n = sSup {p : ℕ | p.Prime ∧ p ∣ n} := by
-  by_cases hn_zero : n = 0
-  · subst n
-    simpa using (Set.Infinite.Nat.sSup_eq_zero infinite_setOf_prime).symm
-  · have hn : 1 < n := Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨hn_zero, hn_one⟩
-    have h_lub : IsLUB {p : ℕ | p.Prime ∧ p ∣ n} (maxPrimeFac n) :=
+  obtain rfl | hn : n = 0 ∨ 1 < n := by lia
+  · simpa using (Set.Infinite.Nat.sSup_eq_zero infinite_setOf_prime).symm
+  · have h_lub : IsLUB {p : ℕ | p.Prime ∧ p ∣ n} (maxPrimeFac n) :=
       isLeast_maxPrimeFac hn
     exact (h_lub.csSup_eq
       ⟨maxPrimeFac n, prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd⟩).symm

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -31,6 +31,13 @@ def maxPrimeFac (n : ℕ) : ℕ := n.primeFactorsList.getLastI
 lemma maxPrimeFac_eq_getLastI (n : ℕ) :
     maxPrimeFac n = n.primeFactorsList.getLastI := rfl
 
+example : maxPrimeFac 0 = 0 := by decide +kernel
+example : maxPrimeFac 1 = 0 := by decide +kernel
+example : maxPrimeFac 12 = 3 := by decide +kernel
+example : maxPrimeFac 97 = 97 := by decide +kernel
+example : maxPrimeFac 125 = 5 := by decide +kernel
+example : maxPrimeFac 360 = 5 := by decide +kernel
+
 @[simp]
 lemma maxPrimeFac_zero :
     maxPrimeFac 0 = 0 := by

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -45,15 +45,61 @@ lemma prime_maxPrimeFac_of_one_lt (n : ℕ) (h : 1 < n) :
   simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
     List.getLast?_eq_getLast_of_ne_nil hn] using hprime
 
-lemma maxPrimeFac_eq_of_dvd_of_le
-    (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) (h_le : maxPrimeFac n ≤ p) :
-    maxPrimeFac n = p := by
-  refine le_antisymm h_le ?_
+/-- The greatest prime factor of `n > 1` divides `n`. -/
+lemma maxPrimeFac_dvd (n : ℕ) (h : 1 < n) :
+    maxPrimeFac n ∣ n := by
+  have hn : n.primeFactorsList ≠ [] := (primeFactorsList_ne_nil n).2 h
+  have hmem : n.primeFactorsList.getLast hn ∈ n.primeFactorsList := List.getLast_mem hn
+  have hdvd : n.primeFactorsList.getLast hn ∣ n := dvd_of_mem_primeFactorsList hmem
+  simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
+    List.getLast?_eq_getLast_of_ne_nil hn] using hdvd
+
+/-- Every prime factor of a positive natural number is at most its greatest prime factor. -/
+lemma le_maxPrimeFac
+    (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) :
+    p ≤ maxPrimeFac n := by
   have hmem : p ∈ n.primeFactorsList := (mem_primeFactorsList hn.ne').2 ⟨hp, h_dvd⟩
   have hp_last : p ≤ n.primeFactorsList.getLast (List.ne_nil_of_mem hmem) :=
     (primeFactorsList_sorted n).pairwise.rel_getLast hmem
   simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
     List.getLast?_eq_getLast_of_ne_nil (List.ne_nil_of_mem hmem)] using hp_last
+
+lemma maxPrimeFac_eq_of_dvd_of_le
+    (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) (h_le : maxPrimeFac n ≤ p) :
+    maxPrimeFac n = p := by
+  exact le_antisymm h_le (le_maxPrimeFac n p hn hp h_dvd)
+
+/-- The computable greatest prime factor agrees with its supremum characterization. -/
+lemma maxPrimeFac_eq_sSup (n : ℕ) :
+    maxPrimeFac n = sSup {p : ℕ | p.Prime ∧ p ∣ n} := by
+  rcases lt_trichotomy n 1 with hn | rfl | hn
+  case inr.inr =>
+    set s := {p : ℕ | p.Prime ∧ p ∣ n}
+    have hs₀ : s.Nonempty :=
+      ⟨maxPrimeFac n, prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd n hn⟩
+    have hs₁ : BddAbove s := by
+      refine ⟨n, ?_⟩
+      rintro p ⟨_, hp⟩
+      exact Nat.le_of_dvd (zero_lt_of_lt hn) hp
+    apply le_antisymm
+    · exact le_csSup hs₁
+        ⟨prime_maxPrimeFac_of_one_lt n hn, maxPrimeFac_dvd n hn⟩
+    · apply csSup_le hs₀
+      rintro p ⟨hp, h_dvd⟩
+      exact le_maxPrimeFac n p (zero_lt_of_lt hn) hp h_dvd
+  case inl =>
+    simp only [lt_one_iff] at hn
+    subst n
+    simpa using (Set.Infinite.Nat.sSup_eq_zero infinite_setOf_prime).symm
+  case inr.inl =>
+    suffices {p : ℕ | p.Prime ∧ p = 1} = ∅ by
+      have hset : {p : ℕ | p.Prime ∧ p ∣ 1} = ∅ := by
+        simpa using this
+      rw [hset]
+      simp
+    ext p
+    simp
+    exact fun hp => hp.ne_one
 
 @[simp]
 lemma one_lt_maxPrimeFac_iff (n : ℕ) :

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -93,6 +93,19 @@ lemma Prime.maxPrimeFac_eq_self {p : ℕ} (hp : p.Prime) :
   apply maxPrimeFac_eq_of_dvd_of_le p p hp.pos hp (dvd_refl p)
   exact Nat.le_of_dvd hp.pos maxPrimeFac_dvd
 
+/-- The fixed points of `maxPrimeFac` are zero, one, and the primes. -/
+@[simp]
+lemma maxPrimeFac_eq_self_iff {n : ℕ} :
+    maxPrimeFac n = n ↔ n ≤ 1 ∨ n.Prime := by
+  constructor
+  · intro h
+    by_cases hn : n ≤ 1
+    · exact Or.inl hn
+    · exact Or.inr <| h ▸ prime_maxPrimeFac_of_one_lt n (lt_of_not_ge hn)
+  · rintro (hn | hn)
+    · obtain rfl | rfl := Nat.le_one_iff_eq_zero_or_eq_one.mp hn <;> simp
+    · exact hn.maxPrimeFac_eq_self
+
 /-- The greatest prime factor of a nontrivial prime power is its prime base. -/
 lemma Prime.maxPrimeFac_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
     Nat.maxPrimeFac (p ^ k) = p := by

--- a/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
+++ b/FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean
@@ -24,46 +24,36 @@ namespace Nat
 
 /-- The greatest prime divisor of a natural number `n > 1`.
 
-Takes the junk value `0` for `n = 0` and `n = 1`.
-
-TODO Consider redefining this using the computable implementation:
-`n.primeFactorsList.getLastI`. -/
-noncomputable def maxPrimeFac (n : ℕ) : ℕ := sSup {p : ℕ | p.Prime ∧ p ∣ n}
+Takes the junk value `0` for `n = 0` and `n = 1`. -/
+def maxPrimeFac (n : ℕ) : ℕ := n.primeFactorsList.getLastI
 
 @[simp]
 lemma maxPrimeFac_zero :
     maxPrimeFac 0 = 0 := by
-  simpa [maxPrimeFac] using Set.Infinite.Nat.sSup_eq_zero infinite_setOf_prime
+  simp [maxPrimeFac, List.getLastI]
 
 @[simp]
 lemma maxPrimeFac_one :
     maxPrimeFac 1 = 0 := by
-  suffices {p : ℕ | p.Prime ∧ p = 1} = ∅ by simp [maxPrimeFac, this]
-  aesop
+  simp [maxPrimeFac, List.getLastI]
 
 lemma prime_maxPrimeFac_of_one_lt (n : ℕ) (h : 1 < n) :
     Prime (maxPrimeFac n) := by
-  set s := {p : ℕ | p.Prime ∧ p ∣ n} with hs
-  have hs₀ : s.Nonempty := by
-    simp only [Set.Nonempty, Set.mem_setOf_eq, ← ne_one_iff_exists_prime_dvd, hs]
-    omega
-  have hs₁ : BddAbove s := by
-    use n
-    simp only [hs, mem_upperBounds, Set.mem_setOf_eq, and_imp]
-    exact fun p _ hp ↦ Nat.le_of_dvd (zero_lt_of_lt h) hp
-  exact (Nat.sSup_mem hs₀ hs₁).1
+  have hn : n.primeFactorsList ≠ [] := (primeFactorsList_ne_nil n).2 h
+  have hmem : n.primeFactorsList.getLast hn ∈ n.primeFactorsList := List.getLast_mem hn
+  have hprime : Prime (n.primeFactorsList.getLast hn) := prime_of_mem_primeFactorsList hmem
+  simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
+    List.getLast?_eq_getLast_of_ne_nil hn] using hprime
 
 lemma maxPrimeFac_eq_of_dvd_of_le
     (n p : ℕ) (hn : 0 < n) (hp : p.Prime) (h_dvd : p ∣ n) (h_le : maxPrimeFac n ≤ p) :
     maxPrimeFac n = p := by
   refine le_antisymm h_le ?_
-  replace hn : 1 < n := Nat.lt_of_lt_of_le hp.one_lt (Nat.le_of_dvd hn h_dvd)
-  set s := {p : ℕ | p.Prime ∧ p ∣ n} with hs
-  have hs₁ : BddAbove s := by
-    use n
-    simp only [hs, mem_upperBounds, Set.mem_setOf_eq, and_imp]
-    exact fun p _ hp ↦ Nat.le_of_dvd (zero_lt_of_lt hn) hp
-  exact ConditionallyCompleteLattice.le_csSup s p hs₁ ⟨hp, h_dvd⟩
+  have hmem : p ∈ n.primeFactorsList := (mem_primeFactorsList hn.ne').2 ⟨hp, h_dvd⟩
+  have hp_last : p ≤ n.primeFactorsList.getLast (List.ne_nil_of_mem hmem) :=
+    (primeFactorsList_sorted n).pairwise.rel_getLast hmem
+  simpa [maxPrimeFac, List.getLastI_eq_getLast?_getD,
+    List.getLast?_eq_getLast_of_ne_nil (List.ne_nil_of_mem hmem)] using hp_last
 
 @[simp]
 lemma one_lt_maxPrimeFac_iff (n : ℕ) :


### PR DESCRIPTION
Closes #4809.

## Summary

- Redefine `Nat.maxPrimeFac` as `if n = 1 then 1 else n.primeFactorsList.getLastI`, preserving `maxPrimeFac 0 = 0` while adopting `maxPrimeFac 1 = 1`.
- Add structural API for primeness, unconditional divisibility, maximality, fixed points, products, powers with nonzero exponent, and the bound `maxPrimeFac n ≤ n`.
- Characterize `maxPrimeFac n` as the least upper bound of the prime divisors of `n` when `1 < n`.
- Prove that the computable definition agrees with the supremum characterization whenever `n ≠ 1`.
- Characterize the fixed points of `maxPrimeFac` as exactly `0`, `1`, and the primes.
- Add executable regression checks for `0`, `1`, composites, a prime, and a nontrivial prime power.
- Update the proof of Erdős Problem 649 to consume the public `maxPrimeFac` API.

The resulting API includes `Nat.prime_maxPrimeFac_of_one_lt`, `Nat.maxPrimeFac_dvd`, `Nat.le_maxPrimeFac`, `Nat.Prime.maxPrimeFac_eq_self`, `Nat.maxPrimeFac_eq_self_iff`, `Nat.maxPrimeFac_mul`, `Nat.maxPrimeFac_pow`, `Nat.maxPrimeFac_le`, `Nat.isLeast_maxPrimeFac`, and `Nat.maxPrimeFac_eq_sSup`. Clients that need to unfold the definition can use its generated equation theorem rather than a separate redundant unfolding lemma.

## Mathematical and API notes

For `1 < n`, `n.primeFactorsList` is nonempty and sorted. Its final entry is therefore prime, divides `n`, and is at least every other prime divisor of `n`.

The edge conventions are:

```lean
Nat.maxPrimeFac 0 = 0
Nat.maxPrimeFac 1 = 1
```

The fixed-point characterization is a simp lemma:

```lean
Nat.maxPrimeFac n = n ↔ n ≤ 1 ∨ n.Prime
```

Thus the fixed points are exactly `0`, `1`, and the primes. With these conventions, `Nat.maxPrimeFac_dvd` holds for every natural number. The maximality theorem `Nat.le_maxPrimeFac` requires only `n ≠ 0`.

For nonzero natural numbers `m` and `n`, the multiplication law is:

```lean
Nat.maxPrimeFac (m * n) =
  max (Nat.maxPrimeFac m) (Nat.maxPrimeFac n)
```

For `k ≠ 0`, the power law is:

```lean
Nat.maxPrimeFac (n ^ k) = Nat.maxPrimeFac n
```

This generalizes the former prime-specific power theorem. For a prime base, `Nat.Prime.maxPrimeFac_eq_self` recovers the corresponding prime-power result.

For `1 < n`, `Nat.isLeast_maxPrimeFac` states:

```lean
IsLeast (upperBounds {p : ℕ | p.Prime ∧ p ∣ n})
  (Nat.maxPrimeFac n)
```

The supremum characterization is:

```lean
Nat.maxPrimeFac n = sSup {p : ℕ | p.Prime ∧ p ∣ n}
```

under the hypothesis `n ≠ 1`. It still includes `n = 0`. The excluded value `n = 1` is genuinely exceptional: the left-hand side is `1`, while the set of prime divisors is empty and its supremum in `ℕ` is `0`.

The edge-case lemmas, `Nat.Prime.maxPrimeFac_eq_self`, `Nat.maxPrimeFac_eq_self_iff`, and `Nat.maxPrimeFac_pow` are simp lemmas. The definition and supremum characterization are intentionally not general simp rules, so routine simplification does not expand a prime factorization or change representations.

## Verification

The following passed with `--wfail` after rebasing onto current `main`:

- `FormalConjecturesForMathlib.Data.Nat.MaxPrimeFac`
- `FormalConjecturesForMathlib`
- Erdős Problems 370, 371, 373, 383, 648, 649, and 932

Computational checks cover `0`, `1`, `12`, `97`, `125`, and `360`. The `1` case is proved by `rfl`; the nontrivial computations use `decide +kernel`.

Verified with Lean 4.27.0 and Mathlib revision `a3a10db0e9d66acbebf76c5e6a135066525ac900`.

## Scope

This changes two files:

- `FormalConjecturesForMathlib/Data/Nat/MaxPrimeFac.lean`
- `FormalConjectures/ErdosProblems/649.lean`

The Erdős 649 statement and mathematics are unchanged. Its completed proof now uses `Nat.maxPrimeFac_dvd` and `Nat.le_maxPrimeFac` directly instead of reconstructing those facts through the supremum representation.

In the downstream audit, Erdős Problem 371’s underlying set gains only the isolated element `0`, which does not change its natural density. The other statement-level consumers are unaffected by the new value at `1`.

## AI assistance

This contribution was developed with assistance from OpenAI Codex.
