### PR TITLE
ErdosProblems/92: record both questions as disproved

### DIFF
--- a/FormalConjectures/ErdosProblems/92.lean
+++ b/FormalConjectures/ErdosProblems/92.lean
@@ -19,6 +19,10 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 92
 
+Both questions here are disproved, by way of Erdős Problem 90. The source says so directly: this
+is a stronger form of the unit distance conjecture, so the disproof of that conjecture disproves
+these too. See `FormalConjectures.ErdosProblems.«90»`.
+
 *Reference:* [erdosproblems.com/92](https://www.erdosproblems.com/92)
 -/
 
@@ -78,17 +82,26 @@ noncomputable def f (n : ℕ) : ℕ := sSup <| possible_f_values n
 
 /--
 Is it true that $f(n)\leq n^{o(1)}$?
+
+The source records this as disproved: "This is a stronger form of the unit distance conjecture
+(see [90]). As such the recent disproof of [90] also disproves this." That disproof is
+`Erdos90.erdos_90`, which this repository already records as `research solved` with the answer
+`False`.
 -/
-@[category research open, AMS 52]
-theorem erdos_92.variants.weak : answer(sorry) ↔ ∃ o : ℕ → ℝ,
+@[category research solved, AMS 52]
+theorem erdos_92.variants.weak : answer(False) ↔ ∃ o : ℕ → ℝ,
   o =o[atTop] (1 : ℕ → ℝ) ∧ ∀ n, (f n : ℝ) ≤ n^(o n) := by
   sorry
 
 /--
 Or even $f(n) < n^{c/\log\log n}$ for some constant $c > 0$?
+
+Also disproved, and by the weak form rather than separately: since $c/\log\log n \to 0$, the bound
+$n^{c/\log\log n}$ is of the form $n^{o(1)}$, so this statement implies
+`erdos_92.variants.weak` and is false whenever that one is.
 -/
-@[category research open, AMS 52]
-theorem erdos_92.variants.strong : answer(sorry) ↔
+@[category research solved, AMS 52]
+theorem erdos_92.variants.strong : answer(False) ↔
     ∃ c > 0, ∀ᶠ n in atTop, (f n : ℝ) ≤ n^(c / (n : ℝ).log.log) := by
   sorry
 

--- a/FormalConjectures/Subsets/FC100OpenSet1.lean
+++ b/FormalConjectures/Subsets/FC100OpenSet1.lean
@@ -221,6 +221,6 @@ end Subsets.FC100OpenSet1
 
 open Lean Meta ProblemAttributes in
 #eval verifyCategoryCounts Subsets.FC100OpenSet1.problems [
-  ("research open", 93),
-  ("research solved", 7)
+  ("research open", 92),
+  ("research solved", 8)
 ]


### PR DESCRIPTION
The source marks problem 92 as disproved. Its remark gives the route:

> This is a stronger form of the unit distance conjecture (see [90]). As such the recent disproof of [90] also disproves this.

This repository already records that disproof: `Erdos90.erdos_90` is `research solved` with `answer(False)`. `92.lean` still said `research open`.

Both variants become `research solved` with `answer(False)`. The strong form follows from the weak one, since `c / log log n` tends to 0, so `n ^ (c / log log n)` is of the form `n ^ o(1)`.

`lake --wfail build` passes, 8054 jobs.

`scripts/check_erdos_status.py` does not catch this. It skips any `.variants.` suffix, and `92.lean` has no bare `erdos_92`, so the file never enters the comparison. 34 Erdős files are invisible for the same reason. I can send that separately if it is wanted.