### PR TITLE
Add proofs for four textbook statements

### DIFF
--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -28,11 +28,51 @@ namespace Erdos44
 
 -- Reference: https://arxiv.org/pdf/2103.15850
 /-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `2 * √N`. -/
-@[category textbook, AMS 5 11, formal_proof using formal_conjectures at
-  "https://github.com/christianTNG/formal-conjectures/blob/2d9d7f1380c4897f30004f6c909e42e820d3c65f/FormalConjectures/ErdosProblems/44.lean#L32"]
+@[category textbook, AMS 5 11]
 theorem maxSidonSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) :
     maxSidonSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
-  sorry
+  have key : maxSidonSubsetCard (Finset.Icc 1 N) ^ 2 ≤ 4 * N := by
+    -- Pick a Sidon subset of `{1, ..., N}` of maximal size.
+    obtain ⟨B, hB, hBeq⟩ := Finset.exists_mem_eq_sup
+      ((Finset.Icc 1 N).powerset.filter fun B : Finset ℕ ↦ IsSidon (B : Set ℕ))
+      ⟨∅, by simp [IsSidon]⟩ Finset.card
+    rw [maxSidonSubsetCard, hBeq]
+    simp only [Finset.mem_filter, Finset.mem_powerset] at hB
+    obtain ⟨hsub, hsid⟩ := hB
+    -- Distinct ordered pairs of elements of `B` have distinct differences, and each difference
+    -- lies in `{-N, ..., N}`.
+    have hcard : B.offDiag.card ≤ (Finset.Icc (-(N : ℤ)) N).card := by
+      refine Finset.card_le_card_of_injOn (fun p ↦ (p.1 : ℤ) - p.2) ?_ ?_
+      · rintro ⟨a, b⟩ hab
+        rw [Finset.mem_coe, Finset.mem_offDiag] at hab
+        have ha' := Finset.mem_Icc.mp (hsub hab.1)
+        have hb' := Finset.mem_Icc.mp (hsub hab.2.1)
+        simp only [Finset.mem_coe, Finset.mem_Icc]
+        omega
+      · rintro ⟨a, b⟩ ha ⟨c, d⟩ hc hac
+        rw [Finset.mem_coe, Finset.mem_offDiag] at ha hc
+        simp only at hac
+        have hsum : a + d = c + b := by omega
+        rcases hsid a ha.1 c hc.1 d hc.2.1 b ha.2.1 hsum with ⟨h1, h2⟩ | ⟨h1, h2⟩
+        · simp [h1, h2]
+        · exact absurd h1 ha.2.2
+    have hIcc : (Finset.Icc (-(N : ℤ)) N).card = 2 * N + 1 := by
+      rw [Int.card_Icc]
+      omega
+    rw [Finset.offDiag_card, hIcc] at hcard
+    have hle : B.card ≤ N := by simpa using Finset.card_le_card hsub
+    rcases Nat.eq_zero_or_pos B.card with h0 | hpos
+    · simp [h0]
+    have hkk : B.card ≤ B.card * B.card := Nat.le_mul_of_pos_left _ hpos
+    calc B.card ^ 2 = B.card * B.card := sq B.card
+      _ ≤ 2 * N + 1 + B.card := by omega
+      _ ≤ 4 * N := by omega
+  have h1 : ((maxSidonSubsetCard (Finset.Icc 1 N) : ℝ)) ^ 2 ≤ 4 * N := by exact_mod_cast key
+  have h2 : (2 : ℝ) * Real.sqrt N = Real.sqrt (4 * N) := by
+    rw [show (4 : ℝ) * N = 2 ^ 2 * N by ring, Real.sqrt_mul (by positivity),
+      Real.sqrt_sq (by norm_num)]
+  rw [h2, ← Real.sqrt_sq (by positivity : (0 : ℝ) ≤ (maxSidonSubsetCard (Finset.Icc 1 N) : ℝ))]
+  exact Real.sqrt_le_sqrt h1
 
 /--
 **Erdős Problem 44:** Let N ≥ 1 and `A ⊆ {1,…,N}` be a Sidon set. Is it true that, for any ε > 0,

--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -28,7 +28,8 @@ namespace Erdos44
 
 -- Reference: https://arxiv.org/pdf/2103.15850
 /-- The maximum size of a Sidon set in `{1, ..., N}` is less than or equal to `2 * √N`. -/
