### PR TITLE
fix(Wikipedia/EllipticCurveRank): state 8.2(b) for large `H`, not from `H = 2`

### DIFF
--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -137,11 +137,17 @@ naïve height at most `H` is asymptotically `H ^ ((21 - r) / 24 + o(1))`.
 Note: ℰ_H in 8.2(b) should be ℰ_{≤H}, see the statement of Theorem 7.3.3.
 When `r = 1`, the exponent is `20 / 24 = 5 / 6`, which agrees with the exponent in
 `card_heightLE_div_pow_five_div_six_tensto` and is consistent with
-`half_rank_zero_and_half_rank_one`. -/
+`half_rank_zero_and_half_rank_one`.
+The equality is asserted only for large `H`, matching the `o(1)` above: it cannot hold
+at small `H`, because `heightLE H` is empty for `H ≤ 3` (`naiveHeight E ≤ 3` forces
+`A = B = 0`, which both `Δ_ne_zero` and `reduced` exclude) and consists only of the two
+rank-zero curves `y² = x³ ± x` for `4 ≤ H ≤ 26`, while the right hand side is
+`Real.rpow` and hence strictly positive. -/
 @[category research open, AMS 11 14]
 theorem rank_height_count_asymptotic (r : ℕ) (h₁ : 1 ≤ r) (h₂ : r ≤ 20) :
     ∃ f : ℕ → ℝ, atTop.Tendsto f (𝓝 0) ∧
-      ∀ H : ℕ, 1 < H → {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H) := by
+      ∀ᶠ H : ℕ in atTop,
+        {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H) := by
   sorry
 
 /-- [PPVW2016] 8.2(c): the number of elliptic curves over ℚ with rank ≥ 21 and naïve height


### PR DESCRIPTION
Fixes #4994.

## What the declaration said

```lean
@[category research open, AMS 11 14]
theorem rank_height_count_asymptotic (r : ℕ) (h₁ : 1 ≤ r) (h₂ : r ≤ 20) :
    ∃ f : ℕ → ℝ, atTop.Tendsto f (𝓝 0) ∧
      ∀ H : ℕ, 1 < H → {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H) := by
  sorry
```

An **exact equality at every `H > 1`**, where the source states an asymptotic.

## Why that is false

`heightLE H` is empty for small `H`, while the right-hand side is never zero.

* `naiveHeight E ≤ 3` forces `4·|A|³ ≤ 3` and `27·B² ≤ 3`, hence `A = B = 0`; that pair
  is excluded twice — by `Δ_ne_zero` (`4·0³ + 27·0² = 0`) and by `reduced` (every prime
  `p` has `p⁴ ∣ 0` and `p⁶ ∣ 0`). So `heightLE H = ∅` for `H ≤ 3`.
* Because `f : ℕ → ℝ`, `(H : ℝ) ^ ((21 - r)/24 + f H)` elaborates to `Real.rpow`, and
  `Real.rpow_pos_of_pos` gives `(2 : ℝ) ^ x > 0` for every real `x`.

So at `H = 2` (and `H = 3`) the equality reads `0 = positive` for every `f`, and the
`∃ f` has no witness — for every `r` in range. No rank computation is involved.

Enumerating `(A, B)` under `Δ_ne_zero`, `reduced` and `naiveHeight ≤ H`:

| `H` | `heightLE H` |
|---|---|
| `0, 1, 2, 3` | `∅` |
| `4 … 26` | `{(1, 0), (−1, 0)}` |
| `27 …` | `{(±1, 0), (0, ±1), (±1, ±1)}` |

`y² = x³ + x` (conductor 64) and `y² = x³ − x` (conductor 32) both have rank 0 — the
latter is Fermat's theorem that 1 is not a congruent number — so for every `r ≥ 1` the
*filtered* set is empty for all `H ≤ 26`, and the equality fails at each of those too.

## Why the fix is `∀ᶠ`, not a bigger numeral

