### PR TITLE
feat(ErdosProblems): mark Erdős 42 constructive variant as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -52,7 +52,7 @@ every maximal Sidon set A ⊆ {1,…,N} has another Sidon set B ⊆ {1,…,N} of
 disjoint difference sets (apart from 0).
 -/
 @[category research solved, AMS 5 11,
-  formal_proof using lean4 at "https://github.com/KitaKen1/erdos-42-constructive-variant/blob/1f82c76be43cb56f22e2f7f792e392d5fb3ff78c/lean/Erdos42Constructive.lean"]
+  formal_proof using formal_conjectures at "https://github.com/KitaKen1/erdos-42-constructive-variant/blob/1f82c76be43cb56f22e2f7f792e392d5fb3ff78c/lean/Erdos42Constructive.lean"]
 theorem erdos_42.variants.constructive : answer(True) ↔
     ∃ (f : ℕ → ℕ), ∀ (M N : ℕ) (_ : 1 ≤ M) (_ : f M ≤ N),
     ∀ (A : Set ℕ) (_ : IsMaximalSidonSetIn A N), ∃ᵉ (B : Set ℕ),

--- a/FormalConjectures/ErdosProblems/42.lean
+++ b/FormalConjectures/ErdosProblems/42.lean
@@ -51,8 +51,9 @@ This version provides a constructive function f such that for all M ≥ 1 and N 
 every maximal Sidon set A ⊆ {1,…,N} has another Sidon set B ⊆ {1,…,N} of size M with
 disjoint difference sets (apart from 0).
 -/
-@[category research open, AMS 5 11]
-theorem erdos_42.variants.constructive : answer(sorry) ↔
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at "https://github.com/KitaKen1/erdos-42-constructive-variant/blob/1f82c76be43cb56f22e2f7f792e392d5fb3ff78c/lean/Erdos42Constructive.lean"]
+theorem erdos_42.variants.constructive : answer(True) ↔
     ∃ (f : ℕ → ℕ), ∀ (M N : ℕ) (_ : 1 ≤ M) (_ : f M ≤ N),
     ∀ (A : Set ℕ) (_ : IsMaximalSidonSetIn A N), ∃ᵉ (B : Set ℕ),
       B ⊆ Set.Icc 1 N ∧ IsSidon B ∧ B.ncard = M ∧


### PR DESCRIPTION
This PR changes `erdos_42.variants.constructive` from `answer(sorry)` to `answer(True)` and links a kernel-checked Lean proof.

The Lean proof was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

Note: This proof uses the formalization of the main Erdős 42 theorem from [Shashi456's `erdos-formalizations` repository](https://github.com/Shashi456/erdos-formalizations/tree/main/Erdos/P42).

The external proof establishes:

```lean
theorem erdos_42.variants.constructive : answer(True) ↔
    ∃ (f : ℕ → ℕ), ∀ (M N : ℕ) (_ : 1 ≤ M) (_ : f M ≤ N),
      ∀ (A : Set ℕ) (_ : Set.IsMaximalSidonSetIn A N), ∃ᵉ (B : Set ℕ),
        B ⊆ Set.Icc 1 N ∧ IsSidon B ∧ B.ncard = M ∧
          ((A - A) ∩ (B - B) : Set ℕ) = {0}
```

Proof: https://github.com/KitaKen1/erdos-42-constructive-variant/blob/1f82c76be43cb56f22e2f7f792e392d5fb3ff78c/lean/Erdos42Constructive.lean

Repository: https://github.com/KitaKen1/erdos-42-constructive-variant

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-42-constructive-variant%2Fmain%2Flean4web%2FErdos42ConstructiveLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization is assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.