### PR TITLE
feat(Arxiv): mark Fernandes conjecture 1 as solved

### DIFF
--- a/FormalConjectures/Arxiv/2605.12342/Conjecture1.lean
+++ b/FormalConjectures/Arxiv/2605.12342/Conjecture1.lean
@@ -81,7 +81,9 @@ conclusion `∃ g₁ g₂, closure {g₁, g₂} = ⊤` encodes 2-generation (at 
 which $\Gamma_{2 \oplus 2}$ also satisfies. The other three exceptions $(3,3), (4,3), (4,4)$
 have rank $3$ and are genuinely not 2-generated.
 -/
-@[category research open, AMS 20]
+@[category research solved, AMS 20,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/fernandes-conjecture-1-lean/blob/c9360c5608ed2bb3bb5670a68d683cd5a83089d6/lean/FernandesConjecture/FormalConjecturesWrapper.lean#L14-L24"]
 theorem conjecture_1 {m n : ℕ} (hm2 : 2 ≤ m) (hn2 : 2 ≤ n) (hmn : n ≤ m)
     (h_except : (m, n) ∉ ({(2, 2), (3, 3), (4, 3), (4, 4)} : Set (ℕ × ℕ))) :
     ∃ g₁ g₂ : gammaSubgroup m n, Subgroup.closure {g₁, g₂} = ⊤ := by


### PR DESCRIPTION
This PR marks `Arxiv.«2605.12342».conjecture_1` as solved and links a kernel-checked Lean 4 proof.

The Lean proof was developed and formalized by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact Formal Conjectures proposition:

```lean
Arxiv.«2605.12342».FernandesProof.conjecture_1
    {m n : ℕ} (hm2 : 2 ≤ m) (hn2 : 2 ≤ n) (hmn : n ≤ m)
    (h_except : (m, n) ∉ ({(2, 2), (3, 3), (4, 3), (4, 4)} : Set (ℕ × ℕ))) :
    ∃ g₁ g₂ : Arxiv.«2605.12342».gammaSubgroup m n,
      Subgroup.closure {g₁, g₂} = ⊤
```

Proof: https://github.com/KitaKen1/fernandes-conjecture-1-lean/blob/c9360c5608ed2bb3bb5670a68d683cd5a83089d6/lean/FernandesConjecture/FormalConjecturesWrapper.lean#L14-L24

Repository: https://github.com/KitaKen1/fernandes-conjecture-1-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ffernandes-conjecture-1-lean%2Frefs%2Fheads%2Fmain%2Flean4web%2FFernandesConjectureLean4Web.lean

The FC declaration and the proved declaration are checked against the same explicit proposition. `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

Follow-up to #4815 and #4836.

AI Usage Disclosure: This formalization is assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.