-@[category textbook, AMS 5 11]
+@[category textbook, AMS 5 11, formal_proof using formal_conjectures at
+  "https://github.com/christianTNG/formal-conjectures/blob/2d9d7f1380c4897f30004f6c909e42e820d3c65f/FormalConjectures/ErdosProblems/44.lean#L32"]
 theorem maxSidonSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) :
     maxSidonSubsetCard (Icc 1 N) ≤ 2 * Real.sqrt N := by
   sorry

--- a/FormalConjectures/ErdosProblems/649.lean
+++ b/FormalConjectures/ErdosProblems/649.lean
@@ -49,7 +49,8 @@ theorem erdos_649 : answer(False) ↔
 In fact, the answer to this question as written is easily seen to be no, since there are no
 solutions to $2^k\equiv -1\pmod{7}$, and hence this fails with $p=2$ and $q=7$.
 -/
-@[category textbook, AMS 11]
+@[category textbook, AMS 11, formal_proof using formal_conjectures at
+  "https://github.com/christianTNG/formal-conjectures/blob/35efde29598fd5104e5bc91f1e53d77931e7f856/FormalConjectures/ErdosProblems/649.lean#L53"]
 theorem erdos_649.variants.no_solution_two_seven :
     ¬ ∃ n : ℕ, n.maxPrimeFac = 2 ∧ (n + 1).maxPrimeFac = 7 := by
   sorry

--- a/FormalConjectures/ErdosProblems/649.lean
+++ b/FormalConjectures/ErdosProblems/649.lean
@@ -49,11 +49,36 @@ theorem erdos_649 : answer(False) ↔
 In fact, the answer to this question as written is easily seen to be no, since there are no
 solutions to $2^k\equiv -1\pmod{7}$, and hence this fails with $p=2$ and $q=7$.
 -/
-@[category textbook, AMS 11, formal_proof using formal_conjectures at
-  "https://github.com/christianTNG/formal-conjectures/blob/35efde29598fd5104e5bc91f1e53d77931e7f856/FormalConjectures/ErdosProblems/649.lean#L53"]
+@[category textbook, AMS 11]
 theorem erdos_649.variants.no_solution_two_seven :
     ¬ ∃ n : ℕ, n.maxPrimeFac = 2 ∧ (n + 1).maxPrimeFac = 7 := by
-  sorry
+  -- `maxPrimeFac m` is the greatest element of the (bounded, nonempty) set of prime factors of `m`.
+  have hbdd : ∀ m : ℕ, 1 < m → BddAbove {p : ℕ | p.Prime ∧ p ∣ m} := fun m hm ↦
+    ⟨m, fun p ⟨_, hp⟩ ↦ Nat.le_of_dvd (by omega) hp⟩
+  have hne : ∀ m : ℕ, 1 < m → {p : ℕ | p.Prime ∧ p ∣ m}.Nonempty := by
+    intro m hm
+    simpa [Set.Nonempty, ← Nat.ne_one_iff_exists_prime_dvd] using by omega
+  have hdvd : ∀ m : ℕ, 1 < m → m.maxPrimeFac ∣ m := fun m hm ↦
+    (Nat.sSup_mem (hne m hm) (hbdd m hm)).2
+  have hle : ∀ m p : ℕ, 1 < m → p.Prime → p ∣ m → p ≤ m.maxPrimeFac := fun m p hm hp hpd ↦
+    le_csSup (hbdd m hm) ⟨hp, hpd⟩
+  rintro ⟨n, hn, hn'⟩
+  have h1n : 1 < n := by
+    have := (Nat.one_lt_maxPrimeFac_iff n).mp (by omega)
+    omega
+  -- Since `2` is the greatest prime factor of `n`, it is the only one, so `n` is a power of `2`.
+  obtain ⟨k, hpow⟩ : ∃ k, n = 2 ^ k :=
+    ⟨_, Nat.eq_prime_pow_of_unique_prime_dvd (by omega)
+      (fun {q} hq hqd ↦ le_antisymm (hn ▸ hle n q h1n hq hqd) hq.two_le)⟩
+  -- On the other hand `7` divides `n + 1`, i.e. `2 ^ k ≡ -1 (mod 7)`.
+  have h7 : 7 ∣ n + 1 := hn' ▸ hdvd (n + 1) (by omega)
+  -- This is impossible: `2 ^ k` is congruent to `1`, `2` or `4` modulo `7`, never to `6`.
+  have hmod : 2 ^ k % 7 = 2 ^ (k % 3) % 7 := by
+    conv_lhs => rw [← Nat.div_add_mod k 3, pow_add, pow_mul]
+    rw [Nat.mul_mod, Nat.pow_mod]
+    norm_num
+  have hk3 : k % 3 < 3 := Nat.mod_lt _ (by norm_num)
+  interval_cases h : k % 3 <;> omega
 
 /--
 Even with such amendments, this problem is false in a strong sense: Alan Tong has provided the

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -66,7 +66,8 @@ theorem erdos_786.parts.ii : answer(sorry) ↔
 /--
 An example of such a set with density $\frac 1 4$ is given by the integers $\equiv 2\pmod{4}$
 -/
