### PR TITLE
docs: make AGENTS.md more concise, and split into other files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,147 +1,100 @@
 # Agent guidelines
 
 Formal Conjectures states open mathematical problems in Lean 4. It is a statement
-repository, not a proof repository: almost every problem is `sorry`. Each statement must say
-what its source says.
+repository, not a proof repository: almost every problem is `sorry`.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and the
-attributes. This file adds only what CONTRIBUTING does not tell you.
+[CONTRIBUTING.md](CONTRIBUTING.md) is the reference for conventions, folders, and attributes.
+Also follow any `README.md` in the directory that you change.
 
-Follow the style of an existing file. Start by copying one from the same directory. *File
-structure conventions* in CONTRIBUTING gives the skeleton, and a neighbouring file gives the
-rest: a definition with its docstring, a statement with its source, and a variant. A template
-can become incorrect. A file in the repository cannot, because the build compiles it.
+Use these detailed guides when the task needs them:
 
-## Commands
+- [PROOFS.md](PROOFS.md) for proofs and `formal_proof` claims
+- [STATEMENTS.md](STATEMENTS.md) for adding and reviewing statements
 
-Build only the modules that you changed. Do not build the project.
+## Start with existing code
+
+Follow the style of an existing file. Start by copying one from the same directory.
+
+Search Mathlib, `FormalConjecturesForMathlib/`, and nearby problem files before you add a
+definition, API, or notation. Search names and documentation with `rg`. Use `#check` to confirm
+the type of a candidate declaration.
+
+Put each problem in `FormalConjectures/<Source>/`. Keep closely related variants in the same
+file. Put reusable mathematics in `FormalConjecturesForMathlib/`. That directory must not
+contain `sorry`.
+
+Problem files normally import only `FormalConjectures.Util.ProblemImports`.
+`FormalConjecturesForMathlib/` files import only the required Mathlib modules.
+
+## State the source faithfully
+
+Read the cited source. Make the Lean statement, its docstring, and the source agree. Check the
+order and scope of quantifiers, bounds, hypotheses, and all variants. Test empty and smallest
+inputs. See [STATEMENTS.md](STATEMENTS.md) for the detailed checks.
+
+Use `answer(sorry)` only for the information that the problem asks to determine. Put all
+quantifiers after it. A tautological term inside `answer()` is not a mathematical solution.
+
+## Write clear documentation
+
+Write documentation in simple, concise technical English. Prefer short sentences, common
+words, and one instruction or claim per sentence. Remove repetition and details that do not
+help a contributor complete the task.
+
+Use the same style for all repository communication. This includes issues, pull requests,
+reviews, and comments.
+
+Give each module a docstring with its sources. Give each `research open`, `research solved`,
+and `textbook` theorem a concise docstring that states the problem. Explain a non-obvious domain
+restriction when it is needed to exclude a degenerate case.
+
+Use LaTeX for mathematics in problem docstrings. Use code formatting for Lean and Mathlib API
+names. Do not put review notes or a proposed proof of an open problem in a Lean file.
+
+## Keep the Lean simple
+
+- Follow Mathlib naming conventions.
+- Use local notation for notation that is specific to one problem.
+- Omit type annotations that Lean can infer.
+- Write placeholders as `by sorry`.
+- Keep AMS tags in ascending order, such as `AMS 15 51`.
+- Do not use a global `open Classical`. Use `open scoped Classical in` or provide a local
+  `Decidable` instance.
+- Do not add placeholder definitions, incomplete types, unused imports, debug code, or commented
+  out code.
+
+## Build the changed scope
+
+Build every module that you change. Do not build the whole project locally for a problem-file
+change.
 
 ```bash
 lake --wfail build 'FormalConjectures.ErdosProblems.«361»'
 ```
 
+Use the wider target only when the changed scope requires it:
+
 ```bash
-lake --wfail build FormalConjecturesForMathlib   # if you changed a shared definition
-lake --wfail test                                # if you changed FormalConjecturesUtil
-lake --wfail build                               # the whole project. Let CI do this.
+lake --wfail build FormalConjecturesForMathlib  # shared definitions
+lake --wfail test                               # repository utilities
 ```
 
-`--wfail` makes each warning into a failure. CI uses the same option. Two warnings cause most
-of these failures:
+`--wfail` turns warnings into failures, as CI does. Fix every warning in the changed scope.
 
-- `open Classical` causes the `linter.style.openClassical` warning. Write
-  `open scoped Classical in` before the declaration that needs it. As an alternative, supply
-  a `Decidable` instance.
-- The AMS tags must be in ascending order. Write `AMS 15 51`. Do not write `AMS 51 15`.
+## Write a readable pull request
 
-## Where to put a statement
+Keep the pull request description concise and easy to scan. State what changed, why it changed,
+and how you checked it. Include only formalisation choices, limitations, or reviewer notes that
+affect the change. Remove narration, repetition, and unrelated detail.
 