Raising the guard to `3 < H` does not work: the filtered set is still empty for
`4 ≤ H ≤ 26`. Nor does any fixed numeral, because the least `H` at which
`{E ∈ heightLE H | r ≤ E.rank}` becomes non-empty depends on `r`, and grows fast — the
minimal-conductor rank-1 curve 37a1 has reduced model `y² = x³ − 16x + 16` and hence
naïve height `max(4·16³, 27·16²) = 16384`, and for `r = 20` no explicit height bound is
known at all.

So this PR states the equality where [PPVW2016] states it — eventually:

```lean
      ∀ᶠ H : ℕ in atTop,
        {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H)
```

`#ℰ_{≤H}(r) = H^((21−r)/24 + o(1))` is a statement about large `H`, and the docstring
already carried that `o(1)`. The docstring now also records why no small `H` can work,
so the next reader does not have to rediscover it.

## Provenance

PR #252 (*"fix(EllipticCurveRank): corner cases and a sanity check"*) rewrote this
declaration and introduced the `1 < H` guard for exactly this failure mode — its
description reads *"Fix a potential issue when the height bound `H` is 1 in which case
`H ^ _` is always 1"*:

```diff
-    ∃ f : ℕ+ → ℝ, atTop.Tendsto f (𝓝 0) ∧
-      ∀ H : ℕ+, {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H)
+    ∃ f : ℕ → ℝ, atTop.Tendsto f (𝓝 0) ∧
+      ∀ H : ℕ, 1 < H → {E ∈ heightLE H | r ≤ E.rank}.ncard = (H : ℝ) ^ ((21 - r) / 24 + f H)
```

It removed `H = 1`, where the *right*-hand side is `1`, but left `H = 2, 3`, where the
*left*-hand side is `0`.

## Not touched: the sibling

`twentyone_le_rank_height_count_asymptotic` was edited in the same #252 diff but states
`≤` rather than `=`:

```lean
      ∀ H : ℕ, 1 < H → {E ∈ heightLE H | 21 ≤ E.rank}.ncard ≤ (H : ℝ) ^ f H
```

`0 ≤ positive` holds, so it is immune to this failure and is deliberately left alone —
this PR changes one declaration. (One could argue it should read `∀ᶠ` too, for symmetry
with 8.2(c)'s own `o(1)`; that is a style question, not a correctness one, and it is not
made here.)

## The mathematics is unaffected

This is a formalization fix only. The PPVW 8.2(b) heuristic is untouched, the
declaration stays `research open` and still ends in `sorry`, and nothing here bears on
the distribution of ranks of elliptic curves over ℚ.

## What I verified, and what I did not

Verified:

- The file elaborates with no diagnostics under `lean -DwarningAsError=true` with the
  option set the `FormalConjectures` library declares in `lakefile.toml`
  (`pp.unicode.fun=true`, `autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and the `copyright`, `namespace`, `openClassical`,
  `ams_attribute`, `category_attribute`, `conditional_formal_proof`, `moduleDocstring`
  and `latex_docstring` linters). Two negative controls confirm those linters are
  actually live in that configuration: reordering the `AMS` tags gives
  `error: The AMS tags should be ordered as AMS 11 14`, and deleting the `@[category …]`
  attribute gives `Missing AMS attribute` / `Missing problem category attribute`.
- The same run with `-Dgoogle.answer=postpone` is also clean.
- The elaborated statement is the intended one — `#check` with `pp.numericTypes` prints
  the exponent as `((21 : ℝ) - ↑r) / (24 : ℝ) + f H`, i.e. real subtraction and
  `Real.rpow`, not `ℕ`-subtraction.
- The declaration still ends in `sorry` and remains open.
- The `heightLE` table above, by two independent code paths (brute-force enumeration
  over `(A,B) ∈ [−12,12]²` applying both structure fields, and an interval argument on
  `max(4|A|³, 27B²) ≤ 3` followed by the two exclusions).

Not verified: I did **not** run `lake build`, so the full build (downstream modules, the
test driver, `decide`-based elaboration elsewhere) was not exercised; CI is the
authoritative check. The rank-0 facts for `y² = x³ ± x` and the rank of 37a1 are quoted
from the classical literature and standard tables, not recomputed here.

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic) for the audit, the
enumeration, and drafting. The submitter reviewed the declaration, the source, the
computation and the diff, and takes responsibility for the submission.
