### PR TITLE
Mark OEIS A105565 as solved

### DIFF
--- a/FormalConjectures/OEIS/105565.lean
+++ b/FormalConjectures/OEIS/105565.lean
@@ -87,8 +87,13 @@ noncomputable def s (n : ℕ) : Real :=
 /--
 Conjecture: $\beta-2 < S(n)-\alpha n < \beta-1$.
 The constants $\alpha$ and $\beta$ are as defined in the formula section.
+
+Solved by OpenAI Codex, prompted by Adam Haig. A complete Lean 4 proof is
+linked by the `formal_proof` attribute below.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/HaigAd/formal-conjectures/commit/327b99914ce787ab41c67ba645626982e15b0124"]
 theorem conjecture (n : ℕ) (hn : 1 ≤ n) :
     betaConst - 2 < s n - alphaConst * (n : Real) ∧
       s n - alphaConst * (n : Real) < betaConst - 1 := by

--- a/FormalConjectures/OEIS/105565.lean
+++ b/FormalConjectures/OEIS/105565.lean
@@ -93,7 +93,7 @@ linked by the `formal_proof` attribute below.
 -/
 @[category research solved, AMS 11,
   formal_proof using lean4 at
-    "https://github.com/HaigAd/formal-conjectures/commit/327b99914ce787ab41c67ba645626982e15b0124"]
+    "https://github.com/HaigAd/formal-conjectures/blob/327b99914ce787ab41c67ba645626982e15b0124/FormalConjectures/OEIS/105565.lean#L595"]
 theorem conjecture (n : ℕ) (hn : 1 ≤ n) :
     betaConst - 2 < s n - alphaConst * (n : Real) ∧
       s n - alphaConst * (n : Real) < betaConst - 1 := by


### PR DESCRIPTION
## Summary

- marks the OEIS A105565 discrepancy conjecture as solved
- credits OpenAI Codex as the AI proof author and formalizer, prompted by Adam Haig
- links the `formal_proof` attribute to an immutable commit containing the complete Lean 4 proof

## Why

The external proof establishes `OeisA105565.conjecture` against the repository definition, including its bounded Fibonacci-index filter. The proof is longer than the repository's 25–50 line guideline, so this PR retains `sorry` locally and points to the independently buildable proof artifact.

## Verification

- `lake env lean FormalConjectures/OEIS/105565.lean`
- external proof: `lake --wfail build 'FormalConjectures.OEIS.«105565»'` (8,055 jobs)
- external theorem axiom report: `propext`, `Classical.choice`, `Quot.sound`; no `sorryAx`

Proof commit: https://github.com/HaigAd/formal-conjectures/commit/327b99914ce787ab41c67ba645626982e15b0124
