### PR TITLE
Enable the conditional formal_proof linter

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -55,6 +55,7 @@ warn.sorry = false
 # our own linters which only make sense for the problems themselves
 weak.linter.style.ams_attribute = true
 weak.linter.style.category_attribute = true
+weak.linter.style.conditional_formal_proof = true
 weak.linter.style.moduleDocstring = true
 weak.linter.style.latex_docstring = true
 
@@ -67,6 +68,7 @@ warn.sorry = false
 # our own linters which only make sense for the problems themselves
 weak.linter.style.ams_attribute = true
 weak.linter.style.category_attribute = true
+weak.linter.style.conditional_formal_proof = true
 weak.linter.style.moduleDocstring = true
 weak.linter.style.latex_docstring = true
 weak.google.answer = "postpone"


### PR DESCRIPTION
`FormalProofLinter` from #4368 is imported but never switched on: `linter.style.conditional_formal_proof` is missing from `lakefile.toml` and the option defaults to false. The four other style linters are set in both `lean_lib` blocks, so this looks like an oversight.

Nothing uses `conditional formal_proof` yet, so the linter can't fire and this can't break `--wfail`. It means the first one written gets checked.

Checked: the linter's own test still passes, and `751.lean`, `357513.lean` and `MonochromaticQuantumGraph.lean` all build with the option on and no warnings, so it doesn't misfire on plain `formal_proof`.
