### PR TITLE
Add Sidorenko conjecture variants (complete bipartite, even cycles, paths, necessity)

### DIFF
--- a/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
+++ b/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
@@ -999,7 +999,7 @@ theorem sidorenko_conjecture.variants.non_bipartite_necessary :
       simp only [Fintype.card_fin] at hle
       omega
     have hcount : homCount (completeGraph (Fin 3)) (completeGraph (Fin 2)) = 0 := by
-      haveI := hempty
+      have := hempty
       simp [homCount]
     unfold homDensity
     rw [hcount]

--- a/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
+++ b/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
@@ -799,6 +799,161 @@ theorem sidorenko_conjecture.variants.path_blakley_roy (n : ℕ)
       homDensity (pathGraph n) G := by
   sorry
 
+/-- **Homomorphism count of the star `K_{1,m}`.** The number of homomorphisms from the star
+`K_{1,m} = completeBipartiteGraph (Fin 1) (Fin m)` into `G` equals `∑_{c} (G.degree c)^m`.
+
+**Math.** A homomorphism `f : K_{1,m} →g G` is determined by the image `c := f` of the centre
+`Sum.inl 0` together with the images of the `m` leaves `Sum.inr j`, each of which must lie in
+the neighbourhood `N(c)` (and there is no constraint between distinct leaves). So the data is a
+choice of `c` and a function `Fin m → N(c)`, giving `∑_c |N(c)|^m = ∑_c (G.degree c)^m`. -/
+@[category API, AMS 5]
+lemma homCount_star_eq_sum_degree_pow (m : ℕ)
+    [DecidableRel (completeBipartiteGraph (Fin 1) (Fin m)).Adj]
+    {W : Type*} [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] :
+    homCount (completeBipartiteGraph (Fin 1) (Fin m)) G = ∑ c : W, (G.degree c) ^ m := by
+  unfold homCount
+  have hEquiv : (completeBipartiteGraph (Fin 1) (Fin m) →g G) ≃
+      Σ c : W, (Fin m → {w : W // w ∈ G.neighborFinset c}) := by
+    refine
+      { toFun := fun f => ⟨f (Sum.inl 0), fun j => ⟨f (Sum.inr j), ?_⟩⟩
+        invFun := fun x =>
+          { toFun := fun v =>
+              match v with
+              | Sum.inl _ => x.1
+              | Sum.inr j => (x.2 j).val
+            map_rel' := ?_ }
+        left_inv := ?_
+        right_inv := ?_ }
+    · -- `f (Sum.inr j) ∈ N(f (Sum.inl 0))`.
+      rw [mem_neighborFinset]
+      exact f.map_adj (by simp [completeBipartiteGraph])
+    · -- Adjacency preservation for the inverse.
+      rintro a b hab
+      obtain ⟨c, g⟩ := x
+      cases a with
+      | inl i =>
+        cases b with
+        | inl k => simp [completeBipartiteGraph] at hab
+        | inr j =>
+          have hj := (g j).property
+          rw [mem_neighborFinset] at hj
+          exact hj
+      | inr j =>
+        cases b with
+        | inl k =>
+          have hj := (g j).property
+          rw [mem_neighborFinset] at hj
+          exact hj.symm
+        | inr k => simp [completeBipartiteGraph] at hab
+    · -- left_inv
+      intro f
+      ext v
+      cases v with
+      | inl i => obtain rfl := Fin.fin_one_eq_zero i; rfl
+      | inr j => rfl
+    · -- right_inv
+      rintro ⟨c, g⟩
+      rfl
+  rw [Fintype.card_congr hEquiv, Fintype.card_sigma]
+  apply Finset.sum_congr rfl
+  intro c _
+  rw [Fintype.card_fun, Fintype.card_coe, card_neighborFinset_eq_degree, Fintype.card_fin]
+
+/-- **Edge count of the star `K_{1,m}`.** The star `completeBipartiteGraph (Fin 1) (Fin m)`
+has exactly `m` edges (the centre `Sum.inl 0` joined to each of the `m` leaves). -/
+@[category API, AMS 5]
+lemma card_edgeFinset_star (m : ℕ)
+    [DecidableRel (completeBipartiteGraph (Fin 1) (Fin m)).Adj] :
+    (completeBipartiteGraph (Fin 1) (Fin m)).edgeFinset.card = m := by
+  -- Handshake: `2 · #E = ∑ deg = deg(centre) + ∑ deg(leaf) = m + m·1 = 2m`.
+  have hdeg_centre : (completeBipartiteGraph (Fin 1) (Fin m)).degree (Sum.inl 0) = m := by
+    rw [← card_neighborFinset_eq_degree, neighborFinset_eq_filter]
+    rw [show (Finset.univ.filter
+        fun w => (completeBipartiteGraph (Fin 1) (Fin m)).Adj (Sum.inl 0) w)
+        = Finset.univ.map ⟨Sum.inr, Sum.inr_injective⟩ from ?_]
+    · simp
+    · ext w
+      cases w with
+      | inl k => simp [completeBipartiteGraph]
+      | inr k => simp [completeBipartiteGraph]
+  have hdeg_leaf : ∀ j : Fin m, (completeBipartiteGraph (Fin 1) (Fin m)).degree (Sum.inr j) = 1 := by
+    intro j
+    rw [← card_neighborFinset_eq_degree, neighborFinset_eq_filter]
+    rw [show (Finset.univ.filter
+        fun w => (completeBipartiteGraph (Fin 1) (Fin m)).Adj (Sum.inr j) w)
+        = {Sum.inl (0 : Fin 1)} from ?_]
+    · simp
+    · ext w
+      cases w with
+      | inl k => simp [completeBipartiteGraph, Fin.fin_one_eq_zero k]
+      | inr k => simp [completeBipartiteGraph]
+  have hsum : ∑ v : Fin 1 ⊕ Fin m, (completeBipartiteGraph (Fin 1) (Fin m)).degree v = 2 * m := by
+    rw [Fintype.sum_sum_type, Fin.sum_univ_one, hdeg_centre]
+    simp only [hdeg_leaf, Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul,
+      mul_one]
+    ring
+  have h := (completeBipartiteGraph (Fin 1) (Fin m)).sum_degrees_eq_twice_card_edges
+  rw [hsum] at h
+  omega
+
+/--
+**Case: stars `K_{1,m}` (Sidorenko).**
+
+Sidorenko's inequality holds for every star `K_{1,m} = completeBipartiteGraph (Fin 1) (Fin m)`.
+This is a fully proved instance of both `sidorenko_conjecture.variants.complete_bipartite` and
+`sidorenko_tree` (a star is a complete bipartite graph and a tree).
+
+**Proof.** With `d(c) := G.degree c` and `N := |W|`, the star has `m` edges, so the desired
+inequality is `(∑_c d(c) / N^2)^m ≤ (∑_c d(c)^m) / N^{m+1}` (using `t(K_2, G) = ∑_c d(c) / N^2`
+and `t(K_{1,m}, G) = ∑_c d(c)^m / N^{m+1}` via `homCount_star_eq_sum_degree_pow`). After clearing
+denominators this is `(∑_c d(c))^m ≤ N^{m-1} · ∑_c d(c)^m`, the power-mean (Jensen) inequality
+`Finset.pow_sum_div_card_le_sum_pow`. -/
+@[category research solved, AMS 5]
+theorem sidorenko_conjecture.variants.star (m : ℕ)
+    [DecidableRel (completeBipartiteGraph (Fin 1) (Fin m)).Adj]
+    {W : Type} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] :
+    homDensity (completeGraph (Fin 2)) G ^
+        ((completeBipartiteGraph (Fin 1) (Fin m)).edgeFinset.card) ≤
+      homDensity (completeBipartiteGraph (Fin 1) (Fin m)) G := by
+  rw [card_edgeFinset_star]
+  set N : ℕ := Fintype.card W with hN
+  have hNpos : 0 < (N : ℝ) := by exact_mod_cast Fintype.card_pos
+  -- Left-hand base `t(K_2, G) = (∑_c d(c)) / N^2`.
+  have hLbase : homDensity (completeGraph (Fin 2)) G = (∑ c : W, (G.degree c : ℝ)) / (N : ℝ) ^ 2 := by
+    unfold homDensity
+    rw [homCount_completeGraph_fin_two_eq_two_mul_card_edgeFinset,
+      ← G.sum_degrees_eq_twice_card_edges]
+    simp only [Fintype.card_fin, ← hN]
+    push_cast
+    ring
+  -- Right-hand side `t(K_{1,m}, G) = (∑_c d(c)^m) / N^{m+1}`.
+  have hR : homDensity (completeBipartiteGraph (Fin 1) (Fin m)) G
+      = (∑ c : W, (G.degree c : ℝ) ^ m) / (N : ℝ) ^ (m + 1) := by
+    unfold homDensity
+    rw [homCount_star_eq_sum_degree_pow]
+    have hcardV : Fintype.card (Fin 1 ⊕ Fin m) = m + 1 := by simp [add_comm]
+    rw [hcardV, ← hN]
+    push_cast
+    rfl
+  rw [hLbase, hR, div_pow]
+  rcases Nat.eq_zero_or_pos m with hm | hm
+  · -- `m = 0`: both sides equal `1`.
+    subst hm
+    simp [Finset.sum_const, Finset.card_univ, ← hN]
+  · -- `m ≥ 1`: the power-mean (Jensen) inequality `(∑ d)^m / N^{m-1} ≤ ∑ d^m`.
+    obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hm.ne'
+    have hjensen := pow_sum_div_card_le_sum_pow (s := (Finset.univ : Finset W))
+      (f := fun c => (G.degree c : ℝ)) (fun _ _ => by positivity) k
+    rw [Finset.card_univ, ← hN, div_le_iff₀ (by positivity : (0 : ℝ) < (N : ℝ) ^ k)] at hjensen
+    -- hjensen : (∑ c, ↑(d c))^(k+1) ≤ (∑ c, (↑(d c))^(k+1)) * N^k
+    rw [div_le_div_iff₀ (by positivity) (by positivity)]
+    calc (∑ c : W, (G.degree c : ℝ)) ^ (k + 1) * (N : ℝ) ^ (k + 1 + 1)
+        ≤ ((∑ c : W, (G.degree c : ℝ) ^ (k + 1)) * (N : ℝ) ^ k) * (N : ℝ) ^ (k + 1 + 1) :=
+          mul_le_mul_of_nonneg_right hjensen (by positivity)
+      _ = (∑ c : W, (G.degree c : ℝ) ^ (k + 1)) * ((N : ℝ) ^ 2) ^ (k + 1) := by ring
+
 /--
 **Bipartiteness is necessary: the triangle is not a Sidorenko graph.**
 

--- a/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
+++ b/FormalConjectures/Wikipedia/SidorenkoConjecture.lean
@@ -28,6 +28,8 @@ import FormalConjecturesUtil
 * [KLL18] Kim, J.H., Lee, C., Lee, J. (2018). "Two approaches to Sidorenko's conjecture."
   *Trans. Amer. Math. Soc.* 370, pp. 8515--8552.
 * [ArXiv2605] [arXiv:2605.14138](https://arxiv.org/abs/2605.14138)
+* [BR65] Blakley, G. R. and Roy, P. (1965). "A Hölder type inequality for symmetric matrices
+  with nonnegative entries." *Proc. Amer. Math. Soc.* 16, pp. 1244--1245.
 -/
 
 open Finset SimpleGraph
@@ -738,5 +740,116 @@ theorem sidorenko_tree {V W : Type} [Fintype V] [Fintype W]
     --
     -- Deferred to a future commit; see `docs/PHASE2_PROOF_ROADMAP.md` §6.
     sorry
+
+/- ## Further variants of Sidorenko's conjecture -/
+
+/--
+**Case: complete bipartite graphs `K_{s,t}` (Sidorenko 1993).**
+
+Sidorenko's inequality holds when `H = K_{s,t}` is a complete bipartite graph. This is one
+of the earliest known cases; it follows from repeated applications of the Cauchy–Schwarz /
+Hölder inequality. The `s = t = 2` instance is `sidorenko_K22`.
+
+*Reference:* [Si93].
+-/
+@[category research solved, AMS 5]
+theorem sidorenko_conjecture.variants.complete_bipartite (s t : ℕ)
+    [DecidableRel (completeBipartiteGraph (Fin s) (Fin t)).Adj]
+    {W : Type} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] :
+    homDensity (completeGraph (Fin 2)) G ^
+        ((completeBipartiteGraph (Fin s) (Fin t)).edgeFinset.card) ≤
+      homDensity (completeBipartiteGraph (Fin s) (Fin t)) G := by
+  sorry
+
+/--
+**Case: even cycles `C_{2k}` (Sidorenko 1993).**
+
+Sidorenko's inequality holds for every even cycle `C_{2k}` with `k ≥ 2`
+(`cycleGraph (2 * k)`). Even cycles are bipartite; the `k = 2` case `C_4` coincides
+with `K_{2,2}` (`sidorenko_K22`).
+
+*Reference:* [Si93].
+-/
+@[category research solved, AMS 5]
+theorem sidorenko_conjecture.variants.even_cycle (k : ℕ) (hk : 2 ≤ k)
+    {W : Type} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] :
+    homDensity (completeGraph (Fin 2)) G ^
+        ((cycleGraph (2 * k)).edgeFinset.card) ≤
+      homDensity (cycleGraph (2 * k)) G := by
+  sorry
+
+/--
+**Case: paths, the Blakley–Roy inequality (1965).**
+
+For the path `P_n` on `n` vertices (`pathGraph n`), Sidorenko's inequality
+`t(K_2, G)^{e(P_n)} ≤ t(P_n, G)` is the Blakley–Roy inequality, established well before
+Sidorenko's general conjecture. Paths are trees, so this is also a special case of
+`sidorenko_tree`.
+
+*Reference:* [BR65].
+-/
+@[category research solved, AMS 5]
+theorem sidorenko_conjecture.variants.path_blakley_roy (n : ℕ)
+    [DecidableRel (pathGraph n).Adj]
+    {W : Type} [Fintype W] [DecidableEq W] [Nonempty W]
+    (G : SimpleGraph W) [DecidableRel G.Adj] :
+    homDensity (completeGraph (Fin 2)) G ^ ((pathGraph n).edgeFinset.card) ≤
+      homDensity (pathGraph n) G := by
+  sorry
+
+/--
+**Bipartiteness is necessary: the triangle is not a Sidorenko graph.**
+
+The hypothesis `H.IsBipartite` in `sidorenko_conjecture` cannot be dropped. For the
+triangle `H = K_3` (chromatic number `3`, hence not bipartite) and the single edge
+`G = K_2`, Sidorenko's inequality fails: the putative lower bound is
+`t(K_2, K_2)^{e(K_3)} = (1/2)^3 = 1/8`, while the actual density is `t(K_3, K_2) = 0`,
+because there is no graph homomorphism from `K_3` into the triangle-free graph `K_2`
+(such a homomorphism would be an injection `Fin 3 ↪ Fin 2`). So the lower bound `1/8`
+strictly exceeds the true value `0`.
+
+More generally, any `H` containing an odd cycle fails Sidorenko's inequality against a
+suitable bipartite `G`, since then `t(H, G) = 0 < t(K_2, G)^{e(H)}`.
+-/
+@[category research solved, AMS 5]
+theorem sidorenko_conjecture.variants.non_bipartite_necessary :
+    homDensity (completeGraph (Fin 3)) (completeGraph (Fin 2)) <
+      homDensity (completeGraph (Fin 2)) (completeGraph (Fin 2)) ^
+        ((completeGraph (Fin 3)).edgeFinset.card) := by
+  -- `e(K_3) = 3`.
+  have hK3edges : (completeGraph (Fin 3)).edgeFinset.card = 3 := by
+    rw [SimpleGraph.card_edgeFinset_completeGraph_fin]; decide
+  -- `t(K_2, K_2) = homCount(K_2, K_2) / 2^2 = 2 / 4 = 1/2`.
+  have hRHSbase : homDensity (completeGraph (Fin 2)) (completeGraph (Fin 2)) = 1 / 2 := by
+    unfold homDensity
+    rw [homCount_completeGraph_fin_two_eq_two_mul_card_edgeFinset,
+      SimpleGraph.card_edgeFinset_completeGraph_fin]
+    simp only [Fintype.card_fin, Nat.choose_self]
+    norm_num
+  -- `t(K_3, K_2) = 0`: there is no homomorphism `K_3 →g K_2`.
+  have hLHS : homDensity (completeGraph (Fin 3)) (completeGraph (Fin 2)) = 0 := by
+    have hempty : IsEmpty (completeGraph (Fin 3) →g completeGraph (Fin 2)) := by
+      refine ⟨fun f => ?_⟩
+      -- Any homomorphism into a complete graph is injective on adjacent (i.e. distinct) vertices.
+      have hinj : Function.Injective (f : Fin 3 → Fin 2) := by
+        intro a b hab
+        by_contra hne
+        have hadj : (completeGraph (Fin 3)).Adj a b := by
+          rw [completeGraph_eq_top, top_adj]; exact hne
+        have hadj' : (completeGraph (Fin 2)).Adj (f a) (f b) := f.map_adj hadj
+        exact hadj'.ne hab
+      have hle := Fintype.card_le_of_injective _ hinj
+      simp only [Fintype.card_fin] at hle
+      omega
+    have hcount : homCount (completeGraph (Fin 3)) (completeGraph (Fin 2)) = 0 := by
+      haveI := hempty
+      simp [homCount]
+    unfold homDensity
+    rw [hcount]
+    simp
+  rw [hLHS, hK3edges, hRHSbase]
+  norm_num
 
 end SidorenkoConjecture


### PR DESCRIPTION
Extends `FormalConjectures/Wikipedia/SidorenkoConjecture.lean` with variants of Sidorenko's conjecture, following the existing `.variants.` naming convention (cf. `erdos_61.variants.*`).

### Added declarations

| Declaration | Content | Status |
|---|---|---|
| `sidorenko_conjecture.variants.complete_bipartite` | Sidorenko holds for `K_{s,t}` | statement + `sorry` ([Si93]) |
| `sidorenko_conjecture.variants.even_cycle` | Sidorenko holds for even cycles `C_{2k}` | statement + `sorry` ([Si93]) |
| `sidorenko_conjecture.variants.path_blakley_roy` | The Blakley–Roy inequality for paths | statement + `sorry` ([BR65]) |
| `sidorenko_conjecture.variants.star` | Sidorenko holds for stars `K_{1,m}` | **fully proved, `sorry`-free** |
| `sidorenko_conjecture.variants.non_bipartite_necessary` | Bipartiteness is necessary: `K_3` is not Sidorenko | **fully proved, `sorry`-free** |

The complete-bipartite, even-cycle and path cases are classical known-proved results, stated with `sorry` and literature references (matching the `research solved` + reference pattern used elsewhere in the repo).

**Two results are proved outright:**

- **`star`** — Sidorenko's inequality for the star `K_{1,m}`, a fully closed instance of both the (still-open) tree case and the complete-bipartite case. Supporting API: `homCount_star_eq_sum_degree_pow` (`homCount(K_{1,m}, G) = ∑_c (deg c)^m` via an explicit bijection `(K_{1,m} →g G) ≃ Σ c, (Fin m → N(c))`) and `card_edgeFinset_star` (`e(K_{1,m}) = m`). The inequality reduces to the power-mean / Jensen inequality `pow_sum_div_card_le_sum_pow`.

- **`non_bipartite_necessary`** — for the triangle `H = K_3` and single edge `G = K_2`, the putative Sidorenko lower bound `t(K_2, K_2)^{e(K_3)} = (1/2)^3 = 1/8` strictly exceeds the true density `t(K_3, K_2) = 0` (there is no homomorphism `K_3 →g K_2`, as it would inject `Fin 3 ↪ Fin 2`). This shows the `H.IsBipartite` hypothesis in `sidorenko_conjecture` cannot be dropped.

Added `[BR65]` (Blakley–Roy 1965) to the module reference block.

### Verification
- `lake env lean` on the file: only the intended `sorry` warnings (none on `star` or `non_bipartite_necessary`).
- `lake build FormalConjectures.Wikipedia.SidorenkoConjecture`: passes all linters (category / AMS / answer / formal-proof / LaTeX / unused-simp-args).

🤖 Generated with [Claude Code](https://claude.com/claude-code)