### PR TITLE
Wikipedia/MovingSofa: state sofa uniqueness up to a rigid motion

### DIFF
--- a/FormalConjectures/Wikipedia/MovingSofa.lean
+++ b/FormalConjectures/Wikipedia/MovingSofa.lean
@@ -215,10 +215,17 @@ theorem sofaConstant_eq : sofaConstant = answer(volume gerversSofa) := by
 theorem sofaConstant_eq_volume_gerversSofa : sofaConstant = volume gerversSofa := by
   sorry
 
-/-- Gerver's sofa is the unique sofa that attains the sofa constant. -/
+/--
+Gerver's sofa is the unique sofa that attains the sofa constant, up to a rigid motion.
+
+The motion is needed: `horizontalHallway` is $(-\infty, 1] \times [0, 1]$, so a leftward
+translate of any moving sofa is again one, obtained by sliding right and then following the
+original motion. It has the same area, so uniqueness cannot hold on the nose.
+-/
 @[category research open, AMS 49]
-theorem sofaConstant_eq_volume_iff_eq_gerversSofa :
-    ∀ s : Set ℝ², sofaConstant = volume s ↔ s = gerversSofa := by
+theorem volume_eq_sofaConstant_iff_congruent_gerversSofa (s : Set ℝ²)
+    (hs : ∃ m, IsMovingSofa s m) :
+    volume s = sofaConstant ↔ ∃ g : E(2), s = g '' gerversSofa := by
   sorry
 
 end MovingSofa


### PR DESCRIPTION
Closes #4851.

`sofaConstant_eq_volume_iff_eq_gerversSofa` had no hypothesis on `s`, so it said every set in the plane with Gerver's area is Gerver's sofa. KitaKen1's counterexample in the issue: drop a point.

Restricting to moving sofas fixes that but leaves the statement false. `horizontalHallway` is $(-\infty, 1] \times [0, 1]$, unbounded to the left, so a leftward translate `s` of a moving sofa `s` is again one. Take `m' t` to be the translation right by `2td` for `t ≤ 1/2`, and `m (2t-1) ∘ τ_d` for `t ≥ 1/2`. The two agree at `t = 1/2`, `m' 0 = id`, and everything stays in the hallway because the horizontal side is closed under leftward translation. Same area, different set.

So the statement is now uniqueness up to a rigid motion. The reverse direction is invariance of volume under isometries, the forward one is the conjecture. Renamed, since the old name asserted the equality that was the bug.