### PR TITLE
fix(ErdosProblems/33): state `variants.one_mem_lowerBounds` as the lower bound its name describes

### DIFF
--- a/FormalConjectures/ErdosProblems/33.lean
+++ b/FormalConjectures/ErdosProblems/33.lean
@@ -44,11 +44,14 @@ theorem erdos_33 : ⨅ A : {A : Set ℕ | AdditiveBasisCondition A}, Filter.atTo
   sorry
 
 /--
-Erdos observed that this value is finite and > 1.
+Erdos observed that this value is finite and > 1. This records the lower bound `> 1`,
+i.e. that `1` is a strict lower bound for every admissible `A`; the finiteness is
+`erdos_33.variants.vanDoorn`.
 -/
 @[category research solved, AMS 11]
-theorem erdos_33.variants.one_mem_lowerBounds : ∃ A, AdditiveBasisCondition A ∧
-    1 < Filter.atTop.limsup (fun N => (A ∩ Icc 1 N).ncard / √N) := by
+theorem erdos_33.variants.one_mem_lowerBounds :
+    1 < ⨅ A : {A : Set ℕ | AdditiveBasisCondition A}, Filter.atTop.limsup (fun N =>
+      (A.1 ∩ Icc 1 N).ncard / (√N : EReal)) := by
   sorry
 
 /--


### PR DESCRIPTION
Fixes #4978.

## What the declaration says now

```lean
/--
Erdos observed that this value is finite and > 1.
-/
@[category research solved, AMS 11]
theorem erdos_33.variants.one_mem_lowerBounds : ∃ A, AdditiveBasisCondition A ∧
    1 < Filter.atTop.limsup (fun N => (A ∩ Icc 1 N).ncard / √N) := by
  sorry
```

An existential over one `A`, with the `limsup` taken in `ℝ`.

## Why this diverges from the name, the docstring and the file

[erdosproblems.com/33](https://www.erdosproblems.com/33) (OPEN, last edited 27 December 2025)
asks *"What is the smallest possible value of $\limsup \lvert A\cap\{1,\ldots,N\}\rvert/N^{1/2}$?"*
and remarks:

> Erdős observed that there exist $A$ for which the $\limsup$ is finite and $>1$. Moser [Mo65]
> proved that, for any such $A$, $\liminf \lvert A\cap\{1,\ldots,N\}\rvert/N^{1/2}>1.06$.

The docstring renders this as "this value is finite and > 1". *This value* is the smallest
possible value that `erdos_33` asks for, i.e. the `⨅` written in the two neighbouring
declarations. The declaration name says `1 ∈ lowerBounds`. Both describe a claim about the
infimum — a claim about **every** admissible `A`. The statement is about **one** `A` and never
mentions the infimum.

## Provenance: this was a lower bound, and the change was incidental to a typing fix

* #631 (original): `1 ∈ lowerBounds { c : ℝ | ∃ (A : Set ℕ), AdditiveBasisCondition A ∧
  Filter.atTop.limsup (fun N => (Set.bdd A N).card / √N) = c}` — the lower-bound form the name
  still refers to.
* #1206 *"fix: typing in `erdos_33`"* moved `erdos_33` and `variants.vanDoorn` from `ℝ` to
  `EReal`, for the reason given in its own commit message: *"if `limsup` is infinite, then it
  gets the junk `0` value in `Real`"*. In the same commit `one_mem_lowerBounds` was rewritten to
  `∃ A, AdditiveBasisCondition A → 1 < limsup …` (*"Can avoid some unnecessary casting … by not
  using `lowerBounds`"*) and left in `ℝ`.
* #2226 replaced that `→` by `∧`, i.e. repaired the `∃ x, P x → Q` pattern that AGENTS.md and
  this repository's `ExistsImplicationLinter` flag, and kept the existential and the `ℝ`-valued
  `limsup`.

So the two declarations on either side were repaired against the junk-value problem, and this
one was replaced by a different statement instead of being cast.

## Why the current form is defective

1. **It is not the claim its name and its docstring make.** Nothing about the infimum, and
   nothing about all `A`, is asserted.
2. **What content it does have rides on a junk value.** In `ℝ`,
   `Filter.limsup u f = sInf {a | ∀ᶠ n in f, u n ≤ a}` and `Real.sInf_empty : sInf ∅ = 0`.
   So `1 < limsup u` silently doubles as "`u` is eventually bounded above": the *finite* half of
   the docstring is carried only by `sInf ∅ = 0`. That is exactly the situation #1206 moved the
   neighbouring declarations to `EReal` to avoid.

## Correction to the issue I filed

#4978 offers `A = ℕ` as a trivial witness, on the grounds that `limsup (N/√N) = ⊤`. **That is
wrong for this declaration**, and I have posted the correction on the issue. The `limsup` here
elaborates in `ℝ`, not `EReal`, so for `A = ℕ` the ratio `√N` is unbounded, the set is empty,
`sInf ∅ = 0`, and `1 < 0` fails. Machine-checked, no `sorry`
(`#print axioms` gives `[propext, Classical.choice, Quot.sound]`):

