### PR TITLE
fix(Wikipedia): rule out negative radii in SquarePacking

### DIFF
--- a/FormalConjectures/Wikipedia/SquarePacking.lean
+++ b/FormalConjectures/Wikipedia/SquarePacking.lean
@@ -29,11 +29,16 @@ In each case, we provide a known upper bound, and ask for the least such size.
 - [Wikipedia on packing of circles in a square](https://en.wikipedia.org/wiki/Circle_packing_in_a_square)
 - Friedman, Erich (2009), "Packing unit squares in squares: a survey and new results",
   Electronic Journal of Combinatorics, 1000, Dynamic Survey 7
+- Pirl, U. (1969),
+  ["Der Mindestabstand von $n$ in der Einheitskreisscheibe gelegenen Punkten"](https://doi.org/10.1002/mana.19690400110),
+  Mathematische Nachrichten, 40: 111–124
 - A website with visualizations of packings:
   [link](https://erich-friedman.github.io/packing/)
 -/
 
 open EuclideanGeometry
+
+open scoped NNReal
 
 universe u
 
@@ -54,11 +59,12 @@ def UnitSquare : Set ℝ² := Square 1
 
 /--
 A circle of a particular radius as a subset of the Euclidean plane.
+The radius is a nonnegative real, so that `Circle r` is always the disc of radius $r$.
 Not including border, so that circles that touch at the border are disjoint,
 but a circle internal to another shape is a subset of that shape.
 -/
-def Circle (r : ℝ) : Set ℝ² :=
-  {p : ℝ² | p 0 ^ 2 + p 1 ^ 2 < r ^ 2}
+def Circle (r : ℝ≥0) : Set ℝ² :=
+  {p : ℝ² | p 0 ^ 2 + p 1 ^ 2 < (r : ℝ) ^ 2}
 
 /--
 The unit circle as a subset of the Euclidean plane.
@@ -77,6 +83,16 @@ structure Packing (n : ℕ) (s : Set ℝ²) (S : Set ℝ²) where
   disjoint : Pairwise fun i j => Disjoint (embeddings i '' s) (embeddings j '' s)
   /-- The images of the embeddings are all inside the larger set `S` -/
   inside : ∀ i : Fin n, embeddings i '' s ⊆ S
+
+/--
+The degenerate circle is empty.
+-/
+@[category test, AMS 51]
+theorem circle_zero : Circle 0 = ∅ := by
+  ext p
+  simp only [Circle, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false, not_lt,
+    NNReal.coe_zero, zero_pow, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true]
+  positivity
 
 /--
 Eleven unit squares can be packed into a square of side length < 3.877084.
@@ -125,7 +141,7 @@ Reference: [Wikipedia](https://en.wikipedia.org/wiki/Square_packing#In_a_circle)
 -/
 @[category textbook, AMS 51]
 theorem three_square_packing_in_circle_bound :
-    Nonempty (Packing 3 UnitSquare (Circle ((5 * √ 17) / 16))) := by
+    Nonempty (Packing 3 UnitSquare (Circle ((5 * NNReal.sqrt 17) / 16))) := by
   sorry
 
 /--
@@ -135,7 +151,7 @@ Reference: [Wikipedia](https://en.wikipedia.org/wiki/Square_packing#In_a_circle)
 -/
 @[category research open, AMS 51]
 theorem least_three_square_packing_in_circle :
-    IsLeast {r : ℝ | Nonempty (Packing 3 UnitSquare (Circle r))} answer(sorry) := by
+    IsLeast {r : ℝ≥0 | Nonempty (Packing 3 UnitSquare (Circle r))} answer(sorry) := by
   sorry
 
 /--
@@ -166,7 +182,9 @@ Dense packings of congruent circles in a circle. Discrete Math 1998;181:139–15
 -/
 @[category textbook, AMS 51]
 theorem fifteen_circle_packing_in_circle_bound :
-    Nonempty (Packing 15 UnitCircle (Circle (1 + √ (6 + 2 / √ 5 + 4 * √ (1 + 2 / √ 5)))) ) := by
+    Nonempty (Packing 15 UnitCircle
+      (Circle (1 + NNReal.sqrt (6 + 2 / NNReal.sqrt 5 +
+        4 * NNReal.sqrt (1 + 2 / NNReal.sqrt 5))))) := by
   sorry
 
 /--
@@ -175,10 +193,11 @@ What is the smallest circle that can contain 15 unit circles?
 Reference:
 Graham RL, Lubachevsky BD, Nurmela KJ, Ostergard PRJ.
 Dense packings of congruent circles in a circle. Discrete Math 1998;181:139–154.
+[Pirl (1969)](https://doi.org/10.1002/mana.19690400110) conjectured this configuration to be optimal.
 -/
 @[category research open, AMS 51]
 theorem least_fifteen_circle_packing_in_circle :
-    IsLeast {r : ℝ | Nonempty (Packing 15 UnitCircle (Circle r))} answer(sorry) := by
+    IsLeast {r : ℝ≥0 | Nonempty (Packing 15 UnitCircle (Circle r))} answer(sorry) := by
   sorry
 
 end SquarePacking


### PR DESCRIPTION
Fixes #4859.

## Summary

`Circle` previously took `r : ℝ` and depended only on `r ^ 2`, making `Circle (-r) = Circle r`. Consequently, the feasible-radius sets in the two circle-minimising statements were unbounded below and could have no least element.

Following the discussion on #4859, this changes the radius type to `ℝ≥0`, making negative radii unrepresentable. The two minimised sets and their `answer` values now also use `ℝ≥0`.

The fixed positive-radius expressions are rewritten using `NNReal.sqrt`. After coercion to `ℝ`, `Real.coe_sqrt` shows that they denote the same values as before. The change also adds a proved sanity check that `Circle 0 = ∅`.

The `Square` definition is unchanged because nonpositive side lengths already produce the empty set and are not affected by this defect.

## Reference clarification

Also adds the [Pirl (1969)](https://doi.org/10.1002/mana.19690400110) reference and notes that he conjectured the 15-circle configuration to be optimal. The existing Graham–Lubachevsky–Nurmela–Östergård reference remains the source for the stated value.

## Verification

- `lake --wfail build`
- `lake --wfail test`
- `extract_names` + category checker: `research_open_with_proof: 0`
- Changed-file category diagnostics: all zero

## AI assistance disclosure

Drafted with AI assistance and machine-checked by the Lean kernel. I reviewed the resulting formalisation and take responsibility for the submitted change.
