### PR TITLE
Mark Erdős Problem 692 Part II target as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/692.lean
+++ b/FormalConjectures/ErdosProblems/692.lean
@@ -65,7 +65,9 @@ theorem erdos_692.parts.i : answer(False) ↔
 Let $\delta_1(n,m)$ be the density of the set of integers with exactly one divisor in $(n,m)$.
 For fixed $n$, where does $\delta_1(n,m)$ achieve its maximum?
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-692-part-ii-lean/blob/30283612d0ddbcea34e0eb38efd6e175e7d7d3cf/lean/Erdos692PartII.lean#L565-L573"]
 theorem erdos_692.parts.ii (n : ℕ) :
     ∀ δ : ℕ → ℕ → ℝ, (∀ a b, IsDelta₁ a b (δ a b)) →
       IsGreatest (δ n '' Set.Ioi (n + 1)) (δ n answer(sorry)) := by


### PR DESCRIPTION
This PR marks `Erdos692.erdos_692.parts.ii` as solved and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

Proof: https://github.com/KitaKen1/erdos-692-part-ii-lean/blob/30283612d0ddbcea34e0eb38efd6e175e7d7d3cf/lean/Erdos692PartII.lean#L565-L573

Repository: https://github.com/KitaKen1/erdos-692-part-ii-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-692-part-ii-lean%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos692PartIILean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.

> [!NOTE]
> **Scope of the result.** The [Erdős Problems page](https://www.erdosproblems.com/692) asks: “For fixed `n`, where does `δ₁(n,m)` achieve its maximum?” This wording may suggest determining or characterizing the maximizing endpoint. By contrast, the registered Lean statement asks only for the existence of some endpoint at which the greatest value is attained.
>
> The proof establishes this existence, reduces the search to a finite interval, and defines `maximizingIndex n` noncomputably using `Classical.choose`. It does not compute or characterize the maximizer, identify the first maximizing endpoint, or prove uniqueness. Thus the literal Formal Conjectures target is proved, but this may not resolve the full intended meaning of the natural-language question.