### PR TITLE
Add formal proof for Erdős Problem 258 constant-base variant

### DIFF
--- a/FormalConjectures/ErdosProblems/258.lean
+++ b/FormalConjectures/ErdosProblems/258.lean
@@ -61,7 +61,8 @@ Is $\sum_n \frac{d(n)}{t^n}$ irrational, where $t ≥ 2$ is an integer.
 
 Solution: True (proved by Erdős, see Erdős Problems website)
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L109-L117"]
 theorem erdos_258.variants.constant : answer(True) ↔ ∀ t ≥ (2 : ℕ),
     Irrational (∑' (n : ℕ), ((n + 1).divisors.card / t^(n + 1))) := by
   sorry


### PR DESCRIPTION
This PR adds a `formal_proof` link to the solved constant-base variant of Erdős Problem 258.

The external proof establishes the exact target theorem:

```lean
theorem erdos_258.variants.constant : answer(True) ↔ ∀ t ≥ (2 : ℕ),
    Irrational (∑' (n : ℕ), ((n + 1).divisors.card / t^(n + 1)))
```

Proof: https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L109-L117

Repository: https://github.com/wcook04/plectis-lean-erdos249-257

The linked adapter states this exact proposition and derives it from `irrational_erdosSum_full_support`, a Lean formalisation of the Erdős 1948 result [Er48]: the irrationality of $\sum_n 1/(b^n - 1)$ for every integer base $b \ge 2$. The adapter step is the general-base Lambert identity relating $\sum_n 1/(t^n - 1)$ to $\sum_n d(n)/t^n$. The analytic content is in the linked repository.

The linked theorem is stated as `True ↔ ∀ t ≥ (2 : ℕ), ...`, which is what `answer(True) ↔ ...` elaborates to here.

`#print axioms` on the linked theorem reports only `propext`, `Classical.choice`, and `Quot.sound`. There is no `sorryAx`.

Verification:

- `lake --wfail build 'FormalConjectures.ErdosProblems.«258»'` succeeds on this branch (8056 jobs, Lean 4.27.0).
- The linked file is built and its axiom budget checked in the source repository's CI: https://github.com/wcook04/plectis-lean-erdos249-257/actions/runs/32084607627

The proof chain is a large development rather than a short self-contained script, so it is hosted externally per `CONTRIBUTING.md` rather than inlined. For the same reason there is no Lean4Web link — the proof does not fit in a playground snippet; the CI run above is the reproducible substitute.

AI Usage Disclosure: the linked Lean development was produced with AI assistance (Claude Code and OpenAI Codex). I have reviewed the target statement identity, the linked proof, the axiom report, and this diff, and I take responsibility for the submission.

> [!NOTE]
> This covers the constant-base case $a_i = t$ only. The main `erdos_258` statement, for an arbitrary sequence $a_n \to \infty$, already carries its own `formal_proof` link in this file and is untouched by this PR.
