### PR TITLE
fix(ErdosProblems/40): `erdos_40`'s `answer` hole is closed by `∅`

### DIFF
--- a/FormalConjectures/ErdosProblems/40.lean
+++ b/FormalConjectures/ErdosProblems/40.lean
@@ -50,9 +50,15 @@ def Erdos40ForSet (G : Set (ℕ → ℝ)) : Prop := ∀ g ∈ G, Tendsto g atTop
 For what functions $g(N) → \infty$ is it true that
 $$\lvert A\cap \{1,\ldots,N\}\rvert \gg \frac{N^{1/2}}{g(N)}$$
 implies $\limsup 1_A\ast 1_A(n)=\infty$?
+
+Asked here in decision form: is there any such $g$ at all? Establishing the
+implication for even one $g(N) → \infty$ already answers Erdős Problem 28
+positively, because a basis of order $2$ satisfies
+$\lvert A\cap \{1,\ldots,N\}\rvert \gg N^{1/2}$.
 -/
 @[category research open, AMS 11]
-theorem erdos_40 : Erdos40ForSet answer(sorry) := by
+theorem erdos_40 :
+    answer(sorry) ↔ ∃ g : ℕ → ℝ, Tendsto g atTop atTop ∧ Erdos40For g := by
   sorry
 
 /--


### PR DESCRIPTION
Fixes #4977.

## What the declaration says now

```lean
def Erdos40ForSet (G : Set (ℕ → ℝ)) : Prop := ∀ g ∈ G, Tendsto g atTop atTop → Erdos40For g

@[category research open, AMS 11]
theorem erdos_40 : Erdos40ForSet answer(sorry) := by
  sorry
```

`Erdos40ForSet` is a bare universal over `G` with no extremality requirement, so
the `answer` hole asserts nothing.

## Why that diverges from the source

erdosproblems.com/40 (read 2026-08-15), `$500`, open:

> For what functions $g(N)\to\infty$ is it true that
> $\lvert A\cap\{1,\ldots,N\}\rvert \gg N^{1/2}/g(N)$ implies
> $\limsup 1_A*1_A(n)=\infty$?

The source asks *which* `g` work. The Lean asks for *some* set of `g`, with no
condition tying that set to the question.

## Minimal witness that the current form is defective

`answer := (∅ : Set (ℕ → ℝ))` closes it, and so does any subset of the functions
that do not tend to infinity. Machine-checked:

```lean
theorem current_trivial : Erdos40ForSet (∅ : Set (ℕ → ℝ)) := by
  simp [Erdos40ForSet]

theorem current_trivial' : Erdos40ForSet {g : ℕ → ℝ | ¬ Tendsto g atTop atTop} :=
  fun _ hg h => absurd h hg
-- both: depends on axioms: [propext, Classical.choice, Quot.sound]
```

## Why I did **not** use the fix suggested in the issue

Issue #4977 proposed an extremality wrapper,
`IsGreatest {G : Set (ℕ → ℝ) | Erdos40ForSet G} answer(sorry)`. **That is also
trivially closable**, and I checked it before writing the diff:

```lean
theorem isGreatest_trivial :
    IsGreatest {G : Set (ℕ → ℝ) | Erdos40ForSet G}
      {g : ℕ → ℝ | Tendsto g atTop atTop → Erdos40For g} :=
  ⟨fun _ hg h => hg h, fun _ hG _ hgG => hG _ hgG⟩
-- depends on axioms: [propext, Classical.choice, Quot.sound]
```

The reason is structural: `Erdos40ForSet G` is a *pointwise* property of the
members of `G`, hence downward closed and closed under unions, so its greatest
element is definitionally `{g | Tendsto g atTop atTop → Erdos40For g}` and the
whole statement is two `fun`s. The same objection kills every "determine the
class" shape — e.g. `{g | Tendsto g atTop atTop ∧ Erdos40For g} = answer(sorry)`
is closed by `rfl`, which is the reflexive-`answer` pattern already collected in
#4923. Replacing one trivial hole with another would not be a fix.

