### PR TITLE
Erdős 243: add Koizumi's Sylvester and Millin rigidity corollaries

### DIFF
--- a/FormalConjectures/ErdosProblems/243.lean
+++ b/FormalConjectures/ErdosProblems/243.lean
@@ -19,7 +19,10 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 243
 
-*Reference:* [erdosproblems.com/243](https://www.erdosproblems.com/243)
+*References:*
+- [erdosproblems.com/243](https://www.erdosproblems.com/243)
+- [Koi25] Koizumi, J., Irrationality of the reciprocal sum of doubly exponential
+  sequences. arXiv:2504.05933 (2025).
 -/
 
 open Filter
@@ -39,6 +42,50 @@ theorem erdos_243 (a : ℕ → ℕ) (ha₀ : StrictMono a)
     (ha₁ : Tendsto (fun n ↦ (a n : ℝ) / a (n - 1) ^ 2) atTop (𝓝 1))
     (ha₂ : Summable ((1 : ℚ) / a ·)) :
       ∀ᶠ n in atTop, a n = a (n - 1) ^ 2 - a (n - 1) + 1 := by
+  sorry
+
+/--
+Sylvester's sequence satisfies the recurrence appearing in the conclusion of
+`erdos_243`, so `erdos_243` asks whether every sequence meeting its hypotheses is
+eventually a shifted Sylvester sequence.
+-/
+@[category test, AMS 11]
+theorem erdos_243.sylvester_satisfies_recurrence (n : ℕ) :
+    Nat.sylvester (n + 1) = Nat.sylvester n ^ 2 - Nat.sylvester n + 1 :=
+  Nat.sylvester_succ n
+
+/--
+Koizumi [Koi25, Corollary 2] proved that the two-sided bound
+$2/3 \leq a_n^2/a_{n+1} \leq 4/3$ together with $\sum 1/a_n = 1$ determines the
+sequence completely: it must be Sylvester's sequence $2, 3, 7, 43, 1807, \dots$.
+
+Compare `erdos_243`, which assumes the ratio *tends to* $1$ and only that the sum is
+rational, and asks for the Sylvester recurrence eventually. Here the ratio hypothesis
+is a bound rather than a limit, the sum is pinned to $1$, and the conclusion is exact
+equality at every index.
+-/
+@[category research solved, AMS 11]
+theorem erdos_243.variants.sylvester_of_tsum_eq_one (a : ℕ → ℕ)
+    (ha : ∀ n, 0 < a n)
+    (hlb : ∀ n, 2 / 3 ≤ (a n : ℝ) ^ 2 / a (n + 1))
+    (hub : ∀ n, (a n : ℝ) ^ 2 / a (n + 1) ≤ 4 / 3)
+    (hsum : ∑' n, (1 : ℝ) / a n = 1) :
+    ∀ n, a n = Nat.sylvester n := by
+  sorry
+
+/--
+Koizumi [Koi25, Corollary 3] proved the companion characterisation for the Millin
+series: the one-sided bound $a_n^2/a_{n+1} \leq 2/3$ together with
+$\sum 1/a_n = (5 - \sqrt{5})/2$ forces $a_n = F_{2^n}$, where $F$ is the Fibonacci
+sequence, so that
+$$\frac{5 - \sqrt 5}{2} = \frac11 + \frac13 + \frac1{21} + \frac1{987} + \cdots.$$
+-/
+@[category research solved, AMS 11]
+theorem erdos_243.variants.fib_of_tsum_eq_millin (a : ℕ → ℕ)
+    (ha : ∀ n, 0 < a n)
+    (hub : ∀ n, (a n : ℝ) ^ 2 / a (n + 1) ≤ 2 / 3)
+    (hsum : ∑' n, (1 : ℝ) / a n = (5 - Real.sqrt 5) / 2) :
+    ∀ n, a n = Nat.fib (2 ^ (n + 1)) := by
   sorry
 
 end Erdos243

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -149,6 +149,7 @@ public import FormalConjecturesForMathlib.NumberTheory.Primitive
 public import FormalConjecturesForMathlib.NumberTheory.Semiprime
 public import FormalConjecturesForMathlib.NumberTheory.SierpinskiNumber
 public import FormalConjecturesForMathlib.NumberTheory.SmoothScale
+public import FormalConjecturesForMathlib.NumberTheory.Sylvester
 public import FormalConjecturesForMathlib.NumberTheory.WallSunSunPrimes
 public import FormalConjecturesForMathlib.Order.Filter.Cofinite
 public import FormalConjecturesForMathlib.Order.Filter.atTopBot.Finset

--- a/FormalConjecturesForMathlib/NumberTheory/Sylvester.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Sylvester.lean
@@ -1,0 +1,88 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Tactic.Linarith
+public import Mathlib.Tactic.NormNum
+public import Mathlib.Order.Monotone.Basic
+
+@[expose] public section
+
+/-!
+# Sylvester's sequence
+
+Sylvester's sequence $2, 3, 7, 43, 1807, \dots$
+([OEIS A000058](https://oeis.org/A000058)) is defined by $s_0 = 2$ and
+$s_{n+1} = s_n^2 - s_n + 1$. Its reciprocals sum to $1$:
+$$\frac{1}{2} + \frac{1}{3} + \frac{1}{7} + \frac{1}{43} + \frac{1}{1807} + \cdots = 1.$$
+-/
+
+namespace Nat
+
+/--
+Sylvester's sequence $2, 3, 7, 43, 1807, \dots$, defined by $s_0 = 2$ and
+$s_{n+1} = s_n^2 - s_n + 1$.
+
+The subtraction is truncated, but `Nat.sylvester_le_sq` shows it never truncates.
+-/
+def sylvester : ℕ → ℕ
+  | 0 => 2
+  | n + 1 => sylvester n ^ 2 - sylvester n + 1
+
+@[simp]
+theorem sylvester_zero : sylvester 0 = 2 := rfl
+
+theorem sylvester_succ (n : ℕ) :
+    sylvester (n + 1) = sylvester n ^ 2 - sylvester n + 1 := rfl
+
+theorem two_le_sylvester (n : ℕ) : 2 ≤ sylvester n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    have h : sylvester n + 2 ≤ sylvester n ^ 2 := by nlinarith
+    rw [sylvester_succ]
+    omega
+
+theorem sylvester_pos (n : ℕ) : 0 < sylvester n :=
+  lt_of_lt_of_le (by norm_num) (two_le_sylvester n)
+
+/-- The subtraction in `Nat.sylvester_succ` never truncates. -/
+theorem sylvester_le_sq (n : ℕ) : sylvester n ≤ sylvester n ^ 2 := by
+  have := two_le_sylvester n
+  nlinarith
+
+theorem sylvester_lt_sylvester_succ (n : ℕ) : sylvester n < sylvester (n + 1) := by
+  have h₀ := two_le_sylvester n
+  have h : sylvester n + sylvester n ≤ sylvester n ^ 2 := by nlinarith
+  rw [sylvester_succ]
+  omega
+
+theorem strictMono_sylvester : StrictMono sylvester :=
+  strictMono_nat_of_lt_succ sylvester_lt_sylvester_succ
+
+@[simp]
+theorem sylvester_one : sylvester 1 = 3 := rfl
+
+@[simp]
+theorem sylvester_two : sylvester 2 = 7 := rfl
+
+@[simp]
+theorem sylvester_three : sylvester 3 = 43 := rfl
+
+@[simp]
+theorem sylvester_four : sylvester 4 = 1807 := rfl
+
+end Nat


### PR DESCRIPTION
Closes #5058.

`243.lean` currently holds only the open statement. Koizumi,
[arXiv:2504.05933](https://arxiv.org/abs/2504.05933) (2025), studies exactly
this problem — his Question 5 (p. 3) is Erdős 243 verbatim — and proves two
rigidity corollaries this adds.

**`erdos_243.variants.sylvester_of_tsum_eq_one`** (his Corollary 2, p. 2): if
$2/3 \le a_n^2/a_{n+1} \le 4/3$ and $\sum 1/a_n = 1$, then $a_n$ is Sylvester's
sequence $2, 3, 7, 43, 1807, \dots$. The contrast with `erdos_243` is the point:
there the ratio *tends to* $1$ and the sum is merely rational, and the
conclusion is an *eventual* recurrence; here a two-sided bound plus an exact sum
pins the sequence down at every index.

**`erdos_243.variants.fib_of_tsum_eq_millin`** (his Corollary 3): if
$a_n^2/a_{n+1} \le 2/3$ and $\sum 1/a_n = (5-\sqrt5)/2$, then $a_n = F_{2^n}$.

**`erdos_243.sylvester_satisfies_recurrence`** — a one-line `test` recording
that Sylvester's sequence satisfies the recurrence in the conclusion of
`erdos_243`, so the two statements are visibly about the same recurrence.

Sylvester's sequence is not in Mathlib, so
`FormalConjecturesForMathlib/NumberTheory/Sylvester.lean` defines it with basic
API (`two_le_sylvester`, `strictMono_sylvester`, and the first values). That
file is fully proved — no `sorry`, and every declaration audits to
`[propext, Classical.choice, Quot.sound]` or less.

Checks:

- Builds clean against current `main` (`33c6a2d`): 0 errors, 0 warnings.
- Both corollaries were checked numerically against their claimed witnesses
  before formalising. Sylvester gives ratios
  $4/3, 9/7, 49/43, 1849/1807$ — all in $[2/3, 4/3]$, with $s_1^2/s_2 = 4/3$
  meeting the bound exactly — and $\sum 1/s_n = 1$. The Fibonacci witness gives
  ratios converging to $1/\sqrt5 \approx 0.447 \le 2/3$ and
  $\sum 1/F_{2^n} = 1.381966011250105 = (5-\sqrt5)/2$.
- The same paper's Theorem 4 is already cited in `263.lean`; these corollaries
  are not used there.

No originality is claimed — the theorems are Koizumi's. The contribution is
their formal statement plus the Sylvester definition needed to express them.

AI Usage Disclosure: this contribution was produced with AI assistance. I have
read the corollaries in the source paper, checked the index conventions against
his $n \ge 1$ numbering, verified the witnesses numerically, and reviewed this
diff, and I take responsibility for the submission.

> [!NOTE]
> These are adjacent solved results, not special cases of `erdos_243`, which
> remains open and is untouched.