```lean
-- the limsup in the current declaration really is ℝ-valued
example : (fun (A : Set ℕ) => Filter.atTop.limsup (fun N => (A ∩ Icc 1 N).ncard / √N)) =
    (fun (A : Set ℕ) => Filter.atTop.limsup (fun N => ((A ∩ Icc 1 N).ncard : ℝ) / √(N : ℝ))) := rfl

theorem lt_limsup_nonempty (u : ℕ → ℝ) (h : (1 : ℝ) < Filter.atTop.limsup u) :
    {a : ℝ | ∀ᶠ n in Filter.atTop, u n ≤ a}.Nonempty := by
  by_contra hc
  rw [Set.not_nonempty_iff_eq_empty] at hc
  rw [Filter.limsup_eq, hc, Real.sInf_empty] at h
  linarith

theorem univ_not_witness :
    ¬ ((1 : ℝ) < Filter.atTop.limsup
      (fun N : ℕ => (((Set.univ : Set ℕ) ∩ Icc 1 N).ncard : ℝ) / √(N : ℝ))) := by
  intro h
  obtain ⟨a, ha⟩ := lt_limsup_nonempty _ h
  simp only [Set.mem_setOf_eq] at ha
  have hgo : Filter.Tendsto (fun N : ℕ => √(N : ℝ)) Filter.atTop Filter.atTop :=
    Real.tendsto_sqrt_atTop.comp tendsto_natCast_atTop_atTop
  have hbig : ∀ᶠ N : ℕ in Filter.atTop, a < √(N : ℝ) := hgo.eventually_gt_atTop a
  obtain ⟨N, hN1, hN2⟩ := ((ha.and hbig).and (Filter.eventually_gt_atTop 0)).exists
  obtain ⟨hle, hlt⟩ := hN1
  rw [univ_ratio, Real.div_sqrt] at hle
  linarith
```

So the present statement is **not** trivially true. The name/docstring mismatch and the
dependence on `sInf ∅ = 0` are what this PR fixes.

## The repair

```lean
theorem erdos_33.variants.one_mem_lowerBounds :
    1 < ⨅ A : {A : Set ℕ | AdditiveBasisCondition A}, Filter.atTop.limsup (fun N =>
      (A.1 ∩ Icc 1 N).ncard / (√N : EReal)) := by
  sorry
```

The `⨅` expression is copied character for character from `erdos_33` in the same file (and is
the same object `variants.vanDoorn` bounds above), so the three declarations now speak about one
quantity: `erdos_33` asks for its value, this one bounds it below by `1`, `vanDoorn` bounds it
above by `2φ^{5/2}`.

* It stays `research solved`: Moser [Mo65] gives `liminf > 1.06` for every admissible `A`, and
  `liminf ≤ limsup` (`atTop` on `ℕ` is `NeBot`), so every term of the `⨅` exceeds `1.06` and the
  infimum is `≥ 1.06 > 1`.
* The junk direction is now safe: in `EReal` an unbounded ratio gives `⊤`, which can only raise
  an infimum, so no degenerate `A` can make the statement true for the wrong reason. The subtype
  is nonempty (`A = ℕ` satisfies `AdditiveBasisCondition`), so the `⨅` is not the empty-infimum
  junk `⊤` either.
* It remains `sorry`; nothing here is proved.

The docstring gains one sentence saying that this declaration records the `> 1` half and that
the finiteness half is `variants.vanDoorn` (`⨅ … ≤ 2φ^{5/2}`), so docstring and statement agree.

## The other reading of the source, stated plainly

The source sentence is grammatically existential: *"there exist $A$ for which the $\limsup$ is
finite and $>1$"*. If maintainers prefer that reading, the fix is a **rename** rather than a
restatement: keep `∃ A, AdditiveBasisCondition A ∧ …`, rename to something like
`exists_limsup_finite_and_gt_one`, and still move it to `EReal` with an explicit `< ⊤` conjunct
so that *finite* is asserted rather than inherited from `sInf ∅ = 0`. I chose the lower-bound
reading because it is what the name, the docstring and the original #631 statement all encode,
and because the surrounding text on the source page — Moser's `> 1.06` and *"The best-known
lower bound is … ≥ 4/π"* — is about bounds valid for every `A`. I am happy to switch to the
rename instead if you read it the other way; say the word and I will push it.

## Verification

* `lean -DwarningAsError=true FormalConjectures/ErdosProblems/33.lean`, elaborated against this
  repository's already-built `FormalConjecturesUtil` oleans, with the lakefile's options passed
  explicitly: `pp.unicode.fun=true`, `autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and `linter.style.{copyright.formalConjectures, namespace, openClassical,
  ams_attribute, category_attribute, conditional_formal_proof, moduleDocstring,
  latex_docstring}=true`. No errors, no warnings. Repeated with `google.answer=postpone` (the
  `FormalConjecturesAnswerPostpone` library's option): also clean.
* I did **not** run `lake build`. So I have not exercised the lake targets themselves, nor any
  module downstream of this one, nor the full linter set as CI configures it. **CI is the
  authoritative check.**
* The block quoted under "Correction to the issue" was elaborated in the same way and
  `#print axioms` reports `[propext, Classical.choice, Quot.sound]` on each of its theorems —
  no `sorryAx`. It is not part of this diff.

## AI assistance disclosure

Prepared with AI assistance (Claude, Anthropic) for the source audit, the Lean checks and the
drafting. I reviewed the source page, the statement, the provenance and the repair, and I take
responsibility for this submission.
