### PR TITLE
perf(scripts/extract_names): more lazily extract git timestamps

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -225,7 +225,7 @@ jobs:
         if: steps.mode.outputs.website_only != 'true'
         run: |
           mkdir -p site/data
-          lake exe extract_names --exclude=statement,docstring,moduleDocstrings \
+          lake exe extract_names --exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified \
             > site/data/conjectures.json
 
       # `extract_names` notices `research open` problems with a sorry-free proof,

--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -166,7 +166,7 @@ instance : ToJson TheoremInfo where
   toJson info := info.toFilteredJson
 
 unsafe def runWithImports {α : Type} (moduleNames : Array Name) (actionToRun : CoreM α) : IO α := do
-  initSearchPath (← findSysroot)
+  initSearchPath (← getBuildDir)
   let imports := moduleNames.map fun n => { module := n }
   let currentCtx := { fileName := "", fileMap := default }
   Lean.enableInitializersExecution
@@ -217,16 +217,20 @@ unsafe def main (args : List String) : IO Unit := do
         "this script so that `answerKind` metadata is extracted correctly."
       throw <| IO.userError usageMsg
 
-  -- Pre-compute git timestamps for each file and build module name array
+  -- Pre-compute git timestamps for each file and build module name array (only when not excluded)
+  let needFirstAdded := !excludeSet.contains "fileFirstAdded"
+  let needLastModified := !excludeSet.contains "fileLastModified"
+  let needGitInfo := needFirstAdded || needLastModified
   let mut moduleNames := #[]
   let mut fileTimestamps : Std.HashMap Name (Option String × Option String) := {}
   for file in leanFiles do
     try
       let modName ← getModuleNameFromFile file
       moduleNames := moduleNames.push modName
-      let firstAdded ← getFileFirstAdded file
-      let lastModified ← getFileLastModified file
-      fileTimestamps := fileTimestamps.insert modName (firstAdded, lastModified)
+      if needGitInfo then
+        let firstAdded ← if needFirstAdded then getFileFirstAdded file else pure none
+        let lastModified ← if needLastModified then getFileLastModified file else pure none
+        fileTimestamps := fileTimestamps.insert modName (firstAdded, lastModified)
     catch _ => pure ()
 
   runWithImports moduleNames do

--- a/site/README.md
+++ b/site/README.md
@@ -100,7 +100,7 @@ If you need the site to reflect local Lean changes (new conjectures, etc.):
 lake exe cache get   # download prebuilt Mathlib oleans (first time only)
 lake build
 mkdir -p site/data
-lake exe extract_names --exclude=statement,docstring,moduleDocstrings > site/data/conjectures.json
+lake exe extract_names --exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified > site/data/conjectures.json
 
 # (Optional) Generate Verso literate fragments for rendered docstrings.
 # Without this, theorem detail pages will lack formatted docstrings and source links.


### PR DESCRIPTION
also: use `getBuildDir`, which seems more appropriate