### PR TITLE
fix(ErdosProblems/477): range `b` over `{f(k) : k ∈ ℤ}` as the source and the docstrings say

### DIFF
--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -36,7 +36,7 @@ $b\in \{ f(n) : n\in\mathbb{Z}\}$ such that $z=a+b$?
 @[category research open, AMS 12]
 theorem erdos_477 : answer(sorry) ↔
     ∃ f : ℤ[X], 2 ≤ f.degree ∧ ∃ A : Set ℤ,
-      ∀ z, ∃! ab ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = ab.1 + ab.2 := by
+      ∀ z, ∃! ab ∈ A ×ˢ (Set.range f.eval), z = ab.1 + ab.2 := by
   sorry
 
 /--
@@ -47,7 +47,7 @@ This is shown in [Sek59].
 @[category research solved, AMS 12]
 theorem erdos_477.variants.S_sq :
     letI f := X ^ 2
-    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
+    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (Set.range f.eval), z = a.1 + a.2 := by
   sorry
 
 /--
@@ -59,7 +59,7 @@ This was found be AlphaProof for the specific instance $X^2 - X + 1$ and then ge
 theorem erdos_477.variants.degree_two_dvd_condition_b_ne_zero {a b c : ℤ} (ha : a ≠ 0) (hb : b ≠ 0)
     (hab : a ∣ b) :
     let f := a • X ^ 2 + b • X + C c
-    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
+    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (Set.range f.eval), z = a.1 + a.2 := by
   sorry
 
 /--
@@ -68,7 +68,7 @@ Probably there is no such $A$ for the polynomial $X^3$.
 @[category research open, AMS 12]
 theorem erdos_477.variants.X_pow_three :
     letI f := X ^ 3
-    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
+    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (Set.range f.eval), z = a.1 + a.2 := by
   sorry
 
 /--
@@ -77,7 +77,7 @@ Probably there is no such $A$ for the polynomial $X^k$ for any $k \ge 2$. This i
 @[category research open, AMS 12]
 theorem erdos_477.variants.monomial (k : ℕ) (hk : 2 ≤ k) :
     letI f := X ^ k
-    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = a.1 + a.2 := by
+    ∀ A : Set ℤ, ∃ z, ¬ ∃! a ∈ A ×ˢ (Set.range f.eval), z = a.1 + a.2 := by
   sorry
 
 end Erdos477

--- a/FormalConjectures/ErdosProblems/477.lean
+++ b/FormalConjectures/ErdosProblems/477.lean
@@ -30,8 +30,8 @@ namespace Erdos477
 
 /--
 Is there a polynomial $f:\mathbb{Z}\to \mathbb{Z}$ of degree at least $2$ and a set
-$A\subset \mathbb{Z}$ such that for any $z\in \mathbb{Z}$ there is exactly one $a\in A$ and
-$b\in \{ f(n) : n\in\mathbb{Z}\}$ such that $z=a+b$?
+$A\subset \mathbb{Z}$ such that for any $n\in \mathbb{Z}$ there is exactly one $a\in A$ and
+$b\in \{ f(k) : k\in\mathbb{Z}\}$ such that $n=a+b$?
 -/
 @[category research open, AMS 12]
 theorem erdos_477 : answer(sorry) ↔


### PR DESCRIPTION
Fixes #4980.

## What the declarations say now

All five declarations in the file range the second summand `b` over `f.eval '' {n | 0 < n}`,
i.e. over `{f(k) : k ≥ 1}`:

```lean
/--
Is there a polynomial $f:\mathbb{Z}\to \mathbb{Z}$ of degree at least $2$ and a set
$A\subset \mathbb{Z}$ such that for any $z\in \mathbb{Z}$ there is exactly one $a\in A$ and
$b\in \{ f(n) : n\in\mathbb{Z}\}$ such that $z=a+b$?
-/
@[category research open, AMS 12]
theorem erdos_477 : answer(sorry) ↔
    ∃ f : ℤ[X], 2 ≤ f.degree ∧ ∃ A : Set ℤ,
      ∀ z, ∃! ab ∈ A ×ˢ (f.eval '' {n | 0 < n}), z = ab.1 + ab.2 := by
  sorry
```

The docstring of that very declaration says `n ∈ ℤ`. The statement says `{n | 0 < n}`.

## Why this diverges from the source

