### PR TITLE
Mark Green's Open Problem 52 logarithmic variant as solved

### DIFF
--- a/FormalConjectures/GreensOpenProblems/52.lean
+++ b/FormalConjectures/GreensOpenProblems/52.lean
@@ -43,9 +43,11 @@ theorem green_52 :
 /--
 Could $2A$ even contain a coset of codimension $O(\log K)$?
 -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/green-52-log-counterexample/blob/16cb5d0/lean/Green52LogCounterexampleFC.lean#L661-L668"]
 theorem green_52_log :
-    answer(sorry) ↔ ∃ (C D : ℝ), ∀ (n K : ℕ) (A : Set (𝔽₂ n)) (S : Finset (𝔽₂ n)),
+    answer(False) ↔ ∃ (C D : ℝ), ∀ (n K : ℕ) (A : Set (𝔽₂ n)) (S : Finset (𝔽₂ n)),
       0 < K → S.card = K → A + (S : Set (𝔽₂ n)) = Set.univ →
       ∃ (V : AffineSubspace (ZMod 2) (𝔽₂ n)), (V : Set (𝔽₂ n)) ⊆ A + A ∧
         (n : ℝ) ≤ (Module.finrank (ZMod 2) V.direction : ℝ) + C * log (K : ℝ) + D := by

--- a/FormalConjectures/GreensOpenProblems/52.lean
+++ b/FormalConjectures/GreensOpenProblems/52.lean
@@ -42,6 +42,14 @@ theorem green_52 :
 
 /--
 Could $2A$ even contain a coset of codimension $O(\log K)$?
+
+From [Green's 2025 update](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.52):
+
+> Update 2025. Kaave Hosseini and Ryan Alweiss have independently pointed out
+> that the second question is far too optimistic. To see this, let $A$ be a Hamming ball
+> of radius $n/2 - \sqrt{n}$. There is a set $S$ of size $O(n)$ such that
+> $A + S = \mathbb{F}_2^n$; a random choice of $S$ will work. However, every subspace
+> contained in $A - A$ has codimension $\gg \sqrt{n}$.
 -/
 @[category research solved, AMS 5 11,
   formal_proof using lean4 at


### PR DESCRIPTION
This PR changes `Green52.green_52_log` from `answer(sorry)` to `answer(False)` and links a kernel-checked Lean proof.

It leaves the qualitative statement `Green52.green_52` open.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem Green52.green_52_log_solved :
    answer(False) ↔ ∃ (C D : ℝ), ∀ (n K : ℕ) (A : Set (𝔽₂ n))
      (S : Finset (𝔽₂ n)),
      0 < K → S.card = K → A + (S : Set (𝔽₂ n)) = Set.univ →
      ∃ (V : AffineSubspace (ZMod 2) (𝔽₂ n)), (V : Set (𝔽₂ n)) ⊆ A + A ∧
        (n : ℝ) ≤ (Module.finrank (ZMod 2) V.direction : ℝ) +
          C * log (K : ℝ) + D
```

Proof: https://github.com/KitaKen1/green-52-log-counterexample/blob/16cb5d0/lean/Green52LogCounterexampleFC.lean#L661-L668

Repository: https://github.com/KitaKen1/green-52-log-counterexample

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fgreen-52-log-counterexample%2Frefs%2Fheads%2Fmain%2Flean4web%2FGreen52LogCounterexampleLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.

> [!NOTE]
> This formalizes the Hamming-ball counterexample recorded in the 2025 update to [Green's Open Problem 52](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.52), where Green credits Kaave Hosseini and Ryan Alweiss with independently observing that the `O(log K)` bound is too optimistic.
>
> The Lean proof supplies a kernel-checked version of this obstruction, using an explicit Walsh-character covering set.