### PR TITLE
Mark arXiv 2607.03582 Conjecture 5 as solved

### DIFF
--- a/FormalConjectures/Arxiv/2607.03582/LpRogersShephard.lean
+++ b/FormalConjectures/Arxiv/2607.03582/LpRogersShephard.lean
@@ -87,7 +87,9 @@ theorem volume_lpSum_eq_of_isParallelogramAtOrigin (K : Set ℝ²)
 centre of symmetry containing the origin, for $p > 1$, equality in Corollary 29 holds only for
 parallelograms with a vertex at the origin.
 -/
-@[category research open, AMS 52]
+@[category research solved, AMS 52,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/lp-rogers-shephard-conjectures-lean/blob/c646c668c0568b8533bf5534abcf02aab4d2df72/lean/LpRogersShephardFC.lean#L108-L128"]
 theorem isParallelogramAtOrigin_of_volume_lpSum_eq :
     answer(sorry) ↔ ∀ (K : Set ℝ²), Convex ℝ K → IsCompact K → (interior K).Nonempty →
       HasCentreOfSymmetry K → (0 : ℝ²) ∈ K → ∀ p q : ℝ, 1 < p → 1 / p + 1 / q = 1 →


### PR DESCRIPTION
This PR marks `Arxiv.«2607.03582».isParallelogramAtOrigin_of_volume_lpSum_eq` as solved and links a kernel-checked Lean proof.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

Proof: https://github.com/KitaKen1/lp-rogers-shephard-conjectures-lean/blob/c646c668c0568b8533bf5534abcf02aab4d2df72/lean/LpRogersShephardFC.lean#L108-L128

Repository: https://github.com/KitaKen1/lp-rogers-shephard-conjectures-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Flp-rogers-shephard-conjectures-lean%2Fc646c668c0568b8533bf5534abcf02aab4d2df72%2Flean4web%2FLpRogersShephardLean4WebAll.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, using GPT-5.6 sol.

> [!NOTE]
> This PR targets Conjecture 5. The linked repository also proves Conjecture 4.
>
> The Lean4Web target theorem for Conjecture 4 is:
>
> ```lean
> theorem Conjecture4.volume_lpSum_le :
>     (∀ (n : ℕ), 1 ≤ n → ∀ (K : Set (Ambient n)),
>         Convex ℝ K → IsCompact K → (interior K).Nonempty →
>         HasCentreOfSymmetryN K → (0 : Ambient n) ∈ K →
>         ∀ p q : ℝ, 1 < p → 1 / p + 1 / q = 1 →
>           volume (lpSumN p K (-K)) ≤
>             ENNReal.ofReal (symmetricRSConstant n q) * volume K) ∧
>       (∀ (n : ℕ), 1 ≤ n → ∀ p q : ℝ, 1 < p → 1 / p + 1 / q = 1 →
>         volume (lpSumN p (unitCube n) (-(unitCube n))) =
>           ENNReal.ofReal (symmetricRSConstant n q) * volume (unitCube n)) :=
>   conjecture4_full_proved
> ```
>
> It is checked in the standalone file with `#print axioms Conjecture4.volume_lpSum_le`.