### PR TITLE
ForMathlib/Data/Finset/Card: drop a lemma Mathlib already has

### DIFF
--- a/FormalConjecturesForMathlib/Data/Finset/Card.lean
+++ b/FormalConjecturesForMathlib/Data/Finset/Card.lean
@@ -22,11 +22,7 @@ public import Mathlib.Data.Finset.Card
 namespace Finset
 variable {α : Type*} {s t : Finset α}
 
-lemma card_le_card_iff_of_subset (hst : s ⊆ t) : #t ≤ #s ↔ s = t where
-  mp := eq_of_subset_of_card_le hst
-  mpr := by rintro rfl; rfl
-
 lemma card_lt_card_iff_of_subset (hst : s ⊆ t) : #s < #t ↔ s ≠ t := by
-  rw [← not_le, card_le_card_iff_of_subset hst]
+  rw [← not_le, eq_iff_card_le_of_subset hst]
 
 end Finset


### PR DESCRIPTION
`Finset.card_le_card_iff_of_subset` is Mathlib's `Finset.eq_iff_card_le_of_subset` under a different name. It is there at the Mathlib revision this repo pins, so the duplicate has been sitting here since the file was written.

The only user was `card_lt_card_iff_of_subset` just below it, which now rewrites with the Mathlib lemma. `Johnson.lean` uses that one and is unchanged.

Name matching will not find this sort of thing, since the names differ. I checked by restating the lemma in a file that imports only Mathlib and running `exact?`.