### PR TITLE
ErdosProblems/940: restrict large_integers to r >= 3

### DIFF
--- a/FormalConjectures/ErdosProblems/940.lean
+++ b/FormalConjectures/ErdosProblems/940.lean
@@ -56,12 +56,13 @@ theorem erdos_940.variants.three_cubes :
 
 
 /--
-It is not known if all large integers are the sum of at most $r$-many $r$-powerful numbers.
+Let $r \ge 3$. It is not known if all large integers are the sum of at most $r$-many
+$r$-powerful numbers.
 -/
 @[category research open, AMS 11]
 theorem erdos_940.variants.large_integers :
     answer(sorry) ↔
-    ∀ r ≥ 2, (∀ᶠ x in atTop, ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ x = S.sum) := by
+    ∀ r ≥ 3, (∀ᶠ x in atTop, ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ x = S.sum) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/940.lean
+++ b/FormalConjectures/ErdosProblems/940.lean
@@ -19,7 +19,12 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 940
 
-*Reference:* [erdosproblems.com/940](https://www.erdosproblems.com/940)
+*References:*
+- [erdosproblems.com/940](https://www.erdosproblems.com/940)
+- [BaBr94] Baker, R. C. and Brüdern, J., _On sums of two squarefull numbers_. Math. Proc.
+  Cambridge Philos. Soc. (1994), 1-5.
+- [He88] Heath-Brown, D. R., _Ternary quadratic forms and sums of three square-full numbers_.
+  (1988), 137-163.
 -/
 
 open Filter
@@ -38,6 +43,8 @@ theorem erdos_940 :
 
 /--
 The set of integers which are the sum of at most two $2$-powerful numbers has density $0$.
+
+Erdős called this 'easy'. Baker and Brüdern [BaBr94] gave the first proof in the literature.
 -/
 @[category research solved, AMS 11]
 theorem erdos_940.variants.two :
@@ -47,6 +54,10 @@ theorem erdos_940.variants.two :
 
 /--
 Is it true that the set of integers which are the sum of at most three cubes has density $0$?
+
+The cubes are those of non-negative integers, which is what `Multiset ℕ` gives. This choice
+decides the question: over `ℤ` a sum of three cubes is conjectured to represent every integer
+that is not $\pm 4 \bmod 9$, which is density $7/9$.
 -/
 @[category research open, AMS 11]
 theorem erdos_940.variants.three_cubes :
@@ -69,7 +80,8 @@ theorem erdos_940.variants.large_integers :
 Heath-Brown [He88] has proved that all large numbers are the sum of at most three
 $2$-powerful numbers.
 
-[He88] Heath-Brown, D. R., Ternary quadratic forms and sums of three square-full numbers. (1988), 137--163.
+This is the case $r = 2$ of `Erdos1107.erdos_1107`, which asks the same question with $r + 1$
+summands, and it is stated there as `Erdos1107.erdos_1107.variants.two`.
 -/
 @[category research solved, AMS 11]
 theorem erdos_940.variants.three_powerful :


### PR DESCRIPTION
Fixes an item on #4896, reported by @KitaKen1.

`erdos_940.variants.large_integers` quantified over `r ≥ 2`. The source opens "Let $r\geq 3$", and the whole problem sits under that hypothesis.

At `r = 2` the statement says that almost every integer is a sum of at most two `2`-powerful numbers, so that set is cofinite. `erdos_940.variants.two` is in the same file, is categorised `research solved`, and says the same set has density `0`. `Set.HasDensity` is a `Tendsto`, so the density is unique. Both cannot hold, and so the `answer` slot on a `research open` statement was already decided, for a reason the source excludes.

`erdos_940` itself has `∀ r ≥ 3` and says "Let $r \ge 3$." in its docstring. Only the variant drifted.

The docstring also omitted the bound, so it now states it.

The source treats `r = 2` separately and in the opposite direction: Erdős [Er76d] called the density-zero claim "easy" for `r = 2`, and Baker and Brüdern [BaBr94] proved it.

### Checks I ran

`lake --wfail build 'FormalConjectures.ErdosProblems.«940»'` passes.

I also checked the `r = 2` case numerically before trusting the internal contradiction. Enumerating the `2`-full numbers below `10^7` and taking all pairwise sums, 4212552 integers below `10^7` are not a sum of at most two of them, and the representable proportion falls as the range grows: 0.5964 at `10^3`, 0.5842 at `10^6`, 0.5787 at `10^7`. So the set is not cofinite, independently of `variants.two`.
