### PR TITLE
ErdosProblems/918: `ω` is the fixed ordinal, not a variable

### DIFF
--- a/FormalConjectures/ErdosProblems/918.lean
+++ b/FormalConjectures/ErdosProblems/918.lean
@@ -81,17 +81,22 @@ theorem erdos_918.variants.erdos_hajnal (k : ℕ) (hk : 0 < k) : ∃ (V : Type u
       ∀ (W : Set V) (_ : #W < ℵ_ k), (G.induce W).chromaticCardinal ≤ ℵ₀ := by
   sorry
 
-/-- In [ErHa69] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
+/-- In [Er69b] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
 a likely typo since it can be shown that no such graph exists in this case.
 
 This is the first question with induced subgraphs. -/
+-- Formalisation note: the source states the impossibility for general subgraphs, in a
+-- parenthetical, "assuming subgraph and not induced subgraph was intended". It does not
+-- assert it for induced subgraphs, and the argument for the general case does not carry
+-- over: an induced subgraph on `W` has chromatic cardinal at least that of any subgraph
+-- on `W`, so the edgeless-subgraph argument is unavailable here.
 @[category textbook, AMS 5]
 theorem erdos_918.variants.eq_aleph_0.parts.i :
     ¬∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ 2 ∧ G.chromaticCardinal = ℵ_ 2 ∧
       ∀ (W : Set V) (_ : #W = ℵ₁), (G.induce W).chromaticCardinal = ℵ₀ := by
   sorry
 
-/-- In [ErHa69] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
+/-- In [Er69b] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
 a likely typo since it can be shown that no such graph exists in this case.
 
 This is the first question with all subgraphs. -/
@@ -101,17 +106,22 @@ theorem erdos_918.variants.eq_aleph_0_all_subgraphs.parts.i :
       ∀ (H : G.Subgraph) (_ : #H.verts = ℵ₁), H.coe.chromaticCardinal = ℵ₀ := by
   sorry
 
-/-- In [ErHa69] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
+/-- In [Er69b] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
 a likely typo since it can be shown that no such graph exists in this case.
 
 This is the second question with induced subgraphs. -/
+-- Formalisation note: the source states the impossibility for general subgraphs, in a
+-- parenthetical, "assuming subgraph and not induced subgraph was intended". It does not
+-- assert it for induced subgraphs, and the argument for the general case does not carry
+-- over: an induced subgraph on `W` has chromatic cardinal at least that of any subgraph
+-- on `W`, so the edgeless-subgraph argument is unavailable here.
 @[category textbook, AMS 5]
 theorem erdos_918.variants.eq_aleph_0.parts.ii :
     ¬∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (W : Set V) (_ : #W = ℵ_ ω), (G.induce W).chromaticCardinal = ℵ₀ := by
   sorry
 
-/-- In [ErHa69] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
+/-- In [Er69b] the questions are stated with $= \aleph_0$ rather than $\leq\aleph_0$. This is
 a likely typo since it can be shown that no such graph exists in this case.
 
 This is the second question with all subgraphs. -/

--- a/FormalConjectures/ErdosProblems/918.lean
+++ b/FormalConjectures/ErdosProblems/918.lean
@@ -27,7 +27,7 @@ import FormalConjecturesUtil
 
 universe u
 
-open scoped Cardinal
+open scoped Cardinal Ordinal
 
 namespace Erdos918
 
@@ -42,9 +42,12 @@ theorem erdos_918.parts.i :
 
 /-- Is there a graph with $\aleph_{\omega+1}$ vertices and chromatic number $\aleph_1$ such that
 every subgraph on $\aleph_\omega$ vertices has chromatic number $\leq\aleph_0$? -/
+-- Formalisation note: `ω` here is `Ordinal.omega0`, from `open scoped Ordinal`, as in 623.lean.
+-- It is the fixed first infinite ordinal, not a variable: `variants.erdos_hajnal` settles every
+-- finite `k`, and `ℵ_ω` is the limit of that family, so this asks the single next case.
 @[category research open, AMS 5]
 theorem erdos_918.parts.ii :
-    answer(sorry) ↔ ∀ (ω : Ordinal),
+    answer(sorry) ↔
     ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (W : Set V) (_ : #W = ℵ_ ω), (G.induce W).chromaticCardinal ≤ ℵ₀ := by
   sorry
@@ -62,7 +65,7 @@ theorem erdos_918.variants.all_subgraphs.parts.i :
 every subgraph on $\aleph_\omega$ vertices has chromatic number $\leq\aleph_0$? -/
 @[category research open, AMS 5]
 theorem erdos_918.variants.all_subgraphs.parts.ii :
-    answer(sorry) ↔ ∀ (ω : Ordinal),
+    answer(sorry) ↔
       ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (H : G.Subgraph) (_ : #H.verts = ℵ_ ω), H.coe.chromaticCardinal ≤ ℵ₀ := by
   sorry
@@ -103,7 +106,7 @@ a likely typo since it can be shown that no such graph exists in this case.
 
 This is the second question with induced subgraphs. -/
 @[category textbook, AMS 5]
-theorem erdos_918.variants.eq_aleph_0.parts.ii (ω : Ordinal) :
+theorem erdos_918.variants.eq_aleph_0.parts.ii :
     ¬∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (W : Set V) (_ : #W = ℵ_ ω), (G.induce W).chromaticCardinal = ℵ₀ := by
   sorry
@@ -113,7 +116,7 @@ a likely typo since it can be shown that no such graph exists in this case.
 
 This is the second question with all subgraphs. -/
 @[category textbook, AMS 5]
-theorem erdos_918.variants.eq_aleph_0_all_subgraphs.parts.ii (ω : Ordinal) :
+theorem erdos_918.variants.eq_aleph_0_all_subgraphs.parts.ii :
     ¬∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ (ω + 1) ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (H : G.Subgraph) (_ : #H.verts = ℵ_ ω), H.coe.chromaticCardinal = ℵ₀ := by
   sorry

--- a/FormalConjectures/ErdosProblems/918.lean
+++ b/FormalConjectures/ErdosProblems/918.lean
@@ -54,7 +54,12 @@ theorem erdos_918.parts.ii :
 
 /-- Is there a graph with $\aleph_2$ vertices and chromatic number $\aleph_2$ such that every
 subgraph on $\aleph_1$ vertices has chromatic number $\leq\aleph_0$? -/
--- Formalisation note: It is not clear whether this question for general subgraphs is open or not
+-- Formalisation note: for the `≤ ℵ₀` direction this is the same question as `parts.i`, not a
+-- separate one. Every subgraph on `W` is contained in the induced subgraph on `W`, so its
+-- chromatic cardinal is no larger; and the top subgraph induced on `W` has `coe` equal to
+-- `G.induce W`. So the two quantifications are equivalent and the answers cannot differ. The
+-- `= ℵ₀` pair below is genuinely different, because an edgeless subgraph has chromatic
+-- cardinal `1`, and that is the source's own reason for the impossibility there.
 @[category research open, AMS 5]
 theorem erdos_918.variants.all_subgraphs.parts.i :
     answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), #V = ℵ_ 2 ∧ G.chromaticCardinal = ℵ_ 2 ∧


### PR DESCRIPTION
Four `.ii` statements bind `ω` as a universally quantified variable. Their docstrings say $\aleph_{\omega+1}$ and $\aleph_\omega$. The file disagrees with itself.

The cause is a missing scope. This file has `open scoped Cardinal`. [623.lean](https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/623.lean#L25) has `open scoped Cardinal Ordinal` and writes `ℵ_ ω` as a constant. Without the `Ordinal` scope there is no `ω` to refer to, so a binder was added to make the statements elaborate.

This PR opens `Ordinal` and drops the four binders. Verified: `example : (ω : Ordinal) = Ordinal.omega0 := rfl`, and neither statement takes an `Ordinal` argument now.

### One statement was false

`variants.eq_aleph_0.parts.ii` is `@[category textbook]`, so it asserts a provable statement. With the binder it had to hold at `ω = 0`, where it reads $\aleph_1$ and $\aleph_0$. The complete graph on $\aleph_1$ vertices witnesses the existential it denies: a proper colouring of a complete graph is injective, and every countable induced subgraph is complete on countably many vertices.

`variants.eq_aleph_0_all_subgraphs.parts.ii` survives its binder for an unrelated reason. `SimpleGraph.Subgraph` permits arbitrary `verts` with empty `Adj`, so an edgeless subgraph breaks the `∀ H` clause for every `G`.

### Two further commits

`[ErHa69]` appears in four docstrings. The reference list defines `[ErHa68b]` and `[Er69b]`, and the source cites `\cite{Er69b}`. Changed.

The same docstrings carry the source's justification, which the source states for general subgraphs only: "(assuming subgraph and not induced subgraph was intended)". The induced pair asserts it anyway. A note records the gap.

The note on `all_subgraphs.parts.i` said it is unclear whether the general-subgraph question is open. For `≤ ℵ₀` it is not a separate question: every subgraph on `W` sits inside the induced subgraph on `W`, and the top subgraph induced on `W` has `coe = G.induce W`.

### Open question

Both induced statements keep `@[category textbook]`. For `eq_aleph_0.parts.i` I could neither prove nor refute it, and the source does not back it. A maintainer's call.
