### PR TITLE
Mark Erdős Problem 361 asymptotic variant as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/361.lean
+++ b/FormalConjectures/ErdosProblems/361.lean
@@ -72,10 +72,12 @@ theorem erdos_361 (c : ℝ) (hc : 0 < c) :
 Asymptotic version of Erdős Problem 361: determine the order of growth of the largest cardinality
 as $n \to \infty$.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-361-asymptotic/blob/01376b8a64e4814a006ed1f44cbf270b2a3fbd37/lean/Erdos361AsymptoticFC.lean#L139-L190"]
 theorem erdos_361.asymptotic (c : ℝ) (hc : 0 < c) :
     (fun n ↦ (subsetSumAvoidanceNumber c n : ℝ)) =Θ[atTop]
-      (answer(sorry) : ℕ → ℝ) := by
+      (answer(fun n : ℕ ↦ (n : ℝ)) : ℕ → ℝ) := by
   sorry
 
 end Erdos361


### PR DESCRIPTION
This PR changes `Erdos361.erdos_361.asymptotic` from `answer(sorry)` to the explicit comparison function `answer(fun n : ℕ ↦ (n : ℝ))` and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem erdos_361_asymptotic_solved (c : ℝ) (hc : 0 < c) :
    (fun n ↦ (Erdos361.subsetSumAvoidanceNumber c n : ℝ)) =Θ[atTop]
      (answer(fun n : ℕ ↦ (n : ℝ)) : ℕ → ℝ)
```

Proof: https://github.com/KitaKen1/erdos-361-asymptotic/blob/01376b8a64e4814a006ed1f44cbf270b2a3fbd37/lean/Erdos361AsymptoticFC.lean#L139-L190

Repository: https://github.com/KitaKen1/erdos-361-asymptotic

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-361-asymptotic%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos361AsymptoticLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, using GPT-5.6 sol.