### PR TITLE
Fix lander_parkin_selfridge: add missing positivity hypotheses on n, m

### DIFF
--- a/FormalConjectures/Wikipedia/LanderParkinAndSelfridgeConjecture.lean
+++ b/FormalConjectures/Wikipedia/LanderParkinAndSelfridgeConjecture.lean
@@ -36,6 +36,7 @@ then $k \leq n + m$. -/
 @[category research open, AMS 11]
 theorem lander_parkin_selfridge :
     ∀ (k n m : ℕ) (x : Fin n → ℕ) (y : Fin m → ℕ),
+      0 < n → 0 < m →
       (∀ i, 0 < x i) → (∀ j, 0 < y j) →
       (∀ i j, x i ≠ y j) →
       ∑ i, x i ^ k = ∑ j, y j ^ k →


### PR DESCRIPTION
The statement in `FormalConjectures/Wikipedia/LanderParkinAndSelfridgeConjecture.lean` is provably false as formalized: the docstring specifies "positive integers $k, n, m$", but the binders `(k n m : ℕ)` admit `n = m = 0`. Taking `k = 1, n = m = 0`, both sums are empty (`0 = 0`), every hypothesis holds vacuously, and the conclusion `1 ≤ 0` is false. Machine-checked counterexample:

```lean
example : ¬ (∀ (k n m : ℕ) (x : Fin n → ℕ) (y : Fin m → ℕ),
      (∀ i, 0 < x i) → (∀ j, 0 < y j) → (∀ i j, x i ≠ y j) →
      ∑ i, x i ^ k = ∑ j, y j ^ k → k ≤ n + m) := by
  intro h
  have := h 1 0 0 Fin.elim0 Fin.elim0 (fun i => Fin.elim0 i) (fun j => Fin.elim0 j)
      (fun i j => Fin.elim0 i) (by simp)
  omega
```

(`#print axioms` on the counterexample: `propext, Classical.choice, Quot.sound` only.)

This PR adds `0 < n → 0 < m →` to the statement, matching the docstring's wording. 


