### PR TITLE
refactor(ForMathlib): generalize distance API from ℝ² to MetricSpace

### DIFF
--- a/FormalConjectures/ErdosProblems/90.lean
+++ b/FormalConjectures/ErdosProblems/90.lean
@@ -47,7 +47,7 @@ open Finset
 The set of all possible numbers of unit distances for a configuration of $n$ points.
 -/
 noncomputable def unitDistanceCounts (n : ℕ) : Set ℕ :=
-  {unitDistancePairsCount points | (points : Finset ℝ²) (_ : points.card = n)}
+  {unitDistNum points | (points : Finset ℝ²) (_ : points.card = n)}
 
 /--
 This lemma confirms that the set of possible unit distance counts is bounded above, which
@@ -56,14 +56,9 @@ the total number of pairs of points, $\binom{n}{2}$.
 -/
 @[category test, AMS 52]
 theorem unitDistanceCounts_BddAbove (n : ℕ) : BddAbove <| unitDistanceCounts n := by
-  unfold Erdos90.unitDistanceCounts
-  unfold unitDistancePairsCount
   use n.choose 2
   rintro _ ⟨points, rfl, rfl⟩
-  rw [points.card.choose_two_right]
-  gcongr
-  refine (card_filter_le _ _).trans_eq ?_
-  rw [offDiag_card, Nat.mul_sub_left_distrib, mul_one]
+  exact unitDistNum_le_choose_two points
 
 
 /--
@@ -171,7 +166,7 @@ theorem sawin_lattice_reduction
     (hS_proj : ∀ v ∈ S, ‖π v‖ = 1) :
     ∃ U : Finset ℝ², 0 < U.card ∧
       ((1 : ℝ) - 1/R) ^ (2*d) * (S.card : ℝ) * (U.card : ℝ) ≤
-        (unitDistancePairsCount U : ℝ) := by
+        (unitDistNum U : ℝ) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/96.lean
+++ b/FormalConjectures/ErdosProblems/96.lean
@@ -34,7 +34,7 @@ The set of all possible numbers of unit distances determined by the vertices of 
 $n$-gon.
 -/
 noncomputable def convexUnitDistanceCounts (n : ℕ) : Set ℕ :=
-  {unitDistancePairsCount points | (points : Finset ℝ²) (_ : points.card = n) (_ : ConvexIndep points)}
+  {unitDistNum points | (points : Finset ℝ²) (_ : points.card = n) (_ : ConvexIndep points)}
 
 /--
 This lemma confirms that the set of possible unit-distance counts is bounded above, which
@@ -43,16 +43,9 @@ the total number of pairs of points, $\binom{n}{2}$.
 -/
 @[category test, AMS 52]
 theorem convexUnitDistanceCounts_bddAbove (n : ℕ) : BddAbove <| convexUnitDistanceCounts n := by
-  unfold convexUnitDistanceCounts
-  unfold unitDistancePairsCount
   use n.choose 2
   rintro _ ⟨points, rfl, _, rfl⟩
-  rw [points.card.choose_two_right]
-  have hle : (points.offDiag.filter fun p : ℝ² × ℝ² => dist p.1 p.2 = 1).card ≤
-      points.offDiag.card := by
-    exact card_filter_le _ _
-  have hdiv := Nat.div_le_div_right (c := 2) hle
-  simpa [offDiag_card, Nat.mul_sub_left_distrib, mul_one] using hdiv
+  exact unitDistNum_le_choose_two points
 
 /--
 The **maximum number of unit distances** determined by the vertices of a convex $n$-gon.

--- a/FormalConjecturesForMathlib/Geometry/2d.lean
+++ b/FormalConjecturesForMathlib/Geometry/2d.lean
@@ -204,35 +204,18 @@ lemma triangle_area_eq_det (a b c : ℝ²) :
     simp [Matrix.det_fin_two, Matrix.det_fin_three, Module.Basis.toMatrix, this]
   ring
 
-/-- The multiplicity of the distance `d` determined by `points`, that is, the number of unordered
-pairs of distinct points at distance `d` apart. -/
-noncomputable def distanceMultiplicity (points : Finset ℝ²) (d : ℝ) : ℕ :=
-  #(points.offDiag.filter fun (pair : ℝ² × ℝ²) => dist pair.1 pair.2 = d) / 2
-
 /--
 The minimum number of distinct distances guaranteed for any set of $n$ points.
 -/
 noncomputable def minimalDistinctDistances (n : ℕ) : ℕ :=
   sInf {(distinctDistances points : ℝ) | (points : Finset ℝ²) (_ : points.card = n)}
 
