### PR TITLE
feat: formalize the Lennon–Pittel stable matchings conjecture

### DIFF
--- a/FormalConjectures/Paper/LennonPittelStableMatchings.lean
+++ b/FormalConjectures/Paper/LennonPittelStableMatchings.lean
@@ -1,0 +1,60 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Lennon–Pittel conjecture on random stable matchings
+
+*References:*
+- [On the Likely Number of Stable Marriages](https://etd.ohiolink.edu/acprod/odb_etd/ws/send_file/send?accession=osu1194991095&disposition=inline)
+  by *Craig Lennon*, PhD dissertation, The Ohio State University (2007).
+- [On the Likely Number of Solutions for the Stable Marriage Problem](https://doi.org/10.1017/S0963548308009607)
+  by *Craig Lennon and Boris Pittel*, *Combinatorics, Probability and Computing* 18 (2009),
+  371–421.
+
+Let $S_n$ be the number of stable matchings under uniformly random complete strict preferences.
+-/
+
+open Filter
+open scoped Topology
+
+namespace LennonPittel
+
+/-- Sanity check: the uniform profile distribution has total mass one. -/
+@[category test, AMS 5 60]
+theorem uniform_profile_univ (n : ℕ) :
+    (StableMarriage.uniformProfile n).toMeasure Set.univ = 1 := by
+  simp
+
+/--
+The [Lennon–Pittel conjecture](https://doi.org/10.1017/S0963548308009607) states that for every
+positive nonincreasing sequence $\varepsilon_n \to 0$, the probability that the number $S_n$ of
+stable matchings is at least $\varepsilon_n \mathbb{E}[S_n]$ tends to one.
+-/
+@[category research open, AMS 5 60]
+theorem lennon_pittel_conjecture
+    (ε : ℕ → ℝ) (hε_pos : ∀ n, 0 < ε n) (hε_antitone : Antitone ε)
+    (hε_tendsto : Tendsto ε atTop (𝓝 0)) :
+    Tendsto
+      (fun n ↦
+        (StableMarriage.uniformProfile n).toMeasure
+          {p | (StableMarriage.numStableMatchings p : ℝ) ≥
+            ε n * StableMarriage.expectedNumStableMatchings n})
+      atTop (𝓝 1) := by
+  sorry
+
+end LennonPittel

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -91,6 +91,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.UnitDistance
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.VertexDistance
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.WellTotallyDominated
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.WienerIndex
+public import FormalConjecturesForMathlib.Combinatorics.StableMarriage
 public import FormalConjecturesForMathlib.Combinatorics.YoungDiagram
 public import FormalConjecturesForMathlib.Computability.DFA
 public import FormalConjecturesForMathlib.Computability.Encoding

--- a/FormalConjecturesForMathlib/Combinatorics/StableMarriage.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/StableMarriage.lean
@@ -18,6 +18,8 @@ module
 public import Mathlib.Data.Fintype.Perm
 public import Mathlib.Data.Fintype.Pi
 public import Mathlib.Data.Fintype.Prod
+public import Mathlib.Probability.Distributions.Uniform
+public import Mathlib.Probability.ProbabilityMassFunction.Integrals
 
 @[expose] public section
 
@@ -65,5 +67,16 @@ def IsStable {n : ℕ} (p : Profile n) (μ : Matching n) : Prop :=
 noncomputable def numStableMatchings {n : ℕ} (p : Profile n) : ℕ := by
   classical
   exact Fintype.card {μ : Matching n // IsStable p μ}
+
+/-- The discrete measurable structure on preference profiles. -/
+instance {n : ℕ} : MeasurableSpace (Profile n) := ⊤
+
+/-- The uniform probability mass function on preference profiles. -/
+noncomputable def uniformProfile (n : ℕ) : PMF (Profile n) :=
+  PMF.uniformOfFintype (Profile n)
+
+/-- The expected number of stable matchings under the uniform profile distribution. -/
+noncomputable def expectedNumStableMatchings (n : ℕ) : ℝ :=
+  ∫ p, (numStableMatchings p : ℝ) ∂((uniformProfile n).toMeasure)
 
 end StableMarriage

--- a/FormalConjecturesForMathlib/Combinatorics/StableMarriage.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/StableMarriage.lean
@@ -1,0 +1,69 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Fintype.Perm
+public import Mathlib.Data.Fintype.Pi
+public import Mathlib.Data.Fintype.Prod
+
+@[expose] public section
+
+/-!
+# Stable marriage
+
+A minimal finite model of the stable marriage problem with complete strict preferences.
+-/
+
+namespace StableMarriage
+
+/-- A preference profile for `n` men and `n` women. Each permutation maps a candidate to their
+rank, with lower ranks preferred. -/
+structure Profile (n : ℕ) where
+  /-- The rank that each man assigns to each woman. -/
+  manRank : Fin n → Equiv.Perm (Fin n)
+  /-- The rank that each woman assigns to each man. -/
+  womanRank : Fin n → Equiv.Perm (Fin n)
+  deriving Inhabited
+
+/-- Preference profiles form a finite type. -/
+instance {n : ℕ} : Fintype (Profile n) :=
+  Fintype.ofEquiv
+    ((Fin n → Equiv.Perm (Fin n)) × (Fin n → Equiv.Perm (Fin n)))
+    { toFun := fun p => ⟨p.1, p.2⟩
+      invFun := fun p => (p.manRank, p.womanRank)
+      left_inv := fun _ => rfl
+      right_inv := fun _ => rfl }
+
+/-- A complete matching of `n` men to `n` women. -/
+abbrev Matching (n : ℕ) := Equiv.Perm (Fin n)
+
+/-- A man and woman form a blocking pair when they are not matched to each other and each ranks
+the other above their current partner. -/
+def IsBlockingPair {n : ℕ} (p : Profile n) (μ : Matching n) (m w : Fin n) : Prop :=
+  μ m ≠ w ∧
+    p.manRank m w < p.manRank m (μ m) ∧
+      p.womanRank w m < p.womanRank w (μ.symm w)
+
+/-- A matching is stable when it has no blocking pair. -/
+def IsStable {n : ℕ} (p : Profile n) (μ : Matching n) : Prop :=
+  ∀ m w, ¬ IsBlockingPair p μ m w
+
+/-- The number of stable complete matchings for a preference profile. -/
+noncomputable def numStableMatchings {n : ℕ} (p : Profile n) : ℕ := by
+  classical
+  exact Fintype.card {μ : Matching n // IsStable p μ}
+
+end StableMarriage


### PR DESCRIPTION
## Summary

This PR formalizes the Lennon–Pittel conjecture on the number of stable matchings in a uniformly random stable-marriage instance. If $S_n$ denotes the number of stable complete matchings for $n$ men and $n$ women with independently and uniformly random strict preference orderings, the conjecture states that for every positive nonincreasing sequence $\varepsilon_n \to 0$,

$$
\Pr\left(S_n \geq \varepsilon_n \mathbb{E}[S_n]\right) \to 1
\qquad \text{as } n \to \infty.
$$

The PR adds the minimal finite stable-marriage model needed to state this conjecture, including preference profiles, complete matchings, blocking pairs, stability, the number of stable matchings, the uniform distribution over preference profiles, and the expected number of stable matchings. It then states the Lennon–Pittel conjecture as an open research theorem.

## Formalization decisions

* Each agent's strict preference ordering is represented by a permutation from candidates to ranks. Thus `manRank m w` is the rank man $m$ assigns to woman $w$, and analogously for women's rankings.
* Smaller ranks represent stronger preferences, so $w_1$ is preferred to $w_2$ exactly when the rank assigned to $w_1$ is smaller.
* A complete matching is represented by a permutation $\mu$ from men to women.
* The woman matched to a man $m$ is $\mu(m)$, while the man matched to a woman $w$ is obtained from the inverse permutation, $\mu^{-1}(w)$.
* Random preference profiles are modeled by the uniform PMF on the complete finite type of profiles. Since a profile consists of one arbitrary permutation for each of the $2n$ agents, this uniform law is the joint law in which all agents' preference lists are independent and uniform.
* The same `uniformProfile n` distribution is used both to define $\mathbb{E}[S_n]$ and to measure the probability of the threshold event $S_n \geq \varepsilon_n \mathbb{E}[S_n]$.

## Scope and limitations

This PR adds only the definitions required to state the Lennon–Pittel conjecture and the conjecture itself. The supporting stable-marriage API is intentionally minimal and definition-oriented.

In particular, it does not add the Gale–Shapley algorithm, general stable-matching theory, moment or asymptotic estimates for $S_n$, independence lemmas, variants of the stable-marriage model, or lemmas intended to provide hints toward a proof of the conjecture.

## Validation

* `lake --wfail build`
* Checked the zero-agent edge case, where the unique empty preference profile has the unique empty matching, which is stable.
* Checked normalization of the uniform profile law: for every $n$, the measure of the full profile space is $1$.

## References

* Craig Lennon, *[On the Likely Number of Stable Marriages](https://etd.ohiolink.edu/acprod/odb_etd/ws/send_file/send?accession=osu1194991095&disposition=inline)* (2007)
* Craig Lennon and Boris Pittel, *[On the Likely Number of Solutions for the Stable Marriage Problem](https://doi.org/10.1017/S0963548308009607)* (2009)

## AI use

I used OpenAI Codex for repository and API research, drafting and checking the Lean implementation, running builds, and semantic audits of the formalization. I reviewed the resulting implementation and understand the mathematical statement and the formalization choices described above.

Fixes #4847
