### PR TITLE
fix: replace answer(sorry) with answer(True) in solved statements

### DIFF
--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -87,42 +87,42 @@ theorem green_14_quadratic :
 /-- [Gr21] proved a lower bound of shape $W(3, r) \gg \exp(c(\log r)^{4/3-o(1)})$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_lower_bound_green :
-    answer(sorry) ↔ ∃ c : ℝ, ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+    answer(True) ↔ ∃ c : ℝ, ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
     (fun (r : ℕ) => Real.exp (c * (Real.log r)^(4/3 - o r))) =O[atTop] fun r => (W 3 r : ℝ) := by
   sorry
 
 /-- [Hu22] improved this to $W(3, r) \gg \exp(c(\log r)^{2-o(1)})$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_lower_bound_hunter :
-    answer(sorry) ↔ ∃ c : ℝ, ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+    answer(True) ↔ ∃ c : ℝ, ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
     (fun (r : ℕ) => Real.exp (c * (Real.log r)^(2 - o r))) =O[atTop] (fun r => (W 3 r : ℝ)) := by
   sorry
 
 /-- [BLR08] proved $W(3, r) \gg r^{2 - 1/\log \log r}$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_lower_bound_brown_landman_robertson :
-    answer(sorry) ↔
+    answer(True) ↔
     (fun (r : ℕ) => (r : ℝ)^(2 - 1 / Real.log (Real.log r))) =O[atTop] (fun r => (W 3 r : ℝ)) := by
   sorry
 
 /-- [LiSh10] proved $W(3, r) \gg (r / \log r)^2$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_lower_bound_li_shu :
-    answer(sorry) ↔
+    answer(True) ↔
     (fun (r : ℕ) => ((r : ℝ) / Real.log r)^2) =O[atTop] (fun r => (W 3 r : ℝ)) := by
   sorry
 
 /-- [Sc20] proves the upper bound $W(3, r) < \exp(r^{1-c})$ for some $c > 0$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_upper_bound_schoen :
-    answer(sorry) ↔ ∃ c : ℝ, 0 < c ∧
+    answer(True) ↔ ∃ c : ℝ, 0 < c ∧
     (fun (r : ℕ) => ((W 3 r) : ℝ)) =O[atTop] (fun r => Real.exp ((r : ℝ) ^ (1 - c))) := by
   sorry
 
 /-- [KeMe23] gives a corresponding upper bound $W(3, r) \ll \exp(C(\log r)^C)$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_upper_bound_kelley_meka :
-    answer(sorry) ↔ ∃ C : ℝ,
+    answer(True) ↔ ∃ C : ℝ,
     (fun (r : ℕ) => ((W 3 r) : ℝ)) =O[atTop] (fun r => Real.exp (C * (Real.log r)^C)) := by
   sorry
 

--- a/FormalConjectures/Paper/LatinSquare.lean
+++ b/FormalConjectures/Paper/LatinSquare.lean
@@ -63,7 +63,7 @@ theorem oddOrderLatinSquareTransversal : answer(sorry) ↔
 The conjecture is known to be true for $n \leq 9$.
 -/
 @[category research solved, AMS 5]
-theorem oddOrderLeq9LatinSquareTransversal : answer(sorry) ↔
+theorem oddOrderLeq9LatinSquareTransversal : answer(True) ↔
     ∀ n ≤ 9, Odd n → ∀ (L : LatinSquare n), ∃ σ, IsTransversal L σ := by
   sorry
 


### PR DESCRIPTION
Per CONTRIBUTING ("If the problem has been solved, `answer(sorry)` should be replaced by `answer(True)` or `answer(False)` accordingly"), this replaces `answer(sorry)` with `answer(True)` in 7 statements already tagged `research solved` whose docstrings state the cited paper proved exactly the formalized claim:

- `FormalConjectures/GreensOpenProblems/14.lean`: `green_14_lower_bound_green` [Gr21], `green_14_lower_bound_hunter` [Hu22], `green_14_lower_bound_brown_landman_robertson` [BLR08], `green_14_lower_bound_li_shu` [LiSh10], `green_14_upper_bound_schoen` [Sc20], `green_14_upper_bound_kelley_meka` [KeMe23]. Each cited result was checked against the paper; the neighbouring `green_14_quadratic` already uses `answer(False)`.
- `FormalConjectures/Paper/LatinSquare.lean`: `oddOrderLeq9LatinSquareTransversal` (transversals of odd-order Latin squares verified for $n \le 9$).

Deliberate `answer(sorry)` placeholders in solved statements were left untouched: ZFC-independence placeholders (`ErdosProblems/1119.lean`, `1175.lean`, documented in their docstrings), value-form constant placeholders (`ErdosProblems/416.lean`, `975.lean`), and question-form headlines whose concrete answer is recorded in a variant (`ErdosProblems/1007.lean`, `1026.lean`).

- [x] `lake --wfail build 'FormalConjectures.GreensOpenProblems.«14»' FormalConjectures.Paper.LatinSquare` passes with no warnings
- [x] Docstrings unchanged; only the `answer( )` terms edited