-Put a problem in `FormalConjectures/<Source>/`. Use one file for each problem. Give the file
-the name of the problem. Put reusable mathematics in `FormalConjecturesForMathlib/`. That
-directory must not contain `sorry`. Only `FormalConjectures/` can contain `sorry`.
+Put reviewer notes in the pull request, not in Lean comments. To close several issues, repeat
+the keyword: `Fixes #1, fixes #2`.
 
-Search before you write a definition. Mathlib, `FormalConjecturesForMathlib/` and the adjacent
-problem files already contain much of what a problem needs. The names are difficult to guess.
-Examples: `trianglesContaining`, `InGeneralPosition`, `NonTrilinear`, `distinctDistances`. The
-notation is also easy to miss: `ℝ²` for `EuclideanSpace ℝ (Fin 2)`, and `≪` for `IsBigO` at
-`atTop`.
+Before requesting review, check that:
 
-## Check the degenerate cases
-
-Most incorrect formalisations are not typographical errors. They are statements that are
-vacuous, or trivially true, or false on an input that the author did not think about. Lean
-gives a junk value in these cases. Thus the file compiles, and the statement continues to read
-correctly. Test the smallest inputs and the empty inputs:
-
-| | |
-|---|---|
-| empty type or set | `∑ i, f i = 0`. Also, `X → ℝ` is a subsingleton. Thus two conditions that look contradictory can both hold |
-| `ZMod 0` | This type is `ℤ`. It is not a finite modulus |
-| `x / 0` | The result is `0`. Thus `∃ m : ℤ, q = m` accepts a pole as an integer. Write `a ∣ b` |
-| `sInf ∅` | The result is `0`. Thus the least such `n` is `0` when no `n` qualifies |
-| `Nat` subtraction | The result truncates to zero |
-
-Some statements are correct only because of a hypothesis such as `0 < N`, `[Nonempty X]` or
-`2 ≤ n`. Write one sentence in the docstring for each such hypothesis. A reviewer cannot
-otherwise know which hypotheses are necessary.
-
-## Compilation is not proof
-
-A file that contains `sorry` compiles. Run this command before you write that a theorem is
-proved:
-
-```lean
-#print axioms my_theorem
--- [propext, Classical.choice, Quot.sound]
-```
-
-`sorryAx` shows that the theorem is not proved.
-
-The three axioms above are the bar for a `research solved` statement. A `test` statement can
-use `decide +native`, which the repository prefers to `native_decide`. It adds at least
-`Lean.ofReduceBool` and `Lean.trustCompiler`, and the exact set depends on the proof. These
-axioms move the work out of the kernel, so run `#print axioms` and name the result in the pull
-request. `decide +kernel` stays within the three axioms above, where it is fast enough.
-
-Do the same for a proof that you cite with `formal_proof`. Read the file and look for `sorry`.
-Run `#print axioms` on the theorem that you cite. Then make sure that this theorem states what
-you claim. A repository can claim a proof of a conjecture and prove a weaker result. The
-correct theorem frequently has a different name.
-
-## Check your own work
-
-Each item below caused an incorrect claim in this repository. Each check is quick.
-
-**Read the matches. Do not count them.** A site search for `coprime` gave four results. This
-looked like a search of the statement text. All four results matched the theorem *name*. A
-count does not tell you why a search matched.
-
-**`grep sorry` also matches prose.** One file had two matches for `sorry`, both in a comment
-that described a plan. The file was almost recorded as incomplete. Use `#print axioms` to
-decide. Use grep only to find the location.
-
-**Look at the data before you describe it.** The claim "the statements are already in
-`conjectures.json`" was incorrect. `extract_names` uses the `--exclude=statement` option, and
-does not write them. Open the file.
-
-**Measure at the correct time.** An environment probe in a later command does not show what an
-attribute saw during elaboration. Lean rewinds the declaration between the two points. Add the
-instrument at the point that your claim is about.
-
-## Statement fidelity
-
-The docstring quotes the source. The Lean must agree with the docstring. If they disagree, the
-Lean is incorrect. Read these again before you submit:
-
-- the order and the scope of the quantifiers
-- `≤` against `<`, `∀ᶠ` against `∀`, asymptotic equivalence against the same order
-- a hypothesis that the prose gives and the Lean omits
-- `∃ x, P x → Q`. The intended statement is almost always `∃ x, P x ∧ Q`. As written, the
-  statement is trivially true. A linter finds this
-
-Prove each `test` statement and each `API` statement that you add. These statements must test
-a definition. A statement that contains `sorry` tests nothing.
-
-## Completeness
-
-- No placeholder definitions (e.g., `def foo : Type := sorry` or `opaque foo : Type*`)
-- No incomplete type annotations or holes
-- All referenced definitions must exist
-- All imports must be correct
-- No new axioms
-
-## Before you open a pull request
-
-- [ ] `lake --wfail build <module>` passes for each module that you changed
-- [ ] the docstring quotes the source, and the module docstring gives a reference
-- [ ] each theorem has a `category` and at least one `AMS` tag, in ascending order
-- [ ] you tested the degenerate inputs: empty, zero, division
-- [ ] you ran `#print axioms` on each theorem that you claim is proved
-- [ ] `FormalConjecturesForMathlib/` contains no `sorry`
-- [ ] you ran `git status` before `git add`. Generated files and `__pycache__` are easy to add
-      by mistake
-- [ ] you read again each file that a script changed. A build that passes is not sufficient
-- [ ] the description contains `Fixes #1, fixes #2`. Repeat the keyword. `Fixes #1, #2` closes
-      only the first issue
-- [ ] the description gives the formalisation decisions and the limitations. Do not put them
-      in the Lean file
+- each changed module builds with `--wfail`
+- each problem theorem has one `category` and at least one AMS tag
+- module and theorem docstrings follow the source and cite it
+- the statement handles its boundary cases
+- `FormalConjecturesForMathlib/` contains no `sorry`
+- the diff contains only intended files and changes

