### PR TITLE
Erdős 257: add finite-period noncollapse solved variant

### DIFF
--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -97,4 +97,30 @@ theorem erdos_257.variants.tsum_top :
     Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
   sorry
 
+/-- The finite Erdős support series at integer base `b`, summed over a finite
+set of exponents. -/
+def finiteErdosSum (F : Finset ℕ) (b : ℕ) : ℚ :=
+  ∑ n ∈ F, 1 / ((b : ℚ) ^ n - 1)
+
+/--
+For every nonempty finite support not containing `0`, and every integer base
+`b ≥ 2` coprime to the reduced denominator of that finite sum, the
+multiplicative order of `b` modulo that denominator is exactly the lcm of the
+support: the period does not collapse.
+
+This is a finite-support fact. It does not decide the infinite-set
+irrationality asked about in `erdos_257`.
+
+The coprimality hypothesis is kept: discharging it is already proved in the
+linked development, but it is not a one-line Mathlib fact.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/c04870f7f7f2166f38fc4077033792ef6486f209/adapters/FormalConjecturesVariants.lean#L348-L354"]
+theorem erdos_257.variants.finite_period_noncollapse
+    (F : Finset ℕ) (b : ℕ)
+    (hF : F.Nonempty) (h0 : 0 ∉ F) (hb : 2 ≤ b)
+    (hcop : Nat.Coprime b (finiteErdosSum F b).den) :
+    orderOf (ZMod.unitOfCoprime b hcop) = F.lcm id := by
+  sorry
+
 end Erdos257


### PR DESCRIPTION
Closes #5039.

`257.lean` currently carries the open infinite-set question, a textbook
Lambert identity, and a solved divisor-count variant. This PR does not answer
the open question. It adds one formally proved finite-support result about
the same series.

```lean
def finiteErdosSum (F : Finset ℕ) (b : ℕ) : ℚ :=
  ∑ n ∈ F, 1 / ((b : ℚ) ^ n - 1)

theorem erdos_257.variants.finite_period_noncollapse
    (F : Finset ℕ) (b : ℕ)
    (hF : F.Nonempty) (h0 : 0 ∉ F) (hb : 2 ≤ b)
    (hcop : Nat.Coprime b (finiteErdosSum F b).den) :
    orderOf (ZMod.unitOfCoprime b hcop) = F.lcm id
```

Proof:

https://github.com/wcook04/plectis-lean-erdos249-257/blob/c04870f7f7f2166f38fc4077033792ef6486f209/adapters/FormalConjecturesVariants.lean#L348-L354

Repository: https://github.com/wcook04/plectis-lean-erdos249-257

The linked adapter restates this proposition over a second copy of
`finiteErdosSum` — the two definition blocks are byte-identical — so the
linked theorem is about this constant rather than a nearby copy of it. The
proof is accepted from the existing theorem with no bridging step.

The coprimality hypothesis is kept. Discharging it is already proved in that
corpus, but it is not a one-line Mathlib fact.

`#print axioms` on the linked theorem reports only `propext`,
`Classical.choice`, and `Quot.sound`. There is no `sorryAx`.

Verification:

- `lake --wfail build 'FormalConjectures.ErdosProblems.«257»'` succeeds on this
  branch (8056 jobs, Lean 4.27.0).
- The linked file lives on Plectis `main` at
  [`c04870f`](https://github.com/wcook04/plectis-lean-erdos249-257/commit/c04870f7f7f2166f38fc4077033792ef6486f209)
  (squash-merge of https://github.com/wcook04/plectis-lean-erdos249-257/pull/80).

The proof chain is a large development rather than a short self-contained
script, so it is hosted externally per `CONTRIBUTING.md` rather than inlined.
For the same reason there is no Lean4Web link.

This does not touch #5033's divisor-count `formal_proof` link. Adjacent edit
on the same file; the new hunk is only the definition and this variant.

AI Usage Disclosure: the linked Lean development and this contribution were
produced with AI assistance (Claude Code, OpenAI Codex, and Cursor). I have
reviewed the statement identity, the linked proof, the axiom report, and this
diff, and I take responsibility for the submission.

> [!NOTE]
> This records a formally proved solved variant about finite supports of the
> Erdős 257 series. The main `erdos_257` statement — irrationality of the
> infinite-set sum — remains open and is untouched by this PR.
