### PR TITLE
WrittenOnTheWallII: disprove conjecture 176

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture176.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture176.lean
@@ -1,0 +1,58 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Written on the Wall II - Conjecture 176
+
+*Reference:*
+[E. DeLaVina, Written on the Wall II, Conjectures of Graffiti.pc](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
+
+The conjecture is false for the graph `D₇`, formed from two triangles by
+joining distinguished vertices with a path of seven edges. It has at most four
+leaves in a spanning tree and largest induced bipartite subgraph order ten.
+The two maximum-degree vertices of its square are at distance five in the
+original graph, so the claimed inequality would give `14 ≥ 17`.
+-/
+
+namespace WrittenOnTheWallII.GraphConjecture176
+
+open SimpleGraph
+
+/-- The maximum-degree vertices of `G²`, presented using finite graph distance. -/
+def squareMaximumDegreeVertices {V : Type} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] : Set V :=
+  let squareDegree (v : V) :=
+    (Finset.univ.filter fun w => v ≠ w ∧ computable_dist G v w ≤ 2).card
+  {v | squareDegree v = Finset.univ.sup squareDegree}
+
+/--
+WOWII Conjecture 176 asked whether every nontrivial finite connected simple
+graph `G` satisfies
+`Ls(G) + b(G) ≥ n(G) + dist_min(G, M(G²))`.
+The answer is no, witnessed by `D₇`.
+-/
+@[category research solved, AMS 5,
+  formal_proof using lean4 at "https://github.com/Kuberwastaken/c5-k4/blob/b0ba2b9206176b4fc30bd633de206ac230b4e01f/lean/GraphConjecture176.lean#L1-L377"]
+theorem conjecture176 : answer(False) ↔
+    ∀ (V : Type) [Fintype V] [DecidableEq V] [Nontrivial V]
+      (G : SimpleGraph V) [DecidableRel G.Adj], G.Connected →
+        Ls G + b G ≥ (Fintype.card V : ℝ) +
+          distMin G (squareMaximumDegreeVertices G) := by
+  sorry
+
+end WrittenOnTheWallII.GraphConjecture176


### PR DESCRIPTION
## Summary

Adds a solved formalization of WOWII Conjecture 176 under the source-faithful reading

`Ls(G) + b(G) ≥ n(G) + dist_min(G, M(G²))`.

The counterexample is `D₇`, formed from two triangles joined at distinguished
vertices by a path of seven edges:

- `n(D₇) = 12`;
- `Ls(D₇) ≤ 4`;
- `b(D₇) = 10`;
- `M(D₇²) = {p₁,p₆}`;
- `dist_D₇(p₁,p₆) = 5`.

The claimed inequality therefore becomes `14 ≥ 17`.

Closes #4910.

## Follow-up discovery pattern

This result is a direct follow-up to the tightness/invariant-separation
program initiated by `C₅[K₄]`. The carrier family exposed a repeated equality
wall for Conjecture 176. Leaving the diameter-two regime separates the
square-selected maximum-degree vertices in the original metric while keeping
`Ls` pinned, producing the new counterexample family.

Project-level method and comparison:
https://github.com/Kuberwastaken/c5-k4/blob/983569772f0da2a813bfb2d4741903c26a9d1abc/README.md#L40-L72

Detailed result:
https://github.com/Kuberwastaken/c5-k4/blob/983569772f0da2a813bfb2d4741903c26a9d1abc/README.md#L191-L212

## Formal proof

The complete no-`sorry` Lean 4 certificate is linked immutably from the declaration:

https://github.com/Kuberwastaken/c5-k4/blob/b0ba2b9206176b4fc30bd633de206ac230b4e01f/lean/GraphConjecture176.lean#L1-L377

The source audit and independent exact verifier are recorded at:

https://github.com/Kuberwastaken/c5-k4/blob/9bfc0586e7afcf3708aea5fe878346d72e266196/results/expansion/wowii_176_disproof.md#L1-L39

Its trust assumptions are `propext`, `Classical.choice`, `Lean.ofReduceBool`,
`Lean.trustCompiler`, and `Quot.sound`; it has no `sorryAx` or project-specific axiom.

## Reading note

The declaration selects the set `M(G²)` using square degrees and measures
`dist_min` back in `G`, following the source definition. `D₇` also refutes
the alternative all-in-`G²` reading.

## Verification

- `lake --wfail build FormalConjectures.WrittenOnTheWallII.GraphConjecture176` passes.
- The external certificate passes `lake env lean -DwarningAsError=true lean/GraphConjecture176.lean`.

## AI assistance disclosure

OpenAI Codex and delegated coding agents assisted with source interpretation,
proof development, independent verification, and submission preparation. The
submitter reviewed the mathematical statement, counterexample, and generated
Lean artifact and takes responsibility for the submission.
