### PR TITLE
ErdosProblems/751: put the Lean proof on the statement it proves

### DIFF
--- a/FormalConjectures/ErdosProblems/751.lean
+++ b/FormalConjectures/ErdosProblems/751.lean
@@ -37,10 +37,13 @@ The answer is no: Bondy and Vince [BoVi98] proved that every graph with minimum 
 has two cycles whose lengths differ by at most $2$, and hence the same is true for every graph with
 chromatic number $4$.
 
-This was formalized in Lean by SpringSense Innovation Institute using ChatGPT.
+`erdos_751.variants.finite` below carries the Lean proof. It assumes a finite vertex type,
+where this quantifies over any `V : Type`, and the two are joined by de Bruijn-Erdős: a graph
+that is not $3$-colourable has a finite subgraph that is not $3$-colourable, and cycles of that
+subgraph are cycles of the whole. Mathlib does not have de Bruijn-Erdős, so that step is not
+formalised here.
 -/
-@[category research solved, AMS 5, formal_proof using lean4 at
-"https://github.com/SpringSense-Innovation-Institute/ai-for-math-lean/blob/main/erdos-problems/erdos751/Erdos751/Main.lean"]
+@[category research solved, AMS 5]
 theorem erdos_751.parts.i :
     answer(False) ↔
       ∀ k : ℕ, ∃ (V : Type) (G : SimpleGraph V), G.chromaticNumber = 4 ∧
@@ -70,6 +73,24 @@ whose lengths differ by at most $2$.
 @[category research solved, AMS 5]
 theorem erdos_751.variants.bondy_vince {V : Type*} [Fintype V] (G : SimpleGraph V)
     [DecidableRel G.Adj] (hG : 3 ≤ G.minDegree) :
+    ∃ m ∈ G.cycleLengths, ∃ m' ∈ G.cycleLengths, m < m' ∧ m' ≤ m + 2 := by
+  sorry
+
+/--
+The finite case of `erdos_751.parts.i`, which is what the Lean proof establishes: a finite graph
+with chromatic number at least $4$ has two cycles whose lengths differ by $1$ or $2$.
+
+The proof reaches this through a $4$-critical subgraph, which supplies the $2$-connectivity and
+the vertex count its Bondy-Vince step needs on top of minimum degree $3$. Those extra hypotheses
+are why it does not also settle `erdos_751.variants.bondy_vince`, which asks for minimum degree
+$3$ alone.
+
+This was formalized in Lean by SpringSense Innovation Institute using ChatGPT.
+-/
+@[category research solved, AMS 5, formal_proof using lean4 at
+"https://github.com/SpringSense-Innovation-Institute/ai-for-math-lean/blob/ae3ead960a494cf81b28541c477e50997cb03999/erdos-problems/erdos751/Erdos751/Main.lean#L40-L69"]
+theorem erdos_751.variants.finite {V : Type*} [Fintype V] (G : SimpleGraph V)
+    [DecidableRel G.Adj] (hG : (4 : ℕ∞) ≤ G.chromaticNumber) :
     ∃ m ∈ G.cycleLengths, ∃ m' ∈ G.cycleLengths, m < m' ∧ m' ≤ m + 2 := by
   sorry
 


### PR DESCRIPTION
#4797 attached a `formal_proof` link to `erdos_751.parts.i`. The proof behind it does not cover that statement.

`parts.i` quantifies over any `V : Type`. The linked `erdos_751_strong` assumes `[Fintype V]`:

```lean
theorem erdos_751_strong (hχ : (4 : ℕ∞) ≤ G.chromaticNumber) :
    ∃ C1 C2 : BV.Cycle (G := G),
      Nat.dist (BV.Cycle.length C1) (BV.Cycle.length C2) = 1 ∨
      Nat.dist (BV.Cycle.length C1) (BV.Cycle.length C2) = 2
```

Getting from finite to arbitrary `V` is de Bruijn-Erdős: a graph that is not 3-colourable has a finite subgraph that is not 3-colourable, and cycles of the subgraph are cycles of the whole. Mathlib has no such statement, so the step is not available.

So this adds `erdos_751.variants.finite`, which is `erdos_751_strong` in this repo's vocabulary, and moves the link there. `parts.i` keeps `research solved`, since the mathematics holds either way, and its docstring now says where the Lean proof stops.

### The link does not belong on `bondy_vince` either

That is the other place someone might put it. `erdos_751.variants.bondy_vince` asks for minimum degree 3 alone, which is the theorem Bondy and Vince proved. The development's own step is weaker:

```lean
theorem exists_two_cycles_length_dist_1_or_2
    (h2 : VertexTwoConnected (G := G))
    (hδ3 : MinDegreeGE3 (G := G))
    (hcard4 : Fintype.card V ≥ 4) : ...
```

It gets 2-connectivity and the vertex count from a 4-critical subgraph, which only exists because it starts from `χ ≥ 4`. Noted in the docstring.

### Checks

- `FormalConjectures/ErdosProblems/751.lean` builds clean, four `sorry` warnings for the four `research` statements and nothing else.
- The repo is sorry-free and axiom-free across all seven files of the `erdos751` import tree, rather than `Main.lean` alone.
- The URL is pinned to `ae3ead96` rather than `main`, and resolves.
