### PR TITLE
Erdős 257: add four settled infinite-support families

### DIFF
--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -36,6 +36,93 @@ theorem erdos_257 : answer(sorry) ↔ ∀ (A : Set ℕ), A.Infinite →
     Irrational (∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1)) := by
   sorry
 
+/-! ### Settled infinite-support families
+
+`erdos_257` asks whether *every* infinite support gives an irrational sum. The
+four statements below say yes for four named families. They are stated in the
+same shape as the open question, so they need no new definitions.
+
+None of this is new mathematics, and no claim of novelty or priority is made.
+-/
+
+/--
+If an infinite support `A` is eventually periodic -- membership of `n` and of
+`n + m` agree for all `n` past some threshold `N₀` -- then for every integer
+base `b ≥ 2` the sum $\sum_{n \in A} 1/(b^n-1)$ is irrational.
+
+This is the $0$–$1$ coefficient case of Luca–Tachiya, who prove it for
+arbitrary eventually periodic rational coefficients that are not eventually
+zero and every integer base with $|b| > 1$
+(doi:10.1142/S1793042113501121). `A.Infinite` is what stops the indicator
+sequence from being eventually zero.
+
+One settled family. It does not decide `erdos_257`, which quantifies over all
+infinite supports.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L638-L647"]
+theorem erdos_257.variants.eventually_periodic_support
+    (b m N₀ : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hm : 0 < m)
+    (hper : ∀ n : ℕ, N₀ ≤ n → (n + m ∈ A ↔ n ∈ A)) (hA : A.Infinite) :
+    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
+If an infinite support `A` is pairwise coprime and its reciprocals are
+summable, then for every integer base `b ≥ 2` the sum
+$\sum_{n \in A} 1/(b^n-1)$ is irrational.
+
+This is Erdős, *On the Irrationality of Certain Series*, Math. Student 36
+(1968), 222–226, theorem on p. 222, stated over a set rather than a sequence.
+Both hypotheses are kept as Erdős states them.
+
+One settled family. It does not decide `erdos_257`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L650-L660"]
+theorem erdos_257.variants.pairwise_coprime_support
+    (b : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hA : A.Infinite)
+    (hpair : A.Pairwise Nat.Coprime)
+    (hsum : Summable fun a : A => (1 : ℝ) / (a : ℕ)) :
+    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
+For every integer base `b ≥ 2`, the sum over the positive factorials
+$\sum_k 1/(b^{(k+1)!}-1)$ is irrational.
+
+The support is indexed from $1! $ rather than $0!$, so the exponent `1` is not
+repeated. The family lies in the rapidly-growing framework of Erdős–Straus,
+*On the irrationality of certain Ahmes series*, J. Indian Math. Soc. 27 (1964),
+129–133: all earlier denominators divide the latest one, and the next grows too
+fast for the exceptional rational recurrence.
+
+One settled family. It does not decide `erdos_257`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L663-L665"]
+theorem erdos_257.variants.factorial_support (b : ℕ) (hb : 2 ≤ b) :
+    Irrational (∑' k : ℕ, (1 : ℝ) / ((b : ℝ) ^ (Nat.factorial (k + 1)) - 1)) := by
+  sorry
+
+/--
+For every integer base `b ≥ 2`, the sum over the powers of two
+$\sum_k 1/(b^{2^k}-1)$ is irrational.
+
+This is the constant-perturbation case $b_k = -1$ of Erdős–Straus, Example 1,
+pp. 132–133. Duverney later proved the stronger result that the value is
+transcendental (doi:10.1017/S0305004100004783); what is recorded here is the
+irrationality statement.
+
+One settled family. It does not decide `erdos_257`.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/f88e8b686908010a43e9078dda49abbabcfc4079/adapters/FormalConjecturesVariants.lean#L668-L670"]
+theorem erdos_257.variants.two_pow_support (b : ℕ) (hb : 2 ≤ b) :
+    Irrational (∑' k : ℕ, (1 : ℝ) / ((b : ℝ) ^ (2 ^ k) - 1)) := by
+  sorry
+
+
 /--
 Show that
 $$


### PR DESCRIPTION
`erdos_257` asks whether **every** infinite support gives an irrational sum. `257.lean` currently records the question and two variants about the full-support value, but nothing about which supports are already settled. This PR adds four families that are, stated in the same shape as the open question.

```lean
theorem erdos_257.variants.eventually_periodic_support
    (b m N₀ : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hm : 0 < m)
    (hper : ∀ n : ℕ, N₀ ≤ n → (n + m ∈ A ↔ n ∈ A)) (hA : A.Infinite) :
    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1))

theorem erdos_257.variants.pairwise_coprime_support
    (b : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hA : A.Infinite)
    (hpair : A.Pairwise Nat.Coprime)
    (hsum : Summable fun a : A => (1 : ℝ) / (a : ℕ)) :
    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1))

theorem erdos_257.variants.factorial_support (b : ℕ) (hb : 2 ≤ b) :
    Irrational (∑' k : ℕ, (1 : ℝ) / ((b : ℝ) ^ (Nat.factorial (k + 1)) - 1))

theorem erdos_257.variants.two_pow_support (b : ℕ) (hb : 2 ≤ b) :
    Irrational (∑' k : ℕ, (1 : ℝ) / ((b : ℝ) ^ (2 ^ k) - 1))
```

They are separate declarations rather than one conjunction so that each stays searchable and keeps its own hypotheses and its own proof link. They are one PR because they form a single map: what is known about the supports the open question quantifies over.

## No new vocabulary

The two set-indexed statements use the same subtype sum as `erdos_257` itself, and the two explicit families are indexed over `k`, matching their proofs exactly. So there is no `FormalConjecturesForMathlib` file and no index change — the diff is `257.lean` only.

The base is generalised from `2` to any integer `b ≥ 2`, which is what the underlying proofs give.

## Prior art

None of this is new mathematics and no claim of novelty or priority is made for any of it.

- Eventually periodic supports are the $0$–$1$ coefficient case of Luca–Tachiya, *Irrationality of Lambert series associated with a periodic sequence*, IJNT 10 (2014), 623–636, doi:10.1142/S1793042113501121. They prove it for arbitrary eventually periodic rational coefficients not eventually zero, and every integer base with $|b| > 1$.
- Pairwise-coprime supports are Erdős, *On the Irrationality of Certain Series*, Math. Student 36 (1968), 222–226, theorem on p. 222. Both hypotheses are kept as stated there.
- The factorial and powers-of-two families lie in the rapid-growth framework of Erdős–Straus, *On the irrationality of certain Ahmes series*, J. Indian Math. Soc. 27 (1964), 129–133; the powers-of-two case is their Example 1, pp. 132–133.
- Duverney later proved the powers-of-two value transcendental (doi:10.1017/S0305004100004783). What is recorded here is the irrationality statement.

## Receipts

- `lake build 'FormalConjectures.ErdosProblems.«257»'` succeeds on this branch (8056 jobs).
- The linked adapter builds: `lake build FormalConjecturesVariants`, RC=0, 3694 jobs. This is an author-run build, not a CI run — the source repository's Lean workflow did not have its adapter directory in any build gate, which is being fixed separately; until that lands, adapter changes there are verified by author-run builds and axiom audits rather than by CI.
- `#print axioms` on all four linked declarations reports `[propext, Classical.choice, Quot.sound]`. There is no `sorryAx`.
- Negative control: replacing `Nat.factorial (k + 1)` by `Nat.factorial k` is rejected with a type mismatch, so the index convention is load-bearing rather than incidental.

The proof chains are large developments rather than short self-contained scripts, so they are hosted externally per `CONTRIBUTING.md` and linked at an immutable commit.

AI Usage Disclosure: the linked Lean development and this contribution were produced with AI assistance. I have reviewed the statement identity of all four variants against their proofs, the axiom report, the attributions above, and this diff, and I take responsibility for the submission.

> [!NOTE]
> These are four settled support families. They do not prove irrationality for every infinite support, so `erdos_257` remains open and is untouched by this PR.