-/-- Given a finite set of points in the, we define the number of distinct distances between
-a given point and all other points -/
-noncomputable def distinctDistancesFrom (points : Finset ℝ²) (pt : ℝ²) : ℕ :=
-  #(points.image fun x => dist x pt)
-
 /-- Let $x_1,\ldots,x_n\in \mathbb{R}^2$ and let $R(x_i)=\#\{ \lvert x_j-x_i\rvert : j\neq i\}$,
 where the points are ordered such that
 $$R(x_1)\leq \cdots \leq R(x_n).$$
 Let $g(n)$ be the maximum number of distinct values the $R(x_i)$ can take.-/
 noncomputable def maximalDistinctDistancesFrom (n : ℕ) : ℕ :=
-  sSup {#(X.image (distinctDistancesFrom X)) | (X) (_ : #X = n)}
-
-/--
-Given a finite set of points, this function counts the number of **unordered pairs** of distinct
-points that are at a distance of exactly $1$ from each other.
--/
-noncomputable def unitDistancePairsCount (points : Finset ℝ²) : ℕ :=
-  #(points.offDiag.filter (fun p => dist p.1 p.2 = 1)) / 2
+  sSup {#(X.image (distinctDistancesFrom X)) | (X : Finset ℝ²) (_ : #X = n)}
 
 /-- A collection $x_1, \dots, x_n\in\mathbb{R}^2$ is in _general position_
 if no three are collinear and no four lie on a circle.

--- a/FormalConjecturesForMathlib/Geometry/Metric.lean
+++ b/FormalConjecturesForMathlib/Geometry/Metric.lean
@@ -16,6 +16,7 @@ limitations under the License.
 module
 
 public import Mathlib.Data.Finset.Sym
+public import Mathlib.Data.Sym.Card
 public import Mathlib.Topology.MetricSpace.Defs
 
 @[expose] public section
@@ -38,3 +39,31 @@ between pairs of points.
 -/
 noncomputable def distinctDistances (points : Finset X) : ℕ :=
   #(distanceSet points)
+
+/-- The multiplicity of the distance `d` determined by `points`, that is, the number of unordered
+pairs of distinct points at distance `d` apart. -/
+noncomputable def distanceMultiplicity (points : Finset X) (d : ℝ) : ℕ :=
+  #(points.offDiag.filter fun (pair : X × X) => dist pair.1 pair.2 = d) / 2
+
+/-- Given a finite set of points in a metric space, we define the number of distinct distances
+between a given point and all other points. -/
+noncomputable def distinctDistancesFrom (points : Finset X) (pt : X) : ℕ :=
+  #(points.image fun x => dist x pt)
+
+open Classical in
+/-- The number of unit-distance pairs of a finite set of `n` points is at most $\binom{n}{2}$,
+the total number of unordered pairs of distinct points. -/
+theorem unitDistNum_le_choose_two (s : Finset X) : unitDistNum s ≤ (#s).choose 2 := by
+  rw [unitDistNum, ← Sym2.card_image_offDiag]
+  refine Finset.card_le_card fun p hp => ?_
+  obtain ⟨hps, hpd⟩ := Finset.mem_filter.mp hp
+  rw [← Finset.image_diag_union_image_offDiag (s := s), Finset.mem_union] at hps
+  rcases hps with h | h
+  · obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp h
+    obtain ⟨-, ha2⟩ := Finset.mem_diag.mp ha
+    have h1 := Sym2.out_fst_mem (Sym2.mk a)
+    have h2 := Sym2.out_snd_mem (Sym2.mk a)
+    rw [Sym2.mem_iff] at h1 h2
+    rcases h1 with h1 | h1 <;> rcases h2 with h2 | h2 <;>
+      rw [h1, h2] at hpd <;> simp [ha2] at hpd
+  · exact h


### PR DESCRIPTION
Follow-up deferred from the #4397 review:

- `distanceMultiplicity` and `distinctDistancesFrom` move from `Geometry/2d.lean` to `Geometry/Metric.lean`, generalized from `ℝ²` to any `MetricSpace`, joining `distanceSet`/`distinctDistances` which already live there.
- `unitDistancePairsCount` was a duplicate encoding of the pre-existing `unitDistNum`, so it is deleted; its two call sites (ErdosProblems/90, 96) now use `unitDistNum`.
- New lemma `unitDistNum_le_choose_two` replaces the two hand-rolled `BddAbove` proofs in those files.
- No statement semantics change in this PR.

- [x] `lake --wfail build FormalConjecturesForMathlib` + all caller modules (90, 96, 756, 94, 958, 1082, 1084, 1085)
- [x] `lake --wfail test`; `#print axioms unitDistNum_le_choose_two` = `[propext, Classical.choice, Quot.sound]`
