### PR TITLE
fix(VCDimConvex): exclude n = 0 degenerate case

### DIFF
--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -57,10 +57,10 @@ lemma exists_convex_rn_add_two_vc_n_forall_not_hasAddVCNDimAtMost (n : ℕ) :
 lemma hasAddVCNDimAtMost_two_one_of_convex_r3 {C : Set ℝ³} (hC : Convex ℝ C) :
     HasAddVCNDimAtMost C 2 1 := sorry
 
-/-- For every $n$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has
+/-- For every $n \ge 1$ there exists some $d$ such that every convex set in $\mathbb R^{n + 1}$ has
 $\mathrm{VC}_n$ dimension at most $d$. -/
 @[category research open, AMS 5 52]
-lemma exists_hasAddVCNDimAtMost_n_of_convex_rn_add_one (n : ℕ) :
+lemma exists_hasAddVCNDimAtMost_n_of_convex_rn_add_one (n : ℕ) (hn : 1 ≤ n) :
     ∃ d : ℕ, ∀ C : Set (Fin (n + 1) → ℝ), Convex ℝ C → HasAddVCNDimAtMost C n d := sorry
 
 /-- If $n \ge 2$, every convex set in $\mathbb R^{n + 1}$ has $\mathrm{VC}_n$ dimension at most 1.


### PR DESCRIPTION
Fixes #5022 by adding `(hn : 1 ≤ n)` (the `n = 0` disproof is in the issue).
