### PR TITLE
ErdosProblems/750: mark the linked proof conditional on Stiebitz's theorem

### DIFF
--- a/FormalConjectures/ErdosProblems/750.lean
+++ b/FormalConjectures/ErdosProblems/750.lean
@@ -31,11 +31,88 @@ import FormalConjecturesUtil
   (N.S.) (1995), 61-65.
 - [ErHa67b] Erdős, P. and Hajnal, András, On chromatic graphs. Mat. Lapok (1967), 1--4.
 - [UlamErdos750](https://www.ulam.ai/research/erdos750.pdf)
+- [St85] Stiebitz, M., _Beiträge zur Theorie der färbungskritischen Graphen_. Habilitation,
+  TH Ilmenau (1985).
+- [SaSt89] Sachs, H. and Stiebitz, M., _On constructive methods in the theory of colour-critical
+  graphs_. Discrete Math. (1989), 287-296.
+- [MuSt19] Müller, T. and Stehlík, M., _Generalised Mycielski graphs and the Borsuk-Ulam theorem_.
+  Electron. J. Combin. (2019), P4.8.
 -/
 
-open Filter Finset NNReal
+open Filter Finset NNReal SimpleGraph
+
+universe u
 
 namespace Erdos750
+
+/--
+Vertices of the generalised Mycielskian $M_s(G)$: $s$ copies of the vertices of $G$, one per
+level, and a single apex.
+-/
+abbrev MycVerts (s : ℕ) (V : Type u) : Type u := (Fin s × V) ⊕ Unit
+
+/--
+Adjacency of the generalised Mycielskian, before `SimpleGraph.fromRel` packages it as a graph.
+
+Two level-`0` vertices are adjacent when the underlying vertices are; a level-`i` vertex and a
+level-`i + 1` vertex are adjacent when the underlying vertices are; and the apex is adjacent to
+every vertex on the top level. The relation is already symmetric and irreflexive, so `fromRel`
+changes nothing about it.
+-/
+def MycAdj (s : ℕ) {V : Type u} (G : SimpleGraph V) : MycVerts s V → MycVerts s V → Prop
+  | Sum.inl (i, u), Sum.inl (j, v) =>
+      (i.val = 0 ∧ j.val = 0 ∧ G.Adj u v) ∨ (j.val = i.val + 1 ∧ G.Adj u v) ∨
+        (i.val = j.val + 1 ∧ G.Adj u v)
+  | Sum.inl (i, _), Sum.inr () => i.val + 1 = s
+  | Sum.inr (), Sum.inl (i, _) => i.val + 1 = s
+  | Sum.inr (), Sum.inr () => False
+
+/--
+The **generalised Mycielskian** $M_s(G)$. $M_2(G)$ is the classical Mycielskian, and $M_1(G)$
+adds a vertex joined to everything.
+-/
+def genMyc (s : ℕ) {V : Type u} (G : SimpleGraph V) : SimpleGraph (MycVerts s V) :=
+  .fromRel (MycAdj s G)
+
+/-- The apex of $M_s(G)$ is adjacent to every vertex on the top level. -/
+@[category test, AMS 5]
+theorem genMyc_apex_adj_top {V : Type u} (G : SimpleGraph V) (s : ℕ) (hs : 0 < s) (v : V) :
+    (genMyc s G).Adj (Sum.inr ()) (Sum.inl (⟨s - 1, by omega⟩, v)) := by
+  refine ⟨by simp, Or.inl ?_⟩
+  show s - 1 + 1 = s
+  omega
+
+/-- Two level-`0` vertices of $M_s(G)$ are adjacent exactly when the underlying vertices are. -/
+@[category test, AMS 5]
+theorem genMyc_adj_level_zero {V : Type u} (G : SimpleGraph V) {s : ℕ} (hs : 0 < s) {u v : V}
+    (huv : G.Adj u v) :
+    (genMyc s G).Adj (Sum.inl (⟨0, hs⟩, u)) (Sum.inl (⟨0, hs⟩, v)) := by
+  refine ⟨by simpa using huv.ne, Or.inl ?_⟩
+  exact Or.inl ⟨rfl, rfl, huv⟩
+
+/--
+`G` belongs to the class $M_r$, meaning it is built from $K_2$ by $r - 2$ generalised
+Mycielskians. Stiebitz's theorem is about this class and not about arbitrary graphs: it is false
+that $\chi(M_s(H)) = \chi(H) + 1$ for every $H$ and every $s$.
+-/
+def IsRecursivelyBuiltMr : ∀ (_r : ℕ) {_V : Type u} (_G : SimpleGraph _V), Prop
+  | 0, _, _ => False
+  | 1, _, _ => False
+  | 2, _, G => Nonempty (G ≃g completeGraph (Fin 2))
+  | r + 3, _, G => ∃ (W : Type u) (H : SimpleGraph W) (s : ℕ),
+      1 ≤ s ∧ IsRecursivelyBuiltMr (r + 2) H ∧ Nonempty (G ≃g genMyc s H)
+
+/--
+**Stiebitz's theorem** [St85]: every graph in $M_r$ has chromatic number at least $r$. The
+matching upper bound follows from the construction, so the chromatic number is exactly $r$.
+
+This is stated ahead of `erdos_750` because the formal proof linked there assumes it, and the
+`assuming` clause must name a declaration that already exists. See also [SaSt89] and [MuSt19].
+-/
+@[category research solved, AMS 5]
+theorem erdos_750.variants.stiebitz {V : Type u} (G : SimpleGraph V) (r : ℕ)
+    (h : IsRecursivelyBuiltMr r G) : (r : ℕ∞) ≤ G.chromaticNumber := by
+  sorry
 
 /--
 Let $f(m)$ be some function such that $f(m)\to \infty$ as $m\to \infty$. Does there exist a
@@ -50,9 +127,15 @@ Indeed, this constructs a graph with infinite chromatic number such that every s
 vertices can be made bipartite after deleting at most $f(m)$ many vertices.
 
 This was formalized in Lean by Ammanamanchi using Claude Code 4.7 and GPT-5.5 Pro.
+
+The linked proof is not complete on its own. It declares Stiebitz's theorem as an axiom and
+derives the result from it, so it is marked `conditional` and names
+`erdos_750.variants.stiebitz`.
 -/
-@[category research solved, AMS 5, formal_proof using lean4 at
-"https://github.com/Shashi456/erdos-formalizations/blob/main/Erdos/P750/Proof.lean"]
+@[category research solved, AMS 5,
+  conditional formal_proof using lean4 at
+    "https://github.com/Shashi456/erdos-formalizations/blob/main/Erdos/P750/Proof.lean"
+  assuming erdos_750.variants.stiebitz]
 theorem erdos_750 :
     answer(True) ↔ ∀ (f : ℕ → ℝ≥0) (hf : atTop.Tendsto f atTop),
       ∃ (V : Type*) (G : SimpleGraph V), G.chromaticNumber = ⊤ ∧


### PR DESCRIPTION
Part of #4881. Follows #4884, which did the same for 427.

The proof linked from `erdos_750` is not complete on its own. It declares Stiebitz's theorem as an axiom and derives the result from it:

```lean
axiom stiebitz_lower_bound : ∀ {V : Type u} (G : SimpleGraph V) (r : ℕ),
    IsRecursivelyBuiltMr r G → (r : ℕ∞) ≤ G.chromaticNumber
```

The attribute now says `conditional formal_proof ... assuming erdos_750.variants.stiebitz`.

### Why this is more than one line

427 already stated its assumption. This one did not, and the `assuming` clause must name a declaration. Stating Stiebitz's theorem needs the generalised Mycielskian, which Mathlib does not have in any form. The file therefore gains:

- `MycVerts`, the vertices of `Mₛ(G)`: `s` levels and one apex.
- `MycAdj`, the adjacency relation.
- `genMyc`, the graph itself, as `SimpleGraph.fromRel (MycAdj s G)`.
- `IsRecursivelyBuiltMr`, the class `Mᵣ` of graphs built from `K₂` by iterated generalised Mycielskians.
- `erdos_750.variants.stiebitz`, the statement, with a `sorry` proof.

Stiebitz's theorem is about that class and not about arbitrary graphs. `χ(Mₛ(H)) = χ(H) + 1` is false in general, and the docstring says so.

### Why `fromRel`

`MycAdj` is already symmetric and irreflexive, so `SimpleGraph.fromRel` adds nothing to it: the `v ≠ w` conjunct follows from the relation, and the `r v w ∨ r w v` disjunction collapses. Using it avoids two proof obligations that carry no mathematical content.

Two `test` statements check that this packaging keeps the edges it should:

- `genMyc_apex_adj_top`: the apex is adjacent to every top-level vertex.
- `genMyc_adj_level_zero`: two level-`0` vertices are adjacent when the underlying vertices are.

Both are proved, not `sorry`.

### Checks I ran

`lake build FormalConjectures.ErdosProblems.«750»` completes with no error and no warning, including the two `test` proofs.

### Still open in #4881

1141 has the same defect. It assumes Pollack's Theorem 1.3 and Mertens' third theorem. `check_erdos_status.py` still counts a conditional proof as formally solved; that fix belongs on #4828, which reads the published extract and can use the `proofConditions` field directly.
