### PR TITLE
Mark qualitative upper bounds for Green 37 as solved

### DIFF
--- a/FormalConjectures/GreensOpenProblems/37.lean
+++ b/FormalConjectures/GreensOpenProblems/37.lean
@@ -65,15 +65,21 @@ theorem green_37_theta (k : ℕ) :
   sorry
 
 /-- Determine an upper bound (big O) for `m(N, k)`. -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/green-37-sublinear-upper-bound/blob/d57f5a85a61b6d96bfbb4d2b82a455a3dd39b374/lean/Green37UpperBoundsFC.lean#L236-L240"]
 theorem green_37_bigO (k : ℕ) :
-    (fun N ↦ (m N k : ℝ)) =O[atTop] (answer(sorry) : ℕ → ℝ) := by
+    (fun N ↦ (m N k : ℝ)) =O[atTop]
+      (answer(fun N : ℕ ↦ (N : ℝ)) : ℕ → ℝ) := by
   sorry
 
 /-- Determine a strict upper bound (little o) for `m(N, k)`. -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/green-37-sublinear-upper-bound/blob/d57f5a85a61b6d96bfbb4d2b82a455a3dd39b374/lean/Green37UpperBoundsFC.lean#L230-L234"]
 theorem green_37_littleO (k : ℕ) :
-    (fun N ↦ (m N k : ℝ)) =o[atTop] (answer(sorry) : ℕ → ℝ) := by
+    (fun N ↦ (m N k : ℝ)) =o[atTop]
+      (answer(fun N : ℕ ↦ (N : ℝ)) : ℕ → ℝ) := by
   sorry
 
 end Green37


### PR DESCRIPTION
This PR changes `Green37.green_37_littleO` and `Green37.green_37_bigO` from `answer(sorry)` to `answer(fun N : ℕ ↦ (N : ℝ))` and links a kernel-checked Lean proof.

It leaves `Green37.green_37`, `Green37.green_37_asymptotic`, and `Green37.green_37_theta` open.

The Lean formalization was prepared by [Kenta Kitamura](https://github.com/KitaKen1).

The external proof establishes the exact target theorems:

    theorem Green37.green_37_littleO_solved (k : ℕ) :
        (fun N ↦ (m N k : ℝ)) =o[atTop]
          (answer(fun N : ℕ ↦ (N : ℝ)) : ℕ → ℝ)

    theorem Green37.green_37_bigO_solved (k : ℕ) :
        (fun N ↦ (m N k : ℝ)) =O[atTop]
          (answer(fun N : ℕ ↦ (N : ℝ)) : ℕ → ℝ)

Formal proof: https://github.com/KitaKen1/green-37-sublinear-upper-bound/blob/d57f5a85a61b6d96bfbb4d2b82a455a3dd39b374/lean/Green37UpperBoundsFC.lean#L230-L240

Repository: https://github.com/KitaKen1/green-37-sublinear-upper-bound

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fgreen-37-sublinear-upper-bound%2Frefs%2Fheads%2Fmain%2Flean4web%2FGreen37UpperBoundsLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, using GPT-5.6 sol.