### PR TITLE
ErdosProblems/1063: take the comparator's lcm in the naturals

### DIFF
--- a/FormalConjectures/ErdosProblems/1063.lean
+++ b/FormalConjectures/ErdosProblems/1063.lean
@@ -41,14 +41,19 @@ noncomputable def n (k : ℕ) : ℕ :=
     ∀ i < k, i ≠ i0 → (m - i) ∣ m.choose k}
 
 /--
-Estimate $n_k$ by finding a better upper bound.
--/
+Estimate $n_k$ by finding a better upper bound than Cambie's
+$n_k \leq k \cdot \operatorname{lcm}(1, \dotsc, k-1)$.
+
+The comparator takes its least common multiple in `ℕ` and casts the result. Writing the
+ascription as `((… ).lcm (fun n : ℕ => n) : ℝ)` instead puts it on the `Finset.lcm`
+application, so the coercion lands on `n` and the `lcm` is taken in `ℝ`, where `lcm` of
+non-zero elements is `1` and the whole comparator collapses to `k`. -/
 @[category research open, AMS 11]
 theorem erdos_1063.better_upper :
     let upper_bound : ℕ → ℝ := answer(sorry)
     (fun k => (n k : ℝ)) =O[atTop] upper_bound ∧
     upper_bound =o[atTop] fun k =>
-      (k : ℝ) * ((Finset.Icc 1 (k - 1)).lcm (fun n : ℕ => n) : ℝ) := by
+      (k : ℝ) * (((Finset.Icc 1 (k - 1)).lcm id : ℕ) : ℝ) := by
   sorry
 
 /--


### PR DESCRIPTION
`better_upper` compares against

```lean
(k : ℝ) * ((Finset.Icc 1 (k - 1)).lcm (fun n : ℕ => n) : ℝ)
```

The ascription sits on the `Finset.lcm` application. So the coercion lands on `n`, and the `lcm` is taken **in ℝ**. Mathlib gives a field a `NormalizedGCDMonoid` instance where `lcm a b = 1` unless one is zero. Every member of `Icc 1 (k-1)` is non-zero. The comparator is therefore `(k : ℝ)`.

Both halves checked, sorry-free:

```lean
#check fun k : ℕ => (k : ℝ) * ((Finset.Icc 1 (k - 1)).lcm (fun n : ℕ => n) : ℝ)
-- fun k => ↑k * (Finset.Icc 1 (k - 1)).lcm fun n => ↑n : ℕ → ℝ

example (a b : ℝ) (ha : a ≠ 0) (hb : b ≠ 0) : lcm a b = 1 := by simp [lcm, ha, hb]
```

### This makes the statement unsatisfiable

`ub =o[atTop] (fun k => (k : ℝ))` gives `n k ≤ k` eventually. But `n k ≥ 2k` whenever the defining set is non-empty. So the statement asserts the set is eventually empty, that is, that `n_k` does not exist. The source defines `n_k` for every `k ≥ 2`, and Monier's `k!` construction exhibits a member for every `k ≥ 3`.

### Why it survived

`n k ≤ k !` is also true when the set is empty. So `monier_upper_bound` carries no existence claim to contradict `better_upper` with. The `sInf ∅ = 0` junk value hides the defect rather than causing it.

### The fix

Cast a natural-number `lcm`, matching `cambie_upper_bound` one screen below. The comparator is now `↑k * ↑((Finset.Icc 1 (k-1)).lcm id)`, which at `k = 5` is `60` rather than `5`. The docstring records the trap, since the two spellings differ by one bracket.

`lake --wfail build` passes. #4938, merged, was docstring-only and left this alone.
