### PR TITLE
fix(ForMathlib): exclude the base point in distinctDistancesFrom

### DIFF
--- a/FormalConjectures/ErdosProblems/1082.lean
+++ b/FormalConjectures/ErdosProblems/1082.lean
@@ -51,6 +51,6 @@ This counterexample has originally been found by Heiko Harborth.
 @[category research solved, AMS 51, formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/0aca4d71095301c0fd2dca32611b7addb2ea735c/FormalConjectures/ErdosProblems/1082.lean"]
 theorem erdos_1082.parts.ii : answer(False) ↔
     ∀ (A : Finset ℝ²) (hA : A.Nonempty) (hA_n3c : NonTrilinear (A : Set ℝ²)),
-    ∃ (a : ℝ²) (ha : a ∈ A), A.card / 2 ≤ distinctDistancesFrom A a - 1 := by
+    ∃ (a : ℝ²) (ha : a ∈ A), A.card / 2 ≤ distinctDistancesFrom A a := by
   sorry
 end Erdos1082

--- a/FormalConjecturesForMathlib/Geometry/Metric.lean
+++ b/FormalConjecturesForMathlib/Geometry/Metric.lean
@@ -46,10 +46,11 @@ pairs of distinct points at distance `d` apart. -/
 noncomputable def distanceMultiplicity (points : Finset X) (d : ℝ) : ℕ :=
   #(points.offDiag.filter fun (pair : X × X) => dist pair.1 pair.2 = d) / 2
 
+open Classical in
 /-- Given a finite set of points in a metric space, we define the number of distinct distances
 between a given point and all other points. -/
 noncomputable def distinctDistancesFrom (points : Finset X) (pt : X) : ℕ :=
-  #(points.image fun x => dist x pt)
+  #((points.erase pt).image fun x => dist x pt)
 
 open Classical in
 /-- The number of unit-distance pairs of a finite set of `n` points is at most $\binom{n}{2}$,


### PR DESCRIPTION
Closes #5064. Stacked on #5063 (the diff shows both commits until that one merges; only the last commit is this PR).

- `distinctDistancesFrom` now erases `pt` before taking the image, matching its docstring and the $j\neq i$ in the docstrings of both consumers.
- `erdos_1082.parts.ii` drops its compensating `- 1`: since `dist x pt = 0 ↔ x = pt`, the old count is exactly the new count plus one, so the statement is propositionally equal and the linked `formal_proof` permalink (0aca4d71) still establishes it. The docstring's "each point only determines 3 distances" now also matches the definition's value.
- `maximalDistinctDistancesFrom` / `erdos_653` are value-invariant: every $R(x_i)$ shifts by exactly 1, which preserves the number of distinct values.

- [x] `lake --wfail build FormalConjecturesForMathlib FormalConjectures.ErdosProblems.«1082» FormalConjectures.ErdosProblems.«653»`
- [x] `python3 scripts/check_category_warnings.py` on the elaborated 1082: clean
