### PR TITLE
Mark OEIS A237271 parity conjectures as solved

### DIFF
--- a/FormalConjectures/OEIS/237271.lean
+++ b/FormalConjectures/OEIS/237271.lean
@@ -159,7 +159,9 @@ Conjecture 4: "a(A000290(n)) is odd." - _Omar E. Pol_, Oct 21 2025
 
 That is, the number of parts in the symmetric representation of $\sigma(n^2)$ is always odd.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a237271-square-hexagonal-parity/blob/430c09114d4ad3a3a2654b9816c8bfdc3cdf38de/lean/OeisA237271ParityFC.lean#L19-L24"]
 theorem conjecture_4 (n : ℕ) (hn : 0 < n) : Odd (a (n ^ 2)) := by
   sorry
 
@@ -169,7 +171,9 @@ Conjecture 5: "a(A000384(n)) is odd." - _Omar E. Pol_, Oct 21 2025
 That is, the number of parts in the symmetric representation of $\sigma(n(2n-1))$ is always odd,
 where $n(2n-1)$ is the $n$-th hexagonal number.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a237271-square-hexagonal-parity/blob/430c09114d4ad3a3a2654b9816c8bfdc3cdf38de/lean/OeisA237271ParityFC.lean#L26-L32"]
 theorem conjecture_5 (n : ℕ) (hn : 0 < n) : Odd (a (n * (2 * n - 1))) := by
   sorry
 


### PR DESCRIPTION
This PR changes `OeisA237271.conjecture_4` and `OeisA237271.conjecture_5` from `category research open` to `category research solved` and links kernel-checked Lean 4 proofs.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proofs establish the exact target statements:

```lean
theorem conjecture_4_solved (n : ℕ) (hn : 0 < n) :
    Odd (OeisA237271.a (n ^ 2))

theorem conjecture_5_solved (n : ℕ) (hn : 0 < n) :
    Odd (OeisA237271.a (n * (2 * n - 1)))
```

Proofs:
- `conjecture_4`: https://github.com/KitaKen1/oeis-a237271-square-hexagonal-parity/blob/430c09114d4ad3a3a2654b9816c8bfdc3cdf38de/lean/OeisA237271ParityFC.lean#L19-L24
- `conjecture_5`: https://github.com/KitaKen1/oeis-a237271-square-hexagonal-parity/blob/430c09114d4ad3a3a2654b9816c8bfdc3cdf38de/lean/OeisA237271ParityFC.lean#L26-L32

Repository: https://github.com/KitaKen1/oeis-a237271-square-hexagonal-parity

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a237271-square-hexagonal-parity%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA237271ParityLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx` in either proof.

AI Usage Disclosure: This formalization and its documentation were developed with assistance from OpenAI Codex.