### PR TITLE
fix(ErdosProblems/952): state the Gaussian moat problem as `answer(sorry) ↔ …`, not as an assertion

### DIFF
--- a/FormalConjectures/ErdosProblems/952.lean
+++ b/FormalConjectures/ErdosProblems/952.lean
@@ -32,7 +32,7 @@ Is there an infinite sequence of distinct Gaussian primes $x_1,x_2,\ldots$
 such that $\lvert x_{n+1}-x_n\rvert \ll 1$?
 -/
 @[category research open, AMS 11]
-theorem erdos_952 :
+theorem erdos_952 : answer(sorry) ↔
   ∃ (x : ℕ → GaussianInt) (C : ℤ),
     Function.Injective x ∧
       ∀ n, Prime (x n) ∧ (x (n + 1) - x n).norm < C := by


### PR DESCRIPTION
Fixes #4981.

## What the declaration says now

```lean
/--
Is there an infinite sequence of distinct Gaussian primes $x_1,x_2,\ldots$
such that $\lvert x_{n+1}-x_n\rvert \ll 1$?
-/
@[category research open, AMS 11]
theorem erdos_952 :
  ∃ (x : ℕ → GaussianInt) (C : ℤ),
    Function.Injective x ∧
      ∀ n, Prime (x n) ∧ (x (n + 1) - x n).norm < C := by
  sorry
```

A bare `theorem` **asserting** that the sequence exists.

## Why this diverges from the source

[erdosproblems.com/952](https://www.erdosproblems.com/952) (OPEN, last edited 08 April 2026) poses
a question, and records the expectation that the answer is *no*:

> Is there an infinite sequence of distinct Gaussian primes $x_1,x_2,\ldots$ such that
> $\lvert x_{n+1}-x_n\rvert \ll 1$?

> The Gaussian moat problem. […] In [Er80] Erdős writes 'the answer is almost certainly negative'.

The docstring quotes the question correctly. The Lean asserts one branch of it — the branch the
cited author calls almost certainly false. The repository's convention for an undetermined
question is `answer(sorry) ↔ …`, as used by `erdos_477` and many others; a bare `theorem` is the
form for a statement believed or known to hold.

## Witness that the current form is defective

There is no trivial-truth loophole to appeal to, which is what makes this a live problem rather
than a cosmetic one: the declaration really does assert the Gaussian moat problem's positive
branch.

* `GaussianInt = ℤ√-1`, so `Zsqrtd.norm z = z.re² + z.im² ≥ 0`, and `norm < C` bounds the
  **squared** step length — a faithful rendering of `|x_{n+1} - x_n| ≪ 1`.
* `Prime (x n)` is primality in `ℤ[i]`.
* `Function.Injective x` forces infinitely many distinct primes, so the sequence must leave every
  bounded set; a single prime has only 4 associates and 2 conjugates, so there is no
  associates-cycling escape.

So the statement is exactly "there is a walk to infinity through Gaussian primes with bounded
steps", which is open and expected to be false. Asserting it commits the repository to an answer
its own cited source doubts. (Gethner–Wagon–Wick and successors have shown no such walk exists
with step size `≤ 6`; that refutes the statement for fixed small `C`, not for the `∃ C` form, so
it is not a counterexample here — only more evidence that the asserted direction is the doubted
one.)

## The repair

```lean
theorem erdos_952 : answer(sorry) ↔
  ∃ (x : ℕ → GaussianInt) (C : ℤ),
    Function.Injective x ∧
      ∀ n, Prime (x n) ∧ (x (n + 1) - x n).norm < C := by
  sorry
```

The right-hand side is untouched — same sequence, same injectivity, same norm bound, same `∃ C`.
The only change is that the declaration now records the question instead of an answer to it, so
`answer` is where the resolution goes if the moat problem is ever settled in either direction. It
stays `research open` and stays `sorry`.

## Not in this PR

The `Prime (x n)` and `norm` encoding is unchanged, including the fact that `norm` is the squared
modulus, so `∃ C` quantifies over a bound on `|x_{n+1} - x_n|²` rather than on
`|x_{n+1} - x_n|`. Those are interchangeable for an `≪ 1` statement, so I left it alone rather
than widen the diff. The `Er77c` attribution note on the source page (the problem is Gordon's and
Motzkin's, not Erdős's) is likewise not touched.

## Verification

* `lean -DwarningAsError=true FormalConjectures/ErdosProblems/952.lean`, elaborated against this
  repository's already-built `FormalConjecturesUtil` oleans, with the lakefile's options passed
  explicitly: `pp.unicode.fun=true`, `autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and `linter.style.{copyright.formalConjectures, namespace, openClassical,
  ams_attribute, category_attribute, conditional_formal_proof, moduleDocstring,
  latex_docstring}=true`. No errors, no warnings. Repeated with `google.answer=postpone` (the
  `FormalConjecturesAnswerPostpone` library's option, which re-elaborates the `answer` syntax in
  postpone mode): also clean.
* I did **not** run `lake build`. So I have not exercised the lake targets themselves, nor any
  module downstream of this one, nor the full linter set as CI configures it. **CI is the
  authoritative check.**
* I did not prove or disprove the right-hand side; the analysis above (norm is the squared step;
  injectivity forces escape to infinity) is pen-and-paper, not formalised.

## AI assistance disclosure

Prepared with AI assistance (Claude, Anthropic) for the source audit, the Lean checks and the
drafting. I reviewed the source page, the statement and the repair, and I take responsibility for
this submission.
