### PR TITLE
Add formal proof for Erdős Problem 257 divisor-count variant

### DIFF
--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -92,7 +92,8 @@ is irrational.
 
 [Er48] Erdős, P., _On arithmetical properties of Lambert series_. J. Indian Math. Soc. (N.S.) (1948), 63-66.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L119-L134"]
 theorem erdos_257.variants.tsum_top :
     Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
   sorry


### PR DESCRIPTION
This PR adds a `formal_proof` link to the solved divisor-count variant of Erdős Problem 257.

The external proof establishes the exact target theorem:

```lean
theorem erdos_257.variants.tsum_top :
    Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ)
```

Proof: https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L119-L134

Repository: https://github.com/wcook04/plectis-lean-erdos249-257

The linked adapter states this exact proposition and derives it from `irrational_erdosSum_full_support`, a Lean formalisation of the Erdős 1948 result [Er48] already cited in this file: the irrationality of $\sum_n 1/(b^n - 1)$ for every integer base $b \ge 2$. The adapter step is the Lambert identity at base 2 — the same identity stated just above as `erdos_257.variants.tsum_top_eq` — together with dropping the vanishing $n = 0$ term. The analytic content is in the linked repository.

`#print axioms` on the linked theorem reports only `propext`, `Classical.choice`, and `Quot.sound`. There is no `sorryAx`.

Verification:

- `lake --wfail build 'FormalConjectures.ErdosProblems.«257»'` succeeds on this branch (8056 jobs, Lean 4.27.0).
- The linked file is built and its axiom budget checked in the source repository's CI: https://github.com/wcook04/plectis-lean-erdos249-257/actions/runs/32084607627

The proof chain is a large development rather than a short self-contained script, so it is hosted externally per `CONTRIBUTING.md` rather than inlined. For the same reason there is no Lean4Web link — the proof does not fit in a playground snippet; the CI run above is the reproducible substitute.

AI Usage Disclosure: the linked Lean development was produced with AI assistance (Claude Code and OpenAI Codex). I have reviewed the target statement identity, the linked proof, the axiom report, and this diff, and I take responsibility for the submission.

> [!NOTE]
> This records a formal proof of the full-support case only. The main `erdos_257` statement — whether $\sum_{n \in A} 1/(2^n - 1)$ is irrational for *every* infinite $A \subseteq \mathbb{N}$ — remains open and is untouched by this PR.