Nor is the maximal instantiation a candidate. `Erdos40ForSet .univ` is the `∀`
form, and it is false: the proof of `erdos_40.variants.implies_erdos_28` in this
same file instantiates it at `g = fun N ↦ √N`, and `Erdos40For (fun N ↦ √N)` fails
for `A = {2 ^ k | k : ℕ}` — there `√N / g N = 1 = O(|A ∩ [1,N]|)` since
`|A ∩ [1,N]| = ⌊log₂ N⌋ + 1`, while `sumRep A n ≤ 2` for every `n`, so the
`limsup` is at most `2`, not `⊤`. (I did not formalise this; see "not verified"
below. It is an observation about `variants.implies_erdos_28`, whose statement
stays true — its hypothesis is simply unsatisfiable — and is out of scope for this
diff.)

## The repair

State the question in decision form, which is the part of it that is neither
trivially closable nor weaker than the source's own reading of its significance:

```lean
theorem erdos_40 :
    answer(sorry) ↔ ∃ g : ℕ → ℝ, Tendsto g atTop atTop ∧ Erdos40For g
```

- `answer(sorry) ↔ …` with no binders is the repository's standard shape for a
  yes/no question, and is exactly what `AnswerLinter` blesses. The answer is `True`
  or `False`; there is no set to instantiate with `∅`.
- It is faithful to the source's own framing of what the problem is worth: "this is
  a stronger form of the Erdős–Turán conjecture [28], since establishing this for
  any function $g(N)\to\infty$ would imply a positive solution to [28]". A basis of
  order 2 has `|A ∩ {1,…,N}| ≫ N^{1/2}`, so a single admissible `g` settles
  Erdős Problem 28. The statement is therefore at least as hard as #28, and open.
- It loses the full characterisation ("*for what* `g`"). That loss is not
  avoidable: `Erdos40For` is antitone in `g` (a smaller `g` is a stronger hypothesis
  on `A`), so the admissible class is downward closed and any Lean rendering of
  "determine that class" is closed by writing the class down — the trap above. If a
  concrete conjectured threshold is ever recorded on the problem page, this should
  become `Erdos40ForSet {g | …}` with that threshold named, which would be strictly
  better; the page currently records none.

`Erdos40For` and `Erdos40ForSet` are both left in place; `Erdos40ForSet` is still
used by `erdos_40.variants.implies_erdos_28`, which is untouched.

## What I verified, and what I did not

Verified:

- The file elaborates with no diagnostics under `lean -DwarningAsError=true` with
  the option set the `FormalConjectures` library uses in `lakefile.toml`
  (`autoImplicit=false`, `relaxedAutoImplicit=false`, `warn.sorry=false`, and the
  `ams_attribute`, `category_attribute`, `conditional_formal_proof`,
  `moduleDocstring`, `latex_docstring`, `namespace`, `openClassical` linters). I
  confirmed those linters are live in that configuration with two negative controls
  (reordering `AMS` tags and deleting a `category` attribute both fail as
  expected). `erdos_40.variants.implies_erdos_28` still compiles unchanged.
- The same run with `-Dgoogle.answer=postpone` is also clean.
- `erdos_40` still ends in `sorry`, and the `∅` witness no longer applies: the
  statement has no set argument to instantiate.
- The four triviality proofs quoted above, each `#print axioms` =
  `[propext, Classical.choice, Quot.sound]`.

Not verified:

- I did **not** run `lake build`; the full build has not been exercised on my side.
  CI is the authoritative check.
- The `Erdos40ForSet .univ` falsity argument above is a paper argument, not a Lean
  proof. It affects no declaration in this diff.

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic) for the source
check, the triviality checks, and drafting. The submitter reviewed the
declaration, the source text, the argument and the diff, and takes responsibility
for the submission.
