### PR TITLE
GreensOpenProblems/72: ask Green's question rather than assert its opposite

### DIFF
--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -26,8 +26,10 @@ for $N$ sufficiently large, is it impossible to have a set of size $2N$ with thi
 The upper bound $2N$ is the easy half and is `allowedSetSize_le` below, by pigeonhole on the
 columns. The open content is whether $2N$ is attained. Green records that it is for $N$ up to
 around 50, that $(3/2 + o(1))N$ points are achievable for arbitrary $N$, and that his "personal
-suspicion is that this is optimal"; the Guy-Kelly heuristic in the Wikipedia reference points the
-same way, at $\pi/\sqrt3 \approx 1.814$. So the expected answer to the question above is yes.
+suspicion is that this is optimal". The Wikipedia reference points the same way: Guy and Kelly
+conjectured $c = \sqrt[3]{2\pi^2/3} \approx 1.874$, and after an error in the heuristic was found
+Guy corrected it to $c = \pi/\sqrt3 \approx 1.814$. Both are below $2$, so the expected answer to
+the question above is yes.
 
 *References:*
 - [Ben Green's Open Problem 72](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.72)

--- a/FormalConjectures/GreensOpenProblems/72.lean
+++ b/FormalConjectures/GreensOpenProblems/72.lean
@@ -20,8 +20,14 @@ import FormalConjecturesUtil
 
 More commonly known as the **no-three-in-line problem**.
 
-Given $N > 2$ and more than $2 * N$ points on an $N \times N$-grid,
-are there $3$ of the points on a common line?
+What is the largest subset of the grid $[N]^2$ with no three points in a line? In particular,
+for $N$ sufficiently large, is it impossible to have a set of size $2N$ with this property?
+
+The upper bound $2N$ is the easy half and is `allowedSetSize_le` below, by pigeonhole on the
+columns. The open content is whether $2N$ is attained. Green records that it is for $N$ up to
+around 50, that $(3/2 + o(1))N$ points are achievable for arbitrary $N$, and that his "personal
+suspicion is that this is optimal"; the Guy-Kelly heuristic in the Wikipedia reference points the
+same way, at $\pi/\sqrt3 \approx 1.814$. So the expected answer to the question above is yes.
 
 *References:*
 - [Ben Green's Open Problem 72](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.72)
@@ -75,20 +81,29 @@ def NoKInLineFor (k : ℕ) (N : ℕ) : Prop :=
 /-- The **no-k-in-line problem**:
 For $N \geq k$ and $k > 2$, the AllowedSetSize is $(k - 1) N$, i. e. on an $N \times N$ subset,
 there is a set of $(k - 1) N$ points for which no $k$ lie on a line (and not such a set of bigger size).
+
+Note the range. [GK2025] proves this for $k > 10^{37}$, which is `no_k_in_line_big` below. At
+$k = 3$ it is the claim Green expects to fail for large $N$, so this statement is not a
+conjecture anyone has made across the whole range $k > 2$.
 -/
 @[category research open, AMS 5 52]
 theorem NoKInLine {k : ℕ} {N : ℕ} (hk : 2 < k) (h : k ≤ N) : NoKInLineFor k N := by
   sorry
 
 /-- **Green's Open Problem 72 / No-three-in-line problem**:
-The no-k-in-line conjecture holds for $k = 3$. -/
+For $N$ sufficiently large, is it impossible to have $2N$ points in $[N]^2$ with no three in a
+line? Green suspects the answer is yes, and that $(3/2 + o(1))N$ is optimal. -/
 @[category research open, AMS 5 52]
-theorem green_72 {N : ℕ} (hN : 3 ≤ N) : NoKInLineFor 3 N := by
+theorem green_72 : answer(sorry) ↔ ∀ᶠ N in Filter.atTop, ¬ NoKInLineFor 3 N := by
   sorry
 
 alias no_three_in_line := green_72
 
-/-- Does the no-three-in-line problem hold when $N$ is big enough? -/
+/-- Is $2N$ attained for all sufficiently large $N$?
+
+This is not the negation of `green_72`. Negating that one gives $\exists^f N$ where this asks
+$\forall^f N$, so both can be answered `False` if the behaviour oscillates. Green asks his
+question in the `green_72` form. -/
 @[category research open, AMS 5 52]
 theorem green_72.variants.eventually : answer(sorry) ↔ ∀ᶠ N in Filter.atTop, NoKInLineFor 3 N := by
   sorry


### PR DESCRIPTION
`green_72` asserted `NoKInLineFor 3 N` for every `N ≥ 3`, that is `AllowedSetSize 3 N = 2 * N`. Green asks the opposite:

> for $N$ sufficiently large is it impossible to have a set of size $2N$ with this property?

His comments add that $2N$ configurations exist only "for $N$ up to around 50", that $(3/2 + o(1))N$ is achievable for arbitrary $N$, and that "my personal suspicion is that this is optimal". The file's other cited reference agrees: Guy and Kelly conjectured $c \approx 1.874$, and Guy later corrected it to $c \approx 1.814$. Both are below 2.

So the file asserted, as a `research open` theorem, what both its cited sources expect to fail. It now asks the source's question:

```lean
theorem green_72 : answer(sorry) ↔ ∀ᶠ N in Filter.atTop, ¬ NoKInLineFor 3 N
```

**This also fixes a decided answer slot.** As a bare theorem, `green_72` proved the right-hand side of `green_72.variants.eventually`, so a `research open` slot was settled by a neighbour. As a slot it settles nothing. The two are not negations, since negating an `∀ᶠ` gives an `∃ᶠ`, so both stay open, and the variant's docstring now says how they differ.

**The module docstring** asked whether more than $2N$ points force three on a line. That is the pigeonhole half, which `allowedSetSize_le` proves twenty lines later. It now states Green's question.

**Left alone.** `NoKInLine` contains the same claim at `k = 3`. GK2025 proves it for `k > 10^37`, so the range is a maintainer's call. Its docstring now records that nobody conjectures it across `k > 2`.

`lake --wfail build` passes.

Validation on the updated head: `lake --wfail build 'FormalConjectures.GreensOpenProblems.«72»'`. The changed module builds without warnings. This mathematical correction is independently mergeable.
