### PR TITLE
Erdős 257: settled support families, and the structure of the value space

### DIFF
--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -38,7 +38,7 @@ theorem erdos_257 : answer(sorry) ↔ ∀ (A : Set ℕ), A.Infinite →
     Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1)) := by
   sorry
 
-/-! ### Settled infinite-support families
+/- ### Settled infinite-support families
 
 `erdos_257` asks whether *every* infinite support gives an irrational sum. The
 four statements below say yes for four named families. They are stated in the

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -24,6 +24,8 @@ import FormalConjecturesUtil
 
 namespace Erdos257
 
+open scoped ENNReal
+
 /--
 Let $A\subseteq\mathbb{N}$ be an infinite set. Is
 $$
@@ -95,6 +97,37 @@ is irrational.
 @[category research solved, AMS 11]
 theorem erdos_257.variants.tsum_top :
     Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
+  sorry
+
+/--
+For a set `J` of allowed positive-exponent coordinates, the Mersenne
+achievement set restricted to `J` has an exact Lebesgue-measure dichotomy: if
+the forbidden coordinates form a finite set `F`, the measure is $2^{-|F|}$; if
+infinitely many coordinates are forbidden, the measure is zero.
+
+Coordinate `k` carries the term $1/(2^{k+1}-1)$. Taking `J = Set.univ`, so
+`F = ∅`, gives Lebesgue measure exactly `1` for the unrestricted achievement
+set of these weights.
+
+Kovač–Tao (doi:10.1007/s10474-025-01528-0, §2.1.2 and Remark 4.1) record the
+strict-tail inequality and Cantor-set structure for these exact Lambert
+weights; the measure of a fast achievement set is classical (Kakeya; see
+Bartoszewicz–Filipczak–Prus-Wiśniowski, doi:10.1007/s40879-020-00438-5). No
+claim of mathematical novelty or priority is made.
+
+This is a solved structural variant about the geometry of the value space. It
+does not decide whether every infinite-support subseries has an irrational
+sum, so `erdos_257` remains open.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/ceaee37f2df872af9e19c90f2b88d87f06fec85d/adapters/FormalConjecturesVariants.lean#L566-L573"]
+theorem erdos_257.variants.support_measure_dichotomy (J : Set ℕ) :
+    (∃ F : Finset ℕ,
+        J = (↑F : Set ℕ)ᶜ ∧
+          MeasureTheory.volume (supportedMersenneAchievementSet J) =
+            ((2 : ℝ≥0∞) ^ F.card)⁻¹) ∨
+      (Jᶜ.Infinite ∧
+        MeasureTheory.volume (supportedMersenneAchievementSet J) = 0) := by
   sorry
 
 end Erdos257

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -130,4 +130,37 @@ theorem erdos_257.variants.support_measure_dichotomy (J : Set ℕ) :
         MeasureTheory.volume (supportedMersenneAchievementSet J) = 0) := by
   sorry
 
+/--
+For a set `J` of allowed coordinates, the Mersenne digit map restricted to `J`
+is injective, and its range is compact, totally disconnected and nowhere
+dense; when `J` is infinite that range is perfect as well.
+
+Coordinate `k` carries the term $1/(2^{k+1}-1)$. At `J = Set.univ` this is the
+statement for the unrestricted achievement set, and the injectivity conjunct is
+then unique coding: distinct supports give distinct subseries sums. `IsClosed`
+is left out on purpose rather than overlooked -- the set is a compact subset of
+`ℝ`, and `Perfect` carries closedness in its own first component.
+
+Kovač–Tao (doi:10.1007/s10474-025-01528-0, Remark 4.1) prove the strict-tail
+inequality for these exact weights and record both the unique coding and the
+Cantor-set conclusion; the underlying achievement-set topology is classical,
+going back to Kakeya. No claim of novelty or priority is made for any of it.
+What is offered here is the Lean statement for arbitrary `J` -- total
+disconnectedness and nowhere density descend along `⊆`, so the restricted case
+costs nothing over the full one -- together with a machine-checked proof.
+
+This is a solved structural variant about the geometry of the value space. It
+does not decide whether every infinite-support subseries has an irrational sum,
+so `erdos_257` remains open.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L597-L608"]
+theorem erdos_257.variants.supported_achievement_set_geometry (J : Set ℕ) :
+    Function.Injective (supportedMersenneDigitValue J) ∧
+      IsCompact (supportedMersenneAchievementSet J) ∧
+        IsTotallyDisconnected (supportedMersenneAchievementSet J) ∧
+          IsNowhereDense (supportedMersenneAchievementSet J) ∧
+            (J.Infinite → Perfect (supportedMersenneAchievementSet J)) := by
+  sorry
+
 end Erdos257

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -97,4 +97,30 @@ theorem erdos_257.variants.tsum_top :
     Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
   sorry
 
