### PR TITLE
Erdős 269: add the three-prime smooth-prefix LCM identity

### DIFF
--- a/FormalConjectures/ErdosProblems/269.lean
+++ b/FormalConjectures/ErdosProblems/269.lean
@@ -84,4 +84,25 @@ theorem erdos_269.variants.infinite (P : Set ℕ) (h : ∀ p ∈ P, p.Prime) (h_
   Irrational (series P) := by
   sorry
 
+/--
+For three pairwise distinct primes $p$, $q$, $r$ and any cutoff $x$, the least
+common multiple of all $\{p,q,r\}$-smooth numbers $p^i q^j r^k \le x$ is the
+product of the largest pure powers of $p$, $q$ and $r$ that are at most $x$:
+$$ \operatorname{lcm}\{p^i q^j r^k \le x\}
+   = p^{\lfloor \log_p x \rfloor} q^{\lfloor \log_q x \rfloor}
+     r^{\lfloor \log_r x \rfloor}. $$
+The pairwise-distinctness hypotheses are necessary: for $p = q = 2$, $r = 5$
+and $x = 100$ the two sides are $1600$ and $102400$.
+
+This is a finite structural identity for the running least common multiple.
+It does not establish rationality or irrationality of `series`, and it does
+not resolve either open finite-prime variant of this problem.
+-/
+@[category textbook, AMS 11]
+theorem erdos_269.variants.smooth_prefix_lcm
+    {p q r : ℕ} (hp : p.Prime) (hq : q.Prime) (hr : r.Prime)
+    (hpq : p ≠ q) (hpr : p ≠ r) (hqr : q ≠ r) (x : ℕ) :
+    smoothPrefixLcm p q r x = threePrimeHeight p q r x :=
+  smoothPrefixLcm_eq_threePrimeHeight hp hq hr hpq hpr hqr x
+
 end Erdos269

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -149,6 +149,7 @@ public import FormalConjecturesForMathlib.NumberTheory.Primitive
 public import FormalConjecturesForMathlib.NumberTheory.Semiprime
 public import FormalConjecturesForMathlib.NumberTheory.SierpinskiNumber
 public import FormalConjecturesForMathlib.NumberTheory.SmoothScale
+public import FormalConjecturesForMathlib.NumberTheory.ThreePrimeSmoothLcm
 public import FormalConjecturesForMathlib.NumberTheory.WallSunSunPrimes
 public import FormalConjecturesForMathlib.Order.Filter.Cofinite
 public import FormalConjecturesForMathlib.Order.Filter.atTopBot.Finset

--- a/FormalConjecturesForMathlib/NumberTheory/ThreePrimeSmoothLcm.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/ThreePrimeSmoothLcm.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjecturesForMathlib/NumberTheory/ThreePrimeSmoothLcm.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/ThreePrimeSmoothLcm.lean
@@ -1,0 +1,179 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+
+public import Mathlib.Algebra.GCDMonoid.Finset
+public import Mathlib.Algebra.GCDMonoid.Nat
+public import Mathlib.Data.Finset.Prod
+public import Mathlib.Data.Nat.Log
+public import Mathlib.Data.Nat.Prime.Basic
+
+@[expose] public section
+
+/-!
+# Three-prime smooth-prefix least common multiples
+
+For three pairwise distinct primes, this file identifies the least common
+multiple of all generated smooth numbers below a cutoff with the product of
+the three largest corresponding pure prime powers.
+
+This is a finite structural identity. It does not establish rationality,
+irrationality or transcendence of the series appearing in Erdős Problem 269.
+-/
+
+namespace Erdos269
+
+/-- The `{p, q, r}`-smooth lattice point with exponent vector `(i, j, k)`. -/
+def smooth3Val (p q r i j k : ℕ) : ℕ :=
+  p ^ i * q ^ j * r ^ k
+
+/--
+The product of the largest pure `p`-, `q`- and `r`-powers not exceeding `x`.
+For pairwise distinct primes and every non-zero cutoff, this is the least
+common multiple of all `{p, q, r}`-smooth numbers at most `x`.
+-/
+def threePrimeHeight (p q r x : ℕ) : ℕ :=
+  p ^ Nat.log p x * q ^ Nat.log q x * r ^ Nat.log r x
+
+/--
+Exponent vectors of the actual `{p, q, r}`-smooth prefix up to `x`.
+The logarithmic box makes the set finite; the final filter retains exactly the
+products that do not exceed the cutoff.
+-/
+def smoothPrefixExponents (p q r x : ℕ) : Finset (ℕ × ℕ × ℕ) :=
+  ((Finset.range (Nat.log p x + 1)) ×ˢ
+      ((Finset.range (Nat.log q x + 1)) ×ˢ
+        (Finset.range (Nat.log r x + 1)))).filter
+    fun e => smooth3Val p q r e.1 e.2.1 e.2.2 ≤ x
+
+/-- The literal least common multiple of the finite smooth prefix. -/
+def smoothPrefixLcm (p q r x : ℕ) : ℕ :=
+  (smoothPrefixExponents p q r x).lcm
+    fun e => smooth3Val p q r e.1 e.2.1 e.2.2
+
+/--
+Every actual smooth-prefix value divides the product of the coordinatewise
+maximal pure powers.
+-/
+theorem smooth3Val_dvd_threePrimeHeight_of_mem
+    {p q r x : ℕ} {e : ℕ × ℕ × ℕ}
+    (he : e ∈ smoothPrefixExponents p q r x) :
+    smooth3Val p q r e.1 e.2.1 e.2.2 ∣ threePrimeHeight p q r x := by
+  rw [smoothPrefixExponents, Finset.mem_filter, Finset.mem_product,
+    Finset.mem_product] at he
+  obtain ⟨⟨hp, hq, hr⟩, -⟩ := he
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hp hq hr
+  exact mul_dvd_mul
+    (mul_dvd_mul (pow_dvd_pow p hp) (pow_dvd_pow q hq))
+    (pow_dvd_pow r hr)
+
+/-- The smooth-prefix LCM divides the three-prime height. -/
+theorem smoothPrefixLcm_dvd_threePrimeHeight (p q r x : ℕ) :
+    smoothPrefixLcm p q r x ∣ threePrimeHeight p q r x :=
+  Finset.lcm_dvd fun _ he => smooth3Val_dvd_threePrimeHeight_of_mem he
+
+/-- The maximal pure `p`-power occurs in every non-empty cutoff prefix. -/
+theorem pureFirst_mem_smoothPrefixExponents
+    {p q r x : ℕ} (hx : x ≠ 0) :
+    (Nat.log p x, 0, 0) ∈ smoothPrefixExponents p q r x := by
+  rw [smoothPrefixExponents, Finset.mem_filter]
+  refine ⟨?_, ?_⟩
+  · simp [Finset.mem_product, Nat.lt_succ_iff]
+  · simpa [smooth3Val] using Nat.pow_log_le_self p hx
+
+/-- The maximal pure `q`-power occurs in every non-empty cutoff prefix. -/
+theorem pureSecond_mem_smoothPrefixExponents
+    {p q r x : ℕ} (hx : x ≠ 0) :
+    (0, Nat.log q x, 0) ∈ smoothPrefixExponents p q r x := by
+  rw [smoothPrefixExponents, Finset.mem_filter]
+  refine ⟨?_, ?_⟩
+  · simp [Finset.mem_product, Nat.lt_succ_iff]
+  · simpa [smooth3Val] using Nat.pow_log_le_self q hx
+
+/-- The maximal pure `r`-power occurs in every non-empty cutoff prefix. -/
+theorem pureThird_mem_smoothPrefixExponents
+    {p q r x : ℕ} (hx : x ≠ 0) :
+    (0, 0, Nat.log r x) ∈ smoothPrefixExponents p q r x := by
+  rw [smoothPrefixExponents, Finset.mem_filter]
+  refine ⟨?_, ?_⟩
+  · simp [Finset.mem_product, Nat.lt_succ_iff]
+  · simpa [smooth3Val] using Nat.pow_log_le_self r hx
+
+/--
+For three pairwise distinct primes and a non-zero cutoff, the smooth-prefix
+LCM is exactly the product of the three largest pure prime powers below the
+cutoff.
+-/
+theorem smoothPrefixLcm_eq_threePrimeHeight_of_ne_zero
+    {p q r x : ℕ} (hp : p.Prime) (hq : q.Prime) (hr : r.Prime)
+    (hpq : p ≠ q) (hpr : p ≠ r) (hqr : q ≠ r) (hx : x ≠ 0) :
+    smoothPrefixLcm p q r x = threePrimeHeight p q r x := by
+  refine Nat.dvd_antisymm (smoothPrefixLcm_dvd_threePrimeHeight p q r x) ?_
+  have hpDvd : p ^ Nat.log p x ∣ smoothPrefixLcm p q r x := by
+    have h :=
+      Finset.dvd_lcm
+        (f := fun e : ℕ × ℕ × ℕ => smooth3Val p q r e.1 e.2.1 e.2.2)
+        (pureFirst_mem_smoothPrefixExponents (p := p) (q := q) (r := r) hx)
+    simpa [smoothPrefixLcm, smooth3Val] using h
+  have hqDvd : q ^ Nat.log q x ∣ smoothPrefixLcm p q r x := by
+    have h :=
+      Finset.dvd_lcm
+        (f := fun e : ℕ × ℕ × ℕ => smooth3Val p q r e.1 e.2.1 e.2.2)
+        (pureSecond_mem_smoothPrefixExponents (p := p) (q := q) (r := r) hx)
+    simpa [smoothPrefixLcm, smooth3Val] using h
+  have hrDvd : r ^ Nat.log r x ∣ smoothPrefixLcm p q r x := by
+    have h :=
+      Finset.dvd_lcm
+        (f := fun e : ℕ × ℕ × ℕ => smooth3Val p q r e.1 e.2.1 e.2.2)
+        (pureThird_mem_smoothPrefixExponents (p := p) (q := q) (r := r) hx)
+    simpa [smoothPrefixLcm, smooth3Val] using h
+  have hpqCoprime : (p ^ Nat.log p x).Coprime (q ^ Nat.log q x) :=
+    Nat.Coprime.pow _ _ ((Nat.coprime_primes hp hq).mpr hpq)
+  have hprCoprime : (p ^ Nat.log p x).Coprime (r ^ Nat.log r x) :=
+    Nat.Coprime.pow _ _ ((Nat.coprime_primes hp hr).mpr hpr)
+  have hqrCoprime : (q ^ Nat.log q x).Coprime (r ^ Nat.log r x) :=
+    Nat.Coprime.pow _ _ ((Nat.coprime_primes hq hr).mpr hqr)
+  have hpqDvd :
+      p ^ Nat.log p x * q ^ Nat.log q x ∣ smoothPrefixLcm p q r x :=
+    Nat.Coprime.mul_dvd_of_dvd_of_dvd hpqCoprime hpDvd hqDvd
+  have hpqrCoprime :
+      (p ^ Nat.log p x * q ^ Nat.log q x).Coprime (r ^ Nat.log r x) :=
+    Nat.coprime_mul_iff_left.mpr ⟨hprCoprime, hqrCoprime⟩
+  exact Nat.Coprime.mul_dvd_of_dvd_of_dvd hpqrCoprime hpqDvd hrDvd
+
+/-- At the zero cutoff the smooth prefix is empty, so both sides equal `1`. -/
+theorem smoothPrefixLcm_zero_eq_threePrimeHeight_zero (p q r : ℕ) :
+    smoothPrefixLcm p q r 0 = threePrimeHeight p q r 0 := by
+  simp [smoothPrefixLcm, threePrimeHeight, smoothPrefixExponents, smooth3Val,
+    Finset.filter_singleton]
+
+/--
+For three pairwise distinct primes and **every** cutoff, the least common
+multiple of the `{p, q, r}`-smooth numbers at most `x` is the product of the
+largest pure `p`-, `q`- and `r`-powers at most `x`.
+-/
+theorem smoothPrefixLcm_eq_threePrimeHeight
+    {p q r : ℕ} (hp : p.Prime) (hq : q.Prime) (hr : r.Prime)
+    (hpq : p ≠ q) (hpr : p ≠ r) (hqr : q ≠ r) (x : ℕ) :
+    smoothPrefixLcm p q r x = threePrimeHeight p q r x := by
+  rcases Nat.eq_zero_or_pos x with hx | hx
+  · subst hx
+    exact smoothPrefixLcm_zero_eq_threePrimeHeight_zero p q r
+  · exact smoothPrefixLcm_eq_threePrimeHeight_of_ne_zero hp hq hr hpq hpr hqr
+      hx.ne'
+
+end Erdos269


### PR DESCRIPTION
Closes #5051.

This PR adds a finite structural identity associated with Erdős Problem 269.

For three pairwise distinct primes `p`, `q`, `r` and **any** cutoff `x`, the
least common multiple of all values `p^i q^j r^k ≤ x` is

    p^(Nat.log p x) * q^(Nat.log q x) * r^(Nat.log r x).

Unlike my other contributions, **the proof is entirely in this repository** —
there is no external `formal_proof` link and no trust dependency outside
Mathlib. It is short: every smooth-prefix value divides the coordinatewise
maximal product, each maximal pure power occurs in the prefix, and pairwise
coprimality of powers of distinct primes gives the reverse divisibility.

The pairwise-distinctness hypotheses are load-bearing rather than decorative.
At `p = q = 2`, `r = 5`, `x = 100` the two sides are `1600` and `102400`.
A worked positive instance: at `p,q,r = 2,3,5` and `x = 100`, both sides are
`129600 = 2⁶·3⁴·5²`.

The identity holds at `x = 0` as well, where the prefix is empty and both
sides are `1`, so the statement carries no non-vacuity hypothesis.

## Category

`textbook`, following CONTRIBUTING: this is elementary valuation bookkeeping
included as a building block of a research problem, not a research-level
result. The running least common multiple is the object Erdős 269 is about,
so the identity is directly related to the problem.

## Files

- `FormalConjecturesForMathlib/NumberTheory/ThreePrimeSmoothLcm.lean` (new)
- `FormalConjecturesForMathlib.lean` (index import)
- `FormalConjectures/ErdosProblems/269.lean` (one restatement)

## Validation

- `lake --wfail build FormalConjecturesForMathlib.NumberTheory.ThreePrimeSmoothLcm`
- `lake --wfail build FormalConjecturesForMathlib`
- `lake --wfail build 'FormalConjectures.ErdosProblems.«269»'`
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]`,
  no `sorryAx`
- No `sorry`, `axiom` or `opaque` in the new file

## Scope

This does not prove rationality, irrationality or transcendence of `series`.
The finite-prime case of Erdős 269, including the three-prime case, remains
open. The two existing open declarations are untouched. The identity is
elementary and no originality or priority claim is made.

AI Usage Disclosure: the linked Lean development and this contribution were produced with AI assistance. I have reviewed the statement identity, the linked proofs, and this diff, and I take responsibility for the submission.
