### PR TITLE
Add formal proof for Erdős Problem 1049 integer-base variant

### DIFF
--- a/FormalConjectures/ErdosProblems/1049.lean
+++ b/FormalConjectures/ErdosProblems/1049.lean
@@ -44,7 +44,8 @@ theorem erdos_1049 :
 /--
 Erdős [Er48] proved that this is true if $t\geq 2$ is an integer.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L94-L107"]
 theorem erdos_1049.variants.geq_2_integer :
      ∀ t : ℤ, t ≥ 2 → Irrational (∑' n : ℕ+, 1 / ((t : ℝ) ^ (n : ℕ) - 1)) := by
   sorry


### PR DESCRIPTION
This PR adds a `formal_proof` link to the solved integer-base variant of Erdős Problem 1049.

The external proof establishes the exact target theorem:

```lean
theorem erdos_1049.variants.geq_2_integer :
     ∀ t : ℤ, t ≥ 2 → Irrational (∑' n : ℕ+, 1 / ((t : ℝ) ^ (n : ℕ) - 1))
```

Proof: https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L94-L107

Repository: https://github.com/wcook04/plectis-lean-erdos249-257

The linked adapter states this exact proposition and derives it from `irrational_erdosSum_full_support`, a Lean formalisation of the Erdős 1948 result [Er48] already cited in this file: the irrationality of $\sum_n 1/(b^n - 1)$ for every integer base $b \ge 2$. The adapter step is the cast from `t : ℤ` to a natural base together with the `ℕ+`-to-`ℕ` reindexing; the analytic content is in the linked repository.

`#print axioms` on the linked theorem reports only `propext`, `Classical.choice`, and `Quot.sound`. There is no `sorryAx`.

Verification:

- `lake --wfail build 'FormalConjectures.ErdosProblems.«1049»'` succeeds on this branch (8056 jobs, Lean 4.27.0).
- The linked file is built and its axiom budget checked in the source repository's CI: https://github.com/wcook04/plectis-lean-erdos249-257/actions/runs/32084607627

The proof chain is a large development rather than a short self-contained script, so it is hosted externally per `CONTRIBUTING.md` rather than inlined. For the same reason there is no Lean4Web link — the proof does not fit in a playground snippet; the CI run above is the reproducible substitute.

AI Usage Disclosure: the linked Lean development was produced with AI assistance (Claude Code and OpenAI Codex). I have reviewed the target statement identity, the linked proof, the axiom report, and this diff, and I take responsibility for the submission.

> [!NOTE]
> This records a formal proof of the solved integer-base variant only. The main `erdos_1049` statement — Chowla's conjecture for all rational $t > 1$ — remains open and is untouched by this PR.
