### PR TITLE
Erdős 251: add the prime-gap summation-by-parts identity and irrationality transfer

### DIFF
--- a/FormalConjectures/ErdosProblems/251.lean
+++ b/FormalConjectures/ErdosProblems/251.lean
@@ -31,4 +31,40 @@ Is $\sum_{n=1}^\infty \frac{p_n}{2^n}$ irrational? Here $p_n$ is the $n$-th prim
 theorem erdos_251 : answer(sorry) ↔ Irrational (∑' n : ℕ, (Nat.nth Nat.Prime n) / (2 ^ n)) := by
   sorry
 
+/--
+Summation by parts relates the series in `erdos_251` to the corresponding
+series of consecutive prime gaps:
+$$ \sum_{n \ge 0} \frac{p_n}{2^n} = 4 + \sum_{n \ge 0} \frac{p_{n+1} - p_n}{2^n}. $$
+The constant is $4$ rather than $2$ because `erdos_251` is indexed from
+$n = 0$, so its first term is $p_0/2^0 = 2$ and the whole series is twice the
+classical one-based one.
+
+This is an exact reformulation of the series in `erdos_251`; it does not prove
+that either series is irrational.
+-/
+@[category textbook, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/ceaee37f2df872af9e19c90f2b88d87f06fec85d/adapters/FormalConjecturesVariants.lean#L392-L412"]
+theorem erdos_251.variants.prime_gap_identity :
+    (∑' n : ℕ, (Nat.nth Nat.Prime n : ℝ) / (2 ^ n)) =
+      4 + ∑' n : ℕ, (primeGap n : ℝ) / (2 ^ n) := by
+  sorry
+
+/--
+Irrationality of the prime dyadic series in `erdos_251` is equivalent to
+irrationality of the corresponding consecutive-prime-gap dyadic series.
+
+The equivalence is hypothesis-free: convergence of both series is established
+in the linked proof from the elementary bound $p_n \le 1250(n+1)^4$, so no
+summability premise appears.
+
+This is an exact reformulation, not a proof of the irrationality of either
+series, so `erdos_251` remains open.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/ceaee37f2df872af9e19c90f2b88d87f06fec85d/adapters/FormalConjecturesVariants.lean#L417-L421"]
+theorem erdos_251.variants.prime_gap_transfer :
+    Irrational (∑' n : ℕ, (Nat.nth Nat.Prime n : ℝ) / (2 ^ n)) ↔
+      Irrational (∑' n : ℕ, (primeGap n : ℝ) / (2 ^ n)) := by
+  sorry
+
 end Erdos251


### PR DESCRIPTION
Closes #5052.

Two solved variants beside Erdős Problem 251.

With the zero-based indexing the existing `erdos_251` statement uses,
summation by parts gives

    ∑_{n≥0} pₙ/2ⁿ  =  4 + ∑_{n≥0} (pₙ₊₁ - pₙ)/2ⁿ

and consequently irrationality of the prime dyadic series is equivalent to
irrationality of the corresponding consecutive-prime-gap dyadic series.

The constant is `4`, not `2`, because `erdos_251` sums from `n = 0`, so its
first term is `p₀/2⁰ = 2` and the whole series is twice the classical
one-based one.

## No new support vocabulary

This PR changes **one file**. `primeGap` is already defined in
`FormalConjecturesForMathlib/NumberTheory/PrimeGap.lean` and re-exported
through `FormalConjecturesUtil`, so the statement is expressible from
`Nat.nth Nat.Prime` and `primeGap` alone. The linked repository declares
`primeGap` with upstream's body and proves the two agree by `rfl`, so the
proof link resolves to the exact proposition rather than a near copy.

## Hypothesis-free

The equivalence carries no summability premise. Convergence is discharged
inside the linked proof from the elementary bound `pₙ ≤ 1250(n+1)⁴`, itself
proved there from central-binomial growth and prime counting rather than from
the prime number theorem.

## Validation

- `lake --wfail build 'FormalConjectures.ErdosProblems.«251»'`
- `#print axioms` on both linked declarations:
  `[propext, Classical.choice, Quot.sound]`, no `sorryAx`
- Two statement-identity negative controls, both type mismatches:
  `4 → 5`, and `primeGap n → primeGap (n + 1)`
- `scripts/check_release.py` in the proof repository: 9569 checks pass

## Scope

These are exact reformulations. They do not prove either series irrational,
and `erdos_251` remains open and untouched. The summation-by-parts equivalence
is elementary and has been noted publicly before; no originality or priority
claim is made. The contribution is its exact Lean formalisation.

AI Usage Disclosure: the linked Lean development and this contribution were produced with AI assistance. I have reviewed the statement identity, the linked proofs, and this diff, and I take responsibility for the submission.
