### PR TITLE
fix(ErdosProblems/15): state conditional convergence, not `Summable`

### DIFF
--- a/FormalConjectures/ErdosProblems/15.lean
+++ b/FormalConjectures/ErdosProblems/15.lean
@@ -32,10 +32,15 @@ where $p_n$ is the sequence of primes?
 
 Note: In the problem statement, $p_n$ is the $n$-th prime, indexed such that $p_1=2, p_2=3, \ldots$.
 We 0-index here to reflect how Nat.nth works.
+
+Note: convergence here is convergence of the sequence of partial sums, which is what the
+problem asks about. `Summable` would be the wrong notion: it is unconditional summability,
+equivalent over $\mathbb{R}$ to absolute convergence, and $\sum_n n/p_n$ diverges.
 -/
 @[category research open, AMS 11]
 theorem erdos_15 : answer(sorry) ↔
-    Summable (fun k : ℕ => (-1 : ℚ) ^ (k + 1) * (k + 1) / (k.nth Nat.Prime)) := by
+    ∃ l : ℝ, Tendsto (fun N => ∑ k ∈ Finset.range N,
+      (-1 : ℝ) ^ (k + 1) * (k + 1) / (k.nth Nat.Prime)) atTop (𝓝 l) := by
   sorry
 
 


### PR DESCRIPTION
Fixes #4979.

## What the declaration says now

```lean
@[category research open, AMS 11]
theorem erdos_15 : answer(sorry) ↔
    Summable (fun k : ℕ => (-1 : ℚ) ^ (k + 1) * (k + 1) / (k.nth Nat.Prime)) := by
  sorry
```

## Why this diverges from the source

