### PR TITLE
fix(OEIS/237271): `observation_carmichael` should quantify over Carmichael numbers

### DIFF
--- a/FormalConjectures/OEIS/237271.lean
+++ b/FormalConjectures/OEIS/237271.lean
@@ -182,11 +182,12 @@ Observation: "a(A002997(n)) >= 3, at least for 1 <= n <= 10000."
 - _Omar E. Pol_, Oct 21 2025
 
 That is, $a(k) \ge 3$ for every Carmichael number $k$.
-A002997 is the sequence of Carmichael numbers.
+A002997 is the sequence of Carmichael numbers: the composite numbers $k$ such that
+$b^{k-1} \equiv 1 \pmod k$ for every $b$ coprime to $k$. This is `IsCarmichael`,
+which also forces $k$ to be composite.
 -/
 @[category research open, AMS 11]
-theorem observation_carmichael (k : ℕ)
-    (hk : ¬ k.Prime ∧ 1 < k ∧ ∀ a : ZMod k, a ≠ 0 → a ^ (k - 1) = 1) :
+theorem observation_carmichael (k : ℕ) (hk : IsCarmichael k) :
     3 ≤ a k := by
   sorry
 


### PR DESCRIPTION
Fixes #4974.

## What the declaration says now

```lean
@[category research open, AMS 11]
theorem observation_carmichael (k : ℕ)
    (hk : ¬ k.Prime ∧ 1 < k ∧ ∀ a : ZMod k, a ≠ 0 → a ^ (k - 1) = 1) :
    3 ≤ a k := by
  sorry
```

The Fermat condition is quantified over **every nonzero** `a : ZMod k`.

## Why that diverges from the source

A002997 (`%N` line, oeis.org/A002997, read 2026-08-15):

> Carmichael numbers: composite numbers `k` such that `a^(k-1) == 1 (mod k)` for
> every `a` **coprime to `k`**.

The declaration's own docstring says the same thing ("$a(k) \ge 3$ for every
Carmichael number $k$. A002997 is the sequence of Carmichael numbers"), so this is
the case AGENTS.md decides against the Lean: the docstring quotes the source, the
Lean disagrees with the docstring, and the Lean is what is incorrect.

Over `ZMod k`, "coprime to `k`" is "is a unit". For composite `k` the nonzero
non-units are precisely what separates the two readings.

## Minimal witness that the current form is defective

The hypothesis has **no models at all**: it is unsatisfiable for every `k`, so the
declaration is vacuously true and closable without using any property of `a`. Here
is the proof, machine-checked against this repository's toolchain:

```lean
theorem old_hyp_unsatisfiable (k : ℕ)
    (hk : ¬ k.Prime ∧ 1 < k ∧ ∀ a : ZMod k, a ≠ 0 → a ^ (k - 1) = 1) : False := by
  obtain ⟨hnp, h1k, hfermat⟩ := hk
  obtain ⟨p, hp, hpk⟩ := Nat.exists_prime_and_dvd (by omega : k ≠ 1)
  obtain ⟨m, rfl⟩ := hpk
  have hm0 : m ≠ 0 := by rintro rfl; simp at h1k
  have hp1 : 1 < p := hp.one_lt
  have hm1 : 1 < m := by
    rcases Nat.lt_or_ge m 2 with h | h
    · interval_cases m
      · omega
      · simp at hnp; exact absurd hp hnp
    · omega
  have hplt : p < p * m := by nlinarith
  have hmlt : m < p * m := by nlinarith
  have hpne : (p : ZMod (p * m)) ≠ 0 := by
    rw [Ne, ZMod.natCast_eq_zero_iff]
    exact fun h => absurd (Nat.le_of_dvd (by positivity) h) (by omega)
  have hmne : (m : ZMod (p * m)) ≠ 0 := by
    rw [Ne, ZMod.natCast_eq_zero_iff]
    exact fun h => absurd (Nat.le_of_dvd (by omega) h) (by omega)
  have hpow := hfermat (p : ZMod (p * m)) hpne
  have hk1 : p * m - 1 = (p * m - 2) + 1 := by omega
  rw [hk1, pow_succ] at hpow
  have hzero : (p : ZMod (p * m)) * (m : ZMod (p * m)) = 0 := by
    rw [← Nat.cast_mul, ZMod.natCast_self]
  apply hmne
  calc (m : ZMod (p * m))
      = ((p : ZMod (p * m)) ^ (p * m - 2) * (p : ZMod (p * m))) * m := by rw [hpow, one_mul]
    _ = (p : ZMod (p * m)) ^ (p * m - 2) * ((p : ZMod (p * m)) * m) := by ring
    _ = 0 := by rw [hzero, mul_zero]

#print axioms old_hyp_unsatisfiable
-- 'old_hyp_unsatisfiable' depends on axioms: [propext, Classical.choice, Quot.sound]
```

