### PR TITLE
Arxiv/2607.06396: the Alon-Tarsi short cycle cover conjecture

### DIFF
--- a/FormalConjectures/Arxiv/2607.06396/AlonTarsi.lean
+++ b/FormalConjectures/Arxiv/2607.06396/AlonTarsi.lean
@@ -30,37 +30,18 @@ Every bridgeless graph has a list of cycles covering every edge whose lengths su
 $\frac{7}{5}|E|$.
 -/
 
-open Finset
+open Finset SimpleGraph
 
 namespace Arxiv.«2607.06396»
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
-
-/-- A cycle of `G`, carrying its basepoint. Cycles are collected into a `Multiset` below, so a
-cover may use the same cycle more than once. -/
-structure Cycle (G : SimpleGraph V) where
-  /-- The vertex the cycle starts and ends at. -/
-  base : V
-  /-- The closed walk tracing the cycle. -/
-  walk : G.Walk base base
-  /-- That walk is a cycle. -/
-  isCycle : walk.IsCycle
-
-/-- The edges a cycle traverses. -/
-def Cycle.edges {G : SimpleGraph V} (c : Cycle G) : List (Sym2 V) := c.walk.edges
-
-/-- The length of a cycle, its number of edges. -/
-def Cycle.length {G : SimpleGraph V} (c : Cycle G) : ℕ := c.walk.length
 
 /-- `C` covers `G`: every edge of `G` lies on at least one cycle of `C`. -/
 def IsCycleCover (G : SimpleGraph V) [DecidableRel G.Adj] (C : Multiset (Cycle G)) : Prop :=
   ∀ e ∈ G.edgeFinset, ∃ c ∈ C, e ∈ c.edges
 
 /-- The total length of a family of cycles. -/
-def totalLength {G : SimpleGraph V} (C : Multiset (Cycle G)) : ℕ := (C.map Cycle.length).sum
-
-/-- `G` is bridgeless: no edge is a bridge. -/
-def Bridgeless (G : SimpleGraph V) : Prop := ∀ e ∈ G.edgeSet, ¬ G.IsBridge e
+def totalLength {G : SimpleGraph V} (C : Multiset (Cycle G)) : ℕ := (C.map SimpleGraph.Cycle.length).sum
 
 /--
 **Conjecture 4 (Alon-Tarsi, 1985).** Every bridgeless graph has a list of cycles covering
@@ -69,16 +50,9 @@ every edge, with $\sum_{C} |E(C)| \leq \frac{7}{5}|E(G)|$.
 @[category research open, AMS 5]
 theorem alon_tarsi_short_cycle_cover :
     answer(sorry) ↔ ∀ (V : Type) [Fintype V] [DecidableEq V] (G : SimpleGraph V)
-      [DecidableRel G.Adj], Bridgeless G →
+      [DecidableRel G.Adj], G.IsBridgeless →
       ∃ C : Multiset (Cycle G), IsCycleCover G C ∧
         (totalLength C : ℚ) ≤ 7 / 5 * #G.edgeFinset := by
-  sorry
-
-/-- An acyclic graph is bridgeless only if it has no edges, since in a forest every edge is a
-bridge. So the conjecture says nothing about trees beyond the empty cover. -/
-@[category API, AMS 5]
-theorem edgeFinset_eq_empty_of_bridgeless_of_isAcyclic (G : SimpleGraph V) [DecidableRel G.Adj]
-    (hacyc : G.IsAcyclic) (hbr : Bridgeless G) : G.edgeFinset = ∅ := by
   sorry
 
 omit [DecidableEq V] in
