### PR TITLE
fix(Wikipedia/BetrothedNumbers): require `m ≠ n` in `same_parity_betrothed`

### DIFF
--- a/FormalConjectures/Wikipedia/BetrothedNumbers.lean
+++ b/FormalConjectures/Wikipedia/BetrothedNumbers.lean
@@ -56,10 +56,13 @@ Do there exist betrothed numbers $(m, n)$ where both have the same parity
 
 All known betrothed pairs consist of one even and one odd number.
 
+The requirement $m \neq n$ is part of the question: $\mathrm{IsBetrothed}\ n\ n$ says
+$\sigma(n) = 2n + 1$, i.e. that $n$ is quasiperfect, which is the separate open problem
+`QuasiperfectNumbers.exists_quasiperfect`.
 -/
 @[category research open, AMS 11]
 theorem same_parity_betrothed :
-    answer(sorry) ↔ ∃ m n : ℕ, IsBetrothed m n ∧ (Even m ↔ Even n) := by
+    answer(sorry) ↔ ∃ m n : ℕ, m ≠ n ∧ IsBetrothed m n ∧ (Even m ↔ Even n) := by
   sorry
 
 /--


### PR DESCRIPTION
Fixes #4998.

## What the declaration said

```lean
@[category research open, AMS 11]
theorem same_parity_betrothed :
    answer(sorry) ↔ ∃ m n : ℕ, IsBetrothed m n ∧ (Even m ↔ Even n) := by
  sorry
```

## Why that diverges from the source

Wikipedia, *Betrothed numbers*:

> All known **pairs** of betrothed numbers have opposite parity. Any pair of the same
> parity must exceed 10¹³.

Nothing forced `m ≠ n`. With `m := n` both fields of

```lean
@[mk_iff]
structure IsBetrothed (m n : ℕ) : Prop where
  left : σ 1 m = m + n + 1
  right : σ 1 n = m + n + 1
```

collapse to `σ(n) = 2n + 1`, which is exactly this repository's own

```lean
-- FormalConjectures/Wikipedia/QuasiperfectNumbers.lean
def Quasiperfect (n : ℕ) : Prop :=
  σ 1 n = 2 * n + 1
```

and `Even n ↔ Even n` is `Iff.rfl`. So before this change

```
(∃ n, QuasiperfectNumbers.Quasiperfect n) → (∃ m n, IsBetrothed m n ∧ (Even m ↔ Even n))
```

i.e. a positive answer to the open `QuasiperfectNumbers.exists_quasiperfect` would have
settled the right-hand side of `same_parity_betrothed`, via a question unrelated to
betrothed pairs. `n = 0` does not trigger it (`σ(0) = 0 ≠ 1`), so the loophole needs a
genuine quasiperfect number — none is known, and any would be an odd square exceeding
10³⁵ — which is why this was a latent hypothesis gap rather than a proof that the
declaration is trivial.

## The sibling already had the constraint

The other open declaration in the same file enforces distinctness:

```lean
theorem infinitely_many_betrothed :
    answer(sorry) ↔ {p : ℕ × ℕ | p.1 < p.2 ∧ IsBetrothed p.1 p.2}.Infinite
```

so the omission looks unintentional. This PR copies that intent with the smallest
possible conjunct.

## The repair

```lean
theorem same_parity_betrothed :
    answer(sorry) ↔ ∃ m n : ℕ, m ≠ n ∧ IsBetrothed m n ∧ (Even m ↔ Even n) := by
```

`m ≠ n` rather than `m < n`: `IsBetrothed` is symmetric (the file proves
`IsBetrothed.symm`), so the two are equivalent here, and `m ≠ n` is the smaller change
and reads as "a pair of betrothed numbers". The docstring now also records why the
constraint is there, naming `QuasiperfectNumbers.exists_quasiperfect`, so the next
reader does not have to rediscover the interaction.

## Context (does not decide anything)

A `σ` sieve to `5·10⁶` finds **no** `n` with `σ(n) = 2n + 1`, and **35** betrothed pairs
`m < n ≤ 5·10⁶` — `(48, 75), (140, 195), (1050, 1925), (1575, 1648), (2024, 2295),
(5775, 6128), (8892, 16587), (9504, 20735), (62744, 75495), (186615, 206504), …` — all of
opposite parity, matching the literature. The question the docstring asks stays open.

## The mathematics is unaffected

This is a formalization fix only. The same-parity betrothed question and the
quasiperfect question both remain open; the declaration stays `research open` and still
ends in `sorry`.

## What I verified, and what I did not

Verified:

- The file elaborates with no diagnostics under `lean -DwarningAsError=true` with the
  option set the `FormalConjectures` library declares in `lakefile.toml`
  (`pp.unicode.fun=true`, `autoImplicit=false`, `relaxedAutoImplicit=false`,
  `warn.sorry=false`, and the `copyright`, `namespace`, `openClassical`,
  `ams_attribute`, `category_attribute`, `conditional_formal_proof`, `moduleDocstring`
  and `latex_docstring` linters). A negative control confirms those linters are live in
  that configuration: deleting the `@[category …]` attribute gives
  `Missing AMS attribute` / `Missing problem category attribute`.
- The same run with `-Dgoogle.answer=postpone` is also clean, so the `answer(sorry)`
  slot still elaborates.
- The declaration still ends in `sorry` and remains open.
- The sieve figures above.

Not verified: I did **not** run `lake build`, so the full build (downstream modules, the
test driver, `decide`-based elaboration elsewhere) was not exercised; CI is the
authoritative check.

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic) for the source check, the
sieve computation, and drafting. The submitter reviewed the declaration, the source, the
computation and the diff, and takes responsibility for the submission.
