### PR TITLE
Balance the math delimiters in 28 docstrings

### DIFF
--- a/FormalConjectures/Arxiv/1609.08688/sIncreasingrTuples.lean
+++ b/FormalConjectures/Arxiv/1609.08688/sIncreasingrTuples.lean
@@ -76,7 +76,7 @@ theorem lt₂_example_2 : ![5, 6, 1] <₂ ![7, 7, 7] := ⟨0, 2, by simp, by sim
 @[category test, AMS 5]
 theorem lt₂_example_3 : ![7, 7, 7] <₂ ![7, 8, 9] := ⟨1, 2, by simp, by simp⟩
 
-/-- but $(1, 2, 3)$ is not $2$-less than $(1, 2, 4). -/
+/-- but $(1, 2, 3)$ is not $2$-less than $(1, 2, 4)$. -/
 @[category test, AMS 5]
 theorem not_lt₂_example : ¬![1, 2, 3] <₂ ![1, 2, 4] := not_lt₂_of_exists 0 1 zero_ne_one (by simp) (by simp)
 

--- a/FormalConjectures/ErdosProblems/123.lean
+++ b/FormalConjectures/ErdosProblems/123.lean
@@ -76,7 +76,7 @@ Equivalently: is the set $\{a^k b^l c^m : k, l, m \geq 0\}$ d-complete?
 Note: For this not to reduce to the two-integer case, we need the integers
 to be greater than one and distinct.
 
-The prize of $250 is offered by Erdős in [Er97] and [Er97e] for a 'proof or disproof'.
+The prize of \$250 is offered by Erdős in [Er97] and [Er97e] for a 'proof or disproof'.
 
 The main problem was resolved in the affirmative by GPT 5.6 (prompted by Snyder).
 

--- a/FormalConjectures/ErdosProblems/18.lean
+++ b/FormalConjectures/ErdosProblems/18.lean
@@ -156,7 +156,7 @@ theorem practicalH_twelve : practicalH 12 = 3 := by
           fin_cases ha <;> fin_cases hb <;> decide
         exact key B (Finset.mem_powerset.mpr hBp) hBsum.symm
 
-/-- For any practical number $n$, $h(n) ≤ number of divisors of $n$. -/
+/-- For any practical number $n$, $h(n)$ ≤ number of divisors of $n$. -/
 @[category test, AMS 11]
 theorem practicalH_le_divisors (n : ℕ) (hn : Nat.IsPractical n) :
     practicalH n ≤ n.divisors.card := by

--- a/FormalConjectures/ErdosProblems/3.lean
+++ b/FormalConjectures/ErdosProblems/3.lean
@@ -25,7 +25,7 @@ import FormalConjecturesUtil
 namespace Erdos3
 
 /--