[erdosproblems.com/477](https://www.erdosproblems.com/477) (OPEN, last edited 11 April 2026):

> Is there a polynomial $f:\mathbb{Z}\to \mathbb{Z}$ of degree at least $2$ and a set
> $A\subset \mathbb{Z}$ such that for any $n\in \mathbb{Z}$ there is exactly one $a\in A$ and
> $b\in \{ f(k) : k\in\mathbb{Z}\}$ such that $n=a+b$?

`{f(k) : k ≥ 1}` is a proper subset of `{f(k) : k ∈ ℤ}`, and the omitted arguments are the ones
the source's own proof uses.

## Witness that the current form is defective

The degree-2 argument recorded on the problem page is:

> let $f(x)=c_2x^2+c_1x+c_0$ with $c_1\neq 0$. For any infinite $A$ there exist $a,b\in A$ such
> that $a-b=2c_1k$ for some $k\geq 1$, whence $0\neq a-b=f(k)-f(-k)$ and so $n=a+f(-k)=b+f(k)$
> has two distinct solutions.

`f(-k)` is not in `f.eval '' {n | 0 < n}`. The second representation the proof exhibits does not
exist inside the set the Lean quantifies over, so the source's proof does not transfer to
`erdos_477.variants.degree_two_dvd_condition_b_ne_zero`, which is tagged `research solved` on the
strength of exactly that argument.

For `variants.S_sq` (`f = X²`) the divergence happens to be repairable inside the one-sided set —
the page's `c₁ = 0` branch uses `a - b = 4c₂k = f(k+1) - f(k-1)`, and taking `k ≥ 2` keeps both
`k-1 ≥ 1` and `k+1 ≥ 1` — so that one survives either way. The general `a ∣ b` variant is not
repaired by that argument: a one-sided replacement has to realise the required differences as
`a(m - m')(m + m' + s)` with `m, m' ≥ 1`, which does not obviously cover the same residues. I did
not settle whether the one-sided general variant is true; the point is only that it is not the
source's statement and not what the cited proof proves.

## Provenance: the docstring was re-synced to the source and the index set was not

* #1242 *"`n` should be positive in `erdos_477*`"* replaced `Set.range f.eval` with
  `f.eval '' {n | 0 < n}` **and** changed the docstring to match, to `n > 0`. Self-consistent.
* #1510 *"mark as disproved … update to the new statement from erdosproblems.com/477"* rewrote the
  docstring back to the site's wording, `b ∈ {f(n) : n ∈ ℤ}`, and carried the one-sided
  `f.eval '' {n | 0 < n}` forward into every declaration it added.

That is why docstring and statement now contradict each other inside the same declaration. Per
AGENTS.md — *"The docstring quotes the source. The Lean must agree with the docstring. If they
disagree, the Lean is incorrect."* — the statements are the side to change.

## The repair

Replace `f.eval '' {n | 0 < n}` by `Set.range f.eval` in all five declarations. One token per
declaration; nothing else changes, and every declaration keeps its category, its AMS tag, its
docstring and its `sorry`.

What this changes, per declaration:

| declaration | `f` | old `b`-set | new `b`-set | effect |
|---|---|---|---|---|
| `erdos_477` | `∃ f`, `2 ≤ deg f` | `{f(k) : k ≥ 1}` | `{f(k) : k ∈ ℤ}` | now the source's question |
| `variants.S_sq` | `X²` | `{1,4,9,…}` | `{0,1,4,9,…}` | adds `0`; still Sekanina's statement |
| `variants.degree_two_dvd_condition_b_ne_zero` | `aX²+bX+c`, `a ∣ b` | one-sided | two-sided | now matches the cited proof |
| `variants.X_pow_three` | `X³` | `{k³ : k ≥ 1}` | `{k³ : k ∈ ℤ}` | genuinely larger (negative cubes) |
| `variants.monomial` | `Xᵏ`, `k ≥ 2` | one-sided | two-sided | larger for odd `k`, equal for even `k` |

The two open variants stay `sorry` and stay open; the two `research solved` variants now state
what their citations actually prove.

If a one-sided index set was deliberate for some variant, the fix is the other direction — the
docstring should say so and the `research solved` tags should be re-checked against proofs that
respect it. I have assumed not, because the source and the docstrings agree on `k ∈ ℤ`.

## Verification

* `lean -DwarningAsError=true FormalConjectures/ErdosProblems/477.lean`, elaborated against this
  repository's already-built `FormalConjecturesUtil` oleans, with the lakefile's options passed
  explicitly: `pp.unicode.fun=true`, `autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and `linter.style.{copyright.formalConjectures, namespace, openClassical,
  ams_attribute, category_attribute, conditional_formal_proof, moduleDocstring,
  latex_docstring}=true`. No errors, no warnings. Repeated with `google.answer=postpone` (the
  `FormalConjecturesAnswerPostpone` library's option): also clean.
* `Set.range f.eval` elaborates through the same `Polynomial.eval` dot-notation the file already
  relies on (`f.eval : ℤ → ℤ`), so the change is a set swap and nothing else.
* I did **not** run `lake build`. So I have not exercised the lake targets themselves, nor any
  module downstream of this one, nor the full linter set as CI configures it. **CI is the
  authoritative check.**
* I did not prove or disprove any of the five statements, in either the old or the new form.

## AI assistance disclosure

Prepared with AI assistance (Claude, Anthropic) for the source audit, the Lean checks and the
drafting. I reviewed the source page, the statements, the provenance and the repair, and I take
responsibility for this submission.
