### PR TITLE
Mark OEIS A103425 as solved

### DIFF
--- a/FormalConjectures/OEIS/103425.lean
+++ b/FormalConjectures/OEIS/103425.lean
@@ -61,8 +61,10 @@ Is there an $(a, b, c)$ weighted tribonacci sequence with $a, b, c$ relatively p
 which is prime-free?
 -/
 
-@[category research open, AMS 11]
-theorem conjecture : answer(sorry) ↔
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a103425-prime-free/blob/b04b155/lean/OeisA103425FC.lean#L13-L35"]
+theorem conjecture : answer(True) ↔
     ∃ (a b c : ℤ) (x : ℕ → ℤ),
       Nat.gcd (Int.gcd a b) c.natAbs = 1 ∧
       IsWeightedTribonacci a b c x ∧


### PR DESCRIPTION
This PR changes `OeisA103425.conjecture` from `answer(sorry)` to `answer(True)` and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external formalization proves the exact target theorem:

```lean
theorem OeisA103425Proof.formal_conjectures_target : answer(True) ↔
    ∃ (a b c : ℤ) (x : ℕ → ℤ),
      Nat.gcd (Int.gcd a b) c.natAbs = 1 ∧
      OeisA103425.IsWeightedTribonacci a b c x ∧
      ∀ n, ¬ (x n).natAbs.Prime
```

Proof: https://github.com/KitaKen1/oeis-a103425-prime-free/blob/b04b155/lean/OeisA103425FC.lean#L13-L35

Repository: https://github.com/KitaKen1/oeis-a103425-prime-free

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a103425-prime-free%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA103425Lean4Web.lean

`#print axioms` reports only `propext` and `Quot.sound`; there is no `sorryAx`, `native_decide`, or custom axiom.

AI Usage Disclosure: This formalization and PR preparation were assisted by OpenAI Codex.