+/-- The finite Erdős support series at integer base `b`, summed over a finite
+set of exponents. -/
+def finiteErdosSum (F : Finset ℕ) (b : ℕ) : ℚ :=
+  ∑ n ∈ F, 1 / ((b : ℚ) ^ n - 1)
+
+/--
+For every nonempty finite support not containing `0`, and every integer base
+`b ≥ 2` coprime to the reduced denominator of that finite sum, the
+multiplicative order of `b` modulo that denominator is exactly the lcm of the
+support: the period does not collapse.
+
+This is a finite-support fact. It does not decide the infinite-set
+irrationality asked about in `erdos_257`.
+
+The coprimality hypothesis is kept: discharging it is already proved in the
+linked development, but it is not a one-line Mathlib fact.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/c04870f7f7f2166f38fc4077033792ef6486f209/adapters/FormalConjecturesVariants.lean#L348-L354"]
+theorem erdos_257.variants.finite_period_noncollapse
+    (F : Finset ℕ) (b : ℕ)
+    (hF : F.Nonempty) (h0 : 0 ∉ F) (hb : 2 ≤ b)
+    (hcop : Nat.Coprime b (finiteErdosSum F b).den) :
+    orderOf (ZMod.unitOfCoprime b hcop) = F.lcm id := by
+  sorry
+
 end Erdos257

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -36,6 +36,93 @@ theorem erdos_257 : answer(sorry) ↔ ∀ (A : Set ℕ), A.Infinite →
     Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1)) := by
   sorry
 