-@[category textbook, AMS 11]
+@[category textbook, AMS 11, formal_proof using formal_conjectures at
+  "https://github.com/christianTNG/formal-conjectures/blob/6ce00ce5ec1d12b91ffacc369e03536427e556b7/FormalConjectures/ErdosProblems/786.lean#L70"]
 theorem erdos_786.parts.i.example (A : Set ℕ) (hA : A = { n | n % 4 = 2 }) :
     A.HasDensity (1 / 4) ∧ A.IsMulCardSet := by
   sorry

--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -66,11 +66,77 @@ theorem erdos_786.parts.ii : answer(sorry) ↔
 /--
 An example of such a set with density $\frac 1 4$ is given by the integers $\equiv 2\pmod{4}$
 -/
-@[category textbook, AMS 11, formal_proof using formal_conjectures at
-  "https://github.com/christianTNG/formal-conjectures/blob/6ce00ce5ec1d12b91ffacc369e03536427e556b7/FormalConjectures/ErdosProblems/786.lean#L70"]
+@[category textbook, AMS 11]
 theorem erdos_786.parts.i.example (A : Set ℕ) (hA : A = { n | n % 4 = 2 }) :
     A.HasDensity (1 / 4) ∧ A.IsMulCardSet := by
-  sorry
+  subst hA
+  constructor
+  · -- Exactly `(n + 1) / 4` of the naturals below `n` are `≡ 2 (mod 4)`.
+    have hfin : ∀ n : ℕ, ((Finset.range n).filter fun m ↦ m % 4 = 2).card = (n + 1) / 4 := by
+      intro n
+      induction n with
+      | zero => simp
+      | succ n ih =>
+        rw [Finset.range_add_one, Finset.filter_insert]
+        split
+        · rw [Finset.card_insert_of_notMem (by simp)]; omega
+        · omega
+    have hcard : ∀ n : ℕ, ({m : ℕ | m % 4 = 2} ∩ Set.Iio n).ncard = (n + 1) / 4 := by
+      intro n
+      have hset : {m : ℕ | m % 4 = 2} ∩ Set.Iio n
+          = ↑((Finset.range n).filter fun m ↦ m % 4 = 2) := by
+        ext m; simp [Set.mem_Iio, and_comm]
+      rw [hset, Set.ncard_coe_finset, hfin]
+    rw [Set.HasDensity]
+    have hpd : ∀ n : ℕ, ({m : ℕ | m % 4 = 2}).partialDensity Set.univ n
+        = (((n + 1) / 4 : ℕ) : ℝ) / (n : ℝ) := by
+      intro n
+      rw [Set.partialDensity, Set.inter_univ, Set.univ_inter, hcard, Nat.ncard_Iio]
+    simp only [hpd]
+    -- Squeeze `⌊(n + 1) / 4⌋ / n` between `1 / 4 - 1 / n` and `1 / 4 + 1 / n`.
+    have hbdd : ∀ n : ℕ, 1 ≤ n →
+        1 / 4 - 1 / (n : ℝ) ≤ (((n + 1) / 4 : ℕ) : ℝ) / (n : ℝ) ∧
+          (((n + 1) / 4 : ℕ) : ℝ) / (n : ℝ) ≤ 1 / 4 + 1 / (n : ℝ) := by
+      intro n hn
+      have hn0 : (0 : ℝ) < n := by exact_mod_cast hn
+      have h1 : 4 * ((n + 1) / 4) ≤ n + 1 := by omega
+      have h2 : n + 1 < 4 * ((n + 1) / 4) + 4 := by omega
+      have c1 : (4 : ℝ) * (((n + 1) / 4 : ℕ) : ℝ) ≤ (n : ℝ) + 1 := by exact_mod_cast h1
+      have c2 : (n : ℝ) + 1 < 4 * (((n + 1) / 4 : ℕ) : ℝ) + 4 := by exact_mod_cast h2
+      constructor
+      · rw [le_div_iff₀ hn0]; field_simp; linarith
+      · rw [div_le_iff₀ hn0]; field_simp; linarith
+    have hlim : ∀ c : ℝ, Tendsto (fun n : ℕ ↦ 1 / 4 + c * (1 / (n : ℝ))) atTop (𝓝 (1 / 4)) := by
+      intro c
+      simpa using Tendsto.const_add (1 / 4 : ℝ)
+        (Tendsto.const_mul c tendsto_one_div_atTop_nhds_zero_nat)
+    refine tendsto_of_tendsto_of_tendsto_of_le_of_le'
+      (by simpa using hlim (-1)) (by simpa using hlim 1)
+      (eventually_atTop.2 ⟨1, fun n hn ↦ ?_⟩) (eventually_atTop.2 ⟨1, fun n hn ↦ ?_⟩)
+    · simpa using (hbdd n hn).1
+    · simpa using (hbdd n hn).2
+  · -- Every element of the set is exactly divisible by `2`, so the `2`-adic valuation of a
+    -- product of distinct such elements is the number of factors.
+    have key : ∀ s : Finset ℕ, ↑s ⊆ {n : ℕ | n % 4 = 2} →
+        (s.prod id).factorization 2 = s.card := by
+      intro s hs
+      have hmem : ∀ i ∈ s, i % 4 = 2 := fun i hi ↦ hs hi
+      have h0 : ∀ i ∈ s, id i ≠ 0 := fun i hi ↦ by
+        have := hmem i hi; simp only [id]; omega
+      rw [Nat.factorization_prod h0]
+      simp only [Finsupp.finset_sum_apply]
+      rw [Finset.sum_congr rfl (g := fun _ ↦ 1) fun i hi ↦ ?_, Finset.sum_const, smul_eq_mul,
+        mul_one]
+      have h4 := hmem i hi
+      have hi0 : i ≠ 0 := by omega
+      have hd1 : 2 ^ 1 ∣ i := by omega
+      have hd2 : ¬ (2 ^ 2 ∣ i) := by omega
+      rw [Nat.Prime.pow_dvd_iff_le_factorization Nat.prime_two hi0] at hd1
+      rw [Nat.Prime.pow_dvd_iff_le_factorization Nat.prime_two hi0] at hd2
+      simp only [id]
+      omega
+    intro a b ha hb hprod
+    rw [← key a ha, ← key b hb, hprod]
 
 /--
 `consecutivePrimesFrom p k` gives the set of `k + 1` consecutive primes that are at least `p` in

