### PR TITLE
Erdős 68: add the cofinal strict-successor divisibility reformulation

### DIFF
--- a/FormalConjectures/ErdosProblems/68.lean
+++ b/FormalConjectures/ErdosProblems/68.lean
@@ -35,6 +35,29 @@ theorem erdos_68 :
   sorry
 
 /--
+For the exact rational prefix $H_m = \sum_{k=2}^{m} 1/(k!-1)$, let
+$Z_m = \lfloor m!\,H_m \rfloor + 1$ be its strict factorial-grid successor.
+The series in `erdos_68` is irrational exactly when, beyond every cutoff, some
+$Z_m$ fails to be divisible by its index $m$.
+
+The right-hand side is a purely integral, exactly computable condition: no
+real-number reasoning is needed to evaluate it at any index. The equivalence
+is hypothesis-free.
+
+This is an exact arithmetic reformulation of `erdos_68`; it does not decide
+either side, and in particular does not establish that such divisibility
+failures occur cofinally.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/ceaee37f2df872af9e19c90f2b88d87f06fec85d/adapters/FormalConjecturesVariants.lean#L487-L494"]
+theorem erdos_68.variants.iff_cofinal_divisibility_miss :
+    Irrational (∑' n : ℕ, 1 / ((n + 2).factorial - 1 : ℝ)) ↔
+      ∀ B : ℕ, ∃ m : ℕ,
+        B < m ∧
+          ¬ ((m : ℤ) ∣ strictFacTopRat (factorialGapPrefix m) m) := by
+  sorry
+
+/--
 $$\sum_{n=2}^\infty \frac{1}{n!-1} = \sum_{n=2}^\infty \sum_{k=1}^\infty \frac{1}{(n!)^k}$$
 -/
 @[category textbook, AMS 11]

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -137,6 +137,7 @@ public import FormalConjecturesForMathlib.NumberTheory.CoveringSystem
 public import FormalConjecturesForMathlib.NumberTheory.DiophantineApproximation.ZNumber
 public import FormalConjecturesForMathlib.NumberTheory.DirichletCharacter.Basic
 public import FormalConjecturesForMathlib.NumberTheory.Divisors
+public import FormalConjecturesForMathlib.NumberTheory.FactorialGap
 public import FormalConjecturesForMathlib.NumberTheory.Harmonic
 public import FormalConjecturesForMathlib.NumberTheory.Lacunary
 public import FormalConjecturesForMathlib.NumberTheory.LegendreSymbol.Basic

--- a/FormalConjecturesForMathlib/NumberTheory/FactorialGap.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/FactorialGap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjecturesForMathlib/NumberTheory/FactorialGap.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/FactorialGap.lean
@@ -1,0 +1,45 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+
+public import Mathlib.Algebra.BigOperators.Intervals
+public import Mathlib.Data.Nat.Factorial.Basic
+public import Mathlib.Data.Rat.Floor
+
+@[expose] public section
+
+/-!
+# Exact prefixes of the factorial-gap series
+
+Definitions used in arithmetic reformulations of Erdős Problem 68.
+
+Both are exactly computable over `ℚ` and `ℤ`, so the reformulation they
+support can be evaluated at any index without any real-number reasoning.
+-/
+
+namespace Erdos68
+
+/-- The exact rational prefix `∑ k ∈ {2, …, n}, 1 / (k! - 1)` of the
+factorial-gap series. -/
+def factorialGapPrefix (n : ℕ) : ℚ :=
+  ∑ k ∈ Finset.Icc 2 n, 1 / ((k.factorial : ℚ) - 1)
+
+/-- The first integer strictly greater than `n! * x`. -/
+def strictFacTopRat (x : ℚ) (n : ℕ) : ℤ :=
+  ⌊(n.factorial : ℚ) * x⌋ + 1
+
+end Erdos68


### PR DESCRIPTION
Closes #5053.

One solved variant beside Erdős Problem 68. It does not prove the series
irrational.

For the exact rational prefix

    H_m = ∑_{k=2}^{m} 1/(k! - 1),

let `Z_m = ⌊m! H_m⌋ + 1` be its strict factorial-grid successor. The theorem
states

    Irrational(∑_{n≥0} 1/((n+2)! - 1))  ⟺  ∀ B, ∃ m > B, m ∤ Z_m.

The right-hand side is purely integral and exactly computable: a reader can
evaluate it at any index over `ℚ` and `ℤ` with no real-number reasoning. The
equivalence is hypothesis-free.

## Two support definitions

`FormalConjecturesForMathlib/NumberTheory/FactorialGap.lean` adds exactly
`factorialGapPrefix` and `strictFacTopRat`. The linked repository declares both
with identical bodies in the namespace this problem file uses, and proves the
copies agree by `rfl`, so the proof link resolves to the exact proposition.

The one non-definitional step in the linked restatement is the reindexing
between the proof repository's universal-tail presentation and upstream's
`n + 2` sum: `1 + 1 + k = k + 2`.

## A sibling variant deliberately withheld

The linked repository also proves an equivalent **carry** formulation: the
series is irrational exactly when the integer carry in the recurrence
`Z_m = m·Z_{m-1} + 1 - b_m` differs from `1` cofinally often. It is not
offered here. A unit carry is exactly the divisibility condition above for
`m ≥ 3`, and both statements quantify cofinally, so finitely many small indices
cannot separate them — they are one theorem in two sets of clothes. The
divisibility form needs two support definitions; the carry form needs five,
including a real-valued predecessor gap. Submitting both would present one
result as two.

## Validation

- `lake --wfail build FormalConjecturesForMathlib.NumberTheory.FactorialGap`
- `lake --wfail build FormalConjecturesForMathlib`
- `lake --wfail build 'FormalConjectures.ErdosProblems.«68»'`
- `#print axioms` on the linked declaration:
  `[propext, Classical.choice, Quot.sound]`, no `sorryAx`
- Two statement-identity negative controls, both type mismatches: prefix
  `Icc → Ico`, and divisor `m → m + 1`
- `scripts/check_release.py` in the proof repository: 9569 checks pass

## Scope

This is an exact arithmetic reformulation. It does not decide either side, and
in particular does not establish that such divisibility failures occur
cofinally. `erdos_68` remains open and untouched. No originality or priority
claim is made.

AI Usage Disclosure: the linked Lean development and this contribution were produced with AI assistance. I have reviewed the statement identity, the linked proofs, and this diff, and I take responsibility for the submission.
