### PR TITLE
fix(ErdosProblems/1055): `IsOfClass` must exclude lower classes (`p 2 = 13`, not `2`)

### DIFF
--- a/FormalConjectures/ErdosProblems/1055.lean
+++ b/FormalConjectures/ErdosProblems/1055.lean
@@ -26,11 +26,18 @@ namespace Erdos1055
 
 /-- A prime $p$ is in class $1$ if the only prime divisors of $p+1$ are
 $2$ or $3$. In general, a prime $p$ is in class $r$ if every prime factor
-of $p+1$ is in some class $\leq r-1$, with equality for at least one prime factor. -/
+of $p+1$ is in some class $\leq r-1$, with equality for at least one prime factor.
+
+The classes partition the primes, so `IsOfClass r p` says that $p$ is in class
+*exactly* $r$: the first conjunct of the successor case rules out every class
+$\leq r - 1$ for $p$ itself. Without it `IsOfClass 2` would also hold of every
+prime of class $1$, because at $r = 2$ the "with equality" clause quantifies over
+the single value $m = 1$ and so says nothing. -/
 def IsOfClass : ℕ+ → ℕ → Prop := fun r ↦
   PNat.caseStrongInductionOn (p := fun (_ : ℕ+) ↦ ℕ → Prop) r
     (fun p ↦ (p + 1).primeFactors ⊆ {2, 3})
     (fun n H p ↦
+      (∀ (m : ℕ+) (hm : m ≤ n), ¬ H m hm p) ∧
       (∀ r ∈ (p + 1).primeFactors,
         ∃ (m : ℕ+) (hm : m ≤ n), H m hm r) ∧
       (∃ r ∈ (p + 1).primeFactors,


### PR DESCRIPTION
Fixes #4976.

## What the declaration says now

```lean
def IsOfClass : ℕ+ → ℕ → Prop := fun r ↦
  PNat.caseStrongInductionOn (p := fun (_ : ℕ+) ↦ ℕ → Prop) r
    (fun p ↦ (p + 1).primeFactors ⊆ {2, 3})
    (fun n H p ↦
      (∀ r ∈ (p + 1).primeFactors,
        ∃ (m : ℕ+) (hm : m ≤ n), H m hm r) ∧
      (∃ r ∈ (p + 1).primeFactors,
        ∀ (m : ℕ+) (hm : m ≤ n), H m hm r → m = n))
```

## Why that diverges from the source

erdosproblems.com/1055 (read 2026-08-15):

> A prime $p$ is in class $1$ if the only prime divisors of $p+1$ are $2$ or $3$.
> In general, a prime $p$ is in class $r$ if every prime factor of $p+1$ is in some
> class $\leq r-1$, with equality for at least one prime factor. … The sequence
> $p_r$ begins $2,13,37,73,1021$ (A005113 in the OEIS).

OEIS A005113 ("Smallest prime in class n … according to the Erdős–Selfridge
classification of primes") spells the recursion out:

> A prime p is in class 1 if (p+1)'s largest prime factor is 2 or 3. If (p+1) has
> other prime factors, p's class is one more than the largest class of its prime
> factors.

Both readings make the classes a **partition** of the primes: each prime is in
exactly one class. The Lean predicate never says so. Its successor case constrains
only the prime factors of `p + 1`; it never excludes `p` itself from a lower class.

## Minimal witness that the current form is defective

At `n = 1` the "with equality for at least one prime factor" clause is vacuous: the
bound variable `m : ℕ+` with `m ≤ 1` ranges over the single value `m = 1`, so
`H 1 _ r → 1 = 1` is trivially true and the conjunct degenerates to
`(p + 1).primeFactors.Nonempty`. So at `r = 2` the clause that is supposed to pin
the class down asserts nothing.

Take `p = 2`:

- `IsOfClass 1 2` holds: `(2+1).primeFactors = {3} ⊆ {2,3}`, so `2` is in class 1;
- `IsOfClass 2 2` **also** holds: the only prime factor of `3` is `3`, and
  `IsOfClass 1 3` holds (`(3+1).primeFactors = {2} ⊆ {2,3}`), which gives the first
  conjunct; the second conjunct is the vacuous one above.

Since `2` is prime and `Erdos1055.p r = Nat.find (exists_p r)`, this gives
`Erdos1055.p 2 = 2`, whereas A005113 begins `2, 13, 37, 73, 1021`, i.e. `p₂ = 13`.

The defect is confined to `r = 2`. For `r ≥ 3` the equality clause is non-vacuous
and, because `IsOfClass 2` behaves as "class `≤ 2`", it does force class exactly
`n`; `r = 1, 3, 4, 5` already reproduce A005113. Over the primes `< 500` the primes
where `IsOfClass 2` disagrees with "class exactly 2" are

```
2, 3, 5, 7, 11, 17, 23, 31, 47, 53, 71, 107, 127, 191, 383, 431
```

— precisely the class-1 primes, all in the "Lean-true / intended-false" direction.

No declaration in the file becomes false: `erdos_1055` reads at `r = 2` as the
weaker "infinitely many primes of class ≤ 2", still open, and the two limit
variants are asymptotic in `r`, so a single perturbed term does not change them.
The material consequence is the value of `p 2`.

## The repair

One conjunct: require `p` itself to be in no class `≤ n`.

```lean
    (fun n H p ↦
      (∀ (m : ℕ+) (hm : m ≤ n), ¬ H m hm p) ∧
      (∀ r ∈ (p + 1).primeFactors,
        ∃ (m : ℕ+) (hm : m ≤ n), H m hm r) ∧
      (∃ r ∈ (p + 1).primeFactors,
        ∀ (m : ℕ+) (hm : m ≤ n), H m hm r → m = n))
```

With it, `IsOfClass r p` holds iff the source's class of `p` is exactly `r`. By
induction on `n`: the base case is unchanged; in the successor case the second and
third conjuncts say `max { class q : q ∣ p+1 prime } = n`, and the new first
conjunct rules out the one case the recursion could not see for itself, namely `n =
1` with `p + 1` being `{2,3}`-smooth. (For `n ≥ 2` the new conjunct is implied by
the others, since a prime factor of class exactly `n ≥ 2` is neither `2` nor `3`.)

The `IsOfClass` docstring gains a sentence recording that the classes are exclusive
and why the extra conjunct is load-bearing; the other four docstrings, which quote
the source verbatim, are untouched.

`exists_p` (`category textbook`) now asserts the source's actual exercise — "for
each `r` there exists a prime `p` of class `r`", with class exactly `r` — and
remains `sorry`.

**Alternative considered.** Adding `¬ ((p + 1).primeFactors ⊆ {2, 3})` instead
would also be sufficient (it is the only case the recursion misses), and is a
smaller conjunct. I chose against it: it fixes the symptom at `n = 1` rather than
stating the property that makes the definition correct, and a reader would have to
redo the "for `n ≥ 2` it is implied" argument to see why one exclusion suffices.
The form above is the definition of an exact class, and is the one the issue asked
for.

## What I verified, and what I did not

Verified:

- The file elaborates with no diagnostics under `lean -DwarningAsError=true` with
  the option set the `FormalConjectures` library uses in `lakefile.toml`
  (`autoImplicit=false`, `relaxedAutoImplicit=false`, `warn.sorry=false`, and the
  `ams_attribute`, `category_attribute`, `conditional_formal_proof`,
  `moduleDocstring`, `latex_docstring`, `namespace`, `openClassical` linters), with
  two negative controls confirming those linters are live in that configuration.
  The same run with `-Dgoogle.answer=postpone` is also clean.
- All four declarations still end in `sorry`; nothing became provable or trivial.
- Semantics: I transcribed the defining equations of `PNat.caseStrongInductionOn`
  for both the current and the repaired definition into an independent
  implementation, and compared them against the sources' class function (class 1 if
  `p+1` is `{2,3}`-smooth, else `1 + max` class over the prime factors of `p+1`),
  computed separately:

  | r | A005113 | class exactly r | current Lean | repaired Lean |
  |---|---|---|---|---|
  | 1 | 2 | 2 | 2 | 2 |
  | 2 | **13** | **13** | **2** | **13** |
  | 3 | 37 | 37 | 37 | 37 |
  | 4 | 73 | 73 | 73 | 73 |
  | 5 | 1021 | 1021 | 1021 | 1021 |
  | 6 | 2917 | 2917 | 2917 | 2917 |

  Over every prime `< 200000` and every `r ∈ {1,…,7}`: the current definition
  disagrees with "class exactly `r`" on 35 `(p, r)` pairs (all at `r = 2`, all
  class-1 primes); the repaired definition disagrees on **0**.

Not verified: this semantic check is a transcription, not a Lean evaluation. I
could not evaluate `IsOfClass` inside Lean because `PNat.caseStrongInductionOn` is
well-founded recursion: `IsOfClass 1 2` is not definitionally
`(3 : ℕ).primeFactors ⊆ {2, 3}`, and the file provides no unfolding lemmas, so even
the base case cannot be discharged by `rfl` or `simp`. I also did **not** run
`lake build`. CI is the authoritative check.

## Deliberately not in this diff

Two follow-ups that this file would benefit from, left out to keep the change to
one conjunct:

- unfolding lemmas `IsOfClass 1 p ↔ …` and `IsOfClass (n+1) p ↔ …`, without which
  the definition cannot be used in a proof at all;
- a `test` lemma pinning `p 2 = 13` against A005113, which would catch exactly this
  shape of error. It needs the unfolding lemmas above, and `p` is `noncomputable`
  (`Nat.find` under `open scoped Classical`), so it is not a one-liner.

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic) for the source
check, the independent recomputation, and drafting. The submitter reviewed the
definition, the source text, the recursion argument and the diff, and takes
responsibility for the submission.
