### PR TITLE
Mark OEIS A100478 as solved

### DIFF
--- a/FormalConjectures/OEIS/100478.lean
+++ b/FormalConjectures/OEIS/100478.lean
@@ -86,9 +86,11 @@ Starting with other values of $a(1)$, $a(2)$, $a(3)$, $a(4)$, $a(5)$ what behavi
 Does the sequence always stick at a single integer after some point, or can it go into a loop,
 or is there a third pattern?
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a100478-eventual-periodicity/blob/642eed0ffee26415528ab8c48c5181826be04860/lean/OeisA100478FC.lean#L158-L168"]
 theorem conjecture (v : Fin 5 → ℕ) (h : ∀ i, v i > 0) :
-  answer(sorry) = ∃ N P : ℕ, P > 0 ∧ (∀ n, n ≥ N → aGeneral v (n + P) = aGeneral v n) := by
+  answer(True) = ∃ N P : ℕ, P > 0 ∧ (∀ n, n ≥ N → aGeneral v (n + P) = aGeneral v n) := by
   sorry
 
 end OeisA100478


### PR DESCRIPTION
This PR changes `OeisA100478.conjecture` from `answer(sorry)` to `answer(True)`, marks it `research solved`, and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem OeisA100478Proof.oeis_a100478_solved
    (v : Fin 5 → ℕ) (_h : ∀ i, v i > 0) :
    answer(True) =
      ∃ N P : ℕ, P > 0 ∧
        ∀ n, n ≥ N → OeisA100478.aGeneral v (n + P) =
          OeisA100478.aGeneral v n
```

Proof: https://github.com/KitaKen1/oeis-a100478-eventual-periodicity/blob/642eed0ffee26415528ab8c48c5181826be04860/lean/OeisA100478FC.lean#L158-L168

Repository: https://github.com/KitaKen1/oeis-a100478-eventual-periodicity

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a100478-eventual-periodicity%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA100478Lean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.