### PR TITLE
Erdős 249: add dyadic-kernel, visible-lattice, and 10^34 denominator-exclusion variants

### DIFF
--- a/FormalConjectures/ErdosProblems/249.lean
+++ b/FormalConjectures/ErdosProblems/249.lean
@@ -44,7 +44,7 @@ This is a structural fact about the coefficients of $\sum_n \phi(n)/2^n$; it
 does not decide the irrationality asked about in `erdos_249`.
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at
-  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/PENDING/adapters/FormalConjecturesErdos249.lean"]
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/92d73cf7a84a1993817020d615b9b046c6ac4b19/adapters/FormalConjecturesVariants.lean#L276-L280"]
 theorem erdos_249.variants.dyadic_kernel_rank (e : ℕ) (he : 1 ≤ e) :
     Module.finrank ℚ
         (Submodule.span ℚ (Set.range (Nat.totientKernelThroughLevelFamily e))) =
@@ -61,7 +61,7 @@ it has an explicit basis on that index. It does not decide the irrationality
 asked about in `erdos_249`.
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at
-  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/PENDING/adapters/FormalConjecturesErdos249.lean"]
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/92d73cf7a84a1993817020d615b9b046c6ac4b19/adapters/FormalConjecturesVariants.lean#L284-L288"]
 theorem erdos_249.variants.odd_core_basis :
     Nonempty
       (Module.Basis Nat.TotientOddCoreIndex ℚ

--- a/FormalConjectures/ErdosProblems/249.lean
+++ b/FormalConjectures/ErdosProblems/249.lean
@@ -90,4 +90,20 @@ theorem erdos_249.variants.visible_lattice_mass {r : ℝ} (hr0 : 0 ≤ r) (hr1 :
       ∑' n : ℕ, (φ n : ℝ) * r ^ n := by
   sorry
 
+/--
+If $\sum_n \phi(n)/2^n$ is rational, its reduced denominator exceeds
+$79639646646701375323355774875831053$. Equivalently, the series is not equal
+to any rational $p$ with $p.\mathrm{den}$ at most that bound.
+
+This is a machine-checked finite exclusion for the constant in `erdos_249`.
+It does not prove irrationality: a rational with a still-larger denominator
+is not ruled out.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/Erdos249257/CertificateKernel.lean#L18384-L18389"]
+theorem erdos_249.variants.denominator_gt_79639646646701375323355774875831053 :
+    ∀ p : ℚ, p.den ≤ 79639646646701375323355774875831053 →
+      (∑' n : ℕ, ((Nat.totient n : ℝ)) / (2 : ℝ) ^ n) ≠ (p : ℝ) := by
+  sorry
+
 end Erdos249

--- a/FormalConjectures/ErdosProblems/249.lean
+++ b/FormalConjectures/ErdosProblems/249.lean
@@ -68,4 +68,26 @@ theorem erdos_249.variants.odd_core_basis :
         (Submodule.span ℚ (Set.range Nat.fullTotientKernelFamily))) := by
   sorry
 
+/--
+For every real $r$ with $0 \leq r < 1$, the ordinary generating function of
+Euler's totient is the $r$-weighted mass of the lattice points visible from the
+origin in the half-open first quadrant:
+$$\sum_{\substack{a > 0 \\ \gcd(a,b) = 1}} r^{a+b} = \sum_n \phi(n) r^n.$$
+
+The finite reason is exact. On the antidiagonal $a + b = n$ we have
+$\gcd(a, b) = \gcd(a, n)$, so the surviving points are the $a \in [1, n]$ coprime
+to $n$ -- precisely $\phi(n)$ of them. The half-open boundary is deliberate:
+$(1, 0)$ is what supplies $\phi(1) = 1$, and the empty antidiagonal at $n = 0$
+matches $\phi(0) = 0$.
+
+At $r = 1/2$ the right-hand side is the series in `erdos_249`. This is an exact
+re-indexing of that constant, not a step towards deciding its irrationality.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/c04870f7f7f2166f38fc4077033792ef6486f209/Erdos249257/GeometricCoprimality.lean#L120-L151"]
+theorem erdos_249.variants.visible_lattice_mass {r : ℝ} (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    (∑' p : ℕ × ℕ, if 0 < p.1 ∧ Nat.Coprime p.1 p.2 then r ^ (p.1 + p.2) else 0) =
+      ∑' n : ℕ, (φ n : ℝ) * r ^ n := by
+  sorry
+
 end Erdos249

--- a/FormalConjectures/ErdosProblems/249.lean
+++ b/FormalConjectures/ErdosProblems/249.lean
@@ -35,4 +35,37 @@ irrational? Here $\phi$ is the Euler totient function.
 theorem erdos_249 : answer(sorry) ↔ Irrational (∑' n : ℕ, (φ n) / (2 ^ n)) := by
   sorry
 
+/--
+Split the coefficient sequence $n \mapsto \phi(n)$ into its dyadic channels
+$n \mapsto \phi(2^j n + r)$. For every $e \geq 1$ the rational span of the
+channels of level at most $e$ has dimension exactly $2^e + 1$.
+
+This is a structural fact about the coefficients of $\sum_n \phi(n)/2^n$; it
+does not decide the irrationality asked about in `erdos_249`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/PENDING/adapters/FormalConjecturesErdos249.lean"]
+theorem erdos_249.variants.dyadic_kernel_rank (e : ℕ) (he : 1 ≤ e) :
+    Module.finrank ℚ
+        (Submodule.span ℚ (Set.range (Nat.totientKernelThroughLevelFamily e))) =
+      2 ^ e + 1 := by
+  sorry
+
+/--
+The rational span of all dyadic channels $n \mapsto \phi(2^j n + r)$ of the
+coefficient sequence of `erdos_249` admits a basis indexed by
+`Nat.TotientOddCoreIndex`.
+
+Coons proved that this span is infinite dimensional; the statement here is that
+it has an explicit basis on that index. It does not decide the irrationality
+asked about in `erdos_249`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/PENDING/adapters/FormalConjecturesErdos249.lean"]
+theorem erdos_249.variants.odd_core_basis :
+    Nonempty
+      (Module.Basis Nat.TotientOddCoreIndex ℚ
+        (Submodule.span ℚ (Set.range Nat.fullTotientKernelFamily))) := by
+  sorry
+
 end Erdos249

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -149,6 +149,7 @@ public import FormalConjecturesForMathlib.NumberTheory.Primitive
 public import FormalConjecturesForMathlib.NumberTheory.Semiprime
 public import FormalConjecturesForMathlib.NumberTheory.SierpinskiNumber
 public import FormalConjecturesForMathlib.NumberTheory.SmoothScale
+public import FormalConjecturesForMathlib.NumberTheory.TotientKernel
 public import FormalConjecturesForMathlib.NumberTheory.WallSunSunPrimes
 public import FormalConjecturesForMathlib.Order.Filter.Cofinite
 public import FormalConjecturesForMathlib.Order.Filter.atTopBot.Finset

--- a/FormalConjecturesForMathlib/NumberTheory/TotientKernel.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/TotientKernel.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjecturesForMathlib/NumberTheory/TotientKernel.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/TotientKernel.lean
@@ -1,0 +1,85 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Nat.Totient
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+
+@[expose] public section
+
+/-!
+# Dyadic channels of Euler's totient
+
+Splitting `n` by its residue modulo a power of two decomposes the totient
+sequence into channels `n ↦ φ (2 ^ j * n + r)`. This file names those channels
+and the two index types under which their rational span is usually described:
+all channels of level at most `e`, and all channels at once.
+
+The level-`0` channel is the totient sequence itself
+(`Nat.totientKernelSeq_zero_zero`), so a statement about the span of these
+families is a statement about the coefficients of `∑ φ(n) / 2 ^ n`.
+-/
+
+open scoped Nat
+
+namespace Nat
+
+/-- The `(j, r)` dyadic channel of Euler's totient: the rational-valued
+sequence `n ↦ φ (2 ^ j * n + r)`. -/
+def totientKernelSeq (j r : ℕ) : ℕ → ℚ := fun n =>
+  φ (2 ^ j * n + r)
+
+@[simp]
+theorem totientKernelSeq_apply (j r n : ℕ) :
+    totientKernelSeq j r n = φ (2 ^ j * n + r) := rfl
+
+/-- The level-`0` channel is the totient sequence itself. -/
+theorem totientKernelSeq_zero_zero : totientKernelSeq 0 0 = fun n => (φ n : ℚ) := by
+  funext n
+  simp
+
+/-- The index of the dyadic totient channels of level at most `e`: a level
+`j ≤ e` together with a residue modulo `2 ^ j`. -/
+abbrev TotientKernelThroughLevelIndex (e : ℕ) :=
+  Σ j : Fin (e + 1), Fin (2 ^ j.val)
+
+/-- Every dyadic totient channel of level at most `e`. -/
+def totientKernelThroughLevelFamily (e : ℕ) :
+    TotientKernelThroughLevelIndex e → ℕ → ℚ
+  | ⟨j, r⟩ => totientKernelSeq j.val r.val
+
+@[simp]
+theorem totientKernelThroughLevelFamily_apply (e : ℕ)
+    (j : Fin (e + 1)) (r : Fin (2 ^ j.val)) :
+    totientKernelThroughLevelFamily e ⟨j, r⟩ = totientKernelSeq j.val r.val := rfl
+
+/-- The index of all dyadic totient channels: a level `j` together with a
+residue modulo `2 ^ j`. -/
+abbrev TotientDyadicKernelIndex := Σ j : ℕ, Fin (2 ^ j)
+
+/-- Every dyadic totient channel. -/
+def fullTotientKernelFamily : TotientDyadicKernelIndex → ℕ → ℚ
+  | ⟨j, r⟩ => totientKernelSeq j r.val
+
+@[simp]
+theorem fullTotientKernelFamily_apply (j : ℕ) (r : Fin (2 ^ j)) :
+    fullTotientKernelFamily ⟨j, r⟩ = totientKernelSeq j r.val := rfl
+
+/-- The index type of the odd-core description of the dyadic totient span: two
+exceptional generators together with one generator per dyadic channel. -/
+abbrev TotientOddCoreIndex := Fin 2 ⊕ Σ j : ℕ, Fin (2 ^ j)
+
+end Nat


### PR DESCRIPTION
Closes #5037.

`249.lean` asks whether $\sum_n \phi(n)/2^n$ is irrational. This PR does not answer that.

The strongest new statement is a machine-checked finite exclusion for that constant:

```lean
theorem erdos_249.variants.denominator_gt_79639646646701375323355774875831053 :
    ∀ p : ℚ, p.den ≤ 79639646646701375323355774875831053 →
      (∑' n : ℕ, ((Nat.totient n : ℝ)) / (2 : ℝ) ^ n) ≠ (p : ℝ)
```

If the series is rational, its reduced denominator exceeds $7.96 \times 10^{34}$. A rational with a still-larger denominator is not ruled out.

The other three statements are structural facts about the same constant (dyadic-kernel rank $2^e+1$, an explicit odd-core basis, and the half-open visible-lattice generating-function identity). None of them decides irrationality.

Proofs:

- denominator exclusion: https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/Erdos249257/CertificateKernel.lean#L18384-L18389
- rank: https://github.com/wcook04/plectis-lean-erdos249-257/blob/92d73cf7a84a1993817020d615b9b046c6ac4b19/adapters/FormalConjecturesVariants.lean#L276-L280
- basis: https://github.com/wcook04/plectis-lean-erdos249-257/blob/92d73cf7a84a1993817020d615b9b046c6ac4b19/adapters/FormalConjecturesVariants.lean#L284-L288
- visible lattice: https://github.com/wcook04/plectis-lean-erdos249-257/blob/c04870f7f7f2166f38fc4077033792ef6486f209/Erdos249257/GeometricCoprimality.lean#L120-L151

Repository: https://github.com/wcook04/plectis-lean-erdos249-257

The first two coefficient theorems need six definitions in `FormalConjecturesForMathlib/NumberTheory/TotientKernel.lean`. The visible-lattice identity and the denominator exclusion use only Mathlib vocabulary, so they link directly.

No originality or priority claim is made for the Farey/gap method. The contribution is the Lean-checked bound on this specific series.

AI Usage Disclosure: the linked Lean development and this contribution were produced with AI assistance. I have reviewed the statement identity of the four variants, the linked proofs, and this diff, and I take responsibility for the submission.

> [!NOTE]
> This records solved variants about the constant in Erdős 249, including a $10^{34}$ denominator exclusion. The main `erdos_249` irrationality statement remains open.