### PR TITLE
site: search the statements the browse page shows

### DIFF
--- a/site/src/js/browse.js
+++ b/site/src/js/browse.js
@@ -88,10 +88,31 @@ function writeURL() {
 // ---------------------------------------------------------------------------
 // Filter / sort
 // ---------------------------------------------------------------------------
+// The statement text lives in the Verso fragments, as HTML. Strip the tags once per
+// theorem and keep the result, so typing does not re-parse 3551 documents on every keystroke.
+const statementTextCache = new Map();
+
+function statementText(c) {
+  if (!statementTextCache.has(c.theorem)) {
+    const html = FC.problemDocHTML(c, versoFragments);
+    let text = '';
+    if (html) {
+      const el = document.createElement('div');
+      el.innerHTML = html;
+      text = (el.textContent || '').toLowerCase();
+    }
+    statementTextCache.set(c.theorem, text);
+  }
+  return statementTextCache.get(c.theorem);
+}
+
 function applyFilters() {
   const q = state.query.toLowerCase();
   filtered = allConjectures.filter(c => {
-    if (q && !c.displayTheorem.toLowerCase().includes(q)) return false;
+    // Match the statement as well as the name: someone looking for "distinct distances"
+    // knows the mathematics, not that we call it `Erdos307.erdos_307.variants.coprime`.
+    if (q && !c.displayTheorem.toLowerCase().includes(q) && !statementText(c).includes(q))
+      return false;
     if (state.categories.size  && !state.categories.has(c.category))   return false;
     if (state.collections.size && !state.collections.has(c.collection)) return false;
     if (state.subjects.size) {
@@ -297,6 +318,7 @@ async function init() {
 
   allConjectures = data.conjectures;
   versoFragments = data.versoFragments || { moduleDocs: {}, constLinks: {} };
+  statementTextCache.clear();
 
   // Handle OAuth callback and prefetch votes (disabled)
   // await FC.voting.handleOAuthCallback();

--- a/site/src/js/browse.js
+++ b/site/src/js/browse.js
@@ -89,7 +89,7 @@ function writeURL() {
 // Filter / sort
 // ---------------------------------------------------------------------------
 // The statement text lives in the Verso fragments, as HTML. Strip the tags once per
-// theorem and keep the result, so typing does not re-parse 3551 documents on every keystroke.
+// theorem and keep the result, so typing does not re-parse every entry on every keystroke.
 const statementTextCache = new Map();
 
 function statementText(c) {

--- a/site/src/templates/browse.html
+++ b/site/src/templates/browse.html
@@ -79,7 +79,7 @@
           type="search"
           class="search-input"
           id="search-input"
-          placeholder="Search by theorem name…"
+          placeholder="Search names and statements…"
           aria-label="Search theorems"
           autocomplete="off"
           spellcheck="false"


### PR DESCRIPTION
Closes #4831.

The browse page shows each statement but the search only matched theorem names, so the text on screen was not findable. Measured on a local build of the site, before and after:

| query | before | after |
|---|---:|---:|
| `coprime positive integers` | 0 | 3 |
| `distinct distances` | 0 | 13 |
| `chromatic` | 60 | 146 |
| `erdos_330` | 1 | 1 |
| empty | 3,551 | 3,551 |

No new data is fetched. `versoFragments` is already loaded on the page and already renders these statements through `FC.problemDocHTML`; the filter now matches against it as well as the name. `build.js` deliberately keeps `statement` and `docstring` out of `conjectures.json`, and this does not change that.

The fragment HTML is stripped to text once per theorem and cached, so typing does not re-parse 3551 documents per keystroke. Timed in the browser: 13ms for the first keystroke that builds the cache, then 5 to 18ms.

The placeholder said "Search by theorem name", which was accurate and is now "Search names and statements".
