### PR TITLE
Mark three Erdős 357 growth targets as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/357.lean
+++ b/FormalConjectures/ErdosProblems/357.lean
@@ -78,9 +78,12 @@ theorem erdos_357.parts.ii.bigTheta_version :
 /-- Let $f(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 < \dotsc < a_k \le n$
 such that all sums of the shape $\sum_{u \le i \le v} a_i$ are distinct.
 How does $f(n)$ grow? Can we find a (good) explicit function $g$ such that $g = o(f)$ ? -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-357-additional-targets/blob/b60766de669af22303446a7d16563d7b7680ae7e/lean/Erdos357AdditionalTargetsFC.lean#L282-L285"]
 theorem erdos_357.parts.ii.littleO_version :
-    (answer(sorry) : ℕ → ℝ) =o[atTop] (fun n ↦ (f n : ℝ)) := by
+    (answer(fun n : ℕ ↦ Real.log (n : ℝ)) : ℕ → ℝ) =o[atTop]
+      (fun n ↦ (f n : ℝ)) := by
   sorry
 
 /-- Let $f(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 < \dotsc < a_k \le n$
@@ -157,9 +160,12 @@ theorem erdos_357.variants.monotone.parts.i : (fun n ↦ (h n : ℝ)) =o[atTop] 
 /-- Let $h(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 \leq \dotsc \leq a_k \le n$
 such that all sums of the shape $\sum_{u \le i \le v} a_i$ are distinct. How does $h(n)$ grow?
 Can we find a (good) explicit function $g$ such that $g = O(h)$ ? -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-357-additional-targets/blob/b60766de669af22303446a7d16563d7b7680ae7e/lean/Erdos357AdditionalTargetsFC.lean#L287-L290"]
 theorem erdos_357.variants.monotone.parts.ii.bigO_version :
-    (answer(sorry) : ℕ → ℝ) =O[atTop] (fun n ↦ (h n : ℝ)) := by
+    (answer(fun n : ℕ ↦ √(n : ℝ)) : ℕ → ℝ) =O[atTop]
+      (fun n ↦ (h n : ℝ)) := by
   sorry
 
 /-- Let $h(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 \leq \dotsc \leq a_k \le n$
@@ -181,9 +187,12 @@ theorem erdos_357.variants.monotone.parts.ii.bigTheta_version :
 /-- Let $h(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 \leq \dotsc \leq a_k \le n$
 such that all sums of the shape $\sum_{u \le i \le v} a_i$ are distinct. How does $h(n)$ grow?
 Can we find a (good) explicit function $g$ such that $g = o(h)$ ? -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-357-additional-targets/blob/b60766de669af22303446a7d16563d7b7680ae7e/lean/Erdos357AdditionalTargetsFC.lean#L292-L295"]
 theorem erdos_357.variants.monotone.parts.ii.littleO_version :
-    (answer(sorry) : ℕ → ℝ) =o[atTop] (fun n ↦ (h n : ℝ)) := by
+    (answer(fun n : ℕ ↦ Real.log (n : ℝ)) : ℕ → ℝ) =o[atTop]
+      (fun n ↦ (h n : ℝ)) := by
   sorry
 
 /-- Let $h(n)$ be the maximal $k$ such that there exist integers $1 \le a_1 \leq \dotsc \leq a_k \le n$


### PR DESCRIPTION
This PR changes three registered Erdős Problem 357 growth targets from `answer(sorry)` to explicit answers and links kernel-checked Lean proofs:

- `Erdos357.erdos_357.parts.ii.littleO_version`: `n ↦ log n`
- `Erdos357.erdos_357.variants.monotone.parts.ii.bigO_version`: `n ↦ √n`
- `Erdos357.erdos_357.variants.monotone.parts.ii.littleO_version`: `n ↦ log n`

It leaves the central open problems `f(n) = o(n)` and `h(n) = o(n)`, the upper-growth and Big-Theta variants, and the infinite-sequence variants unchanged.

The Lean formalization was prepared by KitaKen1 (Kenta Kitamura).

The external proof establishes the exact target theorems:

    theorem Erdos357.erdos_357.parts.ii.littleO_version_solved :
        (answer(fun n : ℕ ↦ Real.log (n : ℝ)) : ℕ → ℝ) =o[atTop]
          (fun n ↦ (Erdos357.f n : ℝ))

    theorem Erdos357.erdos_357.variants.monotone.parts.ii.bigO_version_solved :
        (answer(fun n : ℕ ↦ √(n : ℝ)) : ℕ → ℝ) =O[atTop]
          (fun n ↦ (Erdos357.h n : ℝ))

    theorem Erdos357.erdos_357.variants.monotone.parts.ii.littleO_version_solved :
        (answer(fun n : ℕ ↦ Real.log (n : ℝ)) : ℕ → ℝ) =o[atTop]
          (fun n ↦ (Erdos357.h n : ℝ))

Proofs:
- strict little-o: https://github.com/KitaKen1/erdos-357-additional-targets/blob/b60766de669af22303446a7d16563d7b7680ae7e/lean/Erdos357AdditionalTargetsFC.lean#L282-L285
- monotone Big-O: https://github.com/KitaKen1/erdos-357-additional-targets/blob/b60766de669af22303446a7d16563d7b7680ae7e/lean/Erdos357AdditionalTargetsFC.lean#L287-L290
- monotone little-o: https://github.com/KitaKen1/erdos-357-additional-targets/blob/b60766de669af22303446a7d16563d7b7680ae7e/lean/Erdos357AdditionalTargetsFC.lean#L292-L295

Repository:
https://github.com/KitaKen1/erdos-357-additional-targets

Lean4Web:
https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-357-additional-targets%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos357AdditionalTargetsLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, using GPT-5.6 sol.