### PR TITLE
feat(OEIS): add the A260194 universal-jumps question

### DIFF
--- a/FormalConjectures/OEIS/260194.lean
+++ b/FormalConjectures/OEIS/260194.lean
@@ -29,25 +29,15 @@ an adjacent difference.
 
 namespace OeisA260194
 
-/-- Three consecutive values of A260194, carried as the state of its recursion. -/
-structure State where
-  first : ℕ
-  second : ℕ
-  third : ℕ
-
-/-- Advance three consecutive terms by the recurrence
-$a(n+1) = a(n) + \gcd(a(n),a(n-2))$. -/
-def State.next (s : State) : State :=
-  ⟨s.second, s.third, s.third + Nat.gcd s.third s.first⟩
-
-/-- The state after `n` shifts, initialized by the three terms $1,1,1$. -/
-def state : ℕ → State
-  | 0 => ⟨1, 1, 1⟩
-  | n + 1 => (state n).next
-
-/-- OEIS A260194, shifted so that Lean index zero is the first OEIS term. -/
-def a (n : ℕ) : ℕ :=
-  (state n).first
+/--
+OEIS A260194, shifted so that Lean index zero is the first OEIS term, with recurrence
+$a(n+3) = a(n+2) + \gcd(a(n+2),a(n))$ and initial values $a(0)=a(1)=a(2)=1$.
+-/
+def a : ℕ → ℕ
+  | 0 => 1
+  | 1 => 1
+  | 2 => 1
+  | n + 3 => a (n + 2) + Nat.gcd (a (n + 2)) (a n)
 
 @[category test, AMS 11]
 theorem a_0 : a 0 = 1 := by rfl
@@ -79,8 +69,10 @@ theorem a_8 : a 8 = 10 := by rfl
 @[category test, AMS 11]
 theorem a_9 : a 9 = 12 := by rfl
 
