### PR TITLE
check_erdos_status: add a --problem filter

### DIFF
--- a/scripts/check_erdos_status.py
+++ b/scripts/check_erdos_status.py
@@ -7,6 +7,7 @@ on the main theorem in the corresponding .lean file.
 
 Usage:
   python check_erdos_status.py               # Print mismatches as JSON
+  python check_erdos_status.py --problem 80  # Only that problem
   python check_erdos_status.py --create-issues  # Also create GitHub issues
 """
 
@@ -311,8 +312,34 @@ def close_resolved_issues(mismatches):
         ])
 
 
+def problem_argument(argv):
+    """The value of `--problem N`, or None.
+
+    A reviewer working on one problem should not have to read a repository-wide list and
+    decide for themselves that their number is absent.
+    """
+    if "--problem" not in argv:
+        return None
+    index = argv.index("--problem")
+    if index + 1 >= len(argv):
+        sys.exit("--problem needs a problem number, for example --problem 80")
+    return argv[index + 1]
+
+
 def main():
     mismatches = find_mismatches()
+
+    wanted = problem_argument(sys.argv)
+    if wanted is not None:
+        mismatches = [m for m in mismatches if m["number"] == wanted]
+        json.dump(mismatches, sys.stdout, indent=2)
+        print()
+        # An empty list is the pass, and saying so beats printing `[]` at a reader.
+        if not mismatches:
+            print(f"Erdős problem {wanted}: the repository and erdosproblems.com agree.",
+                  file=sys.stderr)
+        return 1 if mismatches else 0
+
     json.dump(mismatches, sys.stdout, indent=2)
     print()  # trailing newline
 

--- a/scripts/test_check_erdos_status.py
+++ b/scripts/test_check_erdos_status.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from check_erdos_status import issues_to_close
+from check_erdos_status import issues_to_close, problem_argument
 
 
 def issue(number, problem, repo="solved", site="formally solved"):
@@ -62,3 +62,19 @@ class IssuesToCloseTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ProblemArgumentTest(unittest.TestCase):
+
+    def test_reads_the_number_after_the_flag(self):
+        self.assertEqual(problem_argument(["prog", "--problem", "80"]), "80")
+
+    def test_absent_flag_gives_none(self):
+        self.assertIsNone(problem_argument(["prog"]))
+
+    def test_absent_flag_with_other_arguments_gives_none(self):
+        self.assertIsNone(problem_argument(["prog", "--create-issues"]))
+
+    def test_flag_with_no_value_exits(self):
+        with self.assertRaises(SystemExit):
+            problem_argument(["prog", "--problem"])


### PR DESCRIPTION
`check_erdos_status.py` prints every mismatch in the repository. A reviewer working on one problem has to read a list of 22 and satisfy themselves that their number is absent.

`--problem N` filters to that problem, and says plainly when there is nothing:

```
$ python3 scripts/check_erdos_status.py --problem 80
Erdős problem 80: the repository and erdosproblems.com agree.
[]

$ python3 scripts/check_erdos_status.py --problem 90
[
  {
    "number": "90",
    "lean_status": "solved",
    "yaml_status": "formally solved"
  }
]
```

The exit code keeps its meaning: `0` when the named problem agrees, `1` when it does not. The message goes to stderr, so the JSON on stdout stays machine-readable.

Without the flag nothing changes, including `--create-issues`.

### Why

This came out of a review pass. Two independent reviewers ran the script on a file, saw a repository-wide list, and had to work out that the output was not about the file in front of them. One of them ran it on a `Paper/` module, where it is not applicable at all.

### Checks I ran

Four new tests, and the 27 in `scripts/` pass. Also ran it against live data for a problem that agrees and one that does not.