--- a/PROOFS.md
+++ b/PROOFS.md
@@ -1,0 +1,43 @@
+# Proof contributions
+
+Formal Conjectures is mainly a statement repository. Keep proofs short. For a long proof, prefer
+an external proof and record it with the `formal_proof` attribute.
+
+Do not add an informal proof of an open research problem.
+
+## Tests and API declarations
+
+Prove a `test` or `API` declaration when the proof is short and useful. A long proof may remain
+`by sorry` in `FormalConjectures/`. Do not add a large proof only to remove that placeholder.
+
+For a large computation in a `category test` declaration, `native_decide` may be acceptable.
+Review this case by case. Do not use it in `FormalConjecturesForMathlib/`.
+
+## FormalConjecturesForMathlib
+
+Every theorem in `FormalConjecturesForMathlib/` must have a complete kernel-checked proof. Do not
+use `sorry`, placeholder definitions, or `native_decide` anywhere in that directory. Keep the code
+at Mathlib quality and import only the Mathlib modules that it needs.
+
+## Check proof claims
+
+A file that contains `sorry` can still compile. Before you claim that a theorem is formally
+proved, inspect its axioms:
+
+```lean
+#print axioms my_theorem
+-- [propext, Classical.choice, Quot.sound]
+```
+
+`sorryAx` means that the theorem is not proved. Native evaluation can add axioms such as
+`Lean.ofReduceBool` or `Lean.trustCompiler`; report them when they are relevant.
+
+For a `formal_proof` link:
+
+1. Open the exact file and declaration that the link cites.
+2. Check that the linked statement implies the repository statement.
+3. Check for `sorry` and custom axioms.
+4. Run `#print axioms` on the linked theorem when the project is available.
+5. Use the correct `formal_proof` kind and a stable link.
+
+A repository name, a successful build, or a theorem with a similar name is not enough evidence.

--- a/STATEMENTS.md
+++ b/STATEMENTS.md
@@ -1,0 +1,55 @@
+# Statements
+
+Use this guide when you add or review a formalisation. The main question is whether the Lean
+statement says what its cited source says.
+
+## Read the source and definitions
+
+Read the cited source, including relevant remarks and variants. Do not treat the module docstring
+as an independent source. It is part of the change under review.
+
+Read every non-standard definition used by the statement. Search Mathlib,
+`FormalConjecturesForMathlib/`, and nearby files. Confirm names with `#check` and inspect their
+definitions before you decide what they return on empty or smallest inputs.
+
+A formalisation can add new definitions. Put a generic, reusable definition in
+`FormalConjecturesForMathlib/`. Keep a definition that is specific to one problem in its problem
+file. Never add an `axiom`, `opaque`, or `constant` declaration anywhere in the repository.
+
+## Compare the statements
+
+Check:
+
+- the order and scope of all quantifiers
+- strict and non-strict bounds
+- all hypotheses and domain restrictions
+- equality, asymptotic equivalence, and order relations
+- the direction of implications
+- every variant and special case
+- the category and answer recorded by the source
+
+Be careful with `∃ x, P x → Q`. The intended statement is usually `∃ x, P x ∧ Q`; the first
+form can be trivially true.
+
+For a yes-or-no problem, check that `answer(True)` states a positive answer and `answer(False)`
+states a negative answer. Also check the scope and expected type of `answer(sorry)`. The rest of
+the statement must constrain the unknown answer. It must not make the theorem true for every
+possible answer.
+
+## Check boundary cases
+
+Substitute the smallest permitted value of each parameter. Check empty types, empty sets, zero,
+and missing witnesses. The following table gives common examples. It is not exhaustive.
+
+| Case | Lean behaviour to check |
+| --- | --- |
+| Empty indexed type or set | A sum is `0`; a function type can be a subsingleton. |
+| `ZMod 0` | It is equivalent to `ℤ`, not a finite modulus. |
+| `x / 0` | Division returns `0`. |
+| `sInf ∅` | The value can be `0`. |
+
+A default value is not a defect by itself. Report it only when the statement can reach that input
+and the value changes the mathematical claim.
+
+For each hypothesis, ask whether any object can satisfy it. An impossible hypothesis makes an
+implication vacuously true. Add a domain restriction when the source assumes one.


### PR DESCRIPTION
This PR make the AGENTS.md file more concise, addresses a few comments from a previous PR that had been missed, and splits the AGENTS.md file into several files, some of which have workflow specific instructions (these could be useful later for making skills).