+/-! ### Settled infinite-support families
+
+`erdos_257` asks whether *every* infinite support gives an irrational sum. The
+four statements below say yes for four named families. They are stated in the
+same shape as the open question, so they need no new definitions.
+
+None of this is new mathematics, and no claim of novelty or priority is made.
+-/
+
+/--
+If an infinite support `A` is eventually periodic -- membership of `n` and of
+`n + m` agree for all `n` past some threshold `N₀` -- then for every integer
+base `b ≥ 2` the sum $\sum_{n \in A} 1/(b^n-1)$ is irrational.
+
+This is the $0$–$1$ coefficient case of Luca–Tachiya, who prove it for
+arbitrary eventually periodic rational coefficients that are not eventually
+zero and every integer base with $|b| > 1$
+(doi:10.1142/S1793042113501121). `A.Infinite` is what stops the indicator
+sequence from being eventually zero.
+
+One settled family. It does not decide `erdos_257`, which quantifies over all
+infinite supports.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L638-L647"]
+theorem erdos_257.variants.eventually_periodic_support
+    (b m N₀ : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hm : 0 < m)
+    (hper : ∀ n : ℕ, N₀ ≤ n → (n + m ∈ A ↔ n ∈ A)) (hA : A.Infinite) :
+    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
+If an infinite support `A` is pairwise coprime and its reciprocals are
+summable, then for every integer base `b ≥ 2` the sum
+$\sum_{n \in A} 1/(b^n-1)$ is irrational.
+
+This is Erdős, *On the Irrationality of Certain Series*, Math. Student 36
+(1968), 222–226, theorem on p. 222, stated over a set rather than a sequence.
+Both hypotheses are kept as Erdős states them.
+
+One settled family. It does not decide `erdos_257`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L650-L660"]
+theorem erdos_257.variants.pairwise_coprime_support
+    (b : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hA : A.Infinite)
+    (hpair : A.Pairwise Nat.Coprime)
+    (hsum : Summable fun a : A => (1 : ℝ) / (a : ℕ)) :
+    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
+For every integer base `b ≥ 2`, the sum over the positive factorials
+$\sum_k 1/(b^{(k+1)!}-1)$ is irrational.
+
+The support is indexed from $1! $ rather than $0!$, so the exponent `1` is not
+repeated. The family lies in the rapidly-growing framework of Erdős–Straus,
+*On the irrationality of certain Ahmes series*, J. Indian Math. Soc. 27 (1964),
+129–133: all earlier denominators divide the latest one, and the next grows too
+fast for the exceptional rational recurrence.
+
+One settled family. It does not decide `erdos_257`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L663-L665"]
+theorem erdos_257.variants.factorial_support (b : ℕ) (hb : 2 ≤ b) :
+    Irrational (∑' k : ℕ, (1 : ℝ) / ((b : ℝ) ^ (Nat.factorial (k + 1)) - 1)) := by
+  sorry
+
+/--
+For every integer base `b ≥ 2`, the sum over the powers of two
+$\sum_k 1/(b^{2^k}-1)$ is irrational.
+
+This is the constant-perturbation case $b_k = -1$ of Erdős–Straus, Example 1,
+pp. 132–133. Duverney later proved the stronger result that the value is
+transcendental (doi:10.1017/S0305004100004783); what is recorded here is the
+irrationality statement.
+
+One settled family. It does not decide `erdos_257`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L668-L670"]
+theorem erdos_257.variants.two_pow_support (b : ℕ) (hb : 2 ≤ b) :
+    Irrational (∑' k : ℕ, (1 : ℝ) / ((b : ℝ) ^ (2 ^ k) - 1)) := by
+  sorry
+
+
 /--
 Show that
 $$

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -92,7 +92,8 @@ is irrational.
 
 [Er48] Erdős, P., _On arithmetical properties of Lambert series_. J. Indian Math. Soc. (N.S.) (1948), 63-66.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L119-L134"]
 theorem erdos_257.variants.tsum_top :
     Irrational <| ∑' n, n.divisors.card / (2 ^ n : ℝ) := by
   sorry

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -140,6 +140,7 @@ public import FormalConjecturesForMathlib.NumberTheory.Divisors
 public import FormalConjecturesForMathlib.NumberTheory.Harmonic
 public import FormalConjecturesForMathlib.NumberTheory.Lacunary
 public import FormalConjecturesForMathlib.NumberTheory.LegendreSymbol.Basic
+public import FormalConjecturesForMathlib.NumberTheory.MersenneAchievementSet
 public import FormalConjecturesForMathlib.NumberTheory.NormalNumber
 public import FormalConjecturesForMathlib.NumberTheory.NumberField.Quadratic
 public import FormalConjecturesForMathlib.NumberTheory.PisotNumber

--- a/FormalConjecturesForMathlib/NumberTheory/MersenneAchievementSet.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/MersenneAchievementSet.lean
@@ -1,5 +1,5 @@
 /-
-Copyright 2025 The Formal Conjectures Authors.
+Copyright 2026 The Formal Conjectures Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/FormalConjecturesForMathlib/NumberTheory/MersenneAchievementSet.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/MersenneAchievementSet.lean
@@ -1,0 +1,72 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+
+public import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+
+@[expose] public section
+
+/-!
+# Support-restricted Mersenne achievement sets
+
+Statement vocabulary for the subseries of `∑ n, 1 / (2 ^ n - 1)` appearing in
+Erdős Problem 257.
+
+Coordinate `k` below carries the positive exponent `k + 1`. Exponent `0` is
+excluded: its Mersenne weight `1 / (2 ^ 0 - 1)` is zero under Lean's division
+convention, so it contributes nothing to any subseries.
+-/
+
+namespace Erdos257
+
+/-- The real Mersenne weight `1 / (2 ^ n - 1)`. -/
+noncomputable def mersenneWeight (n : ℕ) : ℝ :=
+  1 / ((2 : ℝ) ^ n - 1)
+
+/-- The contribution of coordinate `k`, carrying exponent `k + 1`. -/
+noncomputable def mersenneDigitTerm (k : ℕ) (b : ℕ → Fin 2) : ℝ :=
+  ((b k : ℕ) : ℝ) * mersenneWeight (k + 1)
+
+/-- The Mersenne subseries value coded by a binary digit string. -/
+noncomputable def positiveMersenneDigitValue (b : ℕ → Fin 2) : ℝ :=
+  ∑' k : ℕ, mersenneDigitTerm k b
+
+/-- Binary digit strings whose nonzero coordinates lie in `J`. -/
+def SupportedMersenneDigits (J : Set ℕ) :=
+  {b : ℕ → Fin 2 // ∀ k, k ∉ J → b k = 0}
+
+/-- The Mersenne digit map restricted to the allowed coordinates `J`. -/
+noncomputable def supportedMersenneDigitValue
+    (J : Set ℕ) (b : SupportedMersenneDigits J) : ℝ :=
+  positiveMersenneDigitValue b.1
+
+/-- All Mersenne subseries sums using only coordinates from `J`. -/
+def supportedMersenneAchievementSet (J : Set ℕ) : Set ℝ :=
+  Set.range (supportedMersenneDigitValue J)
+
+@[simp]
+theorem supportedMersenneDigitValue_apply
+    (J : Set ℕ) (b : SupportedMersenneDigits J) :
+    supportedMersenneDigitValue J b = positiveMersenneDigitValue b.1 :=
+  rfl
+
+theorem mem_supportedMersenneAchievementSet_iff (J : Set ℕ) (x : ℝ) :
+    x ∈ supportedMersenneAchievementSet J ↔
+      ∃ b : SupportedMersenneDigits J, supportedMersenneDigitValue J b = x :=
+  Iff.rfl
+
+end Erdos257


### PR DESCRIPTION
Closes #5054.

This is the single Erdős 257 PR. It supersedes #5033, #5040 and #5047, which I have closed — every declaration from all three is preserved here verbatim, with its own proof link.

They were separate PRs by mistake on my part. `257.lean` is one file that each contribution appends to, so four PRs against it conflict by construction rather than by accident; splitting them created work for a reviewer and none of it was mine to hand over.

`erdos_257` itself is untouched and remains open.

## What the file now contains, in order

**The open question**, then what is settled about it:

| Declaration | Says |
|---|---|
| `eventually_periodic_support` | eventually periodic infinite supports give irrational sums |
| `pairwise_coprime_support` | so do infinite pairwise-coprime supports with summable reciprocals |
| `factorial_support` | so does the positive-factorial support |
| `two_pow_support` | so does the powers-of-two support |

These four are stated in the same shape `erdos_257` uses — `∑' n : A, 1 / (b ^ n - 1)` — so they need no new vocabulary, and the base is generalised from `2` to any integer `b ≥ 2`.

**The classical identities**, `tsum_top_eq` and `tsum_top`, the latter now carrying the formal proof from #5033.

**Structural results:**

| Declaration | Says |
|---|---|
| `finite_period_noncollapse` | for a finite support, the multiplicative order of the base modulo the reduced denominator is exactly the lcm of the support |
| `support_measure_dichotomy` | the support-restricted achievement set has measure `2^(-\|F\|)` for finite omitted `F`, and `0` when infinitely many are omitted |
| `supported_achievement_set_geometry` | that set is also injectively coded, compact, totally disconnected and nowhere dense — and perfect when `J` is infinite |

The last two share the six definitions in `FormalConjecturesForMathlib/NumberTheory/MersenneAchievementSet.lean`, the only support file this PR adds.

The geometry statement is given for arbitrary `J` rather than only the full set. `IsTotallyDisconnected` unfolds to a condition quantified over subsets, so it descends along `⊆` exactly as nowhere density does; at `J = Set.univ` it therefore *is* the full-set statement, with unique coding as its injectivity conjunct. `IsClosed` is deliberately not a conjunct — the set is a compact subset of `ℝ` and `Perfect` already carries closedness.

## Prior art

None of the mathematics here is new, and no claim of novelty or priority is made for any of it.

- Eventually periodic supports are the $0$–$1$ coefficient case of Luca–Tachiya, doi:10.1142/S1793042113501121.
- Pairwise-coprime supports are Erdős, *On the Irrationality of Certain Series*, Math. Student 36 (1968), 222–226, theorem on p. 222.
- The factorial and powers-of-two families sit in the rapid-growth framework of Erdős–Straus, J. Indian Math. Soc. 27 (1964), 129–133; the powers-of-two case is their Example 1. Duverney later proved that value transcendental (doi:10.1017/S0305004100004783); what is recorded here is irrationality.
- Kovač–Tao (doi:10.1007/s10474-025-01528-0, Remark 4.1) prove the strict-tail inequality for these exact weights and record both the unique coding and the Cantor-set conclusion; the achievement-set topology is classical, going back to Kakeya. The measure computation is the part their remark does not carry.

## Receipts

- `lake build 'FormalConjectures.ErdosProblems.«257»'` succeeds on this branch.
- The linked adapter is compiled by CI in the source repository, not only locally: https://github.com/wcook04/plectis-lean-erdos249-257/actions/runs/32196665233 (`Build foreign-corpus variant candidates` → `lake build FormalConjecturesVariants`, green on `main`).
- Every linked declaration audits to `[propext, Classical.choice, Quot.sound]`. There is no `sorryAx`.
- Each upstream statement was diffed textually against the adapter declaration its permalink points at; all match. This matters because the upstream bodies are `sorry`, so nothing else enforces that the link proves the stated proposition.
- Negative control: replacing `Nat.factorial (k + 1)` by `Nat.factorial k` is rejected with a type mismatch, so the index convention is load-bearing rather than incidental.
- Proofs are hosted externally per `CONTRIBUTING.md` and linked at immutable commits.

AI Usage Disclosure: the linked Lean development and this contribution were produced with AI assistance. I have reviewed the statement identity of every variant against its proof, the axiom reports, the attributions above, and this diff, and I take responsibility for the submission.

> [!NOTE]
> These are solved variants and settled support families around Erdős 257. They do not prove irrationality for every infinite support, so `erdos_257` remains open and is untouched.