--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -44,9 +44,9 @@ noncomputable def AllowedSetSize (k : ℕ) (N : ℕ) : ℕ :=
   sSup {r | ∃ s, r = s.card ∧ AllowedSet k N s}
 
 /-- By the pigeon hole principle, the size of a subset of an $N \times N$ grid such that no $k$
-points lie on a line is bounded by $\leq (k - 1) * N$ for $N \geq k$. -/
+points lie on a line is bounded by $\leq (k - 1) * N$. -/
 @[category textbook, AMS 5 52]
-theorem allowedSetSize_le {k : ℕ} {N : ℕ} (_h : k ≤ N) :
+theorem allowedSetSize_le {k : ℕ} {N : ℕ} :
     AllowedSetSize k N ≤ (k - 1) * N := by
   refine csSup_le' ?_
   rintro r ⟨s, rfl, hs⟩

--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -45,7 +45,8 @@ noncomputable def AllowedSetSize (k : ℕ) (N : ℕ) : ℕ :=
 
 /-- By the pigeon hole principle, the size of a subset of an $N \times N$ grid such that no $k$
 points lie on a line is bounded by $\leq (k - 1) * N$ for $N \geq k$. -/
-@[category textbook, AMS 5 52]
+@[category textbook, AMS 5 52, formal_proof using formal_conjectures at
+  "https://github.com/christianTNG/formal-conjectures/blob/d5aaa2cb443e948637e695c5810fb70e93a9cbcd/FormalConjectures/GreensOpenProblems/72.lean#L49"]
 theorem allowedSetSize_le {k : ℕ} {N : ℕ} (h : k ≤ N) :
     AllowedSetSize k N ≤ (k - 1) * N := by
   sorry

--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -45,11 +45,28 @@ noncomputable def AllowedSetSize (k : ℕ) (N : ℕ) : ℕ :=
 
 /-- By the pigeon hole principle, the size of a subset of an $N \times N$ grid such that no $k$
 points lie on a line is bounded by $\leq (k - 1) * N$ for $N \geq k$. -/
-@[category textbook, AMS 5 52, formal_proof using formal_conjectures at
-  "https://github.com/christianTNG/formal-conjectures/blob/d5aaa2cb443e948637e695c5810fb70e93a9cbcd/FormalConjectures/GreensOpenProblems/72.lean#L49"]
-theorem allowedSetSize_le {k : ℕ} {N : ℕ} (h : k ≤ N) :
+@[category textbook, AMS 5 52]
+theorem allowedSetSize_le {k : ℕ} {N : ℕ} (_h : k ≤ N) :
     AllowedSetSize k N ≤ (k - 1) * N := by
-  sorry
+  refine csSup_le' ?_
+  rintro r ⟨s, rfl, hs⟩
+  -- Every column of the grid meets an allowed set in at most $k - 1$ points, since $k$ points
+  -- sharing a first coordinate lie on a common vertical line.
+  have key : ∀ x ∈ Finset.range N, (s.filter fun i => i.1 = x).card ≤ k - 1 := by
+    intro x _
+    by_contra hc
+    obtain ⟨t, hts, htc⟩ := Finset.exists_subset_card_eq (n := k)
+      (s := s.filter fun i => i.1 = x) (by omega)
+    refine hs.not_collinear (hts.trans (Finset.filter_subset _ _)) htc ?_
+    rw [collinear_iff_exists_forall_eq_smul_vadd]
+    refine ⟨((x : ℝ), 0), (0, 1), ?_⟩
+    rintro p ⟨i, hi, rfl⟩
+    exact ⟨i.2, by simp [(Finset.mem_filter.mp (hts hi)).2]⟩
+  calc s.card
+      = ∑ x ∈ Finset.range N, (s.filter fun i => i.1 = x).card :=
+        Finset.card_eq_sum_card_fiberwise fun i hi => Finset.mem_range.mpr (hs.is_bounded i hi).1
+    _ ≤ ∑ _x ∈ Finset.range N, (k - 1) := Finset.sum_le_sum key
+    _ = (k - 1) * N := by simp [mul_comm]
 
 /-- The proposition that the allowed-set size for $k$ and $N$ is $(k - 1) * N$. -/
 def NoKInLineFor (k : ℕ) (N : ℕ) : Prop :=


### PR DESCRIPTION
### What

Replaces `sorry` with a full proof in four `category textbook` statements. Following review, the proofs are inlined here rather than referenced through `formal_proof` links, so all four `formal_proof` attributes added earlier in this PR have been removed again.

| Statement | File | Lines added |
|---|---|---|
| `Green72.allowedSetSize_le` | `FormalConjectures/GreensOpenProblems/72.lean` | 20 |
| `Erdos649.erdos_649.variants.no_solution_two_seven` | `FormalConjectures/ErdosProblems/649.lean` | 27 |
| `Erdos44.maxSidonSubsetCard_icc_bound` | `FormalConjectures/ErdosProblems/44.lean` | 42 |
| `Erdos786.erdos_786.parts.i.example` | `FormalConjectures/ErdosProblems/786.lean` | 68 |

### One statement change

`Green72.allowedSetSize_le` loses its `k ≤ N` hypothesis and now reads `{k N : ℕ} : AllowedSetSize k N ≤ (k - 1) * N`, as suggested in review. The bound holds unconditionally: the column fiber pigeonhole argument bounds each of the `N` columns by `k - 1` points independently of whether `k ≤ N` holds. The docstring drops the matching `for $N \geq k$`.

This does not touch `no_k_in_line_big`, which asserts the equality `AllowedSetSize k N = (k - 1) * N` and therefore does need `k ≤ N` as added in #4523. `allowedSetSize_le` has no call sites, and `AllowedSetSize` is not referenced outside this file.

### Checks

- `lake --wfail build` passes: full build, 9025 jobs, no errors and no warnings.
- All four theorems are `sorry`-free. `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for each.
- No `native_decide` and no `decide +native` in any of the four files.

### Follow up

Happy to look at moving `maxSidonSubsetCard_icc_bound` next to the `SidonSet` definitions in `FormalConjecturesForMathlib` as you suggested, but I would prefer to do that in a separate PR to keep this one focused.

*Disclosure: the proofs were developed with AI assistance (LLM agents) under a machine verification gate: clean `lake --wfail build`, zero `sorry`, and an axiom audit on every theorem.*
