### PR TITLE
Mark OEIS A105801 as solved

### DIFF
--- a/FormalConjectures/OEIS/105801.lean
+++ b/FormalConjectures/OEIS/105801.lean
@@ -60,7 +60,9 @@ theorem a_5 : a 5 = 8 := by decide
 Conjecture: for every $k > 0$ there is an index $m$ such that all the $a(n)$ with $n > m$
 have the same residue $\bmod 3^k$.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a105801-lean/blob/68642a80db062bee7061437b60d31c3e7d626595/lean/OeisA105801FC.lean#L323-L351"]
 theorem conjecture :
     ∀ k : ℕ, 0 < k → ∃ m : ℕ, ∀ n : ℕ, m < n → a n ≡ a (m + 1) [MOD (3^k)] := by
   sorry


### PR DESCRIPTION
This PR changes `OeisA105801.conjecture` from `research open` to `research solved` and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem OeisA105801Proof.conjecture_solved :
    ∀ k : ℕ, 0 < k → ∃ m : ℕ, ∀ n : ℕ, m < n →
      OeisA105801.a n ≡ OeisA105801.a (m + 1) [MOD (3 ^ k)]
```

Proof: https://github.com/KitaKen1/oeis-a105801-lean/blob/68642a80db062bee7061437b60d31c3e7d626595/lean/OeisA105801FC.lean#L323-L351

Repository: https://github.com/KitaKen1/oeis-a105801-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a105801-lean%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA105801Lean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.