### PR TITLE
ErdosProblems/README: say where the LaTeX source is

### DIFF
--- a/FormalConjectures/ErdosProblems/README.md
+++ b/FormalConjectures/ErdosProblems/README.md
@@ -35,6 +35,15 @@ Choose a name that is descriptive of the variant. A common case is when the vari
 ## Docstrings
 Please keep docstrings as close as possible to the text on the Erdős Problems website. You should generally be able to copy and paste the LaTeX statements into the docstrings with only minor formatting adjustments.
 
+The LaTeX of a problem is at `erdosproblems.com/latex/{N}`. Copy from there rather than from the
+rendered page, which runs terms together: `3^7\cdot 61^5` renders as something easily read as
+`3761^5`, and that misreading has reached this repository.
+
+The site answers a request that identifies itself and returns 403 to one that does not, which
+includes the default `Python-urllib` user agent. Send a user agent that names your tool. A 403
+does not mean the source is unreadable, and reconstructing a statement from a neighbouring
+problem instead is how a wrong bound gets copied rather than caught.
+
 The verbatim problem text should appear **only once** — in the theorem docstring, not repeated in the module header docstring (`/-! ... -/`). The module header should contain the problem title and references only.
 
 ## References


### PR DESCRIPTION
Follow-up to #4937, taking @mo271's suggestion there.

He was right that the script was the wrong shape: an agentic system can pull a page and its LaTeX without one, and if we add a script for erdosproblems.com then the same argument asks for one for OEIS, and one for arXiv that fetches the `.tex` rather than the PDF and unpacks it, and an OCR fallback. What was actually missing was the hint. He suggested this README, so here it is, as two sentences next to the existing advice to copy the LaTeX into docstrings.

Both facts cost real time in review:

- **The LaTeX view is at `erdosproblems.com/latex/{N}`.** The rendered page runs terms together, which is how a docstring in this repository came to read `3761^5` where the source has `3^7\cdot 61^5`. That one is being fixed in #4934.
- **The site returns 403 to a request that does not identify itself**, including the default `Python-urllib` user agent, while `curl` gets a 200. This matters less as a recipe than as a warning: the tempting response to the 403 is to give up on the source and reconstruct the statement from a neighbouring problem file, and that is exactly how a bound gets copied from a problem whose statement differs by one. #4933 fixes an instance of that.

No script, no new dependency, documentation only.