-/-- [OEIS A260194](https://oeis.org/A260194) asks:
-"Does every positive integer occur as a difference in this sequence?" -/
+/--
+[OEIS A260194](https://oeis.org/A260194) asks:
+"Does every positive integer occur as a difference in this sequence?"
+-/
 @[category research open, AMS 11]
 theorem conjecture :
     answer(sorry) ↔ ∀ d > 0, ∃ n, a (n + 1) = a n + d := by

--- a/FormalConjectures/OEIS/260194.lean
+++ b/FormalConjectures/OEIS/260194.lean
@@ -70,8 +70,7 @@ theorem a_8 : a 8 = 10 := by rfl
 theorem a_9 : a 9 = 12 := by rfl
 
 /--
-[OEIS A260194](https://oeis.org/A260194) asks:
-"Does every positive integer occur as a difference in this sequence?"
+Does every positive integer occur as a difference in this sequence?
 -/
 @[category research open, AMS 11]
 theorem conjecture :

--- a/FormalConjectures/OEIS/260194.lean
+++ b/FormalConjectures/OEIS/260194.lean
@@ -1,0 +1,89 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# A GCD-Driven Sequence with Universal Jumps
+
+OEIS A260194 begins with three ones and then adds the greatest common divisor of the current term
+and the term two places earlier. The open question asks whether every positive integer occurs as
+an adjacent difference.
+
+*References:*
+- [OEIS A260194](https://oeis.org/A260194)
+-/
+
+namespace OeisA260194
+
+/-- Three consecutive values of A260194, carried as the state of its recursion. -/
+structure State where
+  first : ℕ
+  second : ℕ
+  third : ℕ
+
+/-- Advance three consecutive terms by the recurrence
+$a(n+1) = a(n) + \gcd(a(n),a(n-2))$. -/
+def State.next (s : State) : State :=
+  ⟨s.second, s.third, s.third + Nat.gcd s.third s.first⟩
+
+/-- The state after `n` shifts, initialized by the three terms $1,1,1$. -/
+def state : ℕ → State
+  | 0 => ⟨1, 1, 1⟩
+  | n + 1 => (state n).next
+
+/-- OEIS A260194, shifted so that Lean index zero is the first OEIS term. -/
+def a (n : ℕ) : ℕ :=
+  (state n).first
+
+@[category test, AMS 11]
+theorem a_0 : a 0 = 1 := by rfl
+
+@[category test, AMS 11]
+theorem a_1 : a 1 = 1 := by rfl
+
+@[category test, AMS 11]
+theorem a_2 : a 2 = 1 := by rfl
+
+@[category test, AMS 11]
+theorem a_3 : a 3 = 2 := by rfl
+
+@[category test, AMS 11]
+theorem a_4 : a 4 = 3 := by rfl
+
+@[category test, AMS 11]
+theorem a_5 : a 5 = 4 := by rfl
+
+@[category test, AMS 11]
+theorem a_6 : a 6 = 6 := by rfl
+
+@[category test, AMS 11]
+theorem a_7 : a 7 = 9 := by rfl
+
+@[category test, AMS 11]
+theorem a_8 : a 8 = 10 := by rfl
+
+@[category test, AMS 11]
+theorem a_9 : a 9 = 12 := by rfl
+
+/-- [OEIS A260194](https://oeis.org/A260194) asks:
+"Does every positive integer occur as a difference in this sequence?" -/
+@[category research open, AMS 11]
+theorem conjecture :
+    answer(sorry) ↔ ∀ d > 0, ∃ n, a (n + 1) = a n + d := by
+  sorry
+
+end OeisA260194


### PR DESCRIPTION
Closes #4902

## Summary

This PR formalizes OEIS A260194 and its question of whether every positive integer occurs as an
adjacent difference. The file defines the zero-indexed public sequence `a` directly by its
three-step recurrence, verifies the first ten official values, and preserves the source's question
with an `answer(sorry)` equivalence.

## Formalization choices

OEIS gives three initial values and a recurrence that refers two places back. The public sequence
therefore follows the source directly:

```lean
def a : ℕ → ℕ
  | 0 => 1
  | 1 => 1
  | 2 => 1
  | n + 3 => a (n + 2) + Nat.gcd (a (n + 2)) (a n)
```

The Lean sequence is shifted by one index: `a 0` is OEIS `a(1)`, `a 1` is OEIS `a(2)`, and so on.

The difference condition is written as `a (n + 1) = a n + d`, not as natural-number subtraction.
This expresses an upward jump of size `d` directly. The source asks a yes/no question, so the main
theorem has the form

```lean
answer(sorry) ↔ ∀ d > 0, ∃ n, a (n + 1) = a n + d
```

rather than asserting the right-hand side outright. No `FormalConjecturesForMathlib` change is
needed.

## Intentional proof gap

The recursive definition and all concrete term tests are complete. Only the main open-question
theorem contains placeholders: the unknown answer inside `answer(sorry)` and the proof of its
equivalence.

## Verification

The review branch was rebased onto upstream base
`638da20efd8eeeed2993fc2550fc596dc90c1ce8`. Its current head is
`41b98c8324a0c2d04b32f2ccf299bf5ecfd5891c`, with source blob
`21bf14bd7e4a0558fcde5f7c584f9ef4b14d6663`.

The previous review head `97abb3e8231a3ca56aba5b4f48a40f02a81f0e9f` passed:

- the clean exact-head preflight, including source metadata, import, namespace, proof-gap,
  banned-construct, line-length, whitespace, and changed-file checks;
- focused Lean with only the intended open-question `sorry` warning;
- `env LEAN_NUM_THREADS=2 lake --wfail build FormalConjectures.OEIS.«260194»` (`8055` jobs);
- a combined-import check with the edited `FormalConjectures.OEIS.«2407»` module; and
- all applicable PR CI: `Build project`, `Test scripts`, `check-copyright`, `check-changes`,
  `scan-pr`, `labeler`, and `cla/google` succeeded, while inapplicable jobs skipped.

Reviewer `mo271` approved that head, then requested that the theorem docstring contain only the
source question. Commit `41b98c83` applies that exact documentation-only suggestion. On the new
head, `git diff --check` passed and the PR-base range still contains exactly
`FormalConjectures/OEIS/260194.lean`. Per author direction, no local module gate was rerun; PR CI
is verifying the current head.

## AI use

AI assistance was used to research the source, design and implement the direct recurrence and
theorem, draft the release prose, and support verification. The submitted content remains the
author's responsibility.
