### PR TITLE
Mark OEIS A113250, A113252, and A113255 as solved

### DIFF
--- a/FormalConjectures/OEIS/113250.lean
+++ b/FormalConjectures/OEIS/113250.lean
@@ -59,7 +59,9 @@ theorem a_4 : a 4 = -256 := by rfl
 Conjecture: $a(m, 2n+1)$ is a perfect square for all $m$ (see A113249).
 Specialized to $m = 4$, which is A113250.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean/blob/9b999db08344184285e8050c2722c845fd5f5309/lean/OeisA113249FamilyFC.lean#L106-L114"]
 theorem conjecture : ∀ n : ℕ, IsSquare (a (2 * n + 1)) := by
   sorry
 

--- a/FormalConjectures/OEIS/113252.lean
+++ b/FormalConjectures/OEIS/113252.lean
@@ -61,7 +61,9 @@ theorem a_4 : a 4 = -3856 := by rfl
 Conjecture: $a(m, 2n+1)$ is a perfect square for all $m, n$ (see A113249).
 Specialized for $m=6$, which is A113252.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean/blob/9b999db08344184285e8050c2722c845fd5f5309/lean/OeisA113249FamilyFC.lean#L116-L124"]
 theorem conjecture : ∀ n : ℕ, IsSquare (a (2 * n + 1)) := by
   sorry
 

--- a/FormalConjectures/OEIS/113255.lean
+++ b/FormalConjectures/OEIS/113255.lean
@@ -61,7 +61,9 @@ theorem a_4 : a 4 = -26581 := by rfl
 Conjecture: $a(m, 2n+1)$ is a perfect square for all $m, n$ (see A113249).
 Specialized for $m=9$, which is A113255.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean/blob/9b999db08344184285e8050c2722c845fd5f5309/lean/OeisA113249FamilyFC.lean#L126-L134"]
 theorem conjecture : ∀ n : ℕ, IsSquare (a (2 * n + 1)) := by
   sorry
 


### PR DESCRIPTION
This PR changes `OeisA113250.conjecture`, `OeisA113252.conjecture`, and `OeisA113255.conjecture` from `research open` to `research solved` and links kernel-checked Lean proofs.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

```lean
theorem oeis_a113250_conjecture_solved :
    ∀ n : ℕ, IsSquare (OeisA113250.a (2 * n + 1))

theorem oeis_a113252_conjecture_solved :
    ∀ n : ℕ, IsSquare (OeisA113252.a (2 * n + 1))

theorem oeis_a113255_conjecture_solved :
    ∀ n : ℕ, IsSquare (OeisA113255.a (2 * n + 1))
```

Proofs:
- A113250: https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean/blob/9b999db08344184285e8050c2722c845fd5f5309/lean/OeisA113249FamilyFC.lean#L106-L114
- A113252: https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean/blob/9b999db08344184285e8050c2722c845fd5f5309/lean/OeisA113249FamilyFC.lean#L116-L124
- A113255: https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean/blob/9b999db08344184285e8050c2722c845fd5f5309/lean/OeisA113249FamilyFC.lean#L126-L134

Repository: https://github.com/KitaKen1/oeis-a113249-family-square-terms-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a113249-family-square-terms-lean%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA113249FamilyLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.


AI Usage Disclosure: This formalization and PR writeup were prepared with assistance from OpenAI Codex.