### PR TITLE
ErdosProblems/1063: supply the Monier reference

### DIFF
--- a/FormalConjectures/ErdosProblems/1063.lean
+++ b/FormalConjectures/ErdosProblems/1063.lean
@@ -102,14 +102,22 @@ theorem erdos_1063.variants.small_values :
       · exact absurd hb (by decide)
 
 /-- Monier observed that $n_k \le k!$ for $k \ge 3$ ([Mo85]), since $\binom{k!}{k}$ is divisible
-by $k! - i$ for $1 \le i < k$. -/
+by $k! - i$ for $1 \le i < k$.
+
+The hypothesis `3 ≤ k` is necessary. At $k = 2$ the bound is false: $n_2 = 4$ and $2! = 2$. -/
 @[category research solved, AMS 11]
 theorem erdos_1063.variants.monier_upper_bound {k : ℕ} (hk : 3 ≤ k) :
     n k ≤ k ! := by
   sorry
 
 /-- [Cambie observed](https://www.erdosproblems.com/1063) the improved bound
-$n_k \le k \cdot \operatorname{lcm}(1, \dotsc, k - 1)$. -/
+$n_k \le k \cdot \operatorname{lcm}(1, \dotsc, k - 1)$.
+
+The hypothesis `3 ≤ k` is necessary here too. At $k = 2$ the right hand side is
+$2 \cdot \operatorname{lcm}(1) = 2$, while $n_2 = 4$.
+
+The source writes the bound as $k[2, 3, \dotsc, k-1]$. That agrees with the range used here,
+because including $1$ does not change a least common multiple. -/
 @[category research solved, AMS 11]
 theorem erdos_1063.variants.cambie_upper_bound {k : ℕ} (hk : 3 ≤ k) :
     n k ≤ k * (Finset.Icc 1 (k - 1)).lcm id := by

--- a/FormalConjectures/ErdosProblems/1063.lean
+++ b/FormalConjectures/ErdosProblems/1063.lean
@@ -23,7 +23,8 @@ import FormalConjecturesUtil
  * [erdosproblems.com/1063](https://www.erdosproblems.com/1063)
  * [ErSe83] Erdos, P. and Selfridge, J. L., Problem 6447. Amer. Math. Monthly (1983), 710.
  * [Gu04] Guy, Richard K., _Unsolved problems in number theory_. (2004), Problem B31.
- * [Mo85] Monier (1985). No reference found.
+ * [Mo85] Monier, Jean-Marie, _Problems and Solutions: Solutions of Advanced Problems: 6447_.
+   Amer. Math. Monthly **92** (1985), 435-436.
 -/
 
 open Filter Real
@@ -100,9 +101,8 @@ theorem erdos_1063.variants.small_values :
       · exact absurd hb (by decide)
       · exact absurd hb (by decide)
 
-/-- Monier observed that $n_k \le k!$ for $k \ge 3$ ([Mo85]).
-TODO: Find reference
--/
+/-- Monier observed that $n_k \le k!$ for $k \ge 3$ ([Mo85]), since $\binom{k!}{k}$ is divisible
+by $k! - i$ for $1 \le i < k$. -/
 @[category research solved, AMS 11]
 theorem erdos_1063.variants.monier_upper_bound {k : ℕ} (hk : 3 ≤ k) :
     n k ≤ k ! := by


### PR DESCRIPTION
`1063.lean` records the Monier citation as missing, in two places:

```
 * [Mo85] Monier (1985). No reference found.
```
```
/-- Monier observed that $n_k \le k!$ for $k \ge 3$ ([Mo85]).
TODO: Find reference
-/
```

The citation is on the problem page. `erdosproblems.com/1063` links `[Mo85]` to Monier, Jean-Marie, *Problems and Solutions: Solutions of Advanced Problems: 6447*, Amer. Math. Monthly (1985), 435-436. Crossref confirms volume **92**, page 435, 1985.

Also records Monier's reason for the bound, which the source gives in the same sentence: $\binom{k!}{k}$ is divisible by $k!-i$ for $1 \le i < k$.

Nothing else in the file changes, and the statements are untouched. While reading it I checked the mathematics and found no problem with it:

- `small_values` is right: computing `n k` directly from the definition gives `n 2 = 4`, `n 3 = 6`, `n 4 = 9`, `n 5 = 12`.
- Both upper bounds hold for every `k` from 3 to 12, with `n 3 = 6` tight against Cambie's bound.
- `exists_exception` has no counterexample for `2 ≤ k ≤ 8` and `n` up to 300.
- `n 0 = n 1 = 0` by the `sInf ∅` junk value, since both defining sets are empty, but nothing depends on it: the other statements are guarded by `k ≥ 3`, or asymptotic at `atTop`, or applied at a named `k` between 2 and 5.
- The Lean takes `lcm` over `Finset.Icc 1 (k-1)` where the source writes $k[2,3,\ldots,k-1]$. These agree, because `lcm` with 1 is the identity.