### PR TITLE
ErdosProblems/80: restrict c to the range where the hypothesis is satisfiable

### DIFF
--- a/FormalConjectures/Arxiv/2607.05349/MicroscopicWeighting.lean
+++ b/FormalConjectures/Arxiv/2607.05349/MicroscopicWeighting.lean
@@ -44,11 +44,8 @@ noncomputable def distanceMatrix (X : Type*) [Fintype X] [MetricSpace X] : Matri
 /-- The weighting $\vec{w}(t) = Z(t)^{-1}\mathbf{1}$ at scale `t`.
 
 `Matrix.inv` is `0` on singular matrices, so this is only the intended vector where `Z t` is
-invertible. That holds for all small enough `t > 0`, which is where the limit below is taken.
-Continuity alone does not give this: `Z 0` is the all-ones matrix, which is singular once `X`
-has two points, so `(Z t).det` tends to `0` as `t → 0`. The reason is instead that `(Z t).det`
-is analytic in `t` and tends to `1` as `t → ∞`, since the off-diagonal entries vanish there.
-So it is not identically zero, and its zeros are isolated. -/
+invertible. That is enough here: `Z 0` is the all-ones matrix and `Z` is continuous, so `Z t`
+is invertible for all small enough `t > 0`, which is where the limit below is taken. -/
 noncomputable def weighting (X : Type*) [Fintype X] [DecidableEq X] [MetricSpace X] (t : ℝ) :
     X → ℝ :=
   (similarityMatrix X t)⁻¹ *ᵥ 1

--- a/FormalConjectures/Arxiv/2607.05349/MicroscopicWeighting.lean
+++ b/FormalConjectures/Arxiv/2607.05349/MicroscopicWeighting.lean
@@ -44,8 +44,11 @@ noncomputable def distanceMatrix (X : Type*) [Fintype X] [MetricSpace X] : Matri
 /-- The weighting $\vec{w}(t) = Z(t)^{-1}\mathbf{1}$ at scale `t`.
 
 `Matrix.inv` is `0` on singular matrices, so this is only the intended vector where `Z t` is
-invertible. That is enough here: `Z 0` is the all-ones matrix and `Z` is continuous, so `Z t`
-is invertible for all small enough `t > 0`, which is where the limit below is taken. -/
+invertible. That holds for all small enough `t > 0`, which is where the limit below is taken.
+Continuity alone does not give this: `Z 0` is the all-ones matrix, which is singular once `X`
+has two points, so `(Z t).det` tends to `0` as `t → 0`. The reason is instead that `(Z t).det`
+is analytic in `t` and tends to `1` as `t → ∞`, since the off-diagonal entries vanish there.
+So it is not identically zero, and its zeros are isolated. -/
 noncomputable def weighting (X : Type*) [Fintype X] [DecidableEq X] [MetricSpace X] (t : ℝ) :
     X → ℝ :=
   (similarityMatrix X t)⁻¹ *ᵥ 1

--- a/FormalConjectures/ErdosProblems/80.lean
+++ b/FormalConjectures/ErdosProblems/80.lean
@@ -57,8 +57,10 @@ open Classical in
 /-- $f_c(n)$, the largest book size forced on every admissible graph, which is the least book
 number among them.
 
-`sInf` of the empty set is `0`, so `f c n = 0` also when no graph on `n` vertices has $cn^2$
-edges at all. That is the honest reading: nothing is forced when nothing qualifies. -/
+`sInf` of the empty set is `0`, so `f c n = 0` when no graph on `n` vertices has $cn^2$ edges
+at all. A simple graph has at most $n(n-1)/2$ edges, so that happens for every `n` once
+$c \geq 1/2$. The statements below therefore restrict `c` to the feasible range; without that
+they are false at, say, `c = 2` for reasons unrelated to the question. -/
 noncomputable def f (c : ℝ) (n : ℕ) : ℕ :=
   sInf {m | ∃ G : SimpleGraph (Fin n), Admissible c G ∧ bookNumber G = m}
 
@@ -67,19 +69,24 @@ Let $c>0$ and let $f_c(n)$ be the maximal $m$ such that every graph $G$ with $n$
 at least $cn^2$ edges, where each edge is contained in at least one triangle, must contain a
 book of size $m$, that is, an edge shared by at least $m$ different triangles. Estimate
 $f_c(n)$. In particular, is it true that $f_c(n)>n^\epsilon$ for some $\epsilon>0$?
+
+The bound $c < 1/2$ is what makes the hypothesis satisfiable: a simple graph on $n$ vertices
+has at most $n(n-1)/2$ edges, so no graph has $cn^2$ of them once $c \geq 1/2$.
 -/
 @[category research open, AMS 5]
 theorem erdos_80 :
-    answer(sorry) ↔ ∀ c : ℝ, 0 < c → ∃ ε > (0 : ℝ), ∀ᶠ n : ℕ in atTop,
-      (n : ℝ) ^ ε < f c n := by
+    answer(sorry) ↔ ∀ c : ℝ, 0 < c → c < 1 / 2 →
+      ∃ ε > (0 : ℝ), ∀ᶠ n : ℕ in atTop, (n : ℝ) ^ ε < f c n := by
   sorry
 
 /--
 The weaker question from the same problem: is $f_c(n) \gg \log n$?
+
+Same feasibility bound on `c` as above.
 -/
 @[category research open, AMS 5]
 theorem erdos_80.variants.log :
-    answer(sorry) ↔ ∀ c : ℝ, 0 < c →
+    answer(sorry) ↔ ∀ c : ℝ, 0 < c → c < 1 / 2 →
       (fun n : ℕ ↦ (f c n : ℝ)) ≫ (fun n : ℕ ↦ Real.log n) := by
   sorry
 


### PR DESCRIPTION
Closes #4867.

Both statements quantified over every `c > 0`. `Admissible c G` needs `c * n^2 ≤ #G.edgeFinset`, but a simple graph on `n` vertices has at most `n(n-1)/2` edges, so nothing qualifies once `c ≥ 1/2`. At `c = 2` the set inside `sInf` is empty for every `n`, `f 2 n = 0`, and both answers are `False` for reasons unrelated to the question. Adding `c < 1/2` is @KitaKen1's suggestion and it is the right bound: at `c` just under `1/2` the complete graph qualifies from about `n = 100` on.

Also corrects the `f` docstring. It said the empty case was "the honest reading: nothing is forced when nothing qualifies", which is true as far as it goes but was exactly what hid the problem. It now says when the empty case occurs and why the statements exclude it.

My error, from #4830. Statements only, no proofs affected.