### PR TITLE
Mark OEIS A100474 next semiprime as solved

### DIFF
--- a/FormalConjectures/OEIS/100474.lean
+++ b/FormalConjectures/OEIS/100474.lean
@@ -147,9 +147,12 @@ theorem conjecture : answer(sorry) ↔ ∃ n > 2, (a n).Prime := by
 /--
 What is the next semiprime in the sequence after $a(11)$?
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a100474-next-semiprime/blob/d7781751918e63fd1268b15525bf9554c92fdd4d/lean/OeisA100474NextSemiprimeFC.lean#L1285-L1288"]
 theorem next_semiprime :
-    answer(sorry) = a (sInf {n : ℕ | 11 < n ∧ (a n).IsSemiprime}) := by
+    answer(3852669607062814427999374038085094563026983841699038416757537720951140990693348082633155462564082456461927363575765861495986901576629) =
+      a (sInf {n : ℕ | 11 < n ∧ (a n).IsSemiprime}) := by
   sorry
 
 end OeisA100474


### PR DESCRIPTION
This PR changes `OeisA100474.next_semiprime` from `answer(sorry)` to the explicit value of `a(36)` and links a kernel-checked Lean proof.

It leaves the separate qualitative statement `OeisA100474.conjecture` open.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem OeisA100474.next_semiprime :
    answer(3852669607062814427999374038085094563026983841699038416757537720951140990693348082633155462564082456461927363575765861495986901576629) =
      a (sInf {n : ℕ | 11 < n ∧ (a n).IsSemiprime}) := by
  rw [least_semiprime_index, a_36]
```

Proof: https://github.com/KitaKen1/oeis-a100474-next-semiprime/blob/d7781751918e63fd1268b15525bf9554c92fdd4d/lean/OeisA100474NextSemiprimeFC.lean#L1285-L1288

Repository: https://github.com/KitaKen1/oeis-a100474-next-semiprime

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a100474-next-semiprime%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA100474NextSemiprimeLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT 5.6 sol and Codex GPT 5.6 sol with xhigh reasoning.