### PR TITLE
extract_names: report every `formal_proof` on a declaration, not just one

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -267,10 +267,8 @@ jobs:
               subjects: (c.subjects || []).map(s =>
                 typeof s === 'object' ? s.code : s
               ),
-              formalProofKind: c.formalProofKind || null,
-              formalProofLink: c.formalProofLink || null,
+              formalProofs: c.formalProofs || [],
               hasSorryFreeProof: false,
-              proofConditions: c.proofConditions || [],
             }));
             fs.writeFileSync(
               'site/data/conjectures.json',

--- a/FormalConjecturesUtil/Metadata.lean
+++ b/FormalConjecturesUtil/Metadata.lean
@@ -1,0 +1,66 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Lean
+
+/-!
+# Canonical problem metadata
+
+The website, the Erdős status checker, the proof-link checker, the comparator
+workspace generator and the review tooling all need overlapping facts about
+this repository's declarations, and each has been re-deriving them. This
+module is where the shared representation lives, so that one semantic fact is
+interpreted once.
+
+It starts deliberately small: `FormalProofInfo` is the schema
+`extract_names` exports as `formalProofs` (`schemaVersion` 2), moved here so
+its next consumer imports it rather than restating it. A `ProblemSpec`
+bundling declaration, module, category, subjects, answer holes and source
+range belongs here too, and arrives when `extract_names`' internal
+`TheoremInfo` migrates; growing it ahead of its consumers would be schema
+fiction.
+-/
+
+public section
+open Lean
+
+namespace FormalConjectures.Metadata
+
+/-- One formal proof attached to a declaration. Assumptions belong to the
+individual proof, not to the conjecture: a statement can carry a conditional
+proof and an unconditional one at once, and Erdős 427 does. -/
+public structure FormalProofInfo where
+  kind : String
+  link : String
+  conditions : List String
+
+public def FormalProofInfo.toJson (proof : FormalProofInfo) : Json :=
+  Json.mkObj
+    [("kind", Lean.toJson proof.kind),
+     ("link", Lean.toJson proof.link),
+     ("conditions", Lean.toJson proof.conditions)]
+
+/-- A key that orders the proofs of one declaration deterministically.
+
+The attribute state is a `HashSet`, so it does not preserve the order the
+annotations were written in. Conditions are part of the key: two proofs may
+share kind and link and differ only in what they assume. -/
+public def FormalProofInfo.sortKey (proof : FormalProofInfo) : String :=
+  proof.kind ++ " " ++ proof.link ++ " " ++ String.intercalate "," proof.conditions
+
+end FormalConjectures.Metadata
+end

--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -16,6 +16,7 @@ limitations under the License.
 module
 
 public import Lean
+public meta import FormalConjecturesUtil.Metadata
 public import FormalConjecturesUtil.Attributes.Basic
 public import FormalConjecturesUtil.Answer
 
@@ -119,31 +120,9 @@ def validExcludeKeys : List String :=
    "hasSorryFreeProof", "moduleDocstrings", "answerKinds",
    "fileFirstAdded", "fileLastModified"]
 
-/-- One `formal_proof` annotation: where the proof is, and what it assumes.
-
-A declaration can carry several, so these are reported as a list. `conditions` is empty
-unless the annotation is `conditional`. -/
-structure FormalProofInfo where
-  kind : String
-  link : String
-  conditions : List String
-
-def FormalProofInfo.toJson (proof : FormalProofInfo) : Json :=
-  Json.mkObj
-    [("kind", Lean.toJson proof.kind),
-     ("link", Lean.toJson proof.link),
-     ("conditions", Lean.toJson proof.conditions)]
-
-/-- A key that orders the proofs of one declaration deterministically.
-
-The attribute state is a `HashSet`, so it does not preserve the order the annotations were
-written in and `toArray` may return them differently from one run to the next. Sorting keeps
-the extract stable. -/
-def FormalProofInfo.sortKey (proof : FormalProofInfo) : String :=
-  -- Conditions are part of the key: two proofs may share kind and link and
-  -- differ only in what they assume, and equal keys would let the HashSet's
-  -- order leak through for exactly that pair.
-  proof.kind ++ " " ++ proof.link ++ " " ++ String.intercalate "," proof.conditions
+-- `FormalProofInfo` and its ordering live in `FormalConjecturesUtil.Metadata`,
+-- the shared home for facts more than one tool consumes.
+open FormalConjectures.Metadata
 
 structure TheoremInfo where
   «theorem» : String

--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -115,9 +115,32 @@ def getFileLastModified (file : System.FilePath) : IO (Option String) :=
 
 /-- Valid keys for the `--exclude` flag. -/
 def validExcludeKeys : List String :=
-  ["docstring", "statement", "subjects", "formalProofKind", "formalProofLink",
-   "hasSorryFreeProof", "moduleDocstrings", "answerKinds", "proofConditions",
+  ["docstring", "statement", "subjects", "formalProofs",
+   "hasSorryFreeProof", "moduleDocstrings", "answerKinds",
    "fileFirstAdded", "fileLastModified"]
+
+/-- One `formal_proof` annotation: where the proof is, and what it assumes.
+
+A declaration can carry several, so these are reported as a list. `conditions` is empty
+unless the annotation is `conditional`. -/
+structure FormalProofInfo where
+  kind : String
+  link : String
+  conditions : List String
+
+def FormalProofInfo.toJson (proof : FormalProofInfo) : Json :=
+  Json.mkObj
+    [("kind", Lean.toJson proof.kind),
+     ("link", Lean.toJson proof.link),
+     ("conditions", Lean.toJson proof.conditions)]
+
+/-- A key that orders the proofs of one declaration deterministically.
+
+The attribute state is a `HashSet`, so it does not preserve the order the annotations were
+written in and `toArray` may return them differently from one run to the next. Sorting keeps
+the extract stable. -/
+def FormalProofInfo.sortKey (proof : FormalProofInfo) : String :=
+  proof.kind ++ " " ++ proof.link
 
 structure TheoremInfo where
   «theorem» : String
@@ -126,12 +149,10 @@ structure TheoremInfo where
   subjects : List String
   statement : String
   docstring : Option String
-  formalProofKind : Option String
-  formalProofLink : Option String
+  formalProofs : List FormalProofInfo
   hasSorryFreeProof : Bool
   subsets : List String
   answerKinds : List String
-  proofConditions : List String
   fileFirstAdded : Option String
   fileLastModified : Option String
 
@@ -145,17 +166,13 @@ def TheoremInfo.toFilteredJson (info : TheoremInfo) (exclude : Std.HashSet Strin
     ++ (if exclude.contains "subjects" then [] else [("subjects", toJson info.subjects)])
     ++ (if exclude.contains "statement" then [] else [("statement", toJson info.statement)])
     ++ (if exclude.contains "docstring" then [] else [("docstring", toJson info.docstring)])
-    ++ (if exclude.contains "formalProofKind" then [] else
-        [("formalProofKind", toJson info.formalProofKind)])
-    ++ (if exclude.contains "formalProofLink" then [] else
-        [("formalProofLink", toJson info.formalProofLink)])
+    ++ (if exclude.contains "formalProofs" || info.formalProofs.isEmpty then [] else
+        [("formalProofs", Json.arr (info.formalProofs.map FormalProofInfo.toJson).toArray)])
     ++ (if exclude.contains "hasSorryFreeProof" then [] else
         [("hasSorryFreeProof", toJson info.hasSorryFreeProof)])
     ++ (if info.subsets.isEmpty then [] else [("subsets", toJson info.subsets)])
     ++ (if exclude.contains "answerKinds" then [] else
         [("answerKinds", toJson info.answerKinds)])
-    ++ (if exclude.contains "proofConditions" || info.proofConditions.isEmpty then [] else
-        [("proofConditions", toJson info.proofConditions)])
     ++ (if exclude.contains "fileFirstAdded" then [] else
         [("fileFirstAdded", toJson info.fileFirstAdded)])
     ++ (if exclude.contains "fileLastModified" then [] else
@@ -246,10 +263,12 @@ unsafe def main (args : List String) : IO Unit := do
       categoryMap := categoryMap.insert tag.declName (categoryToString tag.category :: categoryMap.getD tag.declName [])
       categoryFullMap := categoryFullMap.insert tag.declName tag
 
-    -- Create formal proof map
-    let mut formalProofMap : Std.HashMap Name FormalProofTag := {}
+    -- Create formal proof map. A declaration may carry several `formal_proof` annotations,
+    -- so collect them all rather than keeping whichever arrives last.
+    let mut formalProofMap : Std.HashMap Name (List FormalProofTag) := {}
     for tag in formalProofTags do
-      formalProofMap := formalProofMap.insert tag.declName tag
+      formalProofMap :=
+        formalProofMap.insert tag.declName (tag :: formalProofMap.getD tag.declName [])
 
     let mut subjectMap : Std.HashMap Name (List String) := {}
     for tag in subjectTags do
@@ -291,12 +310,15 @@ unsafe def main (args : List String) : IO Unit := do
               let docstring ← findDocString? env name
               if docstring.isNone then
                 IO.eprintln s!"WARNING: Theorem {name} (category: {cats.head!}) is missing a docstring"
-              -- Extract formal proof info from the separate formal_proof attribute
-              let (formalProofKind, formalProofLink) :=
-                if let some tag := formalProofMap.get? name then
-                  (some (formalProofKindToString tag.proofKind), some tag.proofLink)
-                else
-                  (none, none)
+              -- Extract formal proof info from the separate formal_proof attributes. Each
+              -- carries its own `conditions`, since one proof can be conditional while
+              -- another of the same statement is not.
+              let formalProofs :=
+                ((formalProofMap.getD name []).map fun tag =>
+                  { kind := formalProofKindToString tag.proofKind,
+                    link := tag.proofLink,
+                    conditions := tag.conditions.map Name.toString : FormalProofInfo })
+                |>.toArray.qsort (fun a b => a.sortKey < b.sortKey) |>.toList
               -- Check whether the proof term is sorry-free
               let hasSorryFreeProof :=
                 info.value? |>.any (!·.hasSorry)
@@ -311,10 +333,6 @@ unsafe def main (args : List String) : IO Unit := do
                   IO.eprintln s!"WARNING: Theorem {name} is categorised as `API` but has no sorry-free proof"
                 | _, _ => pure ()
               let subsets := (theoremToSubsets.getD name []).toArray.qsort (· < ·) |>.toList
-              -- The unproven hypotheses a conditional formal proof assumes,
-              -- as declaration names.
-              let proofConditions :=
-                ((formalProofMap.get? name).map (·.conditions.map Name.toString)).getD []
               -- Determine answerKinds from the elaborated type
               let answerKinds ← Meta.MetaM.run'
                 (getAnswerKinds info.type)
@@ -327,12 +345,10 @@ unsafe def main (args : List String) : IO Unit := do
                 subjects := subjs,
                 statement := statement,
                 docstring := docstring,
-                formalProofKind := formalProofKind,
-                formalProofLink := formalProofLink,
+                formalProofs := formalProofs,
                 hasSorryFreeProof := hasSorryFreeProof,
                 subsets := subsets
                 answerKinds := answerKinds
-                proofConditions := proofConditions
                 fileFirstAdded := fileFirstAdded
                 fileLastModified := fileLastModified
               } :: allResults

--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -140,7 +140,10 @@ The attribute state is a `HashSet`, so it does not preserve the order the annota
 written in and `toArray` may return them differently from one run to the next. Sorting keeps
 the extract stable. -/
 def FormalProofInfo.sortKey (proof : FormalProofInfo) : String :=
-  proof.kind ++ " " ++ proof.link
+  -- Conditions are part of the key: two proofs may share kind and link and
+  -- differ only in what they assume, and equal keys would let the HashSet's
+  -- order leak through for exactly that pair.
+  proof.kind ++ " " ++ proof.link ++ " " ++ String.intercalate "," proof.conditions
 
 structure TheoremInfo where
   «theorem» : String
@@ -367,7 +370,10 @@ unsafe def main (args : List String) : IO Unit := do
 
     -- Build structured output: { problems: [...], moduleDocstrings: {...} }
     let problemsJson := toJson (allResults.reverse.map (·.toFilteredJson excludeSet))
-    let mut outputFields : List (String × Json) := [("problems", problemsJson)]
+    -- Consumers should not have to guess whether they are reading the old
+    -- `formalProofKind` shape or the `formalProofs` list; say so.
+    let mut outputFields : List (String × Json) :=
+      [("schemaVersion", Lean.toJson (2 : Nat)), ("problems", problemsJson)]
     if !excludeSet.contains "moduleDocstrings" then
       let moduleDocJson := Json.mkObj (moduleDocstrings.reverse.map fun (k, v) => (k, toJson v))
       outputFields := outputFields ++ [("moduleDocstrings", moduleDocJson)]

--- a/site/build.js
+++ b/site/build.js
@@ -177,7 +177,11 @@ function processEntry(entry) {
   // Pick only the fields the website actually uses. Avoids leaking large
   // unused fields (statement, docstring) into the client-side JSON.
   // Docstrings come from versoFragments instead.
-  const hasFormalProof = !!entry.formalProofKind;
+  // A declaration can carry several `formal_proof` annotations. `hasFormalProof` stays a
+  // boolean about the conjecture, so the landing-page and stats counts keep counting
+  // conjectures rather than proofs.
+  const formalProofs = entry.formalProofs || [];
+  const hasFormalProof = formalProofs.length > 0;
   return {
     theorem: entry.theorem,
     module: entry.module,
@@ -193,9 +197,7 @@ function processEntry(entry) {
     categoryCss: catMeta.css,
     subjects,
     hasFormalProof,
-    formalProofKind: entry.formalProofKind || null,
-    formalProofLink: entry.formalProofLink || null,
-    proofConditions: entry.proofConditions || [],
+    formalProofs,
   };
 }
 

--- a/site/src/js/browse.js
+++ b/site/src/js/browse.js
@@ -27,7 +27,6 @@ const state = {
   sort:            'name',
 };
 
-const FORMAL_PROOF_LABELS = FC.FORMAL_PROOF_LABELS;
 
 // ---------------------------------------------------------------------------
 // DOM references
@@ -59,7 +58,7 @@ function readURL() {
   state.formalProofKinds.clear();
   if (params.get('formal_proof') === 'true') {
     // Landing page shortcut: select all proof kinds
-    for (const k of Object.keys(FORMAL_PROOF_LABELS)) state.formalProofKinds.add(k);
+    for (const k of Object.keys(FC.FORMAL_PROOF_LABELS)) state.formalProofKinds.add(k);
   } else {
     for (const v of params.getAll('formal_proof_kind')) state.formalProofKinds.add(v);
   }
@@ -341,7 +340,7 @@ async function init() {
 
   // Build filter UI
   buildCheckboxes(categoryFilters,    categories,      state.categories,      update);
-  buildCheckboxes(formalProofFilters, formalProofKinds, state.formalProofKinds, update, FORMAL_PROOF_LABELS);
+  buildCheckboxes(formalProofFilters, formalProofKinds, state.formalProofKinds, update, FC.FORMAL_PROOF_LABELS);
   buildCheckboxes(collectionFilters,  collections,     state.collections,     update);
   buildCheckboxes(subjectFilters,     subjects,        state.subjects,        update);
 

--- a/site/src/js/browse.js
+++ b/site/src/js/browse.js
@@ -27,12 +27,7 @@ const state = {
   sort:            'name',
 };
 
-// Human-readable labels for formal proof kinds
-const FORMAL_PROOF_LABELS = {
-  'formal_conjectures': 'Formal Conjectures',
-  'lean4':              'Lean 4 (external)',
-  'other_system':       'Other system',
-};
+const FORMAL_PROOF_LABELS = FC.FORMAL_PROOF_LABELS;
 
 // ---------------------------------------------------------------------------
 // DOM references
@@ -119,7 +114,10 @@ function applyFilters() {
       const cSubjects = new Set(c.subjects.map(s => s.name));
       if (![...state.subjects].some(s => cSubjects.has(s))) return false;
     }
-    if (state.formalProofKinds.size && !state.formalProofKinds.has(c.formalProofKind)) return false;
+    // A conjecture can have several formal proofs, of different kinds. Match if any of
+    // them has a selected kind.
+    if (state.formalProofKinds.size &&
+        !(c.formalProofs || []).some(p => state.formalProofKinds.has(p.kind))) return false;
     return true;
   });
 
@@ -326,7 +324,8 @@ async function init() {
 
   // Collect unique values for filters
   const categories      = new Set(allConjectures.map(c => c.category));
-  const formalProofKinds = new Set(allConjectures.map(c => c.formalProofKind).filter(Boolean));
+  const formalProofKinds = new Set(
+    allConjectures.flatMap(c => (c.formalProofs || []).map(p => p.kind)));
   const collections     = new Set(allConjectures.map(c => c.collection));
   const subjects        = new Set(allConjectures.flatMap(c => c.subjects.map(s => s.name)));
 

--- a/site/src/js/main.js
+++ b/site/src/js/main.js
@@ -199,8 +199,16 @@ function theoremURL(theoremName) {
   return `${base}/theorem/?name=${encodeURIComponent(theoremName)}`;
 }
 
+// Human-readable labels for formal proof kinds
+const FORMAL_PROOF_LABELS = {
+  'formal_conjectures': 'Formal Conjectures',
+  'lean4':              'Lean 4 (external)',
+  'other_system':       'Other system',
+};
+
 // Expose helpers as globals for the other scripts
 window.FC = {
+  FORMAL_PROOF_LABELS,
   loadData,
   getCategoryMeta,
   makeBadge,

--- a/site/src/js/theorem.js
+++ b/site/src/js/theorem.js
@@ -489,15 +489,29 @@ function renderDetail(theorem, siblings, verso, contributors) {
       </div>
     </div>` : '';
 
-  // Unproven hypotheses a conditional formal proof assumes, as the names of
-  // declarations stated (with sorry proofs) in the same file.
-  const proofConditions = theorem.proofConditions || [];
-  const proofConditionsSection = proofConditions.length ? `
+  // A statement can carry several `formal_proof` annotations, each with its own
+  // assumptions, so list them one by one. `conditions` names declarations stated with
+  // sorry proofs in the same file.
+  const formalProofs = theorem.formalProofs || [];
+  const isConditional = formalProofs.some(p => (p.conditions || []).length);
+  const formalProofHTML = (proof) => {
+    const label = FC.FORMAL_PROOF_LABELS[proof.kind] || proof.kind;
+    const where = proof.link
+      ? `<a href="${FC.escapeHTML(proof.link)}" target="_blank" rel="noopener">${FC.escapeHTML(label)}</a>`
+      : FC.escapeHTML(label);
+    const conditions = proof.conditions || [];
+    const assumes = conditions.length
+      ? ` assuming ${conditions.map(c => `<code>${FC.escapeHTML(c)}</code>`).join(', ')},
+          stated in this file`
+      : '';
+    return `<li>${where}${assumes}</li>`;
+  };
+  const formalProofsSection = formalProofs.length ? `
     <div class="theorem-detail__section">
-      <div class="detail-label">Assumes</div>
-      <div class="detail-value">The formal proof assumes
-        ${proofConditions.map(c => `<code>${FC.escapeHTML(c)}</code>`).join(', ')},
-        stated in this file.</div>
+      <div class="detail-label">Formal proofs</div>
+      <div class="detail-value"><ul>
+        ${formalProofs.map(formalProofHTML).join('\n')}
+      </ul></div>
     </div>` : '';
 
   const contributorsSection = contributors.length ? `
@@ -518,8 +532,8 @@ function renderDetail(theorem, siblings, verso, contributors) {
     <header class="theorem-detail__header">
       <h1 class="theorem-detail__title">${FC.escapeHTML(theorem.displayTheorem)}</h1>
       <span class="badge ${catMeta.css}" style="font-size:.9rem;padding:.3rem .9rem">${FC.escapeHTML(catMeta.label)}</span>
-      ${proofConditions.length ? `<span class="badge cat-conditional" style="font-size:.9rem;padding:.3rem .9rem"
-        title="The formal proof depends on an unproven assumption">Conditional</span>` : ''}
+      ${isConditional ? `<span class="badge cat-conditional" style="font-size:.9rem;padding:.3rem .9rem"
+        title="A formal proof depends on an unproven assumption">Conditional</span>` : ''}
     </header>
 
     ${moduleDocSection}
@@ -528,7 +542,7 @@ function renderDetail(theorem, siblings, verso, contributors) {
 
     ${codeSection}
 
-    ${proofConditionsSection}
+    ${formalProofsSection}
 
     ${contributorsSection}
 


### PR DESCRIPTION
**Program lane:** Foundation

## What this establishes

`extract_names` currently reports one `formal_proof` per declaration even though a declaration can carry several annotations and assumptions belong to a proof, not to the conjecture. This change introduces the canonical versioned representation: `schemaVersion: 2` with a `formalProofs` list whose entries carry `kind`, `link`, and proof-specific `conditions`.

The list is deterministic despite attribute storage in a `HashSet`, `site/build.js` renders every proof with its own conditions, and `FormalConjecturesUtil.Metadata` becomes the shared home for `FormalProofInfo` rather than leaving each tool to infer a shape.

## Dependency and sequence

This is the first dependency in the [review, verification, and preservation loop](https://github.com/google-deepmind/formal-conjectures/issues/4394). #4884 supplies the first real conditional-proof datum. #4828, #4749, #4951, and #4962 must converge on the list-aware schema after this lands; they should not collapse schema 2 back to one proof per declaration.

## Review question

Does schema 2 correctly model every proof annotation and its conditions, with deterministic export and correct site rendering, and is `FormalConjecturesUtil.Metadata` the right shared boundary for current consumers?

## Explicit boundary

This PR does not update or accept every downstream consumer, does not decide Comparator or preservation policy, and does not imply maintainer acceptance. It introduces no Vela authority or dependency.
