### PR TITLE
feat(site): plot open, solved and formally proved over time

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -255,6 +255,8 @@ jobs:
           echo "Downloading growth plots from $LIVE_URL ..."
           curl -sfL "$LIVE_URL/data/file_counts_white.html" -o site/data/file_counts_white.html || true
           curl -sfL "$LIVE_URL/data/file_counts_dark.html" -o site/data/file_counts_dark.html || true
+          curl -sfL "$LIVE_URL/data/status_counts_white.html" -o site/data/status_counts_white.html || true
+          curl -sfL "$LIVE_URL/data/status_counts_dark.html" -o site/data/status_counts_dark.html || true
           node -e "
             const fs = require('fs');
             const data = JSON.parse(fs.readFileSync('/tmp/live_conjectures.json', 'utf8'));

--- a/site/build.js
+++ b/site/build.js
@@ -690,6 +690,10 @@ async function main() {
   const darkPlotPath = path.join('data', 'file_counts_dark.html');
   if (fs.existsSync(whitePlotPath)) fs.copyFileSync(whitePlotPath, 'site/data/file_counts_white.html');
   if (fs.existsSync(darkPlotPath)) fs.copyFileSync(darkPlotPath, 'site/data/file_counts_dark.html');
+  const whiteStatusPlotPath = path.join('data', 'status_counts_white.html');
+  const darkStatusPlotPath = path.join('data', 'status_counts_dark.html');
+  if (fs.existsSync(whiteStatusPlotPath)) fs.copyFileSync(whiteStatusPlotPath, 'site/data/status_counts_white.html');
+  if (fs.existsSync(darkStatusPlotPath)) fs.copyFileSync(darkStatusPlotPath, 'site/data/status_counts_dark.html');
 
   // ---- Landing page ----
   const indexHtml = readTemplate('index.html');
@@ -719,34 +723,32 @@ async function main() {
   copyStaticTemplate('about.html', 'site/about/index.html');
 
   // ---- Stats page ----
-  let growthPlot = '';
-  if (fs.existsSync(whitePlotPath) && fs.existsSync(darkPlotPath)) {
-    const graphHtmlLight = fs.readFileSync(whitePlotPath, 'utf8');
-    const graphHtmlDark = fs.readFileSync(darkPlotPath, 'utf8');
-    growthPlot = `
-      <style>
-        .theme-dark { display: none; }
-        @media (prefers-color-scheme: dark) {
-          .theme-light { display: none; }
-          .theme-dark { display: block; }
-        }
-      </style>
-      <div class="theme-light">${graphHtmlLight}</div>
-      <div class="theme-dark">${graphHtmlDark}</div>
-    `;
-    console.log('  Loaded repository growth plots.');
-  } else {
-    console.log('  Repository growth plots not found (skipping growth plot).');
-  }
+  const growthPlot = themedPlot(whitePlotPath, darkPlotPath, 'repository growth');
+  const statusPlot = themedPlot(whiteStatusPlotPath, darkStatusPlotPath, 'statement status');
 
   const statsHtml = readTemplate('stats.html');
   writePage('site/stats/index.html', applyBasePath(fill(statsHtml, {
     totalCount:           stats.total,
     growthPlot:           growthPlot,
+    statusPlot:           statusPlot,
     subjectStatusTable:   subjectStatusTableHTML(advancedStats.subjectByCategory),
   })));
 
   console.log('Done. Output in site/');
+}
+
+// Plotly bakes the background into each plot, so both themes are generated and
+// the stats page hides whichever one does not match.
+function themedPlot(lightPath, darkPath, label) {
+  if (!fs.existsSync(lightPath) || !fs.existsSync(darkPath)) {
+    console.log(`  ${label} plots not found (skipping plot).`);
+    return '';
+  }
+  console.log(`  Loaded ${label} plots.`);
+  return `
+      <div class="theme-light">${fs.readFileSync(lightPath, 'utf8')}</div>
+      <div class="theme-dark">${fs.readFileSync(darkPath, 'utf8')}</div>
+    `;
 }
 
 function copyStaticTemplate(templateName, dest) {

--- a/site/plot_growth.py
+++ b/site/plot_growth.py
@@ -3,11 +3,12 @@ import os
 import pandas as pd
 import plotly.express as px
 import re
+import status_counts
 import subprocess
 from datetime import datetime
 
 conf = {
-    'line_color': '#4285F4',
+    'line_colors': ['#4285F4'],
     'line_width': 2,
     'title': dict(
         text='Number of Lean files in Formal Conjectures',
@@ -23,6 +24,22 @@ conf = {
     'ylabel': 'File Count',
     'out_path_prefix': 'site/data/file_counts'
 }
+
+status_conf = dict(
+    conf,
+    # Same dimensions and starting point as the file count, only the series and
+    # where they are written differ.
+    line_colors=['#EA4335', '#34A853', '#4285F4'],
+    title=dict(
+        text='Statements by status in Formal Conjectures',
+        font=dict(size=18),
+        x=0.5,
+        xanchor='center'
+    ),
+    ylabel=['Open', 'Solved', 'Formally proved'],
+    yaxis_title='Statement Count',
+    out_path_prefix='site/data/status_counts'
+)
 
 def get_file_counts_over_time(start_date, columns):
     """
@@ -67,36 +84,38 @@ def get_file_counts_over_time(start_date, columns):
 
     return pd.DataFrame(data, columns=columns)
 
-def plot_file_counts(
+def plot_counts(
       df,
       xlabel,
       ylabel,
       max_width,
       width_pct,
       height,
-      line_color,
+      line_colors,
       line_width,
       title,
       out_path,
-      theme):
+      theme,
+      yaxis_title=None):
     """
-    Plots the number of files over time.
+    Plots one or more counts over time.
 
     Args:
         df (pd.DataFrame): A pandas DataFrame which should contain `xlabel` and `ylabel` as columns
         xlabel (str): The column from `df` to use as the `x`-axis
-        ylabel (str): The column from `df` to use as the `y`-axis
+        ylabel (str | list[str]): The column(s) from `df` to use as the `y`-axis
         max_width (int): Maximum width of plot in `px`
         width_pct (str): % width of plot inside parent div
         height (int): Height of plot in `px`
-        line_color (str): Colour of plotted graph
+        line_colors (list[str]): Colour of each plotted graph, in order
         line_width (float): Width of plotted line in `px`
         title (dict): Dictionary specifying graph title and style
         out_path (str): Save location of html
         theme (str): plotly template suffix to use as plot theme. E.g., use "dark" for "plotly_dark"
+        yaxis_title (str): Label of the `y`-axis, required when `ylabel` names several columns
     """
     out_path = f"{out_path}_{theme}.html"
-    fig = px.line(df, xlabel, ylabel)
+    fig = px.line(df, xlabel, ylabel, color_discrete_sequence=line_colors)
 
     fig.update_layout(
         title=title,
@@ -109,9 +128,14 @@ def plot_file_counts(
     fig.update_yaxes(rangemode='tozero')
 
     fig.update_traces(
-        line=dict(color=line_color, width=line_width, shape='hv'),
+        line=dict(width=line_width, shape='hv'),
         marker=dict(size=6)
     )
+
+    if isinstance(ylabel, list):
+        # For several columns `px` names the axis "value" and the legend
+        # "variable", neither of which says anything to a reader.
+        fig.update_layout(yaxis_title=yaxis_title, legend_title_text='')
 
     fig_html = fig.to_html(
         full_html=False,
@@ -144,17 +168,32 @@ if __name__ == "__main__":
 
     columns = [conf['xlabel'], conf['ylabel']]
     df = get_file_counts_over_time(conf['start_date'], columns)
-    for theme in ["white", "dark"]:
-        plot_file_counts(
-          df=df,
-          xlabel=conf['xlabel'],
-          ylabel=conf['ylabel'],
-          max_width=conf['max_width'],
-          width_pct=conf['width_pct'],
-          height=conf['height_px'],
-          line_color=conf['line_color'],
-          line_width=conf['line_width'],
-          title=conf['title'],
-          out_path=conf['out_path_prefix'],
-          theme=theme
-        )
+
+    status_columns = [status_conf['xlabel']] + status_conf['ylabel']
+    status_df = pd.DataFrame(
+        status_counts.get_status_counts_over_time(
+            status_conf['start_date'], status_columns),
+        columns=status_columns)
+
+    # The last point should agree with the counts `extract_names` reports, so
+    # print it where a mismatch is visible without opening the site.
+    latest = status_df.iloc[-1]
+    print('Latest statement counts: ' +
+          ', '.join(f'{label} {latest[label]}' for label in status_conf['ylabel']))
+
+    for settings, data in [(conf, df), (status_conf, status_df)]:
+        for theme in ["white", "dark"]:
+            plot_counts(
+              df=data,
+              xlabel=settings['xlabel'],
+              ylabel=settings['ylabel'],
+              max_width=settings['max_width'],
+              width_pct=settings['width_pct'],
+              height=settings['height_px'],
+              line_colors=settings['line_colors'],
+              line_width=settings['line_width'],
+              title=settings['title'],
+              out_path=settings['out_path_prefix'],
+              theme=theme,
+              yaxis_title=settings.get('yaxis_title')
+            )

--- a/site/src/templates/stats.html
+++ b/site/src/templates/stats.html
@@ -8,6 +8,13 @@
   <link rel="preload" href="/assets/fonts/LibertinusSans-Regular.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="/assets/css/style.css">
   <link rel="icon" href="/assets/img/formal_conjectures_logo.svg" type="image/svg+xml">
+  <style>
+    .theme-dark { display: none; }
+    @media (prefers-color-scheme: dark) {
+      .theme-light { display: none; }
+      .theme-dark { display: block; }
+    }
+  </style>
 </head>
 <body>
 
@@ -41,6 +48,18 @@
         The number of Lean files in Formal Conjectures over time.
       </p>
       {{growthPlot}}
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2 class="section__title">Statements by status</h2>
+      <p class="section__lede">
+        How many statements are open, how many are solved, and how many carry
+        a link to a formal proof, over time. Formal proofs have only been
+        recorded since January 2026.
+      </p>
+      {{statusPlot}}
     </div>
   </section>
 

--- a/site/status_counts.py
+++ b/site/status_counts.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Statement counts per problem status across the repository's git history.
+
+The status counts on the website come from `lake exe extract_names`, which
+needs a full Lean build and so cannot be repeated for every commit. The counts
+here are read from the source text instead, following the rules that decide
+which declarations `extract_names` reports:
+
+* Only `theorem`, `lemma` and `instance` declarations carry a category.
+* Declarations Lean treats as internal are dropped, that is `private` ones and
+  those with a `_`-prefixed name component.
+* A declaration counts once towards `formally proved` however many
+  `formal_proof` attributes it carries.
+
+Before #3645 a formal proof was recorded as the category
+`research formally solved` rather than as a separate `formal_proof` attribute,
+so both spellings are recognised.
+"""
+
+import re
+import subprocess
+from datetime import datetime
+
+# Same set of files the file count covers.
+SOURCE_PATH = re.compile(r'^FormalConjectures/(?!ForMathlib/).*\.lean$')
+
+# Declaration keywords that may follow an attribute block. `private` is listed
+# so that it can be recognised and skipped; the modifiers before it are not.
+DECLARATION = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)*"
+    r"(?:protected\s+|noncomputable\s+|public\s+|nonrec\s+)*"
+    r"(private|theorem|lemma|instance|def|abbrev|example)\b[ \t]*([^\s:({\[]*)")
+CATEGORISED = ('theorem', 'lemma', 'instance')
+
+CATEGORY = re.compile(
+    r'\bcategory\s+(research\s+solved|research\s+open|textbook|test|API)\b')
+FORMAL_PROOF = re.compile(r'\bformal_proof\s+using\b')
+FORMALLY_SOLVED = re.compile(r'\bcategory\s+research\s+formally\s+solved\b')
+
+STATUSES = ('open', 'solved', 'formal')
+
+
+def strip_comments(source):
+    """Blanks out comments and string literals, keeping every other offset.
+
+    Attribute names are mentioned in docstrings and in commented-out code, so
+    they have to go before anything is matched. Offsets are preserved so that a
+    declaration still follows its attribute block.
+
+    Args:
+        source (str): Contents of a Lean file
+
+    Returns:
+        str: The same text with comments and string literals replaced by spaces
+    """
+    out = list(source)
+    end = len(source)
+    i = 0
+    while i < end:
+        if source.startswith('/-', i):
+            # Block comments nest, so track the depth rather than taking the
+            # first closing marker.
+            depth = 1
+            j = i + 2
+            while j < end and depth:
+                if source.startswith('/-', j):
+                    depth += 1
+                    j += 2
+                elif source.startswith('-/', j):
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+        elif source.startswith('--', i):
+            j = source.find('\n', i)
+            j = end if j < 0 else j
+        elif source[i] == '"':
+            j = i + 1
+            while j < end and source[j] != '"':
+                j += 2 if source[j] == '\\' else 1
+            j = min(j + 1, end)
+        else:
+            i += 1
+            continue
+        for k in range(i, j):
+            if out[k] != '\n':
+                out[k] = ' '
+        i = j
+    return ''.join(out)
+
+
+def attribute_blocks(source):
+    """Yields each `@[...]` block with the text that follows it.
+
+    Args:
+        source (str): Contents of a Lean file, with comments already stripped
+
+    Yields:
+        tuple[str, str]: The contents of the brackets, and the text after them
+    """
+    end = len(source)
+    i = 0
+    while True:
+        start = source.find('@[', i)
+        if start < 0:
+            return
+        depth = 1
+        j = start + 2
+        while j < end and depth:
+            if source[j] == '[':
+                depth += 1
+            elif source[j] == ']':
+                depth -= 1
+            j += 1
+        # A declaration header is never long enough to need more than this.
+        yield source[start + 2:j - 1], source[j:j + 400]
+        i = j
+
+
+def count_statuses(source):
+    """Counts the statements per status in one Lean file.
+
+    Args:
+        source (str): Contents of a Lean file
+
+    Returns:
+        dict[str, int]: Count for each of `STATUSES`
+    """
+    counts = dict.fromkeys(STATUSES, 0)
+    for attributes, following in attribute_blocks(strip_comments(source)):
+        declaration = DECLARATION.match(following)
+        if not declaration or declaration.group(1) not in CATEGORISED:
+            continue
+        if any(part.startswith('_') for part in declaration.group(2).split('.')):
+            continue
+        if FORMALLY_SOLVED.search(attributes):
+            counts['solved'] += 1
+            counts['formal'] += 1
+            continue
+        category = CATEGORY.search(attributes)
+        if category is None:
+            continue
+        if category.group(1) == 'research open':
+            counts['open'] += 1
+        elif category.group(1) == 'research solved':
+            counts['solved'] += 1
+        if FORMAL_PROOF.search(attributes):
+            counts['formal'] += 1
+    return counts
+
+
+def get_status_counts_over_time(start_date, columns):
+    """Retrieves statement counts per status over time.
+
+    Args:
+        start_date (str): Date from which to start collecting commits
+        columns (list[str]): Column labels for the returned rows, the first for
+            the date and the rest for `STATUSES` in order
+
+    Returns:
+        list[list]: One row per commit, each holding a date and the counts
+    """
+    if not isinstance(columns, list) or len(columns) != len(STATUSES) + 1:
+        raise ValueError(
+            f"The `columns` parameter should be a list of length {len(STATUSES) + 1}.")
+
+    command = ['git', 'log', '--pretty=format:%H,%ct']
+    result = subprocess.run(command, capture_output=True, text=True, check=True)
+    commit_lines = [line for line in result.stdout.strip().split('\n') if line]
+    commit_lines.reverse()
+
+    data = []
+    # A blob is its own content hash, so a file that did not change between two
+    # commits is only read and counted once. Without this the same few hundred
+    # files would be parsed again for every commit.
+    counted_blobs = {}
+    reader = subprocess.Popen(['git', 'cat-file', '--batch'],
+                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    try:
+        for line in commit_lines:
+            sha, timestamp = line.split(',')
+            timestamp = int(timestamp)
+            if timestamp <= datetime.fromisoformat(start_date).timestamp():
+                continue
+
+            tree_command = ['git', 'ls-tree', '-r', sha]
+            tree_result = subprocess.run(tree_command, capture_output=True,
+                                         text=True, check=True)
+            totals = dict.fromkeys(STATUSES, 0)
+            for entry in tree_result.stdout.strip().split('\n'):
+                if not entry:
+                    continue
+                metadata, _, path = entry.partition('\t')
+                if not SOURCE_PATH.match(path):
+                    continue
+                blob = metadata.split(' ')[2]
+                if blob not in counted_blobs:
+                    reader.stdin.write(f'{blob}\n'.encode())
+                    reader.stdin.flush()
+                    size = int(reader.stdout.readline().split()[2])
+                    # `git cat-file --batch` appends a newline to the contents.
+                    contents = reader.stdout.read(size + 1)[:-1]
+                    counted_blobs[blob] = count_statuses(
+                        contents.decode('utf-8', 'replace'))
+                for status, count in counted_blobs[blob].items():
+                    totals[status] += count
+
+            data.append([datetime.fromtimestamp(timestamp)] +
+                        [totals[status] for status in STATUSES])
+    finally:
+        reader.stdin.close()
+        reader.wait()
+
+    return data


### PR DESCRIPTION
## Summary

- add `site/status_counts.py`, which counts open statements, solved statements, and statements with a link to a formal proof at every commit
- generalise `plot_growth.py` so a plot can carry several series, and generate a second plot from those counts
- show it on the stats page as "Statements by status", next to the existing file-count plot
- cache counts per blob hash so the history walk stays cheap

Related to #2388, which asks for formally solved statements to be represented on the site. That issue is assigned to @Paul-Lez, so please close this if it overlaps with work already in progress.

## Why

The stats page shows how many Lean files the repository has over time, but nothing about what is in them. The landing page has the current open/solved/formally proved counts, but no history, so it is not visible whether formal proofs are keeping pace with new statements. This adds that history.

## How the counts are obtained

The counts on the site come from `lake exe extract_names`, which needs a full Lean build and so cannot be repeated for ~1600 commits. `status_counts.py` reads them from the source text instead, following the same rules `extract_names` applies:

- only `theorem`, `lemma` and `instance` declarations carry a category
- declarations Lean treats as internal are dropped, that is `private` ones and those with a `_`-prefixed name component
- a declaration counts once towards formally proved however many `formal_proof` attributes it carries
- comments and docstrings are stripped first, since they mention the attribute names in prose

Before #3645 a formal proof was recorded as the category `research formally solved` rather than a separate `formal_proof` attribute, so that spelling is recognised too. Formal proofs were only recorded from January 2026 onwards, so the third series is genuinely zero before then.

This is a second implementation of rules that live in `extract_names`, and it can drift if the attribute syntax changes. To make that visible, the script prints its last data point, which the workflow log shows next to the counts the build produces.

## Verification

- counts checked against the `data/conjectures.json` the live site serves: at the commit it was built from they agree exactly, 1202 open, 1415 solved, 328 formally proved
- `python site/plot_growth.py` with the versions CI pins (`pandas==2.2.3 numpy==2.2.3 plotly==5.20.0`), 16s for all four plots, roughly what the file-count plot alone took before
- `cd site && node build.js`, then both plots checked in a browser in light and dark mode

## AI assistance disclosure

Drafted with AI assistance. The change was built and checked locally, as described under Verification.