### PR TITLE
disprove(OEIS): resolve A113019 fixed-point conjecture

### DIFF
--- a/FormalConjectures/OEIS/113019.lean
+++ b/FormalConjectures/OEIS/113019.lean
@@ -58,9 +58,20 @@ theorem a_4 : a 4 = 1 := by native_decide
 
 /--
 $n=1$ and $32$ are fixed points. Are there any others?
+
+Yes: `387420489 = 9 ^ 9` is a third fixed point, so the proposed
+classification is false.
 -/
-@[category research open, AMS 11]
-theorem conjecture : answer(sorry) ↔ ∀ n : ℕ, a n = n → n = 1 ∨ n = 32 := by
-  sorry
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a113019-counterexample/blob/dc68e0b55c834b24c9e029525deaa562ae144296/lean/OeisA113019FC.lean#L14-L25"]
+theorem conjecture : answer(False) ↔ ∀ n : ℕ, a n = n → n = 1 ∨ n = 32 := by
+  change False ↔ ∀ n : ℕ, a n = n → n = 1 ∨ n = 32
+  constructor
+  · exact False.elim
+  · intro h
+    have hfixed : a 387420489 = 387420489 := by
+      simp [a]
+    rcases h 387420489 hfixed with h | h <;> omega
 
 end OeisA113019

--- a/FormalConjectures/OEIS/113019.lean
+++ b/FormalConjectures/OEIS/113019.lean
@@ -61,9 +61,7 @@ $n=1$ and $32$ are fixed points. Are there any others?
 
 Yes: 9^9 = 387420489 is also a fixed point. - [Kenta Kitamura](https://oeis.org/wiki/User:Kenta_Kitamura), Aug 14 2026
 -/
-@[category research solved, AMS 11,
-  formal_proof using lean4 at
-    "https://github.com/KitaKen1/oeis-a113019-counterexample/blob/dc68e0b55c834b24c9e029525deaa562ae144296/lean/OeisA113019FC.lean#L14-L25"]
+@[category research solved, AMS 11]
 theorem conjecture : answer(False) ↔ ∀ n : ℕ, a n = n → n = 1 ∨ n = 32 := by
   change False ↔ ∀ n : ℕ, a n = n → n = 1 ∨ n = 32
   constructor

--- a/FormalConjectures/OEIS/113019.lean
+++ b/FormalConjectures/OEIS/113019.lean
@@ -59,8 +59,7 @@ theorem a_4 : a 4 = 1 := by native_decide
 /--
 $n=1$ and $32$ are fixed points. Are there any others?
 
-Yes: `387420489 = 9 ^ 9` is a third fixed point, so the proposed
-classification is false.
+Yes: 9^9 = 387420489 is also a fixed point. - [Kenta Kitamura](https://oeis.org/wiki/User:Kenta_Kitamura), Aug 14 2026
 -/
 @[category research solved, AMS 11,
   formal_proof using lean4 at


### PR DESCRIPTION
This PR changes `OeisA113019.conjecture` from `answer(sorry)` to `answer(False)` and adds a kernel-checked Lean proof.

The OEIS comment asks: “n=1 and 32 are fixed points. Are there any others?”
Yes: `387420489 = 9^9` is a third fixed point under the exact current definition, so the proposed classification is false.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).
The external proof establishes the exact target theorem:

```lean
theorem OeisA113019Proof.oeis_a113019_conjecture_solved :
    answer(False) ↔
      ∀ n : ℕ, OeisA113019.a n = n → n = 1 ∨ n = 32
```

Proof: https://github.com/KitaKen1/oeis-a113019-counterexample/blob/dc68e0b55c834b24c9e029525deaa562ae144296/lean/OeisA113019FC.lean#L14-L25

Repository: https://github.com/KitaKen1/oeis-a113019-counterexample

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a113019-counterexample%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA113019Lean4Web.lean

`lake build` succeeds with Lean 4.27.0. `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, using GPT-5.6 sol.