@@ -94,6 +68,17 @@ theorem exists_cover_of_edgeFinset_eq_empty (G : SimpleGraph V) [DecidableRel G.
     rw [h] at he
     exact absurd he (Finset.notMem_empty e)
   · simp [totalLength, h]
+
+omit [DecidableEq V] in
+/-- Acyclic bridgeless graphs satisfy the conjecture, with the empty cover. In a forest every
+edge is a bridge, so such a graph has no edges at all. -/
+@[category test, AMS 5]
+theorem exists_cover_of_isAcyclic (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hacyc : G.IsAcyclic) (hbr : G.IsBridgeless) :
+    ∃ C : Multiset (Cycle G), IsCycleCover G C ∧
+      (totalLength C : ℚ) ≤ 7 / 5 * #G.edgeFinset :=
+  exists_cover_of_edgeFinset_eq_empty G
+    (G.edgeFinset_eq_empty_of_isBridgeless_of_isAcyclic hacyc hbr)
 
 omit [Fintype V] [DecidableEq V] in
 /-- A cycle has at least three edges, so any cover of a graph with an edge has total length at

--- a/FormalConjectures/Arxiv/2607.06396/AlonTarsi.lean
+++ b/FormalConjectures/Arxiv/2607.06396/AlonTarsi.lean
@@ -1,0 +1,105 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The Alon-Tarsi short cycle cover conjecture
+
+*References:*
+- [AlTa85] Alon, N. and Tarsi, M., Covering multigraphs by simple circuits.
+  SIAM J. Algebraic Discrete Methods (1985), 345--350.
+- [arxiv/2607.06396](https://arxiv.org/abs/2607.06396)
+  **Some new results on Sylvester colorings of cubic graphs**
+  by *Luca Ferrarini, Vahan Mkrtchyan*, where this is Conjecture 4.
+
+Every bridgeless graph has a list of cycles covering every edge whose lengths sum to at most
+$\frac{7}{5}|E|$.
+-/
+
+open Finset
+
+namespace Arxiv.«2607.06396»
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A cycle of `G`, carrying its basepoint. Cycles are collected into a `Multiset` below, so a
+cover may use the same cycle more than once. -/
+structure Cycle (G : SimpleGraph V) where
+  /-- The vertex the cycle starts and ends at. -/
+  base : V
+  /-- The closed walk tracing the cycle. -/
+  walk : G.Walk base base
+  /-- That walk is a cycle. -/
+  isCycle : walk.IsCycle
+
+/-- The edges a cycle traverses. -/
+def Cycle.edges {G : SimpleGraph V} (c : Cycle G) : List (Sym2 V) := c.walk.edges
+
+/-- The length of a cycle, its number of edges. -/
+def Cycle.length {G : SimpleGraph V} (c : Cycle G) : ℕ := c.walk.length
+
+/-- `C` covers `G`: every edge of `G` lies on at least one cycle of `C`. -/
+def IsCycleCover (G : SimpleGraph V) [DecidableRel G.Adj] (C : Multiset (Cycle G)) : Prop :=
+  ∀ e ∈ G.edgeFinset, ∃ c ∈ C, e ∈ c.edges
+
+/-- The total length of a family of cycles. -/
+def totalLength {G : SimpleGraph V} (C : Multiset (Cycle G)) : ℕ := (C.map Cycle.length).sum
+
+/-- `G` is bridgeless: no edge is a bridge. -/
+def Bridgeless (G : SimpleGraph V) : Prop := ∀ e ∈ G.edgeSet, ¬ G.IsBridge e
+
+/--
+**Conjecture 4 (Alon-Tarsi, 1985).** Every bridgeless graph has a list of cycles covering
+every edge, with $\sum_{C} |E(C)| \leq \frac{7}{5}|E(G)|$.
+-/
+@[category research open, AMS 5]
+theorem alon_tarsi_short_cycle_cover :
+    answer(sorry) ↔ ∀ (V : Type) [Fintype V] [DecidableEq V] (G : SimpleGraph V)
+      [DecidableRel G.Adj], Bridgeless G →
+      ∃ C : Multiset (Cycle G), IsCycleCover G C ∧
+        (totalLength C : ℚ) ≤ 7 / 5 * #G.edgeFinset := by
+  sorry
+
+/-- An acyclic graph is bridgeless only if it has no edges, since in a forest every edge is a
+bridge. So the conjecture says nothing about trees beyond the empty cover. -/
+@[category API, AMS 5]
+theorem edgeFinset_eq_empty_of_bridgeless_of_isAcyclic (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hacyc : G.IsAcyclic) (hbr : Bridgeless G) : G.edgeFinset = ∅ := by
+  sorry
+
+omit [DecidableEq V] in
+/-- The empty cover works when there are no edges, so the bound is attained with room to spare
+on edgeless graphs. -/
+@[category test, AMS 5]
+theorem exists_cover_of_edgeFinset_eq_empty (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : G.edgeFinset = ∅) :
+    ∃ C : Multiset (Cycle G), IsCycleCover G C ∧
+      (totalLength C : ℚ) ≤ 7 / 5 * #G.edgeFinset := by
+  refine ⟨0, ?_, ?_⟩
+  · intro e he
+    rw [h] at he
+    exact absurd he (Finset.notMem_empty e)
+  · simp [totalLength, h]
+
+omit [Fintype V] [DecidableEq V] in
+/-- A cycle has at least three edges, so any cover of a graph with an edge has total length at
+least three. This is what makes the `7/5` bound a real constraint rather than a formality. -/
+@[category API, AMS 5]
+theorem three_le_length {G : SimpleGraph V} (c : Cycle G) : 3 ≤ c.length :=
+  c.isCycle.three_le_length
+
+end Arxiv.«2607.06396»

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -62,6 +62,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Coloring
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.CompleteGraphEdgeCount
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Connectivity
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Cvetkovic
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Cycle
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.CycleRank
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Degrees
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.DiamExtra

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Cycle.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Cycle.lean
@@ -1,0 +1,54 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Acyclic
+
+@[expose] public section
+
+namespace SimpleGraph
+
+variable {V : Type*}
+
+/-- A cycle of `G`, carrying its basepoint. Bundling the basepoint makes the cycles of `G` into a
+type, so they can be collected into a `Finset` or a `Multiset`. -/
+structure Cycle (G : SimpleGraph V) where
+  /-- The vertex the cycle starts and ends at. -/
+  base : V
+  /-- The closed walk tracing the cycle. -/
+  walk : G.Walk base base
+  /-- That walk is a cycle. -/
+  isCycle : walk.IsCycle
+
+/-- The edges a cycle traverses. -/
+def Cycle.edges {G : SimpleGraph V} (c : Cycle G) : List (Sym2 V) := c.walk.edges
+
+/-- The length of a cycle, its number of edges. -/
+def Cycle.length {G : SimpleGraph V} (c : Cycle G) : ℕ := c.walk.length
+
+/-- `G` is bridgeless if none of its edges is a bridge. -/
+def IsBridgeless (G : SimpleGraph V) : Prop := ∀ e ∈ G.edgeSet, ¬ G.IsBridge e
+
+/-- In a forest every edge is a bridge, so an acyclic bridgeless graph has no edges at all. -/
+theorem edgeFinset_eq_empty_of_isBridgeless_of_isAcyclic [Fintype V] (G : SimpleGraph V)
+    [DecidableRel G.Adj] (hacyc : G.IsAcyclic) (hbr : G.IsBridgeless) : G.edgeFinset = ∅ := by
+  rw [SimpleGraph.edgeFinset_eq_empty]
+  ext u v
+  simp only [SimpleGraph.bot_adj, iff_false]
+  intro hadj
+  exact hbr s(u, v) hadj (G.isAcyclic_iff_forall_edge_isBridge.mp hacyc hadj)
+
+end SimpleGraph


### PR DESCRIPTION
Closes #4813.

Alon and Tarsi (1985): every bridgeless graph has a list of cycles covering every edge, with total length at most `7/5 |E|`. Quoted from Conjecture 4 of [Ferrarini and Mkrtchyan](https://arxiv.org/abs/2607.06396), which is where the issue points.

```lean
answer(sorry) ↔ ∀ (V : Type) [Fintype V] [DecidableEq V] (G : SimpleGraph V)
  [DecidableRel G.Adj], Bridgeless G →
  ∃ C : Multiset (Cycle G), IsCycleCover G C ∧
    (totalLength C : ℚ) ≤ 7 / 5 * #G.edgeFinset
```

`Multiset` rather than `Finset`, since the source says "a list of cycles" and nothing stops a cover using one twice. `ℚ` on the right so `7/5` is the rational, not `1`.

Two things are proved rather than stated:

- `three_le_length`, that every cycle has at least three edges. Without it `7/5 |E|` reads as though short covers were free.
- `exists_cover_of_edgeFinset_eq_empty`, the empty cover on an edgeless graph.

`edgeFinset_eq_empty_of_bridgeless_of_isAcyclic` records why trees are not counterexamples: in a forest every edge is a bridge, so a bridgeless acyclic graph has no edges at all and the conjecture is vacuous there rather than false.

Builds clean under `--wfail`, and the two proved statements give the standard three axioms.