### PR TITLE
feat(ErdosProblems): prove erdos_885 variants k_eq_2 and k_eq_3

### DIFF
--- a/FormalConjectures/ErdosProblems/885.lean
+++ b/FormalConjectures/ErdosProblems/885.lean
@@ -38,6 +38,20 @@ def factorDifferenceSet (n : ℕ) : Set ℕ :=
   {d | ∃ a b : ℕ, n = a * b ∧ (d : ℤ) = |(a : ℤ) - b|}
 
 /--
+For $n \geq 1$ the factor difference set is finite: any factorisation $n = ab$ has
+$a, b \leq n$, so every element of $D(n)$ is at most $n$.
+-/
+@[category API, AMS 11]
+theorem factorDifferenceSet_finite {n : ℕ} (hn : 1 ≤ n) :
+    (factorDifferenceSet n).Finite := by
+  refine (Set.finite_Iic n).subset ?_
+  rintro d ⟨a, b, hab, hd⟩
+  have ha : a ≤ n := Nat.le_of_dvd (by omega) ⟨b, hab⟩
+  have hb : b ≤ n := Nat.le_of_dvd (by omega) ⟨a, hab.trans (Nat.mul_comm a b)⟩
+  have hd' : (d : ℤ) ≤ n := by rw [hd]; exact abs_le.mpr ⟨by omega, by omega⟩
+  exact Set.mem_Iic.mpr (by exact_mod_cast hd')
+
+/--
 Is it true that, for every $k \geq 1$, there exist integers $N_1 < \dots < N_k$ such that
 $|\cap_i D(N_i)| \geq k$?
 -/
@@ -58,7 +72,20 @@ theorem erdos_885.variants.k_eq_2 :
       (∀ n ∈ Ns, 1 ≤ n) ∧
       Ns.card = 2 ∧
       (⋂ n ∈ Ns, factorDifferenceSet n).ncard ≥ 2 := by
-  sorry
+  refine ⟨{12, 42}, by decide, by decide, ?_⟩
+  have hsub : ({1, 11} : Set ℕ) ⊆
+      ⋂ n ∈ ({12, 42} : Finset ℕ), factorDifferenceSet n := by
+    simp only [Set.subset_def, Set.mem_insert_iff, Set.mem_singleton_iff, Set.mem_iInter,
+      Finset.mem_insert, Finset.mem_singleton]
+    rintro d (rfl | rfl) n (rfl | rfl)
+    · exact ⟨3, 4, by norm_num, by norm_num⟩
+    · exact ⟨6, 7, by norm_num, by norm_num⟩
+    · exact ⟨1, 12, by norm_num, by norm_num⟩
+    · exact ⟨3, 14, by norm_num, by norm_num⟩
+  have hfin : (⋂ n ∈ ({12, 42} : Finset ℕ), factorDifferenceSet n).Finite :=
+    (factorDifferenceSet_finite (by norm_num)).subset (Set.iInter₂_subset 12 (by simp))
+  have h2 : ({1, 11} : Set ℕ).ncard = 2 := Set.ncard_pair (by norm_num)
+  exact h2 ▸ Set.ncard_le_ncard hsub hfin
 
 /--
 Jiménez-Urroz [Ji99] proved this for $k=3$.
@@ -69,7 +96,26 @@ theorem erdos_885.variants.k_eq_3 :
       (∀ n ∈ Ns, 1 ≤ n) ∧
       Ns.card = 3 ∧
       (⋂ n ∈ Ns, factorDifferenceSet n).ncard ≥ 3 := by
-  sorry
+  refine ⟨{1936, 4900, 32400}, by decide, by decide, ?_⟩
+  have hsub : ({0, 105, 480} : Set ℕ) ⊆
+      ⋂ n ∈ ({1936, 4900, 32400} : Finset ℕ), factorDifferenceSet n := by
+    simp only [Set.subset_def, Set.mem_insert_iff, Set.mem_singleton_iff, Set.mem_iInter,
+      Finset.mem_insert, Finset.mem_singleton]
+    rintro d (rfl | rfl | rfl) n (rfl | rfl | rfl)
+    · exact ⟨44, 44, by norm_num, by norm_num⟩
+    · exact ⟨70, 70, by norm_num, by norm_num⟩
+    · exact ⟨180, 180, by norm_num, by norm_num⟩
+    · exact ⟨16, 121, by norm_num, by norm_num⟩
+    · exact ⟨35, 140, by norm_num, by norm_num⟩
+    · exact ⟨135, 240, by norm_num, by norm_num⟩
+    · exact ⟨4, 484, by norm_num, by norm_num⟩
+    · exact ⟨10, 490, by norm_num, by norm_num⟩
+    · exact ⟨60, 540, by norm_num, by norm_num⟩
+  have hfin : (⋂ n ∈ ({1936, 4900, 32400} : Finset ℕ), factorDifferenceSet n).Finite :=
+    (factorDifferenceSet_finite (by norm_num)).subset (Set.iInter₂_subset 1936 (by simp))
+  have h3 : ({0, 105, 480} : Set ℕ).ncard = 3 :=
+    Set.ncard_eq_three.mpr ⟨0, 105, 480, by norm_num, by norm_num, by norm_num, rfl⟩
+  exact h3 ▸ Set.ncard_le_ncard hsub hfin
 
 /--
 Bremner [Br19] proved this for $k=4$.


### PR DESCRIPTION
Closes #5050

Replaces the sorry in the 885 variants erdos_885.variants.k_eq_2 and k_eq_3 with explicit witness proofs and adds one shared API lemma (factorDifferenceSet_finite: for n ≥ 1, D(n) is finite since every element is at most n).

For k=2: Ns = {12, 42}. 1 = |3−4| = |6−7| and 11 = |1−12| = |3−14|.
And for k=3: Ns = {1936, 4900, 32400} (= 44², 70², 180²). Common differences {0, 105, 480}. 
The main statement and the k=4 variant remain untouched.

The mathematical results are due to [ErRo97] and [Ji99]. This PR only contributes the first machine-checked proofs with witnesses found independently by my automated search system.
AI disclosure: the proofs are generated by MathPaperAI, which is my automated Lean proof-search pipeline (LLM-driven). 
Everything is kernel-checked and replayed against this repository's pinned toolchain (`lake --wfail build 'FormalConjectures.ErdosProblems.«885»'` passes). #print axioms for all three declarations: [propext, Classical.choice, Quot.sound]. 
I read and verified the proofs myself. Please tell me, if you prefer a formal_proof link!