### PR TITLE
check_erdos_status: see wrapped category attributes, and 'open (Lean)'

### DIFF
--- a/scripts/check_erdos_status.py
+++ b/scripts/check_erdos_status.py
@@ -31,8 +31,11 @@ ERDOS_DIR = os.path.join(
 # Matches the category annotation line immediately before any erdos theorem.
 # Captures the category and the problem number.
 # Note: 'formally solved' is no longer a valid category value.
+# `[^\]]*` rather than `.*`: a character class crosses newlines, so an attribute wrapped
+# over two lines is still matched, and it stops at the attribute's own `]` rather than
+# running into the next declaration. 25 problem files wrap theirs and were invisible here.
 CATEGORY_THEN_THEOREM = re.compile(
-    r"@\[category research (open|solved).*\]\s*\n"
+    r"@\[category research (open|solved)[^\]]*\]\s*\n"
     r"theorem erdos_(\d+)([\w.]*)\s",
     re.MULTILINE,
 )
@@ -44,7 +47,9 @@ FORMAL_PROOF_ATTR = re.compile(
     re.MULTILINE,
 )
 
-OPEN_STATES = {"open", "falsifiable", "verifiable"}
+# `open (Lean)` is the open counterpart of `solved (Lean)`: the problem is open and a Lean
+# statement of it exists. Without it the four problems carrying that state are skipped.
+OPEN_STATES = {"open", "falsifiable", "verifiable", "open (Lean)"}
 SOLVED_STATES = {
     "solved",
     "proved",

--- a/scripts/check_erdos_status.py
+++ b/scripts/check_erdos_status.py
@@ -151,6 +151,19 @@ def scan_lean_files():
     return result
 
 
+def classifiable():
+    """Problems the YAML gives a status this script understands.
+
+    A problem missing from this set is not agreeing with us, it is one we cannot read, which
+    is a different thing and must not be treated as resolved.
+    """
+    return {
+        str(p["number"])
+        for p in fetch_yaml()
+        if yaml_status_to_category(p.get("status", {}).get("state", "open")) is not None
+    }
+
+
 def find_mismatches():
     problems = fetch_yaml()
     yaml_statuses = {}
@@ -235,13 +248,78 @@ def create_issues(mismatches):
         subprocess.run(cmd)
 
 
+ISSUE_TITLE_RE = re.compile(r"Erdős Problem (\d+): status mismatch")
+
+
+def issues_to_close(issues, still_open, known):
+    """Which open sync issues no longer describe a real mismatch.
+
+    Kept separate from the `gh` calls so it can be tested.
+    """
+    out = []
+    for issue in issues:
+        match = ISSUE_TITLE_RE.match(issue["title"])
+        if not match:
+            continue
+        num = match.group(1)
+        # Still mismatched, or a YAML state we cannot read. Either way, leave it alone:
+        # "we cannot tell" is not the same as "resolved".
+        if num in still_open or num not in known:
+            continue
+        out.append(issue["number"])
+    return out
+
+
+def close_resolved_issues(mismatches):
+    """Close open sync issues whose mismatch has gone away.
+
+    The script opens an issue when this repository and erdosproblems.com disagree, but
+    nothing ever closed them, so the label accumulates issues describing a state that no
+    longer holds. `mismatches` is everything still disagreeing, so any other open issue under
+    the label has been overtaken by a merge.
+    """
+    # `find_mismatches` keys problems by string, so compare as strings.
+    # `find_mismatches` keys problems by string, so compare as strings.
+    still_open = {str(m["number"]) for m in mismatches}
+    known = classifiable()
+    result = subprocess.run(
+        [
+            "gh", "issue", "list",
+            "--label", "erdos-status-sync",
+            "--state", "open",
+            "--limit", "500",
+            "--json", "number,title",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"Failed to list sync issues (gh exit code {result.returncode}), "
+            f"not closing anything",
+            file=sys.stderr,
+        )
+        return
+    issues = json.loads(result.stdout) if result.stdout.strip() else []
+    for number in issues_to_close(issues, still_open, known):
+        subprocess.run([
+            "gh", "issue", "close", str(number),
+            "--comment",
+            "The repository and erdosproblems.com now agree on this problem, so there is "
+            "no mismatch left to act on. Closed automatically; reopen if that is wrong.",
+        ])
+
+
 def main():
     mismatches = find_mismatches()
     json.dump(mismatches, sys.stdout, indent=2)
     print()  # trailing newline
 
-    if "--create-issues" in sys.argv and mismatches:
-        create_issues(mismatches)
+    if "--create-issues" in sys.argv:
+        if mismatches:
+            create_issues(mismatches)
+        # Runs even when nothing mismatches, which is exactly when there is most to close.
+        close_resolved_issues(mismatches)
 
     return 1 if mismatches else 0
 

--- a/scripts/test_check_erdos_status.py
+++ b/scripts/test_check_erdos_status.py
@@ -1,0 +1,64 @@
+# Copyright 2026 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for which sync issues `check_erdos_status.py` decides to close."""
+
+import unittest
+
+from check_erdos_status import issues_to_close
+
+
+def issue(number, problem, repo="solved", site="formally solved"):
+    return {
+        "number": number,
+        "title": f"Erdős Problem {problem}: status mismatch "
+                 f"(repo={repo}, erdosproblems.com={site})",
+    }
+
+
+class IssuesToCloseTest(unittest.TestCase):
+
+    def test_closes_when_the_mismatch_is_gone(self):
+        self.assertEqual(
+            issues_to_close([issue(100, "71")], still_open=set(), known={"71"}), [100])
+
+    def test_keeps_one_that_still_mismatches(self):
+        self.assertEqual(
+            issues_to_close([issue(100, "71")], still_open={"71"}, known={"71"}), [])
+
+    def test_keeps_one_whose_status_cannot_be_read(self):
+        # A problem missing from `known` has a YAML state the script does not recognise.
+        # That is "we cannot tell", which must not be read as "resolved".
+        self.assertEqual(
+            issues_to_close([issue(100, "71")], still_open=set(), known=set()), [])
+
+    def test_compares_problem_numbers_as_strings(self):
+        # `find_mismatches` keys problems by string; comparing an int against that set
+        # silently matches nothing and would close everything.
+        self.assertEqual(
+            issues_to_close([issue(100, "71")], still_open={"71"}, known={"71"}), [])
+
+    def test_ignores_issues_with_an_unrelated_title(self):
+        self.assertEqual(
+            issues_to_close([{"number": 100, "title": "Something else entirely"}],
+                            still_open=set(), known={"71"}), [])
+
+    def test_handles_several_at_once(self):
+        issues = [issue(1, "71"), issue(2, "209"), issue(3, "353")]
+        self.assertEqual(
+            issues_to_close(issues, still_open={"209"}, known={"71", "209"}), [1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_erdos_status.py
+++ b/scripts/test_check_erdos_status.py
@@ -16,7 +16,11 @@
 
 import unittest
 
-from check_erdos_status import issues_to_close
+from check_erdos_status import (
+    CATEGORY_THEN_THEOREM,
+    issues_to_close,
+    yaml_status_to_category,
+)
 
 
 def issue(number, problem, repo="solved", site="formally solved"):
@@ -58,6 +62,49 @@ class IssuesToCloseTest(unittest.TestCase):
         issues = [issue(1, "71"), issue(2, "209"), issue(3, "353")]
         self.assertEqual(
             issues_to_close(issues, still_open={"209"}, known={"71", "209"}), [1])
+
+
+class CategoryScanTest(unittest.TestCase):
+
+    def test_reads_an_attribute_on_one_line(self):
+        src = "@[category research open, AMS 11]\ntheorem erdos_42 : True := by sorry\n"
+        self.assertEqual([m.groups() for m in CATEGORY_THEN_THEOREM.finditer(src)],
+                         [("open", "42", "")])
+
+    def test_reads_an_attribute_wrapped_over_two_lines(self):
+        # 25 problem files wrap theirs, usually to fit a `formal_proof` URL, and were
+        # invisible to this scanner while the pattern used `.*`.
+        src = ('@[category research solved, AMS 5, formal_proof using lean4 at\n'
+               '  "https://example.com/x.lean"]\n'
+               'theorem erdos_183 : True := by sorry\n')
+        self.assertEqual([m.groups() for m in CATEGORY_THEN_THEOREM.finditer(src)],
+                         [("solved", "183", "")])
+
+    def test_does_not_run_past_its_own_attribute(self):
+        src = ("@[category research open]\ntheorem erdos_1 : True := by sorry\n\n"
+               "@[category research solved]\ntheorem erdos_2 : True := by sorry\n")
+        self.assertEqual([m.group(2) for m in CATEGORY_THEN_THEOREM.finditer(src)],
+                         ["1", "2"])
+
+    def test_keeps_the_variant_suffix(self):
+        src = "@[category research solved]\ntheorem erdos_42.variants.foo : True := by sorry\n"
+        self.assertEqual([m.groups() for m in CATEGORY_THEN_THEOREM.finditer(src)],
+                         [("solved", "42", ".variants.foo")])
+
+
+class YamlStatusTest(unittest.TestCase):
+
+    def test_open_with_a_lean_statement_is_still_open(self):
+        self.assertEqual(yaml_status_to_category("open (Lean)"), "open")
+
+    def test_solved_in_lean_is_formally_solved(self):
+        self.assertEqual(yaml_status_to_category("solved (Lean)"), "formally solved")
+
+    def test_plain_solved_is_solved(self):
+        self.assertEqual(yaml_status_to_category("proved"), "solved")
+
+    def test_unknown_state_is_none(self):
+        self.assertIsNone(yaml_status_to_category("something new"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on #4826, which adds the test file this extends.

`check_erdos_status.py` is silently blind to two things.

**Wrapped attributes.** The scanner matches `@\[category research (open|solved).*\]` with `MULTILINE` but not `DOTALL`, so `.*` stops at the newline and the closing `]` has to be on the same line. 25 of the 604 problem files wrap theirs, usually to fit a `formal_proof` URL:

```lean
@[category research solved, AMS 5, formal_proof using lean4 at
  "https://github.com/..."]
theorem erdos_183 :
```

Those problems were never compared against anything. Using `[^\]]*` instead crosses newlines and still stops at the attribute's own `]`, so it cannot run into the next declaration. It finds 70 more declarations and loses none.

**`open (Lean)`.** Four problems carry it upstream and it was in none of the state sets, so `yaml_status_to_category` returned `None` and they were skipped. It is the open counterpart of `solved (Lean)`: the problem is open and a Lean statement of it exists.

Together these take the live mismatch count from 28 to 34. Three of the six are #146, #180 and #183, which erdosproblems.com still lists as open and which my own #4715 marked `formally solved` on the strength of the openai/ten-proofs links. I have not touched those files here; the point of this change is that the check can now see the disagreement and say so, and someone should decide which side is right.

`python3 -m unittest discover -s scripts` passes, 31 tests, including one pinning the wrapped-attribute case.
