### PR TITLE
fix(Paper): scope the LatinSquare answer slots inside their quantifier

### DIFF
--- a/FormalConjectures/Paper/LatinSquare.lean
+++ b/FormalConjectures/Paper/LatinSquare.lean
@@ -56,7 +56,7 @@ Each Latin square of odd order has at least one transversal.
 -/
 @[category research open, AMS 5]
 theorem oddOrderLatinSquareTransversal : answer(sorry) ↔
-    Odd n → ∀ (L : LatinSquare n), ∃ σ, IsTransversal L σ := by
+    ∀ (n : ℕ), Odd n → ∀ (L : LatinSquare n), ∃ σ, IsTransversal L σ := by
   sorry
 
 /--
@@ -87,7 +87,7 @@ Every latin square has a near-transversal
 -/
 @[category research open, AMS 5]
 theorem latinSquareNearTransversal : answer(sorry) ↔
-    ∀ (L : LatinSquare n), ∃ ρ σ, IsNearTransversal L ρ σ := by
+    ∀ (n : ℕ) (L : LatinSquare n), ∃ ρ σ, IsNearTransversal L ρ σ := by
   sorry
 
 /-- The number of transversals of the Cayley table of the cyclic group $\mathbb{Z}_n$ -/

--- a/FormalConjectures/Paper/LatinSquare.lean
+++ b/FormalConjectures/Paper/LatinSquare.lean
@@ -30,13 +30,11 @@ This file formalizes some conjectures and theorems around latin squares.
 
 namespace LatinSquare
 
-variable {n : ℕ}
-
 /--
 Two latin squares of the same order are orthogonal if superimposing them gives each ordered pair of
 symbols at most once.
 -/
-def Orthogonal (L M : LatinSquare n) : Prop :=
+def Orthogonal {n : ℕ} (L M : LatinSquare n) : Prop :=
   Function.Injective fun p : Fin n × Fin n => (L.mat p.1 p.2, M.mat p.1 p.2)
 
 /-- A family of latin squares is mutually orthogonal if any two distinct members are orthogonal. -/


### PR DESCRIPTION
`oddOrderLatinSquareTransversal` and `latinSquareNearTransversal` pick up the section
`variable {n : ℕ}`, so each elaborated as `∀ {n}, answer(sorry) ↔ P n` with the answer slot
outside the quantifier. As analyzed in #5009, `answer(False)` was then unreachable for the
odd-order statement (`Odd n → …` is vacuous at even `n`, forcing the answer to `True`), and the
near-transversal statement was provable only if the conjecture held uniformly in `n`. This moves
`∀ n` inside the iff for both.

- Docstrings unchanged: both remain the verbatim Conjectures 3.2 and 5.1 of [Wa2011], which
  quantify over all (odd) orders, so the `∀ n` form is the faithful reading. Both stay
  `research open`. (The `Odd n → …` shape dates to #4186; the scoping issue is orthogonal to
  that fix.)
- Not touched: `latinSquareOrder11Transversal` (fixed order 11) and
  `oddOrderLeq9LatinSquareTransversal` (binds its own `∀ n ≤ 9`; edited in #4965, which this PR
  does not conflict with — different declarations). `molsExistenceProblem` is out of scope per
  CONTRIBUTING, as #5009 itself notes.
- The AnswerLinter blind spot #5009 reports (section variables are invisible to
  `contains_early_args`) will be addressed separately under #1407.

closes #5009

- [x] `lake --wfail build FormalConjectures.Paper.LatinSquare` passes with no warnings
- [x] Elaborated statements read back via `extract_names`: the answer slot is now outermost,
      `∀ n` inside the iff; docstrings byte-identical

