### PR TITLE
Mark OEIS A105751 2-adic conjecture as solved

### DIFF
--- a/FormalConjectures/OEIS/105751.lean
+++ b/FormalConjectures/OEIS/105751.lean
@@ -74,7 +74,9 @@ theorem prime_divides_some_term (p : ℕ) (hp : p.Prime) :
 Moll's conjecture 5.5 extends to this sequence and takes the form:
 (i) the $2$-adic valuation $\nu_2(a(n)) \sim n/4$ as n -> oo.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using formal_conjectures at
+    "https://github.com/KitaKen1/oeis-a105751-two-adic/blob/a9692d90078c4dff1478acaaa70be2fba06a3ef9/lean/OeisA105751TwoAdicFC.lean#L980-L985"]
 theorem conjecture :
     Tendsto (fun n ↦ (4 : ℚ) * (padicValInt 2 (a n) : ℚ) / (n : ℚ)) atTop (nhds 1) := by
   sorry


### PR DESCRIPTION
This PR marks `OeisA105751.conjecture`, the 2-adic asymptotic for OEIS A105751, as `research solved` and links a kernel-checked Lean proof.

It leaves `OeisA105751.conjecture.variants.moll_p_mod_4_eq_1` open.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem A105751Proof.oeisA105751_conjecture :
    Tendsto
      (fun n : ℕ ↦
        (4 : ℚ) * (padicValInt 2 (OeisA105751.a n) : ℚ) / (n : ℚ))
      atTop (nhds 1)
```

Proof: https://github.com/KitaKen1/oeis-a105751-two-adic/blob/a9692d90078c4dff1478acaaa70be2fba06a3ef9/lean/OeisA105751TwoAdicFC.lean#L980-L985

Repository: https://github.com/KitaKen1/oeis-a105751-two-adic

Lean4Web: [Open the standalone proof in Lean4Web](https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a105751-two-adic%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA105751TwoAdicLean4Web.lean)

`#print axioms A105751Proof.oeisA105751_conjecture` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex.