### PR TITLE
fix(Books/Equidistribution): ask the transcendental equidistribution question rather than assert it

### DIFF
--- a/FormalConjectures/Books/UniformDistributionOfSequences/Equidistribution.lean
+++ b/FormalConjectures/Books/UniformDistributionOfSequences/Equidistribution.lean
@@ -60,11 +60,8 @@ theorem isEquidistributedModuloOne_three_halves_pow :
 
 /-- Is the sequence `x * (3 / 2) ^ n` equidistributed modulo `1` for every transcendental `x`?
 
-The reference states equidistribution of `(x ^ n)` for *almost all* `x > 1` (Chapter 1,
-Corollary 4.2), quoted in the module docstring above. It does not state anything for a
-particular `x`, and transcendence is not known to be sufficient for any single sequence of this
-kind — that is precisely the difficulty recorded for `(3 / 2) ^ n` itself. This is therefore
-asked rather than asserted. -/
+The cited reference gives equidistribution of `(x ^ n)` only for *almost all* `x > 1`
+(Chapter 1, Corollary 4.2), so it does not support the universally quantified form. -/
 @[category research open, AMS 11]
 theorem isEquidistributedModuloOne_transcendental_three_halves_pow :
     answer(sorry) ↔ ∀ (x : ℝ), Transcendental ℚ x →

--- a/FormalConjectures/Books/UniformDistributionOfSequences/Equidistribution.lean
+++ b/FormalConjectures/Books/UniformDistributionOfSequences/Equidistribution.lean
@@ -58,12 +58,17 @@ theorem isEquidistributedModuloOne_three_halves_pow :
     IsEquidistributedModuloOne (fun n => (3 / 2 : ℝ)^n) := by
   sorry
 
-/-- For any transcendental number `x`, the sequence `x * (3 / 2) ^ n` is
-equidistributed modulo 1. -/
+/-- Is the sequence `x * (3 / 2) ^ n` equidistributed modulo `1` for every transcendental `x`?
+
+The reference states equidistribution of `(x ^ n)` for *almost all* `x > 1` (Chapter 1,
+Corollary 4.2), quoted in the module docstring above. It does not state anything for a
+particular `x`, and transcendence is not known to be sufficient for any single sequence of this
+kind — that is precisely the difficulty recorded for `(3 / 2) ^ n` itself. This is therefore
+asked rather than asserted. -/
 @[category research open, AMS 11]
-theorem isEquidistributedModuloOne_transcendental_three_halves_pow (x : ℝ)
-    (hx : Transcendental ℚ x) :
-    IsEquidistributedModuloOne (fun n ↦ x * (3 / 2 : ℝ) ^ n) := by
+theorem isEquidistributedModuloOne_transcendental_three_halves_pow :
+    answer(sorry) ↔ ∀ (x : ℝ), Transcendental ℚ x →
+      IsEquidistributedModuloOne (fun n ↦ x * (3 / 2 : ℝ) ^ n) := by
   sorry
 
 /--


### PR DESCRIPTION
## Summary

`isEquidistributedModuloOne_transcendental_three_halves_pow` asserted that **every**
transcendental `x` makes `(x · (3/2)ⁿ)` equidistributed mod 1. The module docstring's own
reference — Kuipers–Niederreiter Ch. 1 Cor. 4.2 — says **almost all** `x > 1`, for the sequence
`(xⁿ)`. The declaration carries no citation of its own; it was added by #3609 as an 8-line diff.

As written the statement is **false**. This PR stops asserting it and asks it instead, using the
`answer(sorry) ↔ …` idiom, in the same spirit as #4941 for `green_72`.

Closes #5003.

## The statement is false

Put `λ = 3/2`, `c = 1/10`, `G = 8`, so `c·λ^G = 6561/2560 ≈ 2.5629 ≥ 2 + c`.

Build nested closed intervals `I_j = [k_j·λ^(−jG), (k_j + c)·λ^(−jG)]` with `k₀ = 1`. At each
step the image of `I_j` under multiplication by `λ^((j+1)G)` has length `c·λ^G`, and the
integers `k` with `[k, k+c]` inside that image fill an interval of length
`c·λ^G − c − 1 = 3745/2560 ≈ 1.46 ≥ 1`, so there are at least two choices of `k_{j+1}`.

* Distinct branches give disjoint intervals (`c < 1`), so the intersection points form a set of
  cardinality `2^ℵ₀`; the algebraic numbers are countable, so **some such `x` is
  transcendental**.
* For every such `x` and every `j`, `Int.fract (x·λ^(jG)) ∈ [0, 1/10]`, so
  `#{m < N : Int.fract (x·λ^m) ∈ [0, 1/10]} ≥ ⌈N/8⌉`. Every limit point of the counting ratio
  is therefore `≥ 1/8`, while `IsEquidistributedModuloOne` demands exactly `1/10` at
  `(c, d) = (0, 1/10)`.

Full derivation, the exact-rational verification over 60 levels, and the duplicate search are in
issue #5003.

## Follow-up

If the construction is accepted, `answer(sorry)` should become `answer(False)` and the category
`research solved`. I did not make that edit here: the refutation is a hand argument, not a
citation or a Lean proof, so recording it as settled seemed to be the reviewer's call rather
than mine. The alternative repair — replacing the declaration with the "almost all" statement
the source actually supports — is also reasonable, but that statement is classical and would
need to be categorised `research solved`, and I have not pinned down which Kuipers–Niederreiter
theorem covers `(x·θⁿ)` for a fixed `θ` as opposed to `(xⁿ)`.

## The mathematics is unaffected

The genuinely open question in this file — whether `((3/2)ⁿ)` itself is equidistributed mod 1,
which Kuipers–Niederreiter record as unknown — is the sibling declaration
`isEquidistributedModuloOne_three_halves_pow`. It is untouched by this PR and by the argument
above.

## Verification

* The new statement was elaborated against Mathlib v4.27.0 in isolation (`import
  FormalConjecturesUtil`, `lean -DautoImplicit=false -DrelaxedAutoImplicit=false
  -DwarningAsError=true`), exit code 0, no errors or warnings.
* **I did not run `lake --wfail build`**: this machine does not have the disk headroom for a
  full build, and only the `FormalConjecturesUtil` / `FormalConjecturesForMathlib` oleans were
  available. The diff is one declaration and its docstring; no definition, import or other
  declaration is touched, and `grep` confirms the changed name is not referenced anywhere else
  in the repository. Please re-run CI accordingly.
* Docstring is LaTeX-free prose plus inline code, matching the surrounding file.

## AI assistance disclosure

Prepared with AI assistance (Claude, Anthropic) for the audit, the construction, the
exact-arithmetic verification, and drafting. The submitter reviewed the declaration, the
argument, and the change, and takes responsibility for the submission.