In words: `1 < k` and `¬ k.Prime` give a factorisation `k = p * m` with `p` prime
and `1 < p, m < k`. Then `(p : ZMod k) ≠ 0`, so the hypothesis makes `p` a unit;
but `p * m = k = 0` in `ZMod k` with `(m : ZMod k) ≠ 0`, so `p` is a zero divisor.
Multiplying by the inverse gives `(m : ZMod k) = 0`, a contradiction.

Concretely, the hypothesis excludes exactly the numbers the observation is about.
Independently computed premise-falsifying witnesses on the first Carmichael
numbers — in each row `a ≠ 0` in `ZMod k` but `a ^ (k-1) ≠ 1`:

| k | a | a^(k-1) mod k |
|---|---|---|
| 561 | 3 | 375 |
| 1105 | 5 | 885 |
| 1729 | 7 | 742 |
| 2465 | 5 | 1480 |
| 2821 | 7 | 2016 |

and no `k ≤ 20000` satisfies the hypothesis.

## The repair

This repository already has the right predicate, in
`FormalConjecturesForMathlib/NumberTheory/Carmichael.lean`:

```lean
def IsCarmichael (n : ℕ) : Prop :=
  ∀ b ≥ 1, n.Coprime b → n.FermatPsp b
```

which is `∀ b ≥ 1` coprime to `n`, `n ∣ b^(n-1) - 1` together with
`¬ n.Prime ∧ 1 < n` (the latter two come from `Nat.FermatPsp`, and are forced
already by `b = 1`) — i.e. exactly A002997. So the fix is

```lean
theorem observation_carmichael (k : ℕ) (hk : IsCarmichael k) : 3 ≤ a k
```

with no new import: `FormalConjecturesUtil` already re-exports
`FormalConjecturesForMathlib`. `ErdosProblems/1057.lean` uses `IsCarmichael` the
same way, and `FormalConjectures/Wikipedia/AgohGiuga.lean` contains
`isCarmichael_561 : IsCarmichael 561`, so the repaired hypothesis is one the
repository already knows to be satisfiable — the point on which the old one failed.

The docstring gains one sentence spelling out A002997's condition, so a reader can
check the Lean against the source without leaving the file.

**Alternative considered.** Issue #4974 suggested keeping the inline form and
writing `∀ a : ZMod k, IsUnit a → a ^ (k - 1) = 1` (or `Nat.Coprime a k → a ^ (k-1)
≡ 1 [MOD k]`). That is mathematically equivalent, but AGENTS.md says to search for
an existing definition before writing one, and the inline version would leave two
spellings of "Carmichael number" in the corpus that no lemma connects. I chose the
existing `IsCarmichael`.

**The underlying observation is not touched.** Omar E. Pol's comment
("Observation : a(A002997(n)) >= 3, at least for 1 <= n <= 10000", A237271, Oct 21
2025) is unaffected: on the nine Carmichael numbers `k ≤ 20000` the values of `a`
are `5, 6, 4, 6, 6, 6, 7, 7, 8`, minimum `4 ≥ 3`. The `a` encoding in this file is
also faithful — it agrees with the A237271 b-file for every `n ≤ 2000`. The defect
was confined to the hypothesis.

## What I verified, and what I did not

Verified:

- The file elaborates with no diagnostics under `lean -DwarningAsError=true` with
  the option set the `FormalConjectures` library uses in `lakefile.toml`
  (`autoImplicit=false`, `relaxedAutoImplicit=false`, `warn.sorry=false`, and the
  `ams_attribute`, `category_attribute`, `conditional_formal_proof`,
  `moduleDocstring`, `latex_docstring`, `namespace`, `openClassical` linters). I
  confirmed those linters are live in that configuration with two negative controls
  (reordering `AMS` tags and deleting a `category` attribute both fail as expected).
- The same run with `-Dgoogle.answer=postpone` is also clean.
- `observation_carmichael` still ends in `sorry` and remains open; the vacuity route
  is gone because `IsCarmichael` has models.
- `old_hyp_unsatisfiable` above, `#print axioms` = `[propext, Classical.choice,
  Quot.sound]`.

Not verified: I did **not** run `lake build`, so the full build (downstream modules
and the test driver) has not been exercised on my side; and I did not run
`#print axioms isCarmichael_561`, because that module's olean was not available in
my environment — I cite it as an existing declaration, not as a checked proof. CI
is the authoritative check.

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic) for the source
check, the independent recomputation, the Lean proof above, and drafting. The
submitter reviewed the declaration, the source text, the argument and the diff, and
takes responsibility for the submission.
