### PR TITLE
fix(ErdosProblems/1093): `k`-smooth means prime factors `≤ k`, not `< k`

### DIFF
--- a/FormalConjectures/ErdosProblems/1093.lean
+++ b/FormalConjectures/ErdosProblems/1093.lean
@@ -27,10 +27,14 @@ namespace Erdos1093
 open Finset Nat
 
 /--
-If defined, the deficiency is the count of $0 \le i < k$ such that $n - i$ is $k$-smooth.
+If defined, the deficiency is the count of $0 \le i < k$ such that $n - i$ is $k$-smooth,
+that is, divisible only by primes $\le k$.
+
+`Nat.smoothNumbers m` is the set of positive naturals all of whose prime factors are
+$< m$, so "$k$-smooth" in the sense above is `Nat.smoothNumbers (k + 1)`.
 -/
 noncomputable def deficiency (n k : ℕ) : ℕ :=
-  #{i ∈ range k | n - i ∈ smoothNumbers k}
+  #{i ∈ range k | n - i ∈ smoothNumbers (k + 1)}
 
 /--
 Are there infinitely many binomial coefficients with deficiency 1?


### PR DESCRIPTION
Fixes #4975.

## What the declaration says now

```lean
noncomputable def deficiency (n k : ℕ) : ℕ :=
  #{i ∈ range k | n - i ∈ smoothNumbers k}
```

## Why that diverges from the source

erdosproblems.com/1093 (read 2026-08-15):

> For $n \geq 2k$ we define the deficiency of $\binom{n}{k}$ as follows. If
> $\binom{n}{k}$ is divisible by a prime $p \leq k$ then the deficiency is
> undefined. Otherwise, **the deficiency is the number of $0 \leq i < k$ such that
> $n-i$ is $k$-smooth, that is, divisible only by primes $\leq k$.**

Mathlib (`Mathlib/NumberTheory/SmoothNumbers.lean`):

```lean
/-- `smoothNumbers n` is the set of *`n`-smooth positive natural numbers*, i.e., the
positive natural numbers all of whose prime factors are less than `n`. -/
def smoothNumbers (n : ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < n}
```

So the docstring said "$k$-smooth" (primes $\le k$) and the code said primes $< k$.
The two readings differ on `m` exactly when `k` is prime and `k \mid m`, which is why
the discrepancy is easy to miss: for composite `k` no `m` separates them.

## Minimal witness that the current form is defective

The problem page lists 23 worked examples. Recomputing all 23 with exact integer
arithmetic (own trial-division factoriser, no CAS):

| | primes `≤ k` (source) | primes `< k` (current Lean) |
|---|---|---|
| catalogue entries reproduced | **23 / 23** | **20 / 23** |

The three that change are exactly the ones with `k` prime:

| $\binom{n}{k}$ | `k` | `k` prime | source | current Lean | separating `n - i` |
|---|---|---|---|---|---|
| $\binom{7}{3}$ | 3 | yes | **1** | **0** | $6 = 2\cdot 3$ |
| $\binom{23}{5}$ | 5 | yes | **1** | **0** | $20 = 2^2\cdot 5$ |
| $\binom{47}{11}$ | 11 | yes | **4** | **3** | $44 = 2^2\cdot 11$ |

All three satisfy the side conditions the two declarations impose, so they are
genuine members of the sets being quantified over: `2 * k ≤ n` holds, and no prime
`p ≤ k` divides the binomial coefficient ($\binom{7}{3} = 35$,
$\binom{23}{5} = 33649$, $\binom{47}{11} = 17417133617$). That side condition is
encoded faithfully as `∀ p, p.Prime → p ∣ choose n k → k < p`; only the threshold
inside `deficiency` diverged.

Consequently two of the page's deficiency-1 examples left the deficiency-1 set of
`erdos_1093.parts.i`, and $\binom{47}{11}$ — the page's only deficiency-4 example —
became a deficiency-3 example, moving it into the set of `.parts.ii`.

Neither open declaration was *false* before this change; they were open questions
about a different function.

## The repair

One token: `smoothNumbers (k + 1)` unfolds to
`{m | m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < k + 1}`, i.e. exactly "all prime factors
`≤ k`". Under it all 23 catalogue entries reproduce the deficiency the page states.

The docstring now also carries the source's clarifying clause ("divisible only by
primes $\le k$") plus one sentence naming the `< m` convention of
`Nat.smoothNumbers`, so the next reader does not have to rediscover the off-by-one.

For context rather than blame: the first commit of the introducing PR #1328 defined
the predicate by hand and correctly —

```lean
/-- A number $n$ is $k$-smooth if all its prime factors are $\le k$. -/
def IsKSmooth (k n : ℕ) : Prop := ∀ p, p.Prime → p ∣ n → p ≤ k
```

— and it was replaced by `smoothNumbers k` in response to a review suggestion to
reuse Mathlib. The `≤`/`<` difference does not appear to have been raised in that
thread, and the two later fixes to this file (#1489, #1532) did not touch it.

## What I verified, and what I did not

Verified:

- The file elaborates with no diagnostics under
  `lean -DwarningAsError=true` with the option set the `FormalConjectures` library
  uses in `lakefile.toml` (`autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and the `ams_attribute`, `category_attribute`,
  `conditional_formal_proof`, `moduleDocstring`, `latex_docstring`, `namespace`,
  `openClassical`, `copyright` linters). I confirmed those linters are actually
  live in that configuration with two negative controls (reordering the `AMS` tags
  and deleting the `category` attribute both fail as expected).
- The same run with `-Dgoogle.answer=postpone` is also clean.
- Both declarations still end in `sorry` and remain open; nothing became provable
  or trivial.
- The 23-entry recomputation above, under both thresholds.

Not verified: I did **not** run `lake build` on this machine, so I have not
exercised the full build (imports of downstream modules, the `test` driver, or
`decide`-based elaboration elsewhere). CI is the authoritative check.

## Deliberately not in this diff

A `test` lemma pinning e.g. `deficiency 7 3 = 1` would catch this shape of error
directly, but `deficiency` is `noncomputable` (membership in a `Set ℕ`), so such a
lemma needs `deficiency` restructured around a decidable predicate. That is a
larger change than this fix and belongs in its own PR.

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic) for the source
check, the recomputation of the catalogue, and drafting. The submitter reviewed the
declaration, the source text, the computation and the diff, and takes
responsibility for the submission.
