### PR TITLE
Erdős 1049: add the Bundschuh–Väänänen rational-base criterion

### DIFF
--- a/FormalConjectures/ErdosProblems/1049.lean
+++ b/FormalConjectures/ErdosProblems/1049.lean
@@ -46,7 +46,8 @@ theorem erdos_1049 :
 /--
 Erdős [Er48] proved that this is true if $t\geq 2$ is an integer.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-lean-erdos249-257/blob/a9104f2f12aa0d4e9da8a93574b14990ed02dc2a/adapters/FormalConjecturesAdapter.lean#L94-L107"]
 theorem erdos_1049.variants.geq_2_integer :
      ∀ t : ℤ, t ≥ 2 → Irrational (∑' n : ℕ+, 1 / ((t : ℝ) ^ (n : ℕ) - 1)) := by
   sorry

--- a/FormalConjectures/ErdosProblems/1049.lean
+++ b/FormalConjectures/ErdosProblems/1049.lean
@@ -23,6 +23,8 @@ import FormalConjecturesUtil
 - [erdosproblems.com/1049](https://www.erdosproblems.com/1049)
 - [Er48] Erdős, P., On arithmetical properties of Lambert series. J. Indian Math. Soc. (N.S.)
   (1948), 63-66.
+- [BV94] Bundschuh, P. and Väänänen, K., Arithmetical investigations of a certain infinite
+  product. Compositio Math. 91 (1994), 175-199.
 -/
 
 namespace Erdos1049
@@ -48,6 +50,88 @@ Erdős [Er48] proved that this is true if $t\geq 2$ is an integer.
 theorem erdos_1049.variants.geq_2_integer :
      ∀ t : ℤ, t ≥ 2 → Irrational (∑' n : ℕ+, 1 / ((t : ℝ) ^ (n : ℕ) - 1)) := by
   sorry
+
+/--
+Bundschuh and Väänänen [BV94, Theorem 2] proved a quantitative linear independence
+result for $E_q$ and $E_q'$ whose $\alpha = -1$ case gives irrationality for a range
+of non-integer rational bases.
+
+Their parameter is $\lambda = \log h(t) / \log t$, where $h$ denotes the absolute
+height; for $t = a/b > 1$ in lowest terms this is $\log a / \log(a/b)$. In the case
+$\alpha = -1$ their Theorem 2 admits every $\lambda < (1/2 + 1/\pi^2)^{-1}$, and
+$L_t(-1) = \sum_{j \geq 1} (t^j - 1)^{-1}$ is the series in question, so the
+conclusion is its irrationality. Solving the condition on $\lambda$ for $a$ and $b$
+gives the hypothesis below.
+
+At $b = 1$ the hypothesis reads $0 < 1/2 - 1/\pi^2$, so this statement contains
+`erdos_1049.variants.geq_2_integer`.
+-/
+@[category research solved, AMS 11]
+theorem erdos_1049.variants.bundschuh_vaananen (t : ℚ) (ht : 1 < t)
+    (hlam : Real.log t.den / Real.log t.num < 1 / 2 - 1 / Real.pi ^ 2) :
+    Irrational (∑' n : ℕ+, 1 / ((t : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
+The Bundschuh–Väänänen condition holds at $t = 7/2$, because
+$$\frac{\log 2}{\log 7} < \frac{9}{25} < \frac{1}{2} - \frac{1}{\pi^2},$$
+the first inequality since $2^{25} < 7^9$ and the second since $\pi^2 > 9$.
+
+This is the smallest denominator-$2$ base the criterion reaches. The bases $a/2$
+with $a$ odd and $1 < a/2 < 7/2$ are $3/2$ and $5/2$, and the condition fails at
+both: see `erdos_1049.variants.bundschuh_vaananen_fails_at_three_halves`, and
+$\log 2 / \log 5 > 2/5 > 1/2 - 1/\pi^2$ since $2^5 > 5^2$ and $\pi^2 < 10$.
+-/
+@[category research solved, AMS 11]
+theorem erdos_1049.variants.seven_halves :
+    Irrational (∑' n : ℕ+, 1 / (((7 / 2 : ℚ) : ℝ) ^ (n : ℕ) - 1)) := by
+  refine erdos_1049.variants.bundschuh_vaananen (7 / 2) (by norm_num) ?_
+  have hden : (((7 / 2 : ℚ)).den : ℝ) = 2 := by norm_num
+  have hnum : (((7 / 2 : ℚ)).num : ℝ) = 7 := by norm_num
+  rw [hden, hnum]
+  have h7 : (0 : ℝ) < Real.log 7 := Real.log_pos (by norm_num)
+  have key : (25 : ℝ) * Real.log 2 < 9 * Real.log 7 := by
+    have h : Real.log ((2 : ℝ) ^ (25 : ℕ)) < Real.log ((7 : ℝ) ^ (9 : ℕ)) :=
+      Real.log_lt_log (by positivity) (by norm_num)
+    rw [Real.log_pow, Real.log_pow] at h
+    push_cast at h
+    linarith
+  have h1 : Real.log 2 / Real.log 7 < 9 / 25 := by
+    rw [div_lt_div_iff₀ h7 (by norm_num)]
+    linarith
+  have hpi : (3 : ℝ) < Real.pi := Real.pi_gt_three
+  have hpi2 : (9 : ℝ) < Real.pi ^ 2 := by nlinarith
+  have hinv : 1 / Real.pi ^ 2 < 1 / 9 :=
+    one_div_lt_one_div_of_lt (by norm_num) hpi2
+  linarith
+
+/--
+The criterion in `erdos_1049.variants.bundschuh_vaananen` does not reach $t = 3/2$:
+$$\frac{\log 2}{\log 3} > \frac{1}{2} > \frac{1}{2} - \frac{1}{\pi^2},$$
+the first inequality since $3 < 2^2$.
+
+So the smallest non-integer rational base lies outside the range covered by [BV94],
+and `erdos_1049` is open there.
+-/
+@[category textbook, AMS 11]
+theorem erdos_1049.variants.bundschuh_vaananen_fails_at_three_halves :
+    ¬ (Real.log ((3 / 2 : ℚ)).den / Real.log ((3 / 2 : ℚ)).num
+        < 1 / 2 - 1 / Real.pi ^ 2) := by
+  have hden : (((3 / 2 : ℚ)).den : ℝ) = 2 := by norm_num
+  have hnum : (((3 / 2 : ℚ)).num : ℝ) = 3 := by norm_num
+  rw [hden, hnum, not_lt]
+  have h3 : (0 : ℝ) < Real.log 3 := Real.log_pos (by norm_num)
+  have key : Real.log 3 < 2 * Real.log 2 := by
+    have h : Real.log 3 < Real.log ((2 : ℝ) ^ (2 : ℕ)) :=
+      Real.log_lt_log (by norm_num) (by norm_num)
+    rw [Real.log_pow] at h
+    push_cast at h
+    linarith
+  have hhalf : (1 : ℝ) / 2 < Real.log 2 / Real.log 3 := by
+    rw [lt_div_iff₀ h3]
+    linarith
+  have hpos : (0 : ℝ) < 1 / Real.pi ^ 2 := by positivity
+  linarith
 
 /--
 Convergent case (`|t| > 1`).


### PR DESCRIPTION
Closes #5056.

This is the single Erdős 1049 PR. It supersedes #5032: `geq_2_integer` now carries the formal_proof permalink from that PR.

`1049.lean` records Erdős's 1948 theorem for integer bases $t \ge 2$ and
nothing for non-integer rational $t$. This adds the published criterion that
covers part of that gap, and the Lean proof link for the integer-base case.

**`erdos_1049.variants.geq_2_integer`** — Erdős [Er48] for integer $t \ge 2$.
The statement was already here; this PR attaches
`formal_proof using lean4` at the existing sorry, pointing at the Lean 4 proof
in `wcook04/plectis-lean-erdos249-257`.

**`erdos_1049.variants.bundschuh_vaananen`** — Bundschuh and Väänänen,
*Arithmetical investigations of a certain infinite product*, Compositio Math.
**91** (1994), 175–199, Theorem 2 (printed p. 177): *"In the special case
$\alpha = -1$ we may even allow $\lambda < (1/2 + 1/\pi^2)^{-1}$."* Their
$L_q(\alpha) = \sum_{j\ge1}(q^j+\alpha)^{-1}$ (p. 177), so $\alpha = -1$ gives
exactly this problem's series, and $\lambda = \log h(q)/\log|q|$ from Theorem 1.
For $t = a/b > 1$ in lowest terms, $\lambda = \log a/\log(a/b)$, and the
condition rearranges to

$$\frac{\log b}{\log a} < \frac12 - \frac1{\pi^2}.$$

Stated with `t.num` and `t.den`, so coprimality and positivity come from the
type. At $b = 1$ the hypothesis reads $0 < 1/2 - 1/\pi^2$, so this statement
contains `erdos_1049.variants.geq_2_integer`. This is a literature statement,
kept `by sorry` per the repository's convention; there is no Lean proof of the
general criterion to link.

**`erdos_1049.variants.seven_halves`** — the criterion applies at $t = 7/2$,
giving irrationality at a non-integer base. Proved from the above via
$\log 2/\log 7 < 9/25 < 1/2 - 1/\pi^2$, the first inequality because
$2^{25} = 33{,}554{,}432 < 40{,}353{,}607 = 7^9$, the second because $\pi^2 > 9$.

**`erdos_1049.variants.bundschuh_vaananen_fails_at_three_halves`** — the
criterion does not reach $t = 3/2$, since $\log 2/\log 3 > 1/2 > 1/2 - 1/\pi^2$
(the first inequality because $3 < 2^2`). This marks the frontier: the smallest
non-integer rational base is outside the published range, and `erdos_1049` is
open there.

Checks:

- The touched module builds with 0 errors and 0 warnings under the Formal
  Conjectures linters (`copyright`, `namespace`, `stubs`, `openClassical`,
  `ams_attribute`, `category_attribute`, `conditional_formal_proof`,
  `moduleDocstring`, `latex_docstring`, `imports`).
- `bundschuh_vaananen_fails_at_three_halves` depends on
  `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`. The Bundschuh–Väänänen
  criterion itself is a literature statement, `by sorry`. `geq_2_integer` remains
  `by sorry` with a `formal_proof` link, as the linter requires.
- $7/2$ is the smallest denominator-$2$ base the criterion reaches: the only
  candidates below it are $3/2$ and $5/2$, and both fail.

No originality is claimed for any of this; the criterion and its proof are
Bundschuh and Väänänen's, and the integer-base proof is Erdős 1948 as
formalised in the linked repository. The contribution is the formal statement,
its reduction to a condition on `t.num` and `t.den`, the two proved statements
locating the boundary, and the proof link on the existing integer-base variant.

AI Usage Disclosure: this contribution was produced with AI assistance. I have
read Theorem 2 in the source paper, checked the reduction of $\lambda$ to the
stated condition, verified the numeric inequalities, and reviewed this diff, and
I take responsibility for the submission.

> [!NOTE]
> This covers a proper subset of the rational bases. `erdos_1049` remains open
> and is untouched.