### PR TITLE
ErdosProblems/1141: mark the linked proof conditional on its two external inputs

### DIFF
--- a/FormalConjectures/ErdosProblems/1141.lean
+++ b/FormalConjectures/ErdosProblems/1141.lean
@@ -28,6 +28,8 @@ import FormalConjecturesUtil
 - [Or26] Y. Oriike, [Lean formalisation of Erdős problem 1141](https://github.com/yuta0x89/ErdosProblems/blob/a1319f732cdee5140faf47d984e2c451c1184803/Erdos1141.lean) (2026)
 - [Po17] P. Pollack, Bounds for the first several prime character nonresidues. Proc. Amer. Math. Soc.
   (2017), 2815--2826.
+- [Me1874] F. Mertens, Ein Beitrag zur analytischen Zahlentheorie. J. Reine Angew. Math. (1874),
+  46--62.
 - [Va99] Various, Some of Paul's favorite problems. Booklet produced for the conference "Paul Erdős
   and his mathematics", Budapest, July 1999 (1999).
 -/
@@ -35,6 +37,47 @@ import FormalConjecturesUtil
 open Nat Set
 
 namespace Erdos1141
+
+/- ## The two external inputs
+
+The formal proof linked on `erdos_1141` below assumes both of these, and states neither. They are
+recorded here so the `assuming` clause on that theorem can name them. -/
+
+/-- The cutoff $m^{1/4 + \varepsilon}$ of Theorem 1.3 of [Po17]. -/
+noncomputable def residuePrimeUpperBound (m : ℕ) (ε : ℝ) : ℝ := (m : ℝ) ^ ((1 / 4 : ℝ) + ε)
+
+/--
+The primes $\ell \leq m^{1/4+\varepsilon}$ with $\chi(\ell) = 1$.
+
+This does not require $\chi$ to be quadratic. That hypothesis belongs to the theorem below, as it
+does in the paper.
+-/
+noncomputable def residuePrimesUpTo (m : ℕ) (χ : DirichletCharacter ℂ m) (ε : ℝ) : Finset ℕ := by
+  classical
+  exact (Finset.range (⌈residuePrimeUpperBound m ε⌉₊ + 1)).filter fun ℓ =>
+    ℓ.Prime ∧ (ℓ : ℝ) ≤ residuePrimeUpperBound m ε ∧ χ (ℓ : ZMod m) = 1
+
+/--
+**Theorem 1.3 of [Po17]**: for a quadratic character to a large enough modulus, the primes below
+$m^{1/4+\varepsilon}$ on which the character is $1$ outnumber any fixed power of $\log m$.
+-/
+@[category research solved, AMS 11]
+theorem erdos_1141.variants.pollack_1_3 (ε A : ℝ) (hε : 0 < ε) (hA : 0 < A) :
+    ∃ m₀ : ℕ, ∀ m : ℕ, m₀ < m → ∀ χ : DirichletCharacter ℂ m, MulChar.IsQuadratic χ →
+      Real.log m ^ A ≤ ((residuePrimesUpTo m χ ε).card : ℝ) := by
+  sorry
+
+/--
+**Mertens' third theorem** [Me1874], in the weakened form the linked proof assumes: the product
+over the primes up to $n$ of $1 - 1/p$ is at least $1/(3\log n)$.
+
+The true asymptotic is $e^{-\gamma}/\log n$, and $e^{-\gamma} > 1/3$, so this bound is weaker than
+the theorem and is what the deduction needs.
+-/
+@[category research solved, AMS 11]
+theorem erdos_1141.variants.mertens_third (n : ℕ) (hn : 3 ≤ n) :
+    1 / (3 * Real.log n) ≤ ∏ p ∈ (Finset.range (n + 1)).filter Nat.Prime, (1 - 1 / (p : ℝ)) := by
+  sorry
 
 /--
 The property that $n-k^2$ is prime for all $k$ with $(n,k)=1$ and $k^2 < n$.
@@ -60,9 +103,14 @@ is $1722$.
 
 The answer is negative: [APSSV26b] proves a stronger finiteness theorem, deducing it from
 Pollack [Po17]. Oriike [Or26] formalised the deduction in Lean.
+
+The linked proof is the deduction and not the whole result. It declares Theorem 1.3 of [Po17] and
+Mertens' third theorem as axioms, so it is marked `conditional` and names both.
 -/
-@[category research solved, AMS 11, formal_proof using lean4 at
-  "https://github.com/yuta0x89/ErdosProblems/blob/a1319f732cdee5140faf47d984e2c451c1184803/Erdos1141.lean"]
+@[category research solved, AMS 11,
+  conditional formal_proof using lean4 at
+    "https://github.com/yuta0x89/ErdosProblems/blob/a1319f732cdee5140faf47d984e2c451c1184803/Erdos1141.lean"
+  assuming erdos_1141.variants.pollack_1_3 erdos_1141.variants.mertens_third]
 theorem erdos_1141 :
     answer(False) ↔ Infinite { n | Erdos1141Prop n } := by
   sorry


### PR DESCRIPTION
Part of #4881. Follows #4884 (427) and #4885 (750). This completes step 1 of that issue.

The proof linked from `erdos_1141` is the deduction and not the whole result, which the docstring already said: "Oriike [Or26] formalised the deduction in Lean." It declares two axioms:

```lean
axiom theorem_1_3 (ε A : ℝ) (hε : 0 < ε) (hA : 0 < A) :
    ∃ m0 : ℕ, ∀ m : ℕ, m > m0 → ∀ χ : DirichletCharacter ℂ m, MulChar.IsQuadratic χ →
      Real.rpow (Real.log (m : ℝ)) A ≤ ((residuePrimesUpTo m χ ε).card : ℝ)

axiom mertens_third_theorem (n : ℕ) (hn : 3 ≤ n) :
    1 / (3 * Real.log n) ≤ ∏ p ∈ (Finset.range (n + 1)).filter Prime, (1 - 1 / (p : ℝ))
```

The attribute now says `conditional formal_proof ... assuming erdos_1141.variants.pollack_1_3 erdos_1141.variants.mertens_third`.

### What the file gains

Neither assumption was stated, so both are added with `sorry` proofs, together with the two definitions Theorem 1.3 needs: `residuePrimeUpperBound` for the cutoff $m^{1/4+\varepsilon}$, and `residuePrimesUpTo` for the primes below it on which the character is $1$. `DirichletCharacter` and `MulChar.IsQuadratic` come from Mathlib, so nothing else had to be built.

### Where the wording differs from the axioms

- The axiom writes `Real.rpow x y` and this writes `x ^ y`. The exponent is real, so the power is `Real.rpow` either way.
- The axiom filters `Finset.range (n + 1)` by `_root_.Prime`, since its file opens `Finset Real` and not `Nat`. This filters by `Nat.Prime`, which is the same predicate on `ℕ`, so the two products are equal.
- `m > m0` is written `m₀ < m`.

Nothing else moved. The bound in the Mertens statement is the weakened one the proof assumes, not the theorem: the true constant is $e^{-\gamma} \approx 0.561$ and the assumed constant is $1/3$. The docstring says so, since a reader who knows Mertens would otherwise wonder why the statement is loose.

### Checks I ran

`lake build FormalConjectures.ErdosProblems.«1141»` completes with no error and no warning. It first warned about a second module docstring, which is now a plain comment.

I did not add `test` statements here. #4885 needed them because it repackaged the adjacency relation through `SimpleGraph.fromRel`; these two statements are transcriptions with no such change.

### What remains in #4881

`check_erdos_status.py` still counts a conditional proof as formally solved. That fix belongs on #4828, which reads the published extract and can use the `proofConditions` field. Separately, 13 `formal_proof` links name no file, so no check can read them.
