### PR TITLE
fix(GreensOpenProblems/40): `variants.all_n` should tend to `𝓝 ⊤`, not `atTop`

### DIFF
--- a/FormalConjectures/GreensOpenProblems/40.lean
+++ b/FormalConjectures/GreensOpenProblems/40.lean
@@ -148,9 +148,13 @@ theorem green_40.f_tilde_le_f (r : ℕ) : f_tilde r ≤ f r := by
 noncomputable def f_all (r : ℕ) : ℝ≥0∞ :=
   limsup (fun n ↦ minDensity n r) atTop
 
-/-- Does $f_{\text{all}}(r) \to \infty$? [Gr24] -/
+/-- Does $f_{\text{all}}(r) \to \infty$? [Gr24]
+
+The target filter is `𝓝 ⊤`, as in `green_40` and `green_40.variants.arbitrary_subsets`. On
+`ℝ≥0∞`, `atTop` is the principal ultrafilter at `⊤`, so `Tendsto f_all atTop atTop` would say
+that `f_all r = ⊤` for all large `r` rather than that `f_all r → ∞`. -/
 @[category research open, AMS 5 94]
-theorem green_40.variants.all_n : answer(sorry) ↔ Tendsto f_all atTop atTop := by
+theorem green_40.variants.all_n : answer(sorry) ↔ Tendsto f_all atTop (𝓝 ⊤) := by
   sorry
 
 end Green40


### PR DESCRIPTION
## Summary

`f_all : ℕ → ℝ≥0∞`, and `ℝ≥0∞` has a greatest element, so `(atTop : Filter ℝ≥0∞) = pure ⊤`.
`Tendsto f_all atTop atTop` therefore asserts that `f_all r = ⊤` for all sufficiently large `r`
— not that `f_all r → ∞`, which is what the docstring asks and what the two sibling
declarations in the same file, `green_40` and `green_40.variants.arbitrary_subsets`, state via
`𝓝 ⊤`. This PR uses `𝓝 ⊤` here too.

Closes #5006.

## Proof that the two differ

Machine-checked against Mathlib v4.27.0 (`lean -DautoImplicit=false -DrelaxedAutoImplicit=false
-DwarningAsError=true`, exit 0, no `sorry`):

```lean
theorem atTop_ennreal_eq : (atTop : Filter ℝ≥0∞) = pure ⊤ := by
  rw [(isTop_top (α := ℝ≥0∞)).atTop_eq]
  have : Set.Ici (⊤ : ℝ≥0∞) = {⊤} := by
    ext x; simp only [Set.mem_Ici, Set.mem_singleton_iff, top_le_iff]
  rw [this, principal_singleton]

theorem tendsto_atTop_ennreal_iff {α : Type*} (l : Filter α) (g : α → ℝ≥0∞) :
    Tendsto g l (atTop : Filter ℝ≥0∞) ↔ ∀ᶠ x in l, g x = ⊤ := by
  rw [atTop_ennreal_eq, tendsto_pure]

theorem tendsto_nhds_top_of_eventually {α : Type*} (l : Filter α) (g : α → ℝ≥0∞)
    (h : ∀ᶠ x in l, g x = ⊤) : Tendsto g l (𝓝 ⊤) :=
  tendsto_nhds_of_eventually_eq h
```

The implication runs one way only, so the old statement was strictly stronger than the question.

## The mathematics is unaffected

Green's Problem 40 is untouched: whether `f(r) → ∞`, and likewise for `f̃` and `f_all`, remains
open. Only the filter in one declaration changes.

## Verification

* The new statement's shape was elaborated against Mathlib v4.27.0 in isolation
  (`import FormalConjecturesUtil`, `answer(sorry) ↔ Tendsto g atTop (𝓝 ⊤)` for
  `g : ℕ → ℝ≥0∞`), exit code 0, no errors or warnings.
* **I did not run `lake --wfail build`**: this machine lacks the disk headroom for a full
  build. The diff is one token in one statement plus a docstring paragraph; no definition or
  import changes, and `grep` confirms `green_40.variants.all_n` is not referenced elsewhere in
  the repository. Please re-run CI accordingly.

## AI assistance disclosure

Prepared with AI assistance (Claude, Anthropic) for the audit, the Lean witnesses and drafting.
The submitter reviewed the declaration, the proof, and the change, and takes responsibility for
the submission.
