### PR TITLE
feat(ErdosProblems): resolve three Erdős 539 exponent variants

### DIFF
--- a/FormalConjectures/ErdosProblems/539.lean
+++ b/FormalConjectures/ErdosProblems/539.lean
@@ -84,9 +84,13 @@ theorem erdos_539.variants.isBigO_sq :
 /-- Let $h(n)$ be maximal such that, for any set $A\subseteq \mathbb{N}$ of size $n$, the
 set$$\left\{ \frac{a}{(a,b)}: a,b\in A\right\}$$has size at least $h(n)$.
 Is $h(n) = \Theta(n^{2/3})$? -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296"]
 theorem erdos_539.variants.sq_cube_root :
-    (fun n ↦ (cofactorThreshold n : ℝ)) =Θ[atTop] fun n ↦ (n : ℝ) ^ ((2 : ℝ) / 3) := by
+    answer(False) ↔
+      ((fun n ↦ (cofactorThreshold n : ℝ)) =Θ[atTop]
+        fun n ↦ (n : ℝ) ^ ((2 : ℝ) / 3)) := by
   sorry
 
 /-- Granville and Roesler [GR99] showed that $$h(n)\ll n^{2/3}$$.-/
@@ -96,9 +100,13 @@ theorem erdos_539.variants.isBigO_sq_cube_root :
   sorry
 
 /-- To prove `erdos_539.variants.sq_cube_root` it suffices to show $$n^{2/3}\ll h(n)$$. -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296"]
 theorem erdos_539.variants.sq_cube_root_isBigO :
-    (fun n : ℕ ↦ (n : ℝ) ^ ((2 : ℝ) / 3)) =O[atTop] fun n ↦ (cofactorThreshold n : ℝ) := by
+    answer(False) ↔
+      ((fun n : ℕ ↦ (n : ℝ) ^ ((2 : ℝ) / 3)) =O[atTop]
+        fun n ↦ (cofactorThreshold n : ℝ)) := by
   sorry
 
 /-- From [Er73]: The determination of
@@ -108,9 +116,13 @@ $$
 will perhaps be not too difficult.
 -/
 -- Formalisation note: it is not clear if this problem has since been solved
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296"]
 theorem erdos_539.variants.limit :
-    atTop.Tendsto (fun n ↦ Real.log (cofactorThreshold n) / Real.log n) answer(sorry) := by
+    atTop.Tendsto
+      (fun n ↦ Real.log (cofactorThreshold n) / Real.log n)
+      answer(𝓝 ((1 : ℝ) / 2)) := by
   sorry
 
 end Erdos539

--- a/FormalConjectures/ErdosProblems/539.lean
+++ b/FormalConjectures/ErdosProblems/539.lean
@@ -36,6 +36,7 @@ it is not clear whether this remains open, but we include it here either way.
 - [erdosproblems.com/539](https://www.erdosproblems.com/539)
 - [GR99] Granville, A., & Roesler, F. (1999). _The Set of Differences of a Given Set_. The American Mathematical Monthly, 106(4), 338–344.
 - [Er73] Erdős, P., _Problems and results on combinatorial number theory_. A survey of combinatorial theory (Proc. Internat. Sympos., Colorado State Univ., Fort Collins, Colo., 1971) (1973), 117-138.
+- [Sc+26] Schmitt, J., Gehrunger, T., Dekoninck, J., Bérczi, G., Kreitner, U., Price, L., & Holmes, D. (2026). _ProofCouncil: An LLM Agent for Solving Open Mathematical Problems_. [arXiv:2607.09474](https://arxiv.org/abs/2607.09474), Appendix A, Theorem A.1.
 -/
 
 open Filter
@@ -83,7 +84,8 @@ theorem erdos_539.variants.isBigO_sq :
 
 /-- Let $h(n)$ be maximal such that, for any set $A\subseteq \mathbb{N}$ of size $n$, the
 set$$\left\{ \frac{a}{(a,b)}: a,b\in A\right\}$$has size at least $h(n)$.
-Is $h(n) = \Theta(n^{2/3})$? -/
+Is $h(n) = \Theta(n^{2/3})$?
+The answer is negative; see [Sc+26, Theorem A.1] and the linked Lean proof. -/
 @[category research solved, AMS 5 11,
   formal_proof using lean4 at
     "https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296"]
@@ -99,7 +101,7 @@ theorem erdos_539.variants.isBigO_sq_cube_root :
     (fun n ↦ (cofactorThreshold n : ℝ)) =O[atTop] fun n ↦ (n : ℝ) ^ ((2 : ℝ) / 3) := by
   sorry
 
-/-- To prove `erdos_539.variants.sq_cube_root` it suffices to show $$n^{2/3}\ll h(n)$$. -/
+/-- This lower bound is false; see [Sc+26, Theorem A.1] and the linked Lean proof. -/
 @[category research solved, AMS 5 11,
   formal_proof using lean4 at
     "https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296"]
@@ -114,8 +116,8 @@ $$
   \lim_{n\to\infty}\frac{\log(h(n))}{\log(n)}
 $$
 will perhaps be not too difficult.
+The limit is $1/2$; see [Sc+26, Theorem A.1] and the linked Lean proof.
 -/
--- Formalisation note: it is not clear if this problem has since been solved
 @[category research solved, AMS 5 11,
   formal_proof using lean4 at
     "https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296"]

--- a/FormalConjectures/ErdosProblems/539.lean
+++ b/FormalConjectures/ErdosProblems/539.lean
@@ -122,7 +122,7 @@ will perhaps be not too difficult.
 theorem erdos_539.variants.limit :
     atTop.Tendsto
       (fun n ↦ Real.log (cofactorThreshold n) / Real.log n)
-      answer(𝓝 ((1 : ℝ) / 2)) := by
+      answer(nhds ((1 : ℝ) / 2)) := by
   sorry
 
 end Erdos539


### PR DESCRIPTION
This PR resolves three exponent-related variants of Erdős Problem 539 and links
a kernel-checked Lean 4 proof.

- `erdos_539.variants.limit`: the logarithmic growth exponent is `1/2`.
- `erdos_539.variants.sq_cube_root_isBigO`: the answer is `False`.
- `erdos_539.variants.sq_cube_root`: the answer is `False`.

The main `erdos_539` problem and the `Θ(√n)` variants remain open.

The Lean proof was developed and formalized by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

Proof:
https://github.com/KitaKen1/erdos-539-formal-conjectures/blob/79897cf9241390eb168572f4a481e29e0e64b5f7/lean/Erdos539/FC.lean#L282-L296

Repository:
https://github.com/KitaKen1/erdos-539-formal-conjectures

Lean4Web:
https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-539-formal-conjectures%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos539.lean

The three exported declarations are checked against the corresponding Formal
Conjectures propositions. `#print axioms` reports only `propext`,
`Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

> [!NOTE]
> **Mathematical source and FC adaptation**
>
> Theorem A.1 of Schmitt et al. (arXiv:2607.09474) proves that the logarithmic
> growth exponent is `1/2` for the threshold defined using finite sets of
> positive integers.
>
> Formal Conjectures instead uses finite sets in `ℕ`, so zero is allowed and the
> paper's theorem does not apply to the FC declarations directly.
>
> Kenta Kitamura ([KitaKen1](https://github.com/KitaKen1)) provided the linked
> Lean 4 proof comparing the two definitions.

AI Usage Disclosure: This formalization is assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.