### PR TITLE
Arxiv/2606.03696: Bondy's conjecture on longest cycles

### DIFF
--- a/FormalConjectures/Arxiv/2606.03696/BondyLongestCycles.lean
+++ b/FormalConjectures/Arxiv/2606.03696/BondyLongestCycles.lean
@@ -1,0 +1,128 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Bondy's conjecture on longest cycles in highly connected graphs
+
+*References:*
+- [arxiv/2606.03696](https://arxiv.org/abs/2606.03696)
+  **Longest cycles and Dirac-type results in highly connected graphs**
+  by *Jie Ma, Bo Ning, Ziyuan Zhao*, where this is Conjecture 1.
+- [Bo80] Bondy, J. A., Longest paths and cycles in graphs of high degree. (1980).
+
+Take a `k`-connected graph with a large minimum degree. Bondy says that the graph outside any
+longest cycle holds no long path.
+
+The case `k = 1` is Dirac's theorem and the case `k = 2` is the theorem of Nash-Williams. The
+case `k = 3` is proved. The cases `k ≥ 4` are open.
+-/
+
+open SimpleGraph
+
+namespace Arxiv.«2606.03696»
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- `G` is `k`-connected: it has more than `k` vertices, and it stays connected after the
+removal of any set of fewer than `k` vertices.
+
+Mathlib has `SimpleGraph.IsEdgeConnected` but no vertex connectivity, so this file states it. -/
+def IsKConnected (G : SimpleGraph V) (k : ℕ) : Prop :=
+  k < Fintype.card V ∧ ∀ S : Finset V, S.card < k → (G.induce ((S : Set V)ᶜ)).Connected
+
+/-- The set of vertices that a walk does not touch. For a longest cycle `C` this set carries
+the graph `G - V(C)` of the conjecture. -/
+def offWalk {a b : V} {G : SimpleGraph V} (w : G.Walk a b) : Set V :=
+  {v | v ∉ w.support}
+
+/--
+**Conjecture 1 (Bondy, 1980).** Let $k \geq 1$ and let $G$ be a $k$-connected graph on $n$
+vertices. If $\delta(G) \geq \frac{n + k(k-1)}{k+1}$, then for every longest cycle $C$ of $G$,
+every path in $G - V(C)$ has at most $k-1$ vertices.
+
+The bound on the number of vertices of a path is written as `+ 1 ≤ k` rather than `≤ k - 1`,
+because subtraction on `ℕ` is truncated. The two forms agree for `k ≥ 1`.
+
+A longest cycle is a cycle whose length is the circumference of `G`.
+-/
+@[category research open, AMS 5]
+theorem bondy_conjecture :
+    answer(sorry) ↔ ∀ (k : ℕ), 1 ≤ k → ∀ (V : Type) [Fintype V] [DecidableEq V]
+      (G : SimpleGraph V) [DecidableRel G.Adj], IsKConnected G k →
+      ((Fintype.card V : ℝ) + k * (k - 1)) / (k + 1) ≤ G.minDegree →
+      ∀ (a : V) (C : G.Walk a a), C.IsCycle → C.length = G.circumference →
+      ∀ (u v : offWalk C) (P : (G.induce (offWalk C)).Walk u v), P.IsPath →
+        P.support.length + 1 ≤ k := by
+  sorry
+
+/--
+The case $k = 1$ is Dirac's theorem. The condition reads $\delta(G) \geq n/2$, and no path in
+$G - V(C)$ can hold a vertex, so a longest cycle covers every vertex.
+-/
+@[category research solved, AMS 5]
+theorem bondy_conjecture.variants.one {G : SimpleGraph V} [DecidableRel G.Adj]
+    (hG : IsKConnected G 1) (hd : ((Fintype.card V : ℝ)) / 2 ≤ G.minDegree)
+    {a : V} (C : G.Walk a a) (hC : C.IsCycle) (hlong : C.length = G.circumference)
+    (u v : offWalk C) (P : (G.induce (offWalk C)).Walk u v) (hP : P.IsPath) :
+    P.support.length + 1 ≤ 1 := by
+  sorry
+
+/--
+The case $k = 2$ is the theorem of Nash-Williams.
+-/
+@[category research solved, AMS 5]
+theorem bondy_conjecture.variants.two {G : SimpleGraph V} [DecidableRel G.Adj]
+    (hG : IsKConnected G 2) (hd : ((Fintype.card V : ℝ) + 2) / 3 ≤ G.minDegree)
+    {a : V} (C : G.Walk a a) (hC : C.IsCycle) (hlong : C.length = G.circumference)
+    (u v : offWalk C) (P : (G.induce (offWalk C)).Walk u v) (hP : P.IsPath) :
+    P.support.length + 1 ≤ 2 := by
+  sorry
+
+/--
+The case $k = 3$ is proved.
+-/
+@[category research solved, AMS 5]
+theorem bondy_conjecture.variants.three {G : SimpleGraph V} [DecidableRel G.Adj]
+    (hG : IsKConnected G 3) (hd : ((Fintype.card V : ℝ) + 6) / 4 ≤ G.minDegree)
+    {a : V} (C : G.Walk a a) (hC : C.IsCycle) (hlong : C.length = G.circumference)
+    (u v : offWalk C) (P : (G.induce (offWalk C)).Walk u v) (hP : P.IsPath) :
+    P.support.length + 1 ≤ 3 := by
+  sorry
+
+/--
+**Theorem 1.1 (Ma-Ning-Zhao, 2026).** The conjecture holds for every graph with enough
+vertices. The full conjecture, for graphs of every size, stays open.
+-/
+@[category research solved, AMS 5]
+theorem bondy_conjecture.variants.large :
+    ∀ k : ℕ, 1 ≤ k → ∃ N : ℕ, ∀ (V : Type) [Fintype V] [DecidableEq V]
+      (G : SimpleGraph V) [DecidableRel G.Adj], N ≤ Fintype.card V → IsKConnected G k →
+      ((Fintype.card V : ℝ) + k * (k - 1)) / (k + 1) ≤ G.minDegree →
+      ∀ (a : V) (C : G.Walk a a), C.IsCycle → C.length = G.circumference →
+      ∀ (u v : offWalk C) (P : (G.induce (offWalk C)).Walk u v), P.IsPath →
+        P.support.length + 1 ≤ k := by
+  sorry
+
+omit [DecidableEq V] in
+/-- A `k`-connected graph has more than `k` vertices, so the graph with no vertices is not
+`k`-connected for any `k`. This shows the hypothesis is not empty of content. -/
+@[category API, AMS 5]
+theorem not_isKConnected_of_card_le {G : SimpleGraph V} {k : ℕ} (h : Fintype.card V ≤ k) :
+    ¬ IsKConnected G k := fun hG => absurd hG.1 (not_lt.mpr h)
+
+end Arxiv.«2606.03696»

--- a/FormalConjectures/Arxiv/2606.03696/BondyLongestCycles.lean
+++ b/FormalConjectures/Arxiv/2606.03696/BondyLongestCycles.lean
@@ -38,13 +38,6 @@ namespace Arxiv.«2606.03696»
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-/-- `G` is `k`-connected: it has more than `k` vertices, and it stays connected after the
-removal of any set of fewer than `k` vertices.
-
-Mathlib has `SimpleGraph.IsEdgeConnected` but no vertex connectivity, so this file states it. -/
-def IsKConnected (G : SimpleGraph V) (k : ℕ) : Prop :=
-  k < Fintype.card V ∧ ∀ S : Finset V, S.card < k → (G.induce ((S : Set V)ᶜ)).Connected
-
 /-- The set of vertices that a walk does not touch. For a longest cycle `C` this set carries
 the graph `G - V(C)` of the conjecture. -/
 def offWalk {a b : V} {G : SimpleGraph V} (w : G.Walk a b) : Set V :=
@@ -117,12 +110,5 @@ theorem bondy_conjecture.variants.large :
       ∀ (u v : offWalk C) (P : (G.induce (offWalk C)).Walk u v), P.IsPath →
         P.support.length + 1 ≤ k := by
   sorry
-
-omit [DecidableEq V] in
-/-- A `k`-connected graph has more than `k` vertices, so the graph with no vertices is not
-`k`-connected for any `k`. This shows the hypothesis is not empty of content. -/
-@[category API, AMS 5]
-theorem not_isKConnected_of_card_le {G : SimpleGraph V} {k : ℕ} (h : Fintype.card V ≤ k) :
-    ¬ IsKConnected G k := fun hG => absurd hG.1 (not_lt.mpr h)
 
 end Arxiv.«2606.03696»

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 module
 
+public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 public import Mathlib.Combinatorics.SimpleGraph.Paths
 
 @[expose] public section
@@ -39,5 +40,17 @@ infinitely connected.
 def InfinitelyConnected {V : Type*} (G : SimpleGraph V) : Prop := Nontrivial V ∧
   Pairwise fun u v ↦ ∃ P : Set (G.Walk u v),
     P.Infinite ∧ (∀ p ∈ P, p.IsPath) ∧ P.Pairwise InternallyDisjoint
+
+/-- `G` is `k`-connected: it has more than `k` vertices, and it stays connected after the
+removal of any set of fewer than `k` vertices.
+
+Mathlib has `SimpleGraph.IsEdgeConnected`, but it has no vertex connectivity. -/
+def IsKConnected {V : Type*} [Fintype V] (G : SimpleGraph V) (k : ℕ) : Prop :=
+  k < Fintype.card V ∧ ∀ S : Finset V, S.card < k → (G.induce ((S : Set V)ᶜ)).Connected
+
+/-- A graph on at most `k` vertices is not `k`-connected. -/
+theorem not_isKConnected_of_card_le {V : Type*} [Fintype V] {G : SimpleGraph V} {k : ℕ}
+    (h : Fintype.card V ≤ k) : ¬ IsKConnected G k :=
+  fun hG => absurd hG.1 (not_lt.mpr h)
 
 end SimpleGraph


### PR DESCRIPTION
Closes #4858. OpenConjecture ID 4126.

Take a `k`-connected graph `G` on `n` vertices. Bondy says that if the minimum degree is at least `(n + k(k-1))/(k+1)`, then no path outside a longest cycle has more than `k-1` vertices.

## Two definitions this file adds

Mathlib has `SimpleGraph.IsEdgeConnected` but no vertex connectivity, so the file states it:

```lean
def IsKConnected (G : SimpleGraph V) (k : ℕ) : Prop :=
  k < Fintype.card V ∧ ∀ S : Finset V, S.card < k → (G.induce ((S : Set V)ᶜ)).Connected
```

`offWalk C` gives the vertices that the cycle does not touch. `G.induce (offWalk C)` is then the graph `G - V(C)` of the conjecture. A longest cycle is a cycle whose length equals `SimpleGraph.circumference`, which `FormalConjecturesForMathlib` supplies.

## Check on the reading

The source says the case `k = 1` is Dirac's theorem. The file agrees. At `k = 1` the conclusion is `P.support.length + 1 ≤ 1`. Every walk has a support of length 1 or more, so no path can exist outside the cycle. The cycle must then cover every vertex, which is what Dirac gives. I proved `1 ≤ P.support.length` to confirm this.

The bound reads `+ 1 ≤ k` and not `≤ k - 1`, because subtraction on `ℕ` is truncated. The two forms agree for `k ≥ 1`.

## Statements

| statement | case | status |
| --- | --- | --- |
| `bondy_conjecture` | all `k ≥ 1` | open |
| `variants.one` | `k = 1` | Dirac |
| `variants.two` | `k = 2` | Nash-Williams |
| `variants.three` | `k = 3` | proved |
| `variants.large` | all `k`, large graphs | Ma, Ning and Zhao 2026 |

The cases `k ≥ 4` stay open for graphs of every size.

Builds clean. Five sorries, one for each research statement.