-If $A \subset \mathbb{N} has $\sum_{n \in A}\frac 1 n = \infty$, then must $A$ contain arbitrarily
+If $A \subset \mathbb{N}$ has $\sum_{n \in A}\frac 1 n = \infty$, then must $A$ contain arbitrarily
 long arithmetic progressions?
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/ErdosProblems/30.lean
+++ b/FormalConjectures/ErdosProblems/30.lean
@@ -33,7 +33,7 @@ noncomputable abbrev h (N : ℕ) : ℕ := Finset.maxSidonSubsetCard (Finset.Icc 
 open Filter
 
 /--
-Is it true that, for every $\varepsilon > 0$, $h(N) = \sqrt N + O_{\varespilon}(N^\varespilon)
+Is it true that, for every $\varepsilon > 0$, $h(N) = \sqrt N + O_{\varepsilon}(N^\varepsilon)$
 -/
 @[category research open, AMS 11]
 theorem erdos_30 : answer(sorry) ↔

--- a/FormalConjectures/ErdosProblems/319.lean
+++ b/FormalConjectures/ErdosProblems/319.lean
@@ -80,7 +80,7 @@ and
 $$
   \sum_{n\in A'}\frac{\delta n}{n} \neq 0
 $$
-for all non-empty $A'\subsetneq A$. Find the simplest $g(N)$ such that $c(N) = O(g(N)). -/
+for all non-empty $A'\subsetneq A$. Find the simplest $g(N)$ such that $c(N) = O(g(N))$. -/
 @[category research open, AMS 5]
 theorem erdos_319.variants.isBigO (N : ℕ) (c : ℕ → ℝ)
     (h : ∀ N, IsGreatest
@@ -99,7 +99,7 @@ and
 $$
   \sum_{n\in A'}\frac{\delta n}{n} \neq 0
 $$
-for all non-empty $A'\subsetneq A$. Find the simplest $g(N)$ such that $c(N) = o(g(N)). -/
+for all non-empty $A'\subsetneq A$. Find the simplest $g(N)$ such that $c(N) = o(g(N))$. -/
 @[category research open, AMS 5]
 theorem erdos_319.variants.isLittleO (N : ℕ) (c : ℕ → ℝ)
     (h : ∀ N, IsGreatest

--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -276,7 +276,7 @@ theorem minimum_overlap.variants.lower.scherk_1955 :
   sorry
 
 /--
-A lower bound of $\frac{4 - \sqrt{6}}{5}.
+A lower bound of $\frac{4 - \sqrt{6}}{5}$.
 See [On the intersection of a linear set with the translation of its complement](https://bibliotekanauki.pl/articles/969027)
 by *Stanisław Świerczkowski1*, Colloquium Mathematicum 5(2), p. 185-197, 1958
 

--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -52,7 +52,7 @@ theorem erdos_477.variants.S_sq :
 
 /--
 There is no such $A$ for any polynomial $f(x) = aX^2 + bX + c$, if $a | b$
-with $a \ne 0$ and $b \ne 0.
+with $a \ne 0$ and $b \ne 0$.
 This was found be AlphaProof for the specific instance $X^2 - X + 1$ and then generalised.
  -/
 @[category research solved, AMS 12]

--- a/FormalConjectures/ErdosProblems/509.lean
+++ b/FormalConjectures/ErdosProblems/509.lean
@@ -98,7 +98,7 @@ theorem erdos_509.variants.Cartan_bound : answer(True) ↔ ∀ (f : ℂ[X]), f.M
   sorry
 
 /--
-Let $f(z) ∈ $ℂ[z]$ be a monic non-constant polynomial. Can the set
+Let $f(z) ∈ ℂ[z]$ be a monic non-constant polynomial. Can the set
 $\{z ∈ ℂ : |f(z)| ≤ 1\}$
 be covered by a set of closed discs the sum of whose radii is $≤ 2.59$?
 Solution: True. This is due to Pommerenke.

--- a/FormalConjectures/ErdosProblems/593.lean
+++ b/FormalConjectures/ErdosProblems/593.lean
@@ -36,7 +36,7 @@ namespace Erdos593
 /- ## Main open problem -/
 
 /--
-**Erdős Problem 593 ($500)**: Characterize those finite 3-uniform hypergraphs which appear
+**Erdős Problem 593 (\$500)**: Characterize those finite 3-uniform hypergraphs which appear
 in every 3-uniform hypergraph of chromatic number $> \aleph_0$.
 
 A natural conjectural characterization, recorded here, is that the obligatory finite 3-uniform

--- a/FormalConjectures/ErdosProblems/595.lean
+++ b/FormalConjectures/ErdosProblems/595.lean
@@ -42,7 +42,7 @@ def IsCountableUnionOfTriangleFree {V : Type*} (G : SimpleGraph V) : Prop :=
 -/
 
 /--
-**Erdős Problem 595 ($250)**: Is there an infinite graph $G$ which contains no $K_4$ and is
+**Erdős Problem 595 (\$250)**: Is there an infinite graph $G$ which contains no $K_4$ and is
 not the union of countably many triangle-free graphs?
 
 A problem of Erdős and Hajnal [Er87].

--- a/FormalConjectures/ErdosProblems/697.lean
+++ b/FormalConjectures/ErdosProblems/697.lean
@@ -41,7 +41,7 @@ theorem density_exists (m : ℕ) (α : ℝ) : ∃ δ, HasDensity
 divisible by some $d \equiv 1 \pmod{m}$ with $1 < d < exp (m ^ \alpha)$ exists. -/
 noncomputable def δ (m : ℕ) (α : ℝ) : ℝ := (density_exists m α).choose
 
-/-- $\delta < \frac{m ^ \alpha + 1}{m}`. This shows that
+/-- $\delta < \frac{m ^ \alpha + 1}{m}$. This shows that
 $lim_{m\rightarrow\infty} \delta (m, \alpha) = 0$ for $\alpha < 1$.
 #TODO: prove this theorem. -/
 @[category research solved, AMS 11]

--- a/FormalConjectures/ErdosProblems/884.lean
+++ b/FormalConjectures/ErdosProblems/884.lean
@@ -50,9 +50,9 @@ in increasing order.
 Does it hold that
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \ll 1 + \sum_{1 \le i < \tau(n)}
  \frac{1}{d_{i + 1} - d_i}$
-for $n \to \infty`, i.e.
+for $n \to \infty$, i.e.
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \in O \left( 1 + \sum_{1 \le i < \tau(n)}
- \frac{1}{d_{i + 1} - d_i}) \right)$?
+ \frac{1}{d_{i + 1} - d_i} \right)$?
 
 This conjecture has been **disproved**:
 - In September 2025, Terence Tao gave a conditional _negative_ answer assuming the prime tuples
@@ -68,9 +68,9 @@ in increasing order.
 Does it hold that
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \ll 1 + \sum_{1 \le i < \tau(n)}
  \frac{1}{d_{i + 1} - d_i}$
-for $n \to \infty`, i.e.
+for $n \to \infty$, i.e.
 $\sum_{1 \le i < j \le \tau(n)} \frac{1}{d_j - d_i} \in O \left( 1 + \sum_{1 \le i < \tau(n)}
- \frac{1}{d_{i + 1} - d_i}) \right)$?
+ \frac{1}{d_{i + 1} - d_i} \right)$?
 
 This conjecture has been **disproved**:
 - In September 2025, Terence Tao gave a conditional _negative_ answer assuming the prime tuples

--- a/FormalConjectures/GreensOpenProblems/4.lean
+++ b/FormalConjectures/GreensOpenProblems/4.lean
@@ -35,7 +35,7 @@ theorem green_4 (n : ℕ) :
   sorry
 
 /-- Defines a family of subsets of $A_n$ where each permutation $\pi$ in a subset obeys $\pi(x)$
-and $\forall v \in I$, \pi(v)\notin I$ for a fixed $x$ and $I$. It is easy to demonstrate that such
+and $\forall v \in I$, $\pi(v)\notin I$ for a fixed $x$ and $I$. It is easy to demonstrate that such
 a subset is product-free, because for any a,b,c in such a set, $(a*b) (x)=a(b(x))\notin I$ but $c(x)
 in I$
 -/

--- a/FormalConjectures/OEIS/110566.lean
+++ b/FormalConjectures/OEIS/110566.lean
@@ -17,7 +17,7 @@ limitations under the License.
 import FormalConjecturesUtil
 
 /-!
-# $a(n) = \operatorname{lcm}\{1,2,\dots,n\}/\operatorname{denom}(H(n))$$
+# $a(n) = \operatorname{lcm}\{1,2,\dots,n\}/\operatorname{denom}(H(n))$
 
 *References:*
 - [A110566](https://oeis.org/A110566)

--- a/FormalConjectures/OEIS/114216.lean
+++ b/FormalConjectures/OEIS/114216.lean
@@ -31,7 +31,7 @@ namespace OeisA114216
 
 /--
 The primary defining sequence `a`.
-$a(n)$ is the largest odd divisor of $a(n-1)$+ \textrm{prime}(n)$.
+$a(n)$ is the largest odd divisor of $a(n-1) + \textrm{prime}(n)$.
 -/
 noncomputable def a (n : ℕ) : ℕ :=
   match n with

--- a/FormalConjectures/OEIS/115366.lean
+++ b/FormalConjectures/OEIS/115366.lean
@@ -53,7 +53,7 @@ theorem a_2 : a 2 = 50 := by native_decide
 theorem a_3 : a 3 = 313 := by native_decide
 
 /--
-Conjecture: $a(n)$A006880(n) \rightarrow 1.77...$
+Conjecture: $a(n)/A006880(n) \rightarrow 1.77...$
 where A006880(n) is the number of primes $\le 10^n$.
 -/
 @[category research open, AMS 11]

--- a/FormalConjectures/OEIS/231201.lean
+++ b/FormalConjectures/OEIS/231201.lean
@@ -21,7 +21,7 @@ import FormalConjecturesUtil
 
 Number of ways to write $n = x+y$, for $x,y > 0$ such that $2^x + y$ is prime.
 
-Zhi-Wei Sun has offered a $1000 prize for the first proof.
+Zhi-Wei Sun has offered a \$1000 prize for the first proof.
 
 *References:*
 - [A231201](https://oeis.org/A231201)

--- a/FormalConjectures/OEIS/232174.lean
+++ b/FormalConjectures/OEIS/232174.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 Any integer $n > 1$ can be written as $x + y$ with $x, y > 0$ such that both $x + ny$ and
 $x^2 + ny^2$ are prime.
 
-Zhi-Wei Sun has offered a $200 prize for the first proof.
+Zhi-Wei Sun has offered a \$200 prize for the first proof.
 
 *References:*
 - [A232174](https://oeis.org/A232174)

--- a/FormalConjectures/OEIS/281976.lean
+++ b/FormalConjectures/OEIS/281976.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 Any integer $n \geq 0$ can be written as $x^2 + y^2 + z^2 + w^2$ with $x, y, z, w$ nonnegative
 integers and $z \leq w$, such that both $x$ and $x + 24y$ are squares.
 
-Zhi-Wei Sun has offered a $2,400 prize for the first proof.
+Zhi-Wei Sun has offered a \$2,400 prize for the first proof.
 
 *References:*
 - [A281976](https://oeis.org/A281976)

--- a/FormalConjectures/OEIS/303656.lean
+++ b/FormalConjectures/OEIS/303656.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 Any integer $n > 1$ can be written as $a^2 + b^2 + 3^c + 5^d$ where $a, b, c, d$ are
 nonnegative integers.
 
-Zhi-Wei Sun has offered a $3,500 prize for the first proof.
+Zhi-Wei Sun has offered a \$3,500 prize for the first proof.
 
 *References:*
 - [A303656](https://oeis.org/A303656)

--- a/FormalConjectures/OEIS/308734.lean
+++ b/FormalConjectures/OEIS/308734.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 Any integer $n > 1$ can be written as $(2^a \cdot 3^b)^2 + (2^c \cdot 5^d)^2 + x^2 + y^2$
 where $a, b, c, d, x, y$ are nonnegative integers.
 
-Zhi-Wei Sun has offered a $2,500 prize for the first proof.
+Zhi-Wei Sun has offered a \$2,500 prize for the first proof.
 
 *References:*
 - [A308734](https://oeis.org/A308734)

--- a/FormalConjectures/OEIS/357513.lean
+++ b/FormalConjectures/OEIS/357513.lean
@@ -79,7 +79,7 @@ theorem a357513_supercongruence (p : ℕ) (hp : p.Prime) (h_ge3 : p ≥ 3) (h_ne
   sorry
 
 /--
-Let m be a nonnegative integer and set $u(n) = $$the numerator of
+Let m be a nonnegative integer and set $u(n)$ = the numerator of
 $$\sum{k=1}^{n} \frac{1}{k^{2m+1}} \binom{n}{k}^2 \binom{n+k}{k}^2$$
 (seems like a typo in the OEIS entry: the sum starts with $k=0$ there. In order
 to avoid a division by zero, we replace start the sum at $k=1$.)

--- a/FormalConjectures/Paper/WeaklyFirstCountable.lean
+++ b/FormalConjectures/Paper/WeaklyFirstCountable.lean
@@ -39,7 +39,7 @@ namespace WeaklyFirstCountable
 universe u
 
 /-- A topological space $X$ is called *weakly first countable* if there exists a function
-$N : X → ℕ → Set X, such that:
+$N : X → ℕ → Set X$, such that:
 
 * For all $x : X, n : ℕ$ we have $x ∈ V x n$
 * For all $x : X, n : ℕ$: $V x (n + 1) ⊆ V x n$

--- a/FormalConjectures/Wikipedia/Bloch.lean
+++ b/FormalConjectures/Wikipedia/Bloch.lean
@@ -122,7 +122,7 @@ theorem blochConstant_lower_bound : Real.sqrt 3 / 4 + 2 * 10 ^ (-4 : ℤ) ≤ bl
   sorry
 
 /-- It is proved in [AG37] that the Bloch constant is bounded above by
-$\frac{1}{\sqrt{1 + \sqrt{3}}}\frac{\Gamma(1/3) \Gamma(11/12)}{\Gamma(1/4)}$$. -/
+$\frac{1}{\sqrt{1 + \sqrt{3}}}\frac{\Gamma(1/3) \Gamma(11/12)}{\Gamma(1/4)}$. -/
 @[category research solved, AMS 30]
 theorem blochConstant_upper_bound :
     blochConstant ≤ Real.Gamma (1 / 3) * Real.Gamma (11 / 12) /

--- a/FormalConjectures/Wikipedia/Gilbreath.lean
+++ b/FormalConjectures/Wikipedia/Gilbreath.lean
@@ -26,7 +26,7 @@ namespace Gilbreath
 
 /--
 **Gilbreath's nth difference**, $d^n$
-Let $d^0(n) = p_n$ and $d^k(n) = |d^{k-1}(n+1) - d^{k-1}(n)|
+Let $d^0(n) = p_n$ and $d^k(n) = |d^{k-1}(n+1) - d^{k-1}(n)|$
 -/
 noncomputable def d : ℕ → (ℕ → ℕ)
   | 0 => fun n ↦ n.nth Nat.Prime


### PR DESCRIPTION
Rendering every problem file as LaTeX found 28 docstrings whose `$` do not pair. A missing
closing delimiter sets the rest of the sentence in maths on the generated site, and the build
does not see it.

Nine are prize amounts: `($500)` and `($250)` in Erdős 593 and 595, and five OEIS entries
writing "offered a $2,400 prize". Each opens maths mid sentence, and each becomes `\$`.

Three close with a backtick instead of a dollar. Erdős 697 writes
`$\delta < \frac{m ^ \alpha + 1}{m}` `, and Erdős 884 writes `for $n \to \infty` ` in each of
its two copies of the same paragraph. That sentence in 884 also closes `\left(` with both a
bare `)` and a `\right)`, so the rendered formula gains a paren. The `\ll` form of the same
expression two lines above has no paren there, which is what settles it.

Two are misspellings. ErdosProblems/30 writes `O_{\varespilon}(N^\varespilon)`, wrong twice on
one line, and never closes the group.

One needed the source rather than a guess. OEIS/115366 read `$a(n)$A006880(n) \rightarrow
1.77...$`, where the stray delimiter could have been a slash, a comma or a product. A115366's
own comment reads `Conjecture: a(n)/A006880(n) -> 1.77...`, so it is a ratio.

The rest are missing closers, a doubled `$$`, a stray `$` in `$f(z) ∈ $ℂ[z]$`, and a missing
opener in GreensOpenProblems/4.

Docstrings only: 28 changed lines, none of them Lean. All 26 modules build with `--wfail`.
