### PR TITLE
Mark MathOverflow 10799 Kahn-Kalai variant as solved

### DIFF
--- a/FormalConjectures/Mathoverflow/10799.lean
+++ b/FormalConjectures/Mathoverflow/10799.lean
@@ -168,8 +168,10 @@ Conjecture 7 from Kahn–Kalai 2006: the same statement as the original
 conjecture, but with the additional assumption that $t$ is the critical probability for $F$,
 namely $\mu_t(F) = 1/2$.
 -/
-@[category research open, AMS 5 60]
-theorem mathoverflow_10799.variants.kahn_kalai_conjecture_7 : answer(sorry) ↔
+@[category research solved, AMS 5 60,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/kahn-kalai-conjecture-7-counterexample/blob/5446d2f/lean/MO10799CounterexampleFC.lean#L2597-L2604"]
+theorem mathoverflow_10799.variants.kahn_kalai_conjecture_7 : answer(False) ↔
     ∀ (n : ℕ) (_ : 2 ≤ n)
     (F : Finset (Finset (Fin n))) (_ : IsMonotoneIncreasing F)
     (s t : ℝ) (_ : 0 < s) (_ : s ≤ t) (_ : t < 1)

--- a/FormalConjectures/Mathoverflow/10799.lean
+++ b/FormalConjectures/Mathoverflow/10799.lean
@@ -164,9 +164,16 @@ theorem mathoverflow_10799 : answer(False) ↔
   sorry
 
 /--
-Conjecture 7 from Kahn–Kalai 2006: the same statement as the original
-conjecture, but with the additional assumption that $t$ is the critical probability for $F$,
+Conjecture 7 from Kahn–Kalai 2006: a fixed-`1000` variant of the original
+conjecture, with the additional assumption that $t$ is the critical probability for $F$,
 namely $\mu_t(F) = 1/2$.
+
+This variant is false by a counterexample due to Sahar Diskin and Uri Kreitner;
+see the [MathOverflow discussion](https://mathoverflow.net/questions/10799/optimal-monotone-families-for-the-discrete-isoperimetric-inequality)
+and the [counterexample note](https://gilkalai.wordpress.com/wp-content/uploads/2026/06/dual_tribes_more_readable.pdf).
+Their construction was adapted to this exact Formal Conjectures statement and
+[formalized in Lean](https://github.com/KitaKen1/kahn-kalai-conjecture-7-counterexample)
+by Kenta Kitamura (KitaKen1).
 -/
 @[category research solved, AMS 5 60,
   formal_proof using lean4 at


### PR DESCRIPTION
This PR changes `Mathoverflow10799.mathoverflow_10799.variants.kahn_kalai_conjecture_7` from `answer(sorry)` to `answer(False)` and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the literal negation of the proposition registered in Formal Conjectures:

```lean
theorem Mathoverflow10799.mathoverflow_10799.variants.kahn_kalai_conjecture_7_is_false :
    ¬ (∀ (n : ℕ) (_ : 2 ≤ n)
      (F : Finset (Finset (Fin n))) (_ : Mathoverflow10799.IsMonotoneIncreasing F)
      (s t : ℝ) (_ : 0 < s) (_ : s ≤ t) (_ : t < 1)
      (_ : Mathoverflow10799.μFamily t F = 1 / 2)
      (_ : t / s > 1000 * Real.log n),
      ∃ p, s ≤ p ∧ p ≤ t ∧ Mathoverflow10799.IsOptimal p F)
```

Proof: https://github.com/KitaKen1/kahn-kalai-conjecture-7-counterexample/blob/5446d2f/lean/MO10799CounterexampleFC.lean#L2597-L2604

Repository: https://github.com/KitaKen1/kahn-kalai-conjecture-7-counterexample

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fkahn-kalai-conjecture-7-counterexample%2Frefs%2Fheads%2Fmain%2Flean4web%2FMO10799CounterexampleLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.