### PR TITLE
Add formal proof for Erdős Problem 979 k = 3

### DIFF
--- a/FormalConjectures/ErdosProblems/979.lean
+++ b/FormalConjectures/ErdosProblems/979.lean
@@ -49,7 +49,9 @@ theorem erdos_979.variants.k2 :
 /--
 Erdős (unpublished)
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-979-k3/blob/930fcc877fa4a2b4fc7c59614cbbab04a6d834ca/lean/K3Lean/Erdos979K3Final.lean#L46-L47"]
 theorem erdos_979.variants.k3 :
     Filter.limsup (fun n => (solutionSet n 3).encard) Filter.atTop = ⊤ := by
   sorry


### PR DESCRIPTION
This PR adds a `formal_proof` link to the solved `k = 3` variant of Erdős Problem 979.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem Erdos979.erdos_979.variants.k3 :
    Filter.limsup (fun n => (Erdos979.solutionSet n 3).encard) Filter.atTop = ⊤
```

Proof: https://github.com/KitaKen1/erdos-979-k3/blob/930fcc877fa4a2b4fc7c59614cbbab04a6d834ca/lean/K3Lean/Erdos979K3Final.lean#L46-L47

Repository: https://github.com/KitaKen1/erdos-979-k3

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-979-k3%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos979Lean4WebLatest.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex, Fable5, and Claude Code.

> [!NOTE]
> Erdős's original `k = 3` proof was unpublished, so its method is unknown. In particular, it is not known whether Erdős used anything resembling the CM/Hecke approach formalized here. This repository gives an independent kernel-checked proof, not a reconstruction of Erdős's argument.