### PR TITLE
Mark Erdős Problem 357 lower Big-O variant as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/357.lean
+++ b/FormalConjectures/ErdosProblems/357.lean
@@ -54,9 +54,11 @@ Similar remarks hold for the `variants.monotone` formalisations later in this fi
 /-- Let $f(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 < \dotsc < a_k \le n$
 such that all sums of the shape $\sum_{u \le i \le v} a_i$ are distinct.
 How does $f(n)$ grow? Can we find a (good) explicit function $g$ such that $g = O(f)$ ? -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-357-sqrt-lower-bound/blob/d40ef76f3af54a644aeb38e68acd15f667994903/lean/Erdos357BigOLowerBoundFC.lean#L221-L224"]
 theorem erdos_357.parts.ii.bigO_version :
-    (answer(sorry) : ℕ → ℝ) =O[atTop] (fun n ↦ (f n : ℝ)) := by
+    (answer(fun n : ℕ ↦ √(n : ℝ)) : ℕ → ℝ) =O[atTop] (fun n ↦ (f n : ℝ)) := by
   sorry
 
 /-- Let $f(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 < \dotsc < a_k \le n$


### PR DESCRIPTION
This PR changes `Erdos357.erdos_357.parts.ii.bigO_version` from `answer(sorry)` to `answer(fun n : ℕ ↦ √(n : ℝ))` and links a kernel-checked Lean proof.

It leaves the central open problem `Erdos357.erdos_357.parts.i`, the other growth variants, and the weakly monotone variants unchanged.

The Lean formalization was prepared by KitaKen1 (Kenta Kitamura).

The external proof establishes the exact target theorem:

```lean
theorem Erdos357.erdos_357.parts.ii.bigO_version_solved :
    (answer(fun n : ℕ ↦ √(n : ℝ)) : ℕ → ℝ) =O[atTop]
      (fun n ↦ (Erdos357.f n : ℝ))
```

Proof: https://github.com/KitaKen1/erdos-357-sqrt-lower-bound/blob/d40ef76f3af54a644aeb38e68acd15f667994903/lean/Erdos357BigOLowerBoundFC.lean#L221-L224

Repository: https://github.com/KitaKen1/erdos-357-sqrt-lower-bound

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-357-sqrt-lower-bound%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos357BigOLowerBoundLean4Web.lean

The proof directly constructs an admissible sequence of length `⌊√n⌋`; it does not depend on `Erdos357.erdos_357.variants.weisenberg`. `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, using GPT-5.6 sol.

> [!NOTE]
> **On whether this is a mathematically meaningful answer.**
>
> The formalization note preceding the five growth declarations explicitly warns that these answer holes can admit formally valid but uninteresting choices—for example, `g = 0` for this lower Big-O target. It also says that merely filling `answer(sorry)` and proving the resulting proposition should not by itself count as solving the question; the answer should be mathematically interesting, and other reasonable formulations of “how does `f(n)` grow?” may exist.
>
> The reason for proposing `g(n) = √n` is that it is positive and unbounded, and the formal proof establishes the concrete combinatorial lower bound `⌊√n⌋ ≤ f(n)` by constructing a strictly increasing sequence in `[1,n]` whose consecutive interval sums are distinct. Thus the proof uses the intended combinatorial meaning of the definition rather than a vacuous comparison function or a mismatch between the prose and the Lean statement. The same `√n` scale also agrees with the stronger known lower bound already recorded in this file.
>
> This is not claimed as a new mathematical lower bound or as a solution of the central open problem `f(n) = o(n)`. It is intended as a direct, sorry-free formal proof and status update for this particular registered lower Big-O target. Since “mathematically interesting” is an informal review criterion rather than a property checked by Lean, whether this answer meets that criterion is ultimately left to the maintainers and reviewers.