### PR TITLE
ErdosProblems/316,399: use the `formal_conjectures` kind for in-repo proofs

### DIFF
--- a/FormalConjectures/ErdosProblems/316.lean
+++ b/FormalConjectures/ErdosProblems/316.lean
@@ -37,7 +37,7 @@ The minimal counterexample is $\{2,3,4,5,6,7,10,11,13,14,15\}$, found by Tom Sto
 
 This was formalized in Lean by Mehta.
 -/
-@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/316.lean"]
+@[category research solved, AMS 5 11, formal_proof using formal_conjectures at ""]
 theorem erdos_316 : answer(False) ↔ ∀ A : Finset ℕ, 0 ∉ A → 1 ∉ A →
     ∑ n ∈ A, (1 / n : ℚ) < 2 → ∃ (A₁ A₂ : Finset ℕ),
       Disjoint A₁ A₂ ∧ A = A₁ ∪ A₂ ∧

--- a/FormalConjectures/ErdosProblems/399.lean
+++ b/FormalConjectures/ErdosProblems/399.lean
@@ -48,7 +48,7 @@ This is discussed in problem D2 of Guy's collection [Gu04].
 
 This was formalized in Lean by Lu using Codex.
 -/
-@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/399.lean"]
+@[category research solved, AMS 11, formal_proof using formal_conjectures at ""]
 theorem erdos_399 : answer(False) ↔
     ¬ ∃ (n x y k : ℕ), 1 < x * y ∧ 2 < k ∧ (n ! = x ^ k + y ^ k ∨ n ! + y ^ k = x ^ k) := by
   show False ↔ _


### PR DESCRIPTION
Closes #4882.

Erdős 316 and 399 are proved in this repository. The attribute on each said the proof was elsewhere, and linked to the file's own URL on GitHub. Both now use the kind for a proof that lives here.

`erdos_316` is proved at 316.lean:45-53 with `decide +kernel`. `erdos_399` is proved at 399.lean:54-56. Neither proof has a `sorry`. The `sorry`s in the two files are on variants, which is normal.

### Why the old form was wrong

- The link pointed at the declaration it was attached to, so it told a reader nothing.
- It used the mutable `main` ref, so it would drift as the file changed.
- It counted as an external proof. #4749 checks it as one.

### Checks I ran

`lake build FormalConjectures.ErdosProblems.«316» FormalConjectures.ErdosProblems.«399»` completes with no error and no warning. The empty link is valid for the `formal_conjectures` kind, where the proof is the statement itself, and the repository already writes it this way in two other places.

### Not in this change

#4881 covers links whose target assumes an axiom. That defect needs new mechanism, and 316 and 399 are not examples of it.
