### PR TITLE
WrittenOnTheWallII: disprove conjecture 181

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture181.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture181.lean
@@ -1,0 +1,62 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Written on the Wall II - Conjecture 181
+
+*Reference:*
+[E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+
+The expression `deg_avg(B(G²))` is formalized by measuring degrees in `G²`,
+the graph whose maximum-eccentricity vertices induce `B(G²)`.
+
+The conjecture is false for the triangular graph `T(7) = L(K₇)`: it has at
+most 16 leaves in a spanning tree, largest induced bipartite subgraph order 6,
+and independence number 3. Its square is `K₂₁`, whose vertices all have
+degree 20, so the claimed inequality would give `22 ≥ 23`.
+-/
+
+namespace WrittenOnTheWallII.GraphConjecture181
+
+open SimpleGraph
+
+/-- The average degree, in `G²`, of the maximum-eccentricity vertices of `G²`. -/
+noncomputable def squarePeripheryAverage {V : Type} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) : ℝ := by
+  classical
+  let square := graphSquare G
+  let periphery := Finset.univ.filter fun v => v ∈ maxEccentricityVertices square
+  exact (∑ v ∈ periphery, ((square.neighborFinset v).card : ℝ)) / periphery.card
+
+/--
+WOWII Conjecture 181 asked whether every nontrivial finite connected simple
+graph `G` satisfies
+
+`Ls G + b G ≥ G.indepNum + deg_avg(B(G²))`.
+
+The answer is no, witnessed by `T(7) = L(K₇)`.
+-/
+@[category research solved, AMS 5,
+  formal_proof using lean4 at "https://github.com/Kuberwastaken/c5-k4/blob/3bfa33d7470055a9a11d9ffde29186245dc3a329/lean/GraphConjecture181.lean#L1-L381"]
+theorem conjecture181 : answer(False) ↔
+    ∀ (V : Type) [Fintype V] [DecidableEq V] [Nontrivial V]
+      (G : SimpleGraph V) [DecidableRel G.Adj], G.Connected →
+        Ls G + b G ≥ G.indepNum + squarePeripheryAverage G := by
+  sorry
+
+end WrittenOnTheWallII.GraphConjecture181


### PR DESCRIPTION
## Summary

Adds a solved formalization of WOWII Conjecture 181 under the reading

`Ls(G) + b(G) ≥ α(G) + deg_avg(B(G²))`,

with degrees measured in `G²`, the graph whose maximum-eccentricity vertices induce `B(G²)`.

The counterexample is `T(7) = L(K₇)`:

- `Ls(T(7)) ≤ 16`;
- `b(T(7)) = 6`;
- `α(T(7)) = 3`;
- `T(7)² = K₂₁`, so the relevant average degree is `20`.

The claimed inequality therefore becomes `22 ≥ 23`.

Closes #4905.

## Formal proof

The complete no-`sorry` Lean 4 certificate is linked immutably from the declaration:

https://github.com/Kuberwastaken/c5-k4/blob/3bfa33d7470055a9a11d9ffde29186245dc3a329/lean/GraphConjecture181.lean#L1-L381

Its trust assumptions are `propext`, `Classical.choice`, `Lean.ofReduceBool`, `Lean.trustCompiler`, and `Quot.sound`; it has no `sorryAx` or project-specific axiom.

## Reading caveat

If `deg_avg(B(G²))` were instead interpreted as measuring the selected vertices degrees back in `G`, this particular witness would not refute that alternative statement (`3 + 10 = 13`). The submitted declaration makes the ambient-square reading explicit.

## Verification

- `lake --wfail build FormalConjectures.WrittenOnTheWallII.GraphConjecture181` passes.
- A full `lake --wfail build` compiled 9,015/9,036 targets before the 60 GB workspace filled with generated C/IR artifacts (`ENOSPC`). After pruning only generated artifacts, all 20 skipped targets and their 8,243-target dependency closure passed with `--wfail`.
- The external certificate passes `lake env lean -DwarningAsError=true`.

## AI assistance disclosure

OpenAI Codex and delegated coding agents assisted with source interpretation, proof development, and verification. The submitter reviewed the mathematical statement, counterexample, and generated Lean artifact and takes responsibility for the submission.