### PR TITLE
scripts: print the LaTeX statement of an Erdős problem

### DIFF
--- a/scripts/erdos_problem.py
+++ b/scripts/erdos_problem.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Print the LaTeX statement of an Erdős problem.
+
+    python3 scripts/erdos_problem.py 940
+
+Reads `erdosproblems.com/latex/<n>`, which serves the LaTeX the site renders,
+and prints the statement, the remarks, the cross-referenced problems and the
+reference list.
+
+Prefer this to the rendered page. Rendering runs terms together, so that
+`3^7\\cdot 61^5` reads as `3761^5`, and that misreading has already reached this
+repository. The remarks matter as much as the statement: a status the site
+records only in its remarks is a common source of a wrong `category`.
+
+The site answers a request that identifies itself and refuses the default
+`Python-urllib` user agent with a 403. This script sends an honest one naming
+the tool. If another fetcher gets a 403, that is the cause, and the fix is to
+name yourself rather than to imitate a browser.
+
+`data/problems.yaml` in `teorth/erdosproblems`, which `check_erdos_status.py`
+reads, carries status and tags only. It has no statement text, so it cannot
+answer whether a formalisation matches its source.
+"""
+
+import argparse
+import html
+import re
+import sys
+import urllib.error
+import urllib.request
+
+URL = "https://www.erdosproblems.com/latex/{}"
+
+USER_AGENT = (
+    "formal-conjectures/erdos_problem.py "
+    "(+https://github.com/google-deepmind/formal-conjectures)"
+)
+
+BLOCK = re.compile(
+    r'<div[^>]*class="problem-(?:text|additional-text)"[^>]*>(.*?)</div>\s*</div>|'
+    r'<div[^>]*class="problem-additional-text"[^>]*>(.*?)</div>',
+    re.S,
+)
+
+
+def fetch(number):
+    """The raw HTML of the LaTeX view, or exit with a readable message."""
+    request = urllib.request.Request(
+        URL.format(number), headers={"User-Agent": USER_AGENT}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+        if error.code in (404, 500):
+            sys.exit(
+                f"erdosproblems.com returned HTTP {error.code} for problem {number}. "
+                "Check that the problem exists."
+            )
+        sys.exit(f"erdosproblems.com returned HTTP {error.code} for problem {number}")
+    except urllib.error.URLError as error:
+        sys.exit(f"could not reach erdosproblems.com: {error.reason}")
+
+
+def to_text(fragment):
+    """One HTML fragment as plain LaTeX."""
+    fragment = re.sub(r"<h3>(.*?)</h3>", r"\n## \1\n", fragment, flags=re.S)
+    fragment = re.sub(r"<br\s*/?>", "\n", fragment)
+    # A link to another problem renders as its number; keep it as [n].
+    fragment = re.sub(r'<a[^>]*href="/(\d+)"[^>]*>.*?</a>', r"[\1]", fragment, flags=re.S)
+    fragment = re.sub(r"<[^>]+>", "", fragment)
+    fragment = html.unescape(fragment)
+    fragment = "\n".join(line.strip() for line in fragment.split("\n"))
+    fragment = re.sub(r"[ \t]+", " ", fragment)
+    fragment = re.sub(r"\n{3,}", "\n\n", fragment)
+    # The trailing "Back to the problem" link becomes a bare [n].
+    fragment = re.sub(r"\n\s*\[\d+\]\s*$", "", fragment)
+    return fragment.strip()
+
+
+def blocks(page):
+    """The statement and remark blocks, in the order the page gives them."""
+    found = []
+    for match in BLOCK.finditer(page):
+        text = to_text(match.group(1) or match.group(2) or "")
+        # The trailing "Back to the problem" link becomes a bare [n].
+        if text and not re.fullmatch(r"\[\d+\]", text):
+            found.append(text)
+    return found
+
+
+def cross_references(page):
+    """Problem numbers this page links to, in order and without repeats."""
+    seen = []
+    for number in re.findall(r'<a[^>]*href="/(\d+)"', page):
+        if number not in seen:
+            seen.append(number)
+    return seen
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("number", help="the problem number, for example 940")
+    args = parser.parse_args(argv)
+
+    page = fetch(args.number)
+    found = blocks(page)
+    if not found:
+        sys.exit(
+            f"could not find the statement of problem {args.number}. "
+            "The page layout may have changed; read the page directly."
+        )
+
+    print(f"# Erdos problem {args.number}")
+    print(f"# {URL.format(args.number)}")
+    for text in found:
+        print()
+        print(text)
+
+    linked = [n for n in cross_references(page) if n != str(args.number)]
+    if linked:
+        print()
+        print("## See also")
+        print(", ".join(f"[{n}]" for n in linked))
+        print()
+        print("# A wrong bound is often a correct bound copied from a neighbour")
+        print("# whose statement differs. Read the problems above.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_erdos_problem.py
+++ b/scripts/test_erdos_problem.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LaTeX that `erdos_problem.py` pulls out of a problem page.
+
+The tests run on saved markup and make no network request.
+"""
+
+import unittest
+
+from erdos_problem import blocks, cross_references, to_text
+
+PAGE = """
+<div class="problem-box">
+  <div class="problem-text">
+    <div id="content" style="white-space: pre-line;">
+      Let $r\\geq 3$.<br><br>Does the set have density $0$?
+    </div>
+  </div>
+  <div class="problem-additional-text" style="white-space: pre-line;">
+    Erd\\H{o}s \\cite{Er76d} claims this is 'easy' for $r=2$.<br>
+    <br>See also <a href="/1081" rel="nofollow">1081</a>, and
+    <a href="/1107" rel="nofollow">1107</a> for the case of $r+1$ summands.
+  </div>
+  <div class="problem-additional-text" style="white-space: pre-line;">
+    <h3>References</h3>
+    [BaBr94] Baker, R. C., <i>On sums of two squarefull numbers</i>. (1994), 1--5.
+  </div>
+  <div class="problem-additional-text" style="text-align:center">
+    <a href="/940">Back to the problem</a>
+  </div>
+</div>
+"""
+
+
+class ToTextTest(unittest.TestCase):
+
+    def test_keeps_latex_unrendered(self):
+        self.assertEqual(to_text("$3^7\\cdot 61^5$"), "$3^7\\cdot 61^5$")
+
+    def test_turns_a_break_into_a_newline(self):
+        self.assertEqual(to_text("one<br>two"), "one\ntwo")
+
+    def test_turns_a_problem_link_into_its_number(self):
+        self.assertEqual(to_text('see <a href="/1107">1107</a> too'), "see [1107] too")
+
+    def test_unescapes_entities(self):
+        self.assertEqual(to_text("a &amp; b"), "a & b")
+
+    def test_drops_a_trailing_back_link(self):
+        self.assertEqual(to_text('body<br><a href="/940">Back to the problem</a>'), "body")
+
+
+class BlocksTest(unittest.TestCase):
+
+    def test_reads_the_statement_first(self):
+        self.assertTrue(blocks(PAGE)[0].startswith("Let $r\\geq 3$."))
+
+    def test_keeps_the_remarks_which_carry_the_status(self):
+        self.assertIn("'easy' for $r=2$", "\n".join(blocks(PAGE)))
+
+    def test_keeps_the_reference_list(self):
+        self.assertIn("[BaBr94] Baker", "\n".join(blocks(PAGE)))
+
+    def test_drops_the_back_link_block(self):
+        self.assertNotIn("[940]", blocks(PAGE))
+
+    def test_finds_no_block_in_an_unrecognised_page(self):
+        self.assertEqual(blocks("<html><body>nothing here</body></html>"), [])
+
+
+class CrossReferencesTest(unittest.TestCase):
+
+    def test_lists_linked_problems_in_order(self):
+        self.assertEqual(cross_references(PAGE), ["1081", "1107", "940"])
+
+    def test_does_not_repeat_a_number(self):
+        self.assertEqual(
+            cross_references('<a href="/12">a</a><a href="/12">b</a>'), ["12"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reading a problem from erdosproblems.com is ad hoc today, and two failure modes recur.

**The site refuses `Python-urllib` with a 403.** It answers a request that identifies itself. A reviewer who hits that 403 tends to give up on the source and reconstruct the statement from a neighbouring problem file, which is how a wrong bound gets copied instead of caught.

**The rendered page runs terms together.** `3^7\cdot 61^5` reads as `3761^5`, and that misreading reached this repository. The `/latex/<n>` view keeps the source, so the reader sees the `\cdot`.

`scripts/erdos_problem.py N` prints the statement, the remarks, the cross-referenced problems and the reference list:

```
$ python3 scripts/erdos_problem.py 940
Let $r\geq 3$. A number $n$ is $r$-powerful if for every prime $p$ which divides $n$ ...

Erd\H{o}s \cite{Er76d} claims that the claim that the set has density $0$ is 'easy' for $r=2$
(a potential 'easy argument' is given in the comments by Tao; this was first proved in the
literature by Baker and Br\"{u}dern \cite{BaBr94}). ...

## References
[BaBr94] Baker, R. C. and Br\"udern, J., On sums of two squarefull numbers. ...

## See also
[941], [1081], [1107]
```

The remarks matter as much as the statement. erdosproblems.com records several answered questions only there, so a formalisation whose `category` disagrees with its source usually disagrees with a remark rather than with the problem text.

`check_erdos_status.py` reads `data/problems.yaml` from `teorth/erdosproblems`, which carries status and tags and no statement text. The two scripts answer different questions and neither replaces the other.

Twelve tests, all on saved markup, no network request. The user agent names the tool and the repository rather than imitating a browser.