[erdosproblems.com/15](https://www.erdosproblems.com/15) (OPEN) asks:

> Is it true that $\sum_{n=1}^\infty(-1)^n\frac{n}{p_n}$ converges, where $p_n$ is the sequence
> of primes?

and records

> Tao [Ta23] has proved that this series does converge assuming a strong form of the
> Hardy-Littlewood prime tuples conjecture.

"Converges" here is convergence of the sequence of partial sums — Erdős's series is alternating
and is not claimed to converge absolutely; Tao's conditional theorem is about the same partial
sums.

Mathlib's `Summable f` is `∃ a, HasSum f a`, and `HasSum` is convergence of the net of
**finite-subset** partial sums, i.e. *unconditional* summability. Over `ℝ` — a finite-dimensional
normed space — unconditional is equivalent to absolute (`Real.summable_abs_iff`). So the current
right-hand side is not the source's question; it is the strictly stronger absolute-convergence
question, which is settled and false.

## Witness that the current form is defective

`Summable` of the stated `ℚ`-valued function is **provably false**, so the current declaration's
`answer` is `False` for reasons that have nothing to do with Erdős's problem:

1. `ℚ ↪ ℝ` is a continuous additive monoid homomorphism, so `HasSum f a` in `ℚ` pushes forward to
   `HasSum f (a : ℝ)` in `ℝ`. (The `ℚ` codomain only makes the statement stronger: it also
   demands that the sum be rational.)
2. In `ℝ`, `Summable.abs` turns `Summable f` into `Summable (fun k => |f k|)`, i.e. convergence
   of $\sum_{n\geq 1} n/p_n$.
3. That series diverges. `p_n ≤ n(log n + log log n)` for `n ≥ 6` (Rosser–Schoenfeld) gives
   `n/p_n ≥ 1/(log n + log log n)`, and $\sum 1/\log n$ diverges. No deep input is needed; the
   prime number theorem's `p_n ∼ n log n` gives the same conclusion.

Steps 1 and 2 are machine-checked; `#print axioms` gives `[propext, Classical.choice, Quot.sound]`
on both, no `sorryAx`:

```lean
theorem summable_rat_to_real (f : ℕ → ℚ) (h : Summable f) :
    Summable (fun k => (f k : ℝ)) :=
  (h.hasSum.map (Rat.castHom ℝ).toAddMonoidHom Rat.continuous_coe_real).summable

theorem reduce (h : Summable (fun k : ℕ => (-1 : ℚ) ^ (k + 1) * (k + 1) / (k.nth Nat.Prime))) :
    Summable (fun k : ℕ => ((k : ℝ) + 1) / (k.nth Nat.Prime)) := by
  have h2 := (summable_rat_to_real _ h).abs
  refine h2.congr fun k => ?_
  push_cast
  rw [abs_div, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul]
  rw [abs_of_nonneg (by positivity : (0 : ℝ) ≤ (k : ℝ) + 1),
    abs_of_nonneg (by positivity : (0 : ℝ) ≤ ((k.nth Nat.Prime : ℕ) : ℝ))]
```

That is: the current right-hand side implies convergence of $\sum_{n\geq 1} n/p_n$, which is step
3's divergent series. Only step 3 is left as a pen-and-paper argument.

So the declaration answers a question the source does not ask, and answers it negatively, while
the question the source does ask is open.

## The repair

```lean
theorem erdos_15 : answer(sorry) ↔
    ∃ l : ℝ, Tendsto (fun N => ∑ k ∈ Finset.range N,
      (-1 : ℝ) ^ (k + 1) * (k + 1) / (k.nth Nat.Prime)) atTop (𝓝 l) := by
  sorry
```

* **Partial sums, not `Summable`.** `∃ l, Tendsto (partial sums) atTop (𝓝 l)` is convergence of
  $\sum_{n\leq N}(-1)^n n/p_n$ as `N → ∞`, which is exactly what the source asks. The
  declaration stays an open `answer(sorry) ↔ …` and stays `sorry`.
* **`ℝ`, not `ℚ`.** The partial sums are rational, but their limit need not be; asking for a
  rational limit would be a different (and much stronger) question. `Tendsto`, `atTop` and `𝓝`
  are already available — the file opens `Filter Topology`.
* **Index and sign bookkeeping unchanged.** With the file's stated 0-indexing,
  `(-1)^(k+1) * (k+1) / Nat.nth Nat.Prime k` at `k = n-1` is `(-1)^n · n / p_n`; at `k = 0` it is
  `-1/2 = (-1)^1·1/p_1`. `Nat.nth Nat.Prime k ≥ 2`, so no division by zero and no junk value.
* **Still open.** The terms `n/p_n` are not monotone, so the alternating series test does not
  apply, and the argument that kills the `Summable` form (absolute divergence) says nothing
  about the partial sums. The source records Tao's proof as conditional on a strong form of the
  Hardy–Littlewood prime tuples conjecture. I did not attempt to prove or disprove the repaired
  right-hand side, and I make no claim that no Mathlib lemma settles it — only that no argument
  I am aware of does, and that the source lists the problem as open.
* I added a `Note:` to the docstring recording why `Summable` is not used, so the next reader
  does not re-introduce it.

For contrast, the neighbouring files use `Summable` correctly, on positive-term series (Erdős 3
`¬ Summable (1/a)`, Erdős 12 `.parts.iii`) — this was an isolated idiom slip, not a convention.

## Not in this PR

The source page also states three further Erdős conjectures about $\sum(-1)^n/(n(p_{n+1}-p_n))$,
$\sum(-1)^n/(p_{n+1}-p_n)$ and $\sum(-1)^n/(n(p_{n+1}-p_n)(\log\log n)^c)$, and the file carries a
`-- TODO: add the other statements from the additional material`. I have deliberately left that
TODO alone so this diff stays one declaration.

## Verification

* `lean -DwarningAsError=true FormalConjectures/ErdosProblems/15.lean`, elaborated against this
  repository's already-built `FormalConjecturesUtil` oleans, with the lakefile's options passed
  explicitly: `pp.unicode.fun=true`, `autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and `linter.style.{copyright.formalConjectures, namespace, openClassical,
  ams_attribute, category_attribute, conditional_formal_proof, moduleDocstring,
  latex_docstring}=true`. No errors, no warnings. Repeated with `google.answer=postpone` (the
  `FormalConjecturesAnswerPostpone` library's option): also clean.
* I did **not** run `lake build`. So I have not exercised the lake targets themselves, nor any
  module downstream of this one, nor the full linter set as CI configures it. **CI is the
  authoritative check.**
* The divergence argument in step 3 is a pen-and-paper argument; I did not formalise it, and the
  PR does not add it to the repository.

## AI assistance disclosure

Prepared with AI assistance (Claude, Anthropic) for the source audit, the Lean checks and the
drafting. I reviewed the source page, the statement and the repair, and I take responsibility
for this submission.
