### PR TITLE
Formalize Carathéodory's and Loewner's conjectures

### DIFF
--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -37,33 +37,34 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- The manifold derivative of a sphere-valued parametrization, with its codomain exposed as the
-ambient Euclidean space. -/
-noncomputable def sphereAmbientMfderiv
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
-  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+/-- A parametrized convex surface whose canonical normal is of class `C^k`.
 
-/-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
-
-The range condition says that the parametrization is the boundary of a convex body. Requiring
-nonempty interior rules out lower-dimensional convex sets. -/
-def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
-  Manifold.IsSmoothEmbedding (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
-    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k n ∧
-    (∀ p, ‖n p‖ = 1) ∧
-    (∀ p v, inner ℝ (n p) (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0) ∧
+The canonical normal is constructed from the derivative of `F` by a globally
+orientation-corrected cross product. Its orthogonality is built into the construction, while the
+injective differential makes it a unit vector. For finite `k`, requiring this normal to be `C^k`
+is stronger than requiring only `F` to be `C^k`. The range condition identifies the surface with
+the boundary of a compact convex body with nonempty interior. -/
+def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
+  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+    Topology.IsEmbedding F ∧
+    (∀ p, Function.Injective (EuclideanHypersurface.sphereAmbientMfderiv F p)) ∧
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
+/-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
+from the derivative of the parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
-  ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
+  ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧
       EuclideanHypersurface.IsUmbilic
-        (sphereAmbientMfderiv F p₁) (sphereAmbientMfderiv n p₁) ∧
+        (EuclideanHypersurface.sphereAmbientMfderiv F p₁)
+        (EuclideanHypersurface.sphereAmbientMfderiv
+          (EuclideanHypersurface.sphereNormal F) p₁) ∧
       EuclideanHypersurface.IsUmbilic
-        (sphereAmbientMfderiv F p₂) (sphereAmbientMfderiv n p₂)
+        (EuclideanHypersurface.sphereAmbientMfderiv F p₂)
+        (EuclideanHypersurface.sphereAmbientMfderiv
+          (EuclideanHypersurface.sphereNormal F) p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -37,6 +37,13 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
+/-- The manifold derivative of a sphere-valued parametrization, with its codomain exposed as the
+ambient Euclidean space. -/
+noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
 /-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
 
 The range condition says that the parametrization is the boundary of a convex body. Requiring
@@ -49,10 +56,11 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
-derivative of the immersion, equivalently when its shape operator is scalar. -/
+/-- A point is umbilic when its second fundamental form is a scalar multiple of its first.
+The second form uses the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
 def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
-  ∃ c : ℝ, mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) n p = c • mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+  EuclideanHypersurface.IsUmbilicByFundamentalForms
+    (sphereAmbientMfderiv F p) (sphereAmbientMfderiv n p)
 
 /-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
+import FormalConjecturesUtil
 import FormalConjectures.Other.LoewnerConjecture
 
 /-!
@@ -48,12 +49,6 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A smooth parametrized convex surface with a smooth choice of unit normal. -/
-abbrev IsSmoothConvexSphere := IsConvexSphereOfClass ∞
-
-/-- A real-analytic parametrized convex surface with a real-analytic choice of unit normal. -/
-abbrev IsAnalyticConvexSphere := IsConvexSphereOfClass ω
-
 /-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
 derivative of the immersion, equivalently when its shape operator is scalar. -/
 def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
@@ -64,18 +59,12 @@ def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
 
-/-- The smooth Carathéodory conjecture. -/
-abbrev SmoothCaratheodoryConjecture := CaratheodoryConjectureOfClass ∞
-
-/-- The real-analytic Carathéodory conjecture. -/
-abbrev AnalyticCaratheodoryConjecture := CaratheodoryConjectureOfClass ω
-
 /-- **The smooth Carathéodory conjecture.**
 
 Every smoothly embedded two-sphere which bounds a convex body has at least two distinct
 umbilic points. -/
 @[category research open, AMS 52 53]
-theorem caratheodory_conjecture : answer(sorry) ↔ SmoothCaratheodoryConjecture := by
+theorem caratheodory_conjecture : answer(sorry) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Carathéodory conjecture.**
@@ -83,14 +72,14 @@ theorem caratheodory_conjecture : answer(sorry) ↔ SmoothCaratheodoryConjecture
 Every real-analytically embedded two-sphere which bounds a convex body has at least two distinct
 umbilic points. This is the classical theorem of Hamburger. -/
 @[category research solved, AMS 52 53]
-theorem caratheodory_conjecture_analytic : AnalyticCaratheodoryConjecture := by
+theorem caratheodory_conjecture_analytic : CaratheodoryConjectureOfClass ω := by
   sorry
 
 /-- The smooth Loewner conjecture implies the smooth Carathéodory conjecture by the
 Poincaré–Hopf index theorem for principal line fields. -/
 @[category research solved, AMS 52 53 57]
 theorem loewner_implies_caratheodory :
-    LoewnerConjecture.SmoothLoewnerConjecture → SmoothCaratheodoryConjecture := by
+    LoewnerConjecture.LoewnerConjectureOfClass ∞ → CaratheodoryConjectureOfClass ∞ := by
   sorry
 
 end CaratheodoryConjecture

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -22,9 +22,8 @@ import FormalConjecturesUtil
 # Carathéodory's conjecture
 
 Carathéodory's conjecture says that every sufficiently smooth closed convex surface in
-three-dimensional Euclidean space has at least two umbilic points. We state the conjecture for
-smooth surfaces and the classical positive result for real-analytic surfaces. We also record
-that Loewner's local index conjecture implies Carathéodory's global conjecture.
+three-dimensional Euclidean space has at least two umbilic points. We record smooth and
+real-analytic versions and the implication from Loewner's local index conjecture.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problems 8.1 and
@@ -38,14 +37,8 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- A parametrized convex surface of class `C^(k + 1)`, whose canonical normal is of class
-`C^k`.
-
-The canonical normal is constructed from the derivative of `F` by a globally
-orientation-corrected cross product. Its orthogonality is built into the construction, while the
-injective differential makes it a unit vector. Its `C^k` regularity follows from the `C^(k + 1)`
-regularity of `F`. The range condition identifies the surface with the boundary of a compact
-convex body with nonempty interior. -/
+/-- A `C^(k + 1)` parametrized convex surface. Its canonical normal is `C^k` by
+`EuclideanHypersurface.contMDiff_sphereNormal`. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
   ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (k + 1) F ∧
     Topology.IsEmbedding F ∧
@@ -61,8 +54,7 @@ theorem IsConvexSphereOfClass.contMDiff_sphereNormal
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) :=
   EuclideanHypersurface.contMDiff_sphereNormal F hF.1 hF.2.2.1
 
-/-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
-from the derivative of the parametrization. -/
+/-- Carathéodory's conjecture for `IsConvexSphereOfClass k` surfaces. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjecturesUtil
+import Mathlib.Analysis.Convex.Body
 import FormalConjectures.Other.LoewnerConjecture
+import FormalConjecturesUtil
 
 /-!
 # Carathéodory's conjecture
@@ -47,10 +48,11 @@ the boundary of a compact convex body with nonempty interior. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
   ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
     Topology.IsEmbedding F ∧
-    (∀ p, Function.Injective (EuclideanHypersurface.sphereAmbientMfderiv F p)) ∧
+    (∀ p, Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) ∧
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
-    ∃ K : Set ℝ³,
-      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
+    ∃ K : ConvexBody ℝ³,
+      (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 
 /-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
 from the derivative of the parametrization. -/
@@ -58,13 +60,15 @@ def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧
       EuclideanHypersurface.IsUmbilic
-        (EuclideanHypersurface.sphereAmbientMfderiv F p₁)
-        (EuclideanHypersurface.sphereAmbientMfderiv
-          (EuclideanHypersurface.sphereNormal F) p₁) ∧
+        (V := TangentSpace (𝓡 2) p₁) (E := ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₁ : TangentSpace (𝓡 2) p₁ →L[ℝ] ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₁ :
+          TangentSpace (𝓡 2) p₁ →L[ℝ] ℝ³) ∧
       EuclideanHypersurface.IsUmbilic
-        (EuclideanHypersurface.sphereAmbientMfderiv F p₂)
-        (EuclideanHypersurface.sphereAmbientMfderiv
-          (EuclideanHypersurface.sphereNormal F) p₂)
+        (V := TangentSpace (𝓡 2) p₂) (E := ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₂ : TangentSpace (𝓡 2) p₂ →L[ℝ] ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₂ :
+          TangentSpace (𝓡 2) p₂ →L[ℝ] ℝ³)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -54,6 +54,13 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ
     ∃ K : ConvexBody ℝ³,
       (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 
+/-- The canonical normal of an `IsConvexSphereOfClass k` surface is of class `C^k`. -/
+@[category test, AMS 52 53]
+theorem IsConvexSphereOfClass.contMDiff_sphereNormal
+    {k : WithTop ℕ∞} {F : sphere (0 : ℝ³) 1 → ℝ³} (hF : IsConvexSphereOfClass k F) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) :=
+  EuclideanHypersurface.contMDiff_sphereNormal F hF.1 hF.2.2.1
+
 /-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
 from the derivative of the parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -42,8 +42,7 @@ namespace CaratheodoryConjecture
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
   ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (k + 1) F ∧
     Topology.IsEmbedding F ∧
-    (∀ p, Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) ∧
+    (∀ p, Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) ∧
     ∃ K : ConvexBody ℝ³,
       (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 
@@ -58,16 +57,12 @@ theorem IsConvexSphereOfClass.contMDiff_sphereNormal
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧
-      EuclideanHypersurface.IsUmbilic
-        (V := TangentSpace (𝓡 2) p₁) (E := ℝ³)
-        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₁ : TangentSpace (𝓡 2) p₁ →L[ℝ] ℝ³)
-        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₁ :
-          TangentSpace (𝓡 2) p₁ →L[ℝ] ℝ³) ∧
-      EuclideanHypersurface.IsUmbilic
-        (V := TangentSpace (𝓡 2) p₂) (E := ℝ³)
-        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₂ : TangentSpace (𝓡 2) p₂ →L[ℝ] ℝ³)
-        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₂ :
-          TangentSpace (𝓡 2) p₂ →L[ℝ] ℝ³)
+      EuclideanHypersurface.IsUmbilic (TangentSpace (𝓡 2) p₁) ℝ³
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₁)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₁) ∧
+      EuclideanHypersurface.IsUmbilic (TangentSpace (𝓡 2) p₂) ℝ³
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₂)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -1,0 +1,96 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Other.LoewnerConjecture
+
+/-!
+# Carathéodory's conjecture
+
+Carathéodory's conjecture says that every sufficiently smooth closed convex surface in
+three-dimensional Euclidean space has at least two umbilic points. We state the conjecture for
+smooth surfaces and the classical positive result for real-analytic surfaces. We also record
+that Loewner's local index conjecture implies Carathéodory's global conjecture.
+
+*References:*
+- [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problems 8.1 and
+  8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
+- [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
+  umbilic points*](https://doi.org/10.1007/BF02392036)
+-/
+
+open Set Metric
+open scoped ContDiff EuclideanGeometry Manifold
+
+namespace CaratheodoryConjecture
+
+/-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
+
+The range condition says that the parametrization is the boundary of a convex body. Requiring
+nonempty interior rules out lower-dimensional convex sets. -/
+def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
+  Manifold.IsSmoothEmbedding (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k n ∧
+    (∀ p, ‖n p‖ = 1) ∧
+    (∀ p v, inner ℝ (n p) (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0) ∧
+    ∃ K : Set ℝ³,
+      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
+
+/-- A smooth parametrized convex surface with a smooth choice of unit normal. -/
+abbrev IsSmoothConvexSphere := IsConvexSphereOfClass ∞
+
+/-- A real-analytic parametrized convex surface with a real-analytic choice of unit normal. -/
+abbrev IsAnalyticConvexSphere := IsConvexSphereOfClass ω
+
+/-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
+derivative of the immersion, equivalently when its shape operator is scalar. -/
+def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
+  ∃ c : ℝ, mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) n p = c • mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
+/-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
+def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
+  ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
+    ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
+
+/-- The smooth Carathéodory conjecture. -/
+abbrev SmoothCaratheodoryConjecture := CaratheodoryConjectureOfClass ∞
+
+/-- The real-analytic Carathéodory conjecture. -/
+abbrev AnalyticCaratheodoryConjecture := CaratheodoryConjectureOfClass ω
+
+/-- **The smooth Carathéodory conjecture.**
+
+Every smoothly embedded two-sphere which bounds a convex body has at least two distinct
+umbilic points. -/
+@[category research open, AMS 52 53]
+theorem caratheodory_conjecture : answer(sorry) ↔ SmoothCaratheodoryConjecture := by
+  sorry
+
+/-- **The real-analytic Carathéodory conjecture.**
+
+Every real-analytically embedded two-sphere which bounds a convex body has at least two distinct
+umbilic points. This is the classical theorem of Hamburger. -/
+@[category research solved, AMS 52 53]
+theorem caratheodory_conjecture_analytic : AnalyticCaratheodoryConjecture := by
+  sorry
+
+/-- The smooth Loewner conjecture implies the smooth Carathéodory conjecture by the
+Poincaré–Hopf index theorem for principal line fields. -/
+@[category research solved, AMS 52 53 57]
+theorem loewner_implies_caratheodory :
+    LoewnerConjecture.SmoothLoewnerConjecture → SmoothCaratheodoryConjecture := by
+  sorry
+
+end CaratheodoryConjecture

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -56,16 +56,14 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A point is umbilic when its second fundamental form is a scalar multiple of its first.
-The second form uses the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
-def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
-  EuclideanHypersurface.IsUmbilicByFundamentalForms
-    (sphereAmbientMfderiv F p) (sphereAmbientMfderiv n p)
-
 /-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
-    ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
+    ∃ p₁ p₂, p₁ ≠ p₂ ∧
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p₁) (sphereAmbientMfderiv n p₁) ∧
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p₂) (sphereAmbientMfderiv n p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -38,19 +38,19 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- A parametrized convex surface whose canonical normal is of class `C^k`.
+/-- A parametrized convex surface of class `C^(k + 1)`, whose canonical normal is of class
+`C^k`.
 
 The canonical normal is constructed from the derivative of `F` by a globally
 orientation-corrected cross product. Its orthogonality is built into the construction, while the
-injective differential makes it a unit vector. For finite `k`, requiring this normal to be `C^k`
-is stronger than requiring only `F` to be `C^k`. The range condition identifies the surface with
-the boundary of a compact convex body with nonempty interior. -/
+injective differential makes it a unit vector. Its `C^k` regularity follows from the `C^(k + 1)`
+regularity of `F`. The range condition identifies the surface with the boundary of a compact
+convex body with nonempty interior. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
-  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (k + 1) F ∧
     Topology.IsEmbedding F ∧
     (∀ p, Function.Injective
       (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) ∧
-    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
     ∃ K : ConvexBody ℝ³,
       (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -1,0 +1,87 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Loewner's conjecture
+
+Loewner's conjecture says that an isolated umbilic point of a sufficiently smooth surface has
+principal-line index at most one. We state the conjecture for smooth functions and the classical
+positive result for real-analytic functions.
+
+*References:*
+- [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problem
+  8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
+- [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
+  umbilic points*](https://doi.org/10.1007/BF02392036)
+-/
+
+open Metric
+open scoped ContDiff
+
+namespace LoewnerConjecture
+
+/-- The trace-free part of the Hessian of `f : ℂ → ℝ`, encoded as a complex number.
+
+Its zeros are precisely the points where the two eigendirections of the Hessian are not
+distinct. The argument of this complex number is twice the angle of a principal line. -/
+noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
+  let H := fderiv ℝ (fun w ↦ fderiv ℝ f w) z
+  (H 1 1 - H Complex.I Complex.I : ℝ) + (2 * H 1 Complex.I : ℝ) * Complex.I
+
+/-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
+
+The lift `θ` records the argument of `q` on a sufficiently small positively oriented circle.
+For a trace-free Hessian, the corresponding principal-line index is `m / 2`. -/
+def HasIsolatedZeroIndex (q : ℂ → ℂ) (z : ℂ) (m : ℤ) : Prop :=
+  ∃ ε > 0,
+    q z = 0 ∧
+      (∀ w, w ≠ z → dist w z < ε → q w ≠ 0) ∧
+      ∃ r, 0 < r ∧ r < ε ∧ ∃ θ : ℝ → ℝ, Continuous θ ∧
+        (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
+          q (z + r * Complex.exp ((t : ℂ) * Complex.I)) /
+            ‖q (z + r * Complex.exp ((t : ℂ) * Complex.I))‖) ∧
+        θ (2 * Real.pi) - θ 0 = 2 * Real.pi * m
+
+/-- Loewner's conjecture for functions of class `C^k` near an isolated umbilic. The integer `m`
+is twice the principal-line index, so the bound `m ≤ 2` says that this index is at most one. -/
+def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
+  ∀ (f : ℂ → ℝ) (z : ℂ) (m : ℤ), ContDiffAt ℝ k f z →
+    HasIsolatedZeroIndex (traceFreeHessian f) z m → m ≤ 2
+
+/-- The smooth Loewner conjecture. -/
+abbrev SmoothLoewnerConjecture := LoewnerConjectureOfClass ∞
+
+/-- The real-analytic Loewner conjecture. -/
+abbrev AnalyticLoewnerConjecture := LoewnerConjectureOfClass ω
+
+/-- **The smooth Loewner conjecture.**
+
+The principal-line index at an isolated umbilic of a smooth Hessian is at most one. -/
+@[category research open, AMS 53 57]
+theorem loewner_conjecture : answer(sorry) ↔ SmoothLoewnerConjecture := by
+  sorry
+
+/-- **The real-analytic Loewner conjecture.**
+
+The principal-line index at an isolated umbilic of a real-analytic Hessian is at most one.
+This is the classical result attributed to Hamburger and subsequently treated by Titus. -/
+@[category research solved, AMS 53 57]
+theorem loewner_conjecture_analytic : AnalyticLoewnerConjecture := by
+  sorry
+
+end LoewnerConjecture

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -39,8 +39,7 @@ namespace LoewnerConjecture
 angle. Its zeros are exactly the points where the Hessian has a repeated eigenvalue. -/
 noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
   let H := iteratedFDeriv ℝ 2 f z
-  (H ![1, 1] - H ![Complex.I, Complex.I] : ℝ) +
-    (2 * H ![1, Complex.I] : ℝ) * Complex.I
+  H ![1, 1] - H ![Complex.I, Complex.I] + 2 * H ![1, Complex.I] * Complex.I
 
 /-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
 

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -63,17 +63,11 @@ def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (f : ℂ → ℝ) (z : ℂ) (m : ℤ), ContDiffAt ℝ k f z →
     HasIsolatedZeroIndex (traceFreeHessian f) z m → m ≤ 2
 
-/-- The smooth Loewner conjecture. -/
-abbrev SmoothLoewnerConjecture := LoewnerConjectureOfClass ∞
-
-/-- The real-analytic Loewner conjecture. -/
-abbrev AnalyticLoewnerConjecture := LoewnerConjectureOfClass ω
-
 /-- **The smooth Loewner conjecture.**
 
 The principal-line index at an isolated umbilic of a smooth Hessian is at most one. -/
 @[category research open, AMS 53 57]
-theorem loewner_conjecture : answer(sorry) ↔ SmoothLoewnerConjecture := by
+theorem loewner_conjecture : answer(sorry) ↔ LoewnerConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Loewner conjecture.**
@@ -81,7 +75,7 @@ theorem loewner_conjecture : answer(sorry) ↔ SmoothLoewnerConjecture := by
 The principal-line index at an isolated umbilic of a real-analytic Hessian is at most one.
 This is the classical result attributed to Hamburger and subsequently treated by Titus. -/
 @[category research solved, AMS 53 57]
-theorem loewner_conjecture_analytic : AnalyticLoewnerConjecture := by
+theorem loewner_conjecture_analytic : LoewnerConjectureOfClass ω := by
   sorry
 
 end LoewnerConjecture

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -21,8 +21,7 @@ import FormalConjecturesUtil
 # Loewner's conjecture
 
 Loewner's conjecture says that an isolated umbilic point of a sufficiently smooth surface has
-principal-line index at most one. We state the conjecture for smooth functions and the classical
-positive result for real-analytic functions.
+principal-line index at most one. We record the smooth conjecture and real-analytic theorem.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problem
@@ -36,10 +35,8 @@ open scoped ContDiff
 
 namespace LoewnerConjecture
 
-/-- The trace-free part of the Hessian of `f : ℂ → ℝ`, encoded as a complex number.
-
-Its zeros are precisely the points where the two eigendirections of the Hessian are not
-distinct. The argument of this complex number is twice the angle of a principal line. -/
+/-- The trace-free Hessian of `f : ℂ → ℝ`, encoded so its argument is twice the principal-line
+angle. Its zeros are exactly the points where the Hessian has a repeated eigenvalue. -/
 noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
   let H := iteratedFDeriv ℝ 2 f z
   (H ![1, 1] - H ![Complex.I, Complex.I] : ℝ) +
@@ -47,9 +44,8 @@ noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
 
 /-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
 
-The function `q` is continuous on the ball witnessing isolation, so its winding number is
-independent of the sufficiently small positively oriented circle used below. The lift `θ` records
-the argument of `q` on one such circle. For a trace-free Hessian, the corresponding principal-line
+Continuity on the witness ball makes the winding number independent of the sufficiently small
+circle; `θ` is an argument lift on one such circle. For a trace-free Hessian, the principal-line
 index is `m / 2`. -/
 def HasIsolatedZeroIndex (q : ℂ → ℂ) (z : ℂ) (m : ℤ) : Prop :=
   ∃ ε > 0,

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
+import Mathlib.Analysis.Normed.Module.Normalize
 import FormalConjecturesUtil
 
 /-!
@@ -40,21 +41,23 @@ namespace LoewnerConjecture
 Its zeros are precisely the points where the two eigendirections of the Hessian are not
 distinct. The argument of this complex number is twice the angle of a principal line. -/
 noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
-  let H := fderiv ℝ (fun w ↦ fderiv ℝ f w) z
-  (H 1 1 - H Complex.I Complex.I : ℝ) + (2 * H 1 Complex.I : ℝ) * Complex.I
+  let H := iteratedFDeriv ℝ 2 f z
+  (H ![1, 1] - H ![Complex.I, Complex.I] : ℝ) +
+    (2 * H ![1, Complex.I] : ℝ) * Complex.I
 
 /-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
 
-The lift `θ` records the argument of `q` on a sufficiently small positively oriented circle.
-For a trace-free Hessian, the corresponding principal-line index is `m / 2`. -/
+The function `q` is continuous on the ball witnessing isolation, so its winding number is
+independent of the sufficiently small positively oriented circle used below. The lift `θ` records
+the argument of `q` on one such circle. For a trace-free Hessian, the corresponding principal-line
+index is `m / 2`. -/
 def HasIsolatedZeroIndex (q : ℂ → ℂ) (z : ℂ) (m : ℤ) : Prop :=
   ∃ ε > 0,
-    q z = 0 ∧
+    ContinuousOn q (ball z ε) ∧ q z = 0 ∧
       (∀ w, w ≠ z → dist w z < ε → q w ≠ 0) ∧
       ∃ r, 0 < r ∧ r < ε ∧ ∃ θ : ℝ → ℝ, Continuous θ ∧
         (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
-          q (z + r * Complex.exp ((t : ℂ) * Complex.I)) /
-            ‖q (z + r * Complex.exp ((t : ℂ) * Complex.I))‖) ∧
+          NormedSpace.normalize (q (z + r * Complex.exp ((t : ℂ) * Complex.I)))) ∧
         θ (2 * Real.pi) - θ 0 = 2 * Real.pi * m
 
 /-- Loewner's conjecture for functions of class `C^k` near an isolated umbilic. The integer `m`

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -122,6 +122,7 @@ public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+public import FormalConjecturesForMathlib.Geometry.SphereImmersionRegularity
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -121,6 +121,7 @@ public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -119,6 +119,7 @@ public import FormalConjecturesForMathlib.Data.ZMod.Fp
 public import FormalConjecturesForMathlib.Data.ZMod.PerfectDifferenceSet
 public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
+public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -42,10 +42,6 @@ Presumably this can be avoided by assuming `[NeZero n]`. -/
 noncomputable instance Module.orientedEuclideanSpaceFinThree : Module.Oriented ℝ ℝ³ (Fin 3) :=
   ⟨Basis.orientation <| PiLp.basisFun ..⟩
 
-/-- Three dimensional euclidean space is three-dimensional. -/
-instance fact_finrank_euclideanSpace_fin_three : Fact (Module.finrank ℝ ℝ³ = 3) :=
-  ⟨finrank_euclideanSpace_fin⟩
-
 namespace EuclideanHypersurface
 
 /-- The usual cross product on three-dimensional Euclidean space, as a bundled continuous

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -24,8 +24,8 @@ public import Mathlib.Topology.Algebra.Module.FiniteDimension
 # Three-dimensional Euclidean geometry
 
 This file supplies the preferred orientation on `ℝ³` and transports the usual cross product on
-coordinate triples to a bundled bilinear map on Euclidean space. It also records the standard
-algebraic and metric identities for this cross product.
+coordinate triples to a bundled continuous bilinear map on Euclidean space. It also records the
+standard algebraic and metric identities for this cross product.
 -/
 
 @[expose] public section
@@ -73,8 +73,7 @@ theorem euclideanCross_anticomm (a b : ℝ³) :
 /-- A vector has zero cross product with itself. -/
 @[simp]
 theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
-  simpa only [euclideanCross_apply, map_zero] using
-    congrArg (WithLp.toLp 2) (cross_self (WithLp.ofLp a))
+  simp [euclideanCross_apply]
 
 /-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
 @[simp]

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -45,7 +45,7 @@ namespace EuclideanHypersurface
 /-- The cross product on `ℝ³`, bundled as a continuous bilinear map. -/
 noncomputable def euclideanCross : ℝ³ →L[ℝ] ℝ³ →L[ℝ] ℝ³ :=
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
-  let f : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+  let f :=
     ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
   LinearMap.toContinuousLinearMap (LinearMap.toContinuousLinearMap.toLinearMap.comp f)
 
@@ -112,7 +112,6 @@ theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
     funext i
     fin_cases i <;> simp
   exact hf ▸ e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
-    (v := ![a, b])
 
 /-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
 theorem euclideanCross_eq_inner_smul_of_orthogonal

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -18,6 +18,7 @@ module
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
 # Three-dimensional Euclidean geometry
@@ -48,10 +49,13 @@ instance fact_finrank_euclideanSpace_fin_three : Fact (Module.finrank ℝ ℝ³ 
 
 namespace EuclideanHypersurface
 
-/-- The usual cross product on three-dimensional Euclidean space, as a bundled bilinear map. -/
-noncomputable def euclideanCross : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+/-- The usual cross product on three-dimensional Euclidean space, as a bundled continuous
+bilinear map. -/
+noncomputable def euclideanCross : ℝ³ →L[ℝ] ℝ³ →L[ℝ] ℝ³ :=
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
-  ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
+  let f : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+    ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
+  LinearMap.toContinuousLinearMap (LinearMap.toContinuousLinearMap.toLinearMap.comp f)
 
 /-- The bundled Euclidean cross product agrees with the coordinate cross product. -/
 theorem euclideanCross_apply (a b : ℝ³) :

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -22,9 +22,7 @@ public import Mathlib.LinearAlgebra.Orientation
 /-!
 # Three-dimensional Euclidean geometry
 
-This file supplies the preferred orientation on `ℝ³` and transports the usual cross product on
-coordinate triples to a bundled continuous bilinear map on Euclidean space. It also records the
-standard algebraic and metric identities for this cross product.
+This file defines the preferred orientation and bundled continuous cross product on `ℝ³`.
 -/
 
 @[expose] public section
@@ -44,8 +42,7 @@ noncomputable instance Module.orientedEuclideanSpaceFinThree : Module.Oriented �
 
 namespace EuclideanHypersurface
 
-/-- The usual cross product on three-dimensional Euclidean space, as a bundled continuous
-bilinear map. -/
+/-- The cross product on `ℝ³`, bundled as a continuous bilinear map. -/
 noncomputable def euclideanCross : ℝ³ →L[ℝ] ℝ³ →L[ℝ] ℝ³ :=
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
   let f : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
@@ -71,13 +68,13 @@ theorem euclideanCross_anticomm (a b : ℝ³) :
 theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
   simp [euclideanCross_apply]
 
-/-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
+/-- The cross product is orthogonal to its left input. -/
 @[simp]
 theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
   simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,
     dot_self_cross]
 
-/-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
+/-- The cross product is orthogonal to its right input. -/
 @[simp]
 theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
   simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -16,13 +16,25 @@ limitations under the License.
 module
 
 public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
+
+public meta import FormalConjecturesUtil.Attributes.Basic
+
+/-!
+# Three-dimensional Euclidean geometry
+
+This file supplies the preferred orientation on `ℝ³` and transports the usual cross product on
+coordinate triples to a bundled bilinear map on Euclidean space. It also records the standard
+algebraic and metric identities for this cross product.
+-/
 
 @[expose] public section
 
 scoped[EuclideanGeometry] notation "ℝ³" => EuclideanSpace ℝ (Fin 3)
 
 open scoped EuclideanGeometry
+open Matrix
 
 /-- The standard basis gives us a preferred orientation in `ℝ³`.
 
@@ -35,3 +47,100 @@ noncomputable instance Module.orientedEuclideanSpaceFinThree : Module.Oriented �
 /-- Three dimensional euclidean space is three-dimensional. -/
 instance fact_finrank_euclideanSpace_fin_three : Fact (Module.finrank ℝ ℝ³ = 3) :=
   ⟨finrank_euclideanSpace_fin⟩
+
+namespace EuclideanHypersurface
+
+/-- The usual cross product on three-dimensional Euclidean space, as a bundled bilinear map. -/
+noncomputable def euclideanCross : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+  let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
+  ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
+
+/-- The bundled Euclidean cross product agrees with the coordinate cross product. -/
+@[category API, AMS 53]
+theorem euclideanCross_apply (a b : ℝ³) :
+    euclideanCross a b =
+      WithLp.toLp 2 (crossProduct (WithLp.ofLp a) (WithLp.ofLp b)) :=
+  rfl
+
+/-- Swapping the arguments of the cross product negates it. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_anticomm (a b : ℝ³) :
+    -euclideanCross a b = euclideanCross b a := by
+  simpa only [euclideanCross_apply, map_neg] using
+    congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
+
+/-- A vector has zero cross product with itself. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
+  simpa only [euclideanCross_apply, map_zero] using
+    congrArg (WithLp.toLp 2) (cross_self (WithLp.ofLp a))
+
+/-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
+  rw [euclideanCross_apply]
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_self_cross]
+
+/-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
+  rw [euclideanCross_apply]
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_cross_self]
+
+/-- The inner product of two cross products is the corresponding Gram-determinant expression. -/
+@[category API, AMS 53]
+theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
+    inner ℝ (euclideanCross a b) (euclideanCross c d) =
+      inner ℝ a c * inner ℝ b d - inner ℝ a d * inner ℝ b c := by
+  simp only [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
+    cross_dot_cross]
+  rw [dotProduct_comm (WithLp.ofLp d) (WithLp.ofLp a)]
+  ring
+
+/-- The right-nested vector triple-product identity. -/
+@[category API, AMS 53]
+theorem euclideanCross_cross (u v w : ℝ³) :
+    euclideanCross u (euclideanCross v w) =
+      inner ℝ u w • v - inner ℝ u v • w := by
+  change WithLp.toLp 2
+    (crossProduct (WithLp.ofLp u) (crossProduct (WithLp.ofLp v) (WithLp.ofLp w))) = _
+  rw [cross_cross_eq_smul_sub_smul']
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial]
+  rw [dotProduct_comm (WithLp.ofLp w) (WithLp.ofLp u),
+    dotProduct_comm (WithLp.ofLp v) (WithLp.ofLp u)]
+  rfl
+
+/-- A cross product is nonzero exactly when its two inputs are linearly independent. -/
+@[category API, AMS 53]
+theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
+    euclideanCross a b ≠ 0 ↔ LinearIndependent ℝ ![a, b] := by
+  let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
+  have hne : euclideanCross a b ≠ 0 ↔ crossProduct (e a) (e b) ≠ 0 := by
+    rw [euclideanCross]
+    exact e.symm.injective.ne_iff
+  rw [hne, crossProduct_ne_zero_iff_linearIndependent]
+  have hLI := e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
+    (v := ![a, b])
+  have hf : e.toLinearMap ∘ ![a, b] = ![e a, e b] := by
+    funext i
+    fin_cases i <;> simp
+  rwa [hf] at hLI
+
+/-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
+@[category API, AMS 53]
+theorem euclideanCross_eq_inner_smul_of_orthogonal
+    (p x y : ℝ³) (hp : ‖p‖ = 1) (hx : inner ℝ p x = 0) (hy : inner ℝ p y = 0) :
+    euclideanCross x y = inner ℝ (euclideanCross x y) p • p := by
+  let c := euclideanCross x y
+  have hpc : euclideanCross p c = 0 := by
+    dsimp only [c]
+    rw [euclideanCross_cross, hy, hx]
+    simp
+  have hpp : inner ℝ p p = 1 := by
+    simp [hp]
+  have hsecond := euclideanCross_cross p p c
+  rw [hpc, map_zero, hpp, one_smul] at hsecond
+  have hc := (sub_eq_zero.mp hsecond.symm).symm
+  simpa only [c, real_inner_comm] using hc
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -18,7 +18,6 @@ module
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
-public import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
 # Three-dimensional Euclidean geometry
@@ -93,8 +92,7 @@ theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
       inner ℝ a c * inner ℝ b d - inner ℝ a d * inner ℝ b c := by
   simp only [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
     cross_dot_cross]
-  rw [dotProduct_comm (WithLp.ofLp d) (WithLp.ofLp a)]
-  ring
+  rw [mul_comm (WithLp.ofLp c ⬝ᵥ WithLp.ofLp b)]
 
 /-- The right-nested vector triple-product identity. -/
 theorem euclideanCross_cross (u v w : ℝ³) :
@@ -130,13 +128,12 @@ theorem euclideanCross_eq_inner_smul_of_orthogonal
   let c := euclideanCross x y
   have hpc : euclideanCross p c = 0 := by
     dsimp only [c]
-    rw [euclideanCross_cross, hy, hx]
-    simp
+    simp only [euclideanCross_cross, hy, hx, zero_smul, sub_zero]
   have hpp : inner ℝ p p = 1 := by
     simp [hp]
   have hsecond := euclideanCross_cross p p c
   rw [hpc, map_zero, hpp, one_smul] at hsecond
-  have hc := (sub_eq_zero.mp hsecond.symm).symm
+  have hc : c = inner ℝ p c • p := (sub_eq_zero.mp hsecond.symm).symm
   simpa only [c, real_inner_comm] using hc
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -66,8 +66,9 @@ theorem euclideanCross_apply (a b : ℝ³) :
 @[simp]
 theorem euclideanCross_anticomm (a b : ℝ³) :
     -euclideanCross a b = euclideanCross b a := by
-  simpa only [euclideanCross_apply, map_neg] using
-    congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
+  rw [euclideanCross_apply, euclideanCross_apply]
+  change WithLp.toLp 2 (-crossProduct (WithLp.ofLp a) (WithLp.ofLp b)) = _
+  exact congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
 
 /-- A vector has zero cross product with itself. -/
 @[simp]
@@ -77,14 +78,14 @@ theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
 /-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
 @[simp]
 theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
-  rw [euclideanCross_apply]
-  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_self_cross]
+  simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,
+    dot_self_cross]
 
 /-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
 @[simp]
 theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
-  rw [euclideanCross_apply]
-  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_cross_self]
+  simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,
+    dot_cross_self]
 
 /-- The inner product of two cross products is the corresponding Gram-determinant expression. -/
 theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
@@ -114,12 +115,11 @@ theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
     rw [euclideanCross]
     exact e.symm.injective.ne_iff
   rw [hne, crossProduct_ne_zero_iff_linearIndependent]
-  have hLI := e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
-    (v := ![a, b])
   have hf : e.toLinearMap ∘ ![a, b] = ![e a, e b] := by
     funext i
     fin_cases i <;> simp
-  rwa [hf] at hLI
+  exact hf ▸ e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
+    (v := ![a, b])
 
 /-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
 theorem euclideanCross_eq_inner_smul_of_orthogonal
@@ -128,12 +128,9 @@ theorem euclideanCross_eq_inner_smul_of_orthogonal
   let c := euclideanCross x y
   have hpc : euclideanCross p c = 0 := by
     dsimp only [c]
-    simp only [euclideanCross_cross, hy, hx, zero_smul, sub_zero]
-  have hpp : inner ℝ p p = 1 := by
-    simp [hp]
+    simp [euclideanCross_cross, hy, hx]
   have hsecond := euclideanCross_cross p p c
-  rw [hpc, map_zero, hpp, one_smul] at hsecond
-  have hc : c = inner ℝ p c • p := (sub_eq_zero.mp hsecond.symm).symm
-  simpa only [c, real_inner_comm] using hc
+  rw [hpc, map_zero, show inner ℝ p p = 1 by simp [hp], one_smul] at hsecond
+  simpa [c, real_inner_comm] using (sub_eq_zero.mp hsecond.symm).symm
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -19,8 +19,6 @@ public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
 
-public meta import FormalConjecturesUtil.Attributes.Basic
-
 /-!
 # Three-dimensional Euclidean geometry
 
@@ -56,39 +54,37 @@ noncomputable def euclideanCross : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
   ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
 
 /-- The bundled Euclidean cross product agrees with the coordinate cross product. -/
-@[category API, AMS 53]
 theorem euclideanCross_apply (a b : ℝ³) :
     euclideanCross a b =
       WithLp.toLp 2 (crossProduct (WithLp.ofLp a) (WithLp.ofLp b)) :=
   rfl
 
 /-- Swapping the arguments of the cross product negates it. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_anticomm (a b : ℝ³) :
     -euclideanCross a b = euclideanCross b a := by
   simpa only [euclideanCross_apply, map_neg] using
     congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
 
 /-- A vector has zero cross product with itself. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
   simpa only [euclideanCross_apply, map_zero] using
     congrArg (WithLp.toLp 2) (cross_self (WithLp.ofLp a))
 
 /-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
   rw [euclideanCross_apply]
   simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_self_cross]
 
 /-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
   rw [euclideanCross_apply]
   simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_cross_self]
 
 /-- The inner product of two cross products is the corresponding Gram-determinant expression. -/
-@[category API, AMS 53]
 theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
     inner ℝ (euclideanCross a b) (euclideanCross c d) =
       inner ℝ a c * inner ℝ b d - inner ℝ a d * inner ℝ b c := by
@@ -98,7 +94,6 @@ theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
   ring
 
 /-- The right-nested vector triple-product identity. -/
-@[category API, AMS 53]
 theorem euclideanCross_cross (u v w : ℝ³) :
     euclideanCross u (euclideanCross v w) =
       inner ℝ u w • v - inner ℝ u v • w := by
@@ -111,7 +106,6 @@ theorem euclideanCross_cross (u v w : ℝ³) :
   rfl
 
 /-- A cross product is nonzero exactly when its two inputs are linearly independent. -/
-@[category API, AMS 53]
 theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
     euclideanCross a b ≠ 0 ↔ LinearIndependent ℝ ![a, b] := by
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
@@ -127,7 +121,6 @@ theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
   rwa [hf] at hLI
 
 /-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
-@[category API, AMS 53]
 theorem euclideanCross_eq_inner_smul_of_orthogonal
     (p x y : ℝ³) (hp : ‖p‖ = 1) (hx : inner ℝ p x = 0) (hy : inner ℝ p y = 0) :
     euclideanCross x y = inner ℝ (euclideanCross x y) p • p := by

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -45,7 +45,8 @@ noncomputable def secondFundamentalFormAt (dn dF : V →L[ℝ] E) :
   -(LinearMap.BilinForm.comp (innerₗ E) dn.toLinearMap dF.toLinearMap)
 
 /-- A point is umbilic when its second fundamental form is a scalar multiple of its first. -/
-def IsUmbilic (dF dn : V →L[ℝ] E) : Prop :=
+def IsUmbilic (V E : Type*) [TopologicalSpace V] [AddCommGroup V] [Module ℝ V]
+    [NormedAddCommGroup E] [InnerProductSpace ℝ E] (dF dn : V →L[ℝ] E) : Prop :=
   ∃ κ : ℝ, secondFundamentalFormAt dn dF = κ • firstFundamentalFormAt dF
 
 @[simp]
@@ -61,7 +62,7 @@ theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
 /-- If `dn = c • dF`, the point is umbilic with scalar `-c` under our sign convention. -/
 theorem isUmbilic_of_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
-    IsUmbilic dF dn := by
+    IsUmbilic V E dF dn := by
   refine ⟨-c, ?_⟩
   ext v w
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
@@ -71,7 +72,7 @@ theorem isUmbilic_of_normal_deriv_eq_smul
 of `dF`. -/
 theorem isUmbilic_iff_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
-    IsUmbilic dF dn ↔ ∃ c : ℝ, dn = c • dF := by
+    IsUmbilic V E dF dn ↔ ∃ c : ℝ, dn = c • dF := by
   constructor
   · rintro ⟨κ, hκ⟩
     refine ⟨-κ, ?_⟩

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -19,8 +19,6 @@ module
 public import Mathlib.Analysis.InnerProductSpace.LinearMap
 public import Mathlib.LinearAlgebra.BilinearForm.Hom
 
-@[expose] public section
-
 /-!
 # Extrinsic fundamental forms in Euclidean space
 
@@ -28,6 +26,8 @@ This small API packages the first and second fundamental forms determined by the
 an immersion and a chosen normal field. The sign in the second form is the convention
 `II(v, w) = -⟪dn(v), dF(w)⟫`; consequently `dn = c • dF` corresponds to `II = (-c) • I`.
 -/
+
+@[expose] public section
 
 open scoped RealInnerProductSpace
 
@@ -51,13 +51,13 @@ def IsUmbilic (dF dn : V →L[ℝ] E) : Prop :=
 
 @[simp]
 theorem firstFundamentalFormAt_apply (dF : V →L[ℝ] E) (v w : V) :
-    firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) := by
-  simp [firstFundamentalFormAt]
+    firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) :=
+  rfl
 
 @[simp]
 theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
-    secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) := by
-  simp [secondFundamentalFormAt]
+    secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) :=
+  rfl
 
 /-- A scalar normal differential makes a point umbilic.
 
@@ -68,8 +68,7 @@ theorem isUmbilic_of_normal_deriv_eq_smul
   refine ⟨-c, ?_⟩
   ext v w
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
-  rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left]
-  ring
+  rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left, neg_mul]
 
 /-- Under a tangency hypothesis, umbilicity is equivalent to the normal differential being a
 scalar multiple of the immersion differential. The range hypothesis is exactly what rules out an
@@ -85,16 +84,12 @@ theorem isUmbilic_iff_normal_deriv_eq_smul
     have horth (w : V) : inner ℝ (dn v + κ • dF v) (dF w) = 0 := by
       have h := congrArg (fun B : LinearMap.BilinForm ℝ V ↦ B v w) hκ
       change -inner ℝ (dn v) (dF w) = κ * inner ℝ (dF v) (dF w) at h
-      rw [inner_add_left, real_inner_smul_left]
-      linarith [h]
+      rw [inner_add_left, real_inner_smul_left, ← h, add_neg_cancel]
     have hrange : dn v + κ • dF v = dF (u + κ • v) := by
       change dF u = dn v at hu
       rw [map_add, map_smul, ← hu]
-    have := horth (u + κ • v)
-    rw [← hrange, real_inner_self_eq_norm_sq] at this
-    have hzero : dn v + κ • dF v = 0 := by
-      apply norm_eq_zero.mp
-      nlinarith [norm_nonneg (dn v + κ • dF v)]
+    have hzero := horth (u + κ • v)
+    rw [← hrange, real_inner_self_eq_norm_sq, sq_eq_zero_iff, norm_eq_zero] at hzero
     simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
       eq_neg_of_add_eq_zero_left hzero
   · rintro ⟨c, hc⟩

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -90,9 +90,8 @@ theorem isUmbilic_iff_normal_deriv_eq_smul
       rw [map_add, map_smul, ← hu]
     have hzero := horth (u + κ • v)
     rw [← hrange, real_inner_self_eq_norm_sq, sq_eq_zero_iff, norm_eq_zero] at hzero
-    simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
+    simpa [ContinuousLinearMap.smul_apply] using
       eq_neg_of_add_eq_zero_left hzero
-  · rintro ⟨c, hc⟩
-    exact isUmbilic_of_normal_deriv_eq_smul dF dn c hc
+  · exact fun ⟨c, hc⟩ ↦ isUmbilic_of_normal_deriv_eq_smul dF dn c hc
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -1,0 +1,106 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.InnerProductSpace.LinearMap
+
+@[expose] public section
+
+/-!
+# Extrinsic fundamental forms in Euclidean space
+
+This small API packages the first and second fundamental forms determined by the differential of
+an immersion and a chosen normal field. The sign in the second form is the convention
+`II(v, w) = -⟪dn(v), dF(w)⟫`; consequently `dn = c • dF` corresponds to `II = (-c) • I`.
+-/
+
+open scoped RealInnerProductSpace
+
+namespace EuclideanHypersurface
+
+variable {V E : Type*} [TopologicalSpace V] [AddCommGroup V] [Module ℝ V]
+  [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The first fundamental form induced by `dF`. -/
+noncomputable def firstFundamentalFormAt (dF : V →L[ℝ] E) : LinearMap.BilinForm ℝ V :=
+  LinearMap.mk₂ ℝ (fun v w ↦ inner ℝ (dF v) (dF w))
+    (by simp [inner_add_left]) (by simp [real_inner_smul_left])
+    (by simp [inner_add_right]) (by simp [real_inner_smul_right])
+
+/-- The second fundamental form for the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
+noncomputable def secondFundamentalFormAt (dn dF : V →L[ℝ] E) :
+    LinearMap.BilinForm ℝ V :=
+  LinearMap.mk₂ ℝ (fun v w ↦ -inner ℝ (dn v) (dF w))
+    (by simp [inner_add_left, add_comm]) (by simp [real_inner_smul_left])
+    (by simp [inner_add_right, add_comm]) (by simp [real_inner_smul_right])
+
+/-- A point is umbilic when its second fundamental form is a scalar multiple of its first. -/
+def IsUmbilicByFundamentalForms (dF dn : V →L[ℝ] E) : Prop :=
+  ∃ κ : ℝ, secondFundamentalFormAt dn dF = κ • firstFundamentalFormAt dF
+
+@[simp]
+theorem firstFundamentalFormAt_apply (dF : V →L[ℝ] E) (v w : V) :
+    firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) := by
+  rfl
+
+@[simp]
+theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
+    secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) := by
+  rfl
+
+/-- A scalar normal differential gives the corresponding scalar second fundamental form.
+
+The minus sign is forced by `secondFundamentalFormAt`'s shape-operator convention. -/
+theorem isUmbilicByFundamentalForms_of_normal_deriv_eq_smul
+    (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
+    IsUmbilicByFundamentalForms dF dn := by
+  refine ⟨-c, ?_⟩
+  ext v w
+  change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
+  rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left]
+  ring
+
+/-- Under tangency hypotheses, the fundamental-form and scalar-normal-differential definitions
+of an umbilic are equivalent. The range hypothesis is exactly what rules out an undetected
+normal component of `dn`. -/
+theorem isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
+    (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
+    IsUmbilicByFundamentalForms dF dn ↔ ∃ c : ℝ, dn = c • dF := by
+  constructor
+  · rintro ⟨κ, hκ⟩
+    refine ⟨-κ, ?_⟩
+    ext v
+    obtain ⟨u, hu⟩ := htangent ⟨v, rfl⟩
+    have horth (w : V) : inner ℝ (dn v + κ • dF v) (dF w) = 0 := by
+      have h := congrArg (fun B : LinearMap.BilinForm ℝ V ↦ B v w) hκ
+      change -inner ℝ (dn v) (dF w) = κ * inner ℝ (dF v) (dF w) at h
+      rw [inner_add_left, real_inner_smul_left]
+      linarith [h]
+    have hrange : dn v + κ • dF v = dF (u + κ • v) := by
+      change dF u = dn v at hu
+      rw [map_add, map_smul, ← hu]
+    have := horth (u + κ • v)
+    rw [← hrange, real_inner_self_eq_norm_sq] at this
+    have hzero : dn v + κ • dF v = 0 := by
+      apply norm_eq_zero.mp
+      nlinarith [norm_nonneg (dn v + κ • dF v)]
+    simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
+      eq_neg_of_add_eq_zero_left hzero
+  · rintro ⟨c, hc⟩
+    exact isUmbilicByFundamentalForms_of_normal_deriv_eq_smul dF dn c hc
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -17,6 +17,7 @@ limitations under the License.
 module
 
 public import Mathlib.Analysis.InnerProductSpace.LinearMap
+public import Mathlib.LinearAlgebra.BilinearForm.Hom
 
 @[expose] public section
 
@@ -37,49 +38,45 @@ variable {V E : Type*} [TopologicalSpace V] [AddCommGroup V] [Module ℝ V]
 
 /-- The first fundamental form induced by `dF`. -/
 noncomputable def firstFundamentalFormAt (dF : V →L[ℝ] E) : LinearMap.BilinForm ℝ V :=
-  LinearMap.mk₂ ℝ (fun v w ↦ inner ℝ (dF v) (dF w))
-    (by simp [inner_add_left]) (by simp [real_inner_smul_left])
-    (by simp [inner_add_right]) (by simp [real_inner_smul_right])
+  LinearMap.BilinForm.comp (innerₗ E) dF.toLinearMap dF.toLinearMap
 
 /-- The second fundamental form for the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
 noncomputable def secondFundamentalFormAt (dn dF : V →L[ℝ] E) :
     LinearMap.BilinForm ℝ V :=
-  LinearMap.mk₂ ℝ (fun v w ↦ -inner ℝ (dn v) (dF w))
-    (by simp [inner_add_left, add_comm]) (by simp [real_inner_smul_left])
-    (by simp [inner_add_right, add_comm]) (by simp [real_inner_smul_right])
+  -(LinearMap.BilinForm.comp (innerₗ E) dn.toLinearMap dF.toLinearMap)
 
 /-- A point is umbilic when its second fundamental form is a scalar multiple of its first. -/
-def IsUmbilicByFundamentalForms (dF dn : V →L[ℝ] E) : Prop :=
+def IsUmbilic (dF dn : V →L[ℝ] E) : Prop :=
   ∃ κ : ℝ, secondFundamentalFormAt dn dF = κ • firstFundamentalFormAt dF
 
 @[simp]
 theorem firstFundamentalFormAt_apply (dF : V →L[ℝ] E) (v w : V) :
     firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) := by
-  rfl
+  simp [firstFundamentalFormAt]
 
 @[simp]
 theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
     secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) := by
-  rfl
+  simp [secondFundamentalFormAt]
 
-/-- A scalar normal differential gives the corresponding scalar second fundamental form.
+/-- A scalar normal differential makes a point umbilic.
 
 The minus sign is forced by `secondFundamentalFormAt`'s shape-operator convention. -/
-theorem isUmbilicByFundamentalForms_of_normal_deriv_eq_smul
+theorem isUmbilic_of_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
-    IsUmbilicByFundamentalForms dF dn := by
+    IsUmbilic dF dn := by
   refine ⟨-c, ?_⟩
   ext v w
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
   rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left]
   ring
 
-/-- Under tangency hypotheses, the fundamental-form and scalar-normal-differential definitions
-of an umbilic are equivalent. The range hypothesis is exactly what rules out an undetected
-normal component of `dn`. -/
-theorem isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
+/-- Under a tangency hypothesis, umbilicity is equivalent to the normal differential being a
+scalar multiple of the immersion differential. The range hypothesis is exactly what rules out an
+undetected normal component of `dn`. -/
+theorem isUmbilic_iff_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
-    IsUmbilicByFundamentalForms dF dn ↔ ∃ c : ℝ, dn = c • dF := by
+    IsUmbilic dF dn ↔ ∃ c : ℝ, dn = c • dF := by
   constructor
   · rintro ⟨κ, hκ⟩
     refine ⟨-κ, ?_⟩
@@ -101,6 +98,6 @@ theorem isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
     simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
       eq_neg_of_add_eq_zero_left hzero
   · rintro ⟨c, hc⟩
-    exact isUmbilicByFundamentalForms_of_normal_deriv_eq_smul dF dn c hc
+    exact isUmbilic_of_normal_deriv_eq_smul dF dn c hc
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -22,9 +22,8 @@ public import Mathlib.LinearAlgebra.BilinearForm.Hom
 /-!
 # Extrinsic fundamental forms in Euclidean space
 
-This small API packages the first and second fundamental forms determined by the differential of
-an immersion and a chosen normal field. The sign in the second form is the convention
-`II(v, w) = -⟪dn(v), dF(w)⟫`; consequently `dn = c • dF` corresponds to `II = (-c) • I`.
+The second fundamental form uses `II(v, w) = -⟪dn(v), dF(w)⟫`, so `dn = c • dF` corresponds
+to `II = (-c) • I`.
 -/
 
 @[expose] public section
@@ -59,9 +58,7 @@ theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
     secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) :=
   rfl
 
-/-- A scalar normal differential makes a point umbilic.
-
-The minus sign is forced by `secondFundamentalFormAt`'s shape-operator convention. -/
+/-- If `dn = c • dF`, the point is umbilic with scalar `-c` under our sign convention. -/
 theorem isUmbilic_of_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
     IsUmbilic dF dn := by
@@ -70,9 +67,8 @@ theorem isUmbilic_of_normal_deriv_eq_smul
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
   rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left, neg_mul]
 
-/-- Under a tangency hypothesis, umbilicity is equivalent to the normal differential being a
-scalar multiple of the immersion differential. The range hypothesis is exactly what rules out an
-undetected normal component of `dn`. -/
+/-- If `dn` is tangent to the immersion, umbilicity is equivalent to `dn` being a scalar multiple
+of `dF`. -/
 theorem isUmbilic_iff_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
     IsUmbilic dF dn ↔ ∃ c : ℝ, dn = c • dF := by

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -66,13 +66,17 @@ noncomputable def sphereNormal
 
 /-- The orientation factor contributed by the standard sphere inclusion is nonzero. -/
 private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³) 1) :
-    let b := sphereTangentBasis p
-    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-    inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
-  dsimp only
+    inner ℝ
+      (euclideanCross
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+          (sphereTangentBasis p 0))
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+          (sphereTangentBasis p 1)))
+      (p : ℝ³) ≠ 0 := by
   letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   let b := sphereTangentBasis p
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  change inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0
   have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
   have hιLI : LinearIndependent ℝ ![dι (b 0), dι (b 1)] := by
     have hmap := b.linearIndependent.map' dι.toLinearMap
@@ -125,7 +129,6 @@ private theorem sphereNormalRaw_ne_zero_iff
   let b := sphereTangentBasis p
   let dF := sphereAmbientMfderiv F p
   have hfactor := sphereInclusionOrientationFactor_ne_zero p
-  dsimp only at hfactor
   rw [sphereNormalRaw]
   dsimp only
   rw [smul_ne_zero_iff, and_iff_right hfactor,

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -214,8 +214,7 @@ theorem inner_sphereNormal_mfderiv
 
 private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    sphereNormalRaw F p ≠ 0 ↔ Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³) := by
+    sphereNormalRaw F p ≠ 0 ↔ Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p) := by
   let b := sphereTangentBasis p
   let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
     mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
@@ -237,16 +236,14 @@ private theorem sphereNormalRaw_ne_zero_iff
 injective. -/
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    sphereNormal F p ≠ 0 ↔ Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³) := by
+    sphereNormal F p ≠ 0 ↔ Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p) := by
   simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
     sphereNormalRaw_ne_zero_iff F p
 
 /-- At an immersion point, the canonical normal has unit length. -/
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
+    (hF : Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) :
     ‖sphereNormal F p‖ = 1 := by
   simpa [sphereNormal] using
     NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -18,6 +18,8 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Normalize
 public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame
+public import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 
 public import FormalConjecturesForMathlib.Geometry.«3d»
 
@@ -36,15 +38,9 @@ normal is independent of the chart orientation.
 @[expose] public section
 
 open Metric
-open scoped EuclideanGeometry Manifold RealInnerProductSpace
+open scoped EuclideanGeometry EuclideanSpace Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
-
-/-- The manifold derivative of a map from the unit two-sphere, with ambient codomain. -/
-noncomputable def sphereAmbientMfderiv
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
-  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
 
 /-- The standard basis of Mathlib's fixed model copy of `ℝ²` for the tangent space at `p`.
 
@@ -52,22 +48,33 @@ This is a coordinate basis used to evaluate the manifold derivative, not a globa
 the sphere. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) :=
-  PiLp.basisFun 2 ℝ (Fin 2)
+  (trivializationAt (EuclideanSpace ℝ (Fin 2)) (TangentSpace (𝓡 2)) p).basisAt
+    (PiLp.basisFun 2 ℝ (Fin 2)) (FiberBundle.mem_baseSet_trivializationAt' p)
 
-private theorem sphereAmbientMfderiv_inclusion_basis_apply
+/-- The basis induced by the tangent-bundle trivialization at its base point agrees with the
+standard model basis. -/
+theorem sphereTangentBasis_apply (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
+    sphereTangentBasis p i = PiLp.basisFun 2 ℝ (Fin 2) i := by
+  change
+    (trivializationAt (EuclideanSpace ℝ (Fin 2)) (TangentSpace (𝓡 2)) p).symmL ℝ p
+        (PiLp.basisFun 2 ℝ (Fin 2) i) = _
+  rw [(tangentBundleCore (𝓡 2) _).trivializationAt_symmL
+    (FiberBundle.mem_baseSet_trivializationAt' p)]
+  exact (tangentBundleCore (𝓡 2) _).coordChange_self _ p
+    ((tangentBundleCore (𝓡 2) _).mem_baseSet_at p) _
+
+private theorem mfderiv_inclusion_sphereTangentBasis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
-    letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-    sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p :
+      TangentSpace (𝓡 2) p →L[ℝ] ℝ³)
         (sphereTangentBasis p i) =
       let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
         (ne_zero_of_mem_unit_sphere (-p))).repr
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
         (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-  dsimp only
-  rw [sphereAmbientMfderiv,
-    ((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
+  rw [((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
   simp only [chartAt, fderivWithin_univ, mfld_simps]
+  rw [sphereTangentBasis_apply]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change
@@ -91,17 +98,16 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
 /-- The standard model basis maps to an orthonormal frame under the derivative of the sphere
 inclusion. -/
 @[simp]
-theorem inner_sphereAmbientMfderiv_inclusion_basis
+theorem inner_mfderiv_inclusion_sphereTangentBasis
     (p : sphere (0 : ℝ³) 1) (i j : Fin 2) :
     inner ℝ
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p i))
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p j)) =
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p (sphereTangentBasis p i))
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p (sphereTangentBasis p j)) =
       if i = j then 1 else 0 := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-  rw [sphereAmbientMfderiv_inclusion_basis_apply p i,
-    sphereAmbientMfderiv_inclusion_basis_apply p j]
+  rw [mfderiv_inclusion_sphereTangentBasis_apply p i,
+    mfderiv_inclusion_sphereTangentBasis_apply p j]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change inner ℝ
@@ -112,18 +118,19 @@ theorem inner_sphereAmbientMfderiv_inclusion_basis
 
 /-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
 family. -/
-theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³) 1) :
+theorem orthonormal_mfderiv_inclusion_sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Orthonormal ℝ fun i : Fin 2 ↦
-      sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p i) :=
-  orthonormal_iff_ite.mpr (inner_sphereAmbientMfderiv_inclusion_basis p)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p (sphereTangentBasis p i)) :=
+  orthonormal_iff_ite.mpr (inner_mfderiv_inclusion_sphereTangentBasis p)
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
 noncomputable def sphereNormalRaw
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let dF := sphereAmbientMfderiv F p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
   inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
     euclideanCross (dF (b 0)) (dF (b 1))
 
@@ -139,10 +146,10 @@ noncomputable def sphereNormal
 /-- The cross product of the inclusion frame is its radial component. -/
 private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
-    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+      mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     euclideanCross (dι (b 0)) (dι (b 1)) =
       inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) • (p : ℝ³) := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   dsimp only
   refine euclideanCross_eq_inner_smul_of_orthogonal _ _ _
     (norm_eq_of_mem_sphere p) ?_ ?_
@@ -154,13 +161,15 @@ private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
 /-- The orientation factor contributed by the standard sphere inclusion has square one. -/
 private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
-    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+      mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ^ 2 = 1 := by
   dsimp only
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
-    orthonormal_sphereAmbientMfderiv_inclusion_basis p
+    orthonormal_mfderiv_inclusion_sphereTangentBasis p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
   change s ^ 2 = 1
@@ -178,7 +187,8 @@ private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1
 theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
     sphereNormalRaw (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
   change s • c = (p : ℝ³)
@@ -188,31 +198,41 @@ theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
 @[simp]
-theorem inner_sphereNormalRaw_sphereAmbientMfderiv
+theorem inner_sphereNormalRaw_mfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
-    inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
-  rw [sphereNormalRaw, real_inner_smul_left, ← (sphereTangentBasis p).sum_repr v, map_sum]
-  simp [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
-    euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
+    inner ℝ (sphereNormalRaw F p)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0 := by
+  let b := sphereTangentBasis p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+  change inner ℝ
+    (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
+      euclideanCross (dF (b 0)) (dF (b 1))) (dF v) = 0
+  rw [real_inner_smul_left, ← b.sum_repr v, map_sum]
+  simp [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right]
 
 /-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
 @[simp]
-theorem inner_sphereNormal_sphereAmbientMfderiv
+theorem inner_sphereNormal_mfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
-    inner ℝ (sphereNormal F p) (sphereAmbientMfderiv F p v) = 0 := by
+    inner ℝ (sphereNormal F p)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0 := by
   rw [sphereNormal, NormedSpace.normalize, real_inner_smul_left,
-    inner_sphereNormalRaw_sphereAmbientMfderiv, mul_zero]
+    inner_sphereNormalRaw_mfderiv, mul_zero]
 
 /-- The raw canonical normal is nonzero exactly at the points where the manifold derivative is
 injective. -/
 private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    sphereNormalRaw F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+    sphereNormalRaw F p ≠ 0 ↔ Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³) := by
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let dF := sphereAmbientMfderiv F p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
   have hfactor : inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
     intro h
     simpa [b, dι, h] using sphere_inclusion_orientation_factor_sq p
@@ -230,14 +250,16 @@ private theorem sphereNormalRaw_ne_zero_iff
 injective. -/
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+    sphereNormal F p ≠ 0 ↔ Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³) := by
   simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
     sphereNormalRaw_ne_zero_iff F p
 
 /-- At an immersion point, the canonical normal has unit length. -/
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : Function.Injective (sphereAmbientMfderiv F p)) :
+    (hF : Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ‖sphereNormal F p‖ = 1 := by
   simpa [sphereNormal] using
     NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
@@ -254,17 +276,19 @@ theorem sphereNormal_eq_of_raw_eq_pos_smul
 sphere inclusion has the outward radial canonical normal. -/
 theorem sphereNormal_eq_radial_of_coercive
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
-    (hnormal : ∀ v, inner ℝ (p : ℝ³) (sphereAmbientMfderiv F p v) = 0)
+    (hnormal : ∀ v, inner ℝ (p : ℝ³)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0)
     (hcoercive : ∀ v,
-      c * ‖sphereAmbientMfderiv
-          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
-        inner ℝ (sphereAmbientMfderiv F p v)
-          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+      c * ‖(show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)‖ ^ 2 ≤
+        inner ℝ (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v)
+          (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+            (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
     sphereNormal F p = (p : ℝ³) := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let dF := sphereAmbientMfderiv F p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
   let u := dι (b 0)
   let v := dι (b 1)
   let x := dF (b 0)
@@ -274,10 +298,11 @@ theorem sphereNormal_eq_radial_of_coercive
   let P := inner ℝ x v
   let Q := inner ℝ y u
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
-    orthonormal_sphereAmbientMfderiv_inclusion_basis p
-  have hApos : 0 < A := hc.trans_le <| by
-    simpa [dF, dι, x, u, A, hON.norm_eq_one] using
-      hcoercive (b 0)
+    orthonormal_mfderiv_inclusion_sphereTangentBasis p
+  have hcoercive0 : c * ‖dι (b 0)‖ ^ 2 ≤ inner ℝ (dF (b 0)) (dι (b 0)) :=
+    hcoercive (b 0)
+  rw [hON.norm_eq_one 0, one_pow, mul_one] at hcoercive0
+  have hApos : 0 < A := hc.trans_le <| by simpa [A, x, u] using hcoercive0
   let s := P + Q
   let t := s • b 0 - (2 * A) • b 1
   have ht : t ≠ 0 := by

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -1,0 +1,175 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.Normed.Module.Normalize
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+
+public import FormalConjecturesForMathlib.Geometry.«3d»
+public meta import FormalConjecturesUtil.Attributes.Basic
+
+/-!
+# A canonical normal for immersed two-spheres in three-space
+
+This file constructs an orientation-compatible normal vector from the cross product of the images
+of the standard basis of the model tangent space. The sign is corrected using the standard sphere
+inclusion, so the result does not depend on whether a sphere chart preserves orientation.
+-/
+
+@[expose] public section
+
+open Metric
+open scoped EuclideanGeometry Manifold RealInnerProductSpace
+
+namespace EuclideanHypersurface
+
+/-- The manifold derivative of a map from the unit two-sphere, with ambient codomain. -/
+noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
+/-- The standard basis of the model tangent space at a point of the unit two-sphere. -/
+noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
+    Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) := by
+  unfold TangentSpace
+  exact PiLp.basisFun 2 ℝ (Fin 2)
+
+/-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
+noncomputable def sphereNormalRaw
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF := sphereAmbientMfderiv F p
+  inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
+    euclideanCross (dF (b 0)) (dF (b 1))
+
+/-- The canonical unit normal of a map from the unit two-sphere to three-space.
+
+For a non-immersion its raw normal can vanish, in which case this definition is zero. -/
+noncomputable def sphereNormal
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
+  NormedSpace.normalize (sphereNormalRaw F p)
+
+/-- The orientation factor contributed by the standard sphere inclusion is nonzero. -/
+private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³) 1) :
+    let b := sphereTangentBasis p
+    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
+  dsimp only
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
+  have hιLI : LinearIndependent ℝ ![dι (b 0), dι (b 1)] := by
+    have hmap := b.linearIndependent.map' dι.toLinearMap
+      (LinearMap.ker_eq_bot_of_injective hι)
+    rw [show ![dι (b 0), dι (b 1)] = dι.toLinearMap ∘ b by
+      funext i
+      fin_cases i <;> rfl]
+    exact hmap
+  have hcross : euclideanCross (dι (b 0)) (dι (b 1)) ≠ 0 :=
+    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hιLI
+  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
+  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
+    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨b i, rfl⟩
+  intro hfactor
+  apply hcross
+  rw [euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) _ _ hp (horth 0) (horth 1),
+    hfactor, zero_smul]
+
+/-- The raw canonical normal is orthogonal to every image tangent vector. -/
+@[simp, category API, AMS 53]
+theorem inner_sphereNormalRaw_sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (v : TangentSpace (𝓡 2) p) :
+    inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
+  rw [sphereNormalRaw]
+  dsimp only
+  rw [real_inner_smul_left]
+  apply mul_eq_zero_of_right
+  rw [← (sphereTangentBasis p).sum_repr v]
+  rw [map_sum]
+  simp only [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
+    euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
+
+/-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
+@[simp, category API, AMS 53]
+theorem inner_sphereNormal_sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (v : TangentSpace (𝓡 2) p) :
+    inner ℝ (sphereNormal F p) (sphereAmbientMfderiv F p v) = 0 := by
+  rw [sphereNormal, NormedSpace.normalize, real_inner_smul_left,
+    inner_sphereNormalRaw_sphereAmbientMfderiv, mul_zero]
+
+/-- The raw canonical normal is nonzero exactly at the points where the manifold derivative is
+injective. -/
+private theorem sphereNormalRaw_ne_zero_iff
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    sphereNormalRaw F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+  let b := sphereTangentBasis p
+  let dF := sphereAmbientMfderiv F p
+  have hfactor := sphereInclusionOrientationFactor_ne_zero p
+  dsimp only at hfactor
+  rw [sphereNormalRaw]
+  dsimp only
+  rw [smul_ne_zero_iff, and_iff_right hfactor,
+    euclideanCross_ne_zero_iff_linearIndependent]
+  have hfamily : dF.toLinearMap ∘ b = ![dF (b 0), dF (b 1)] := by
+    funext i
+    fin_cases i <;> rfl
+  constructor
+  · intro hLI
+    apply LinearMap.injective_of_linearIndependent b.span_eq
+    rw [hfamily]
+    exact hLI
+  · intro hF
+    have hmap := b.linearIndependent.map' dF.toLinearMap
+      (LinearMap.ker_eq_bot_of_injective hF)
+    rwa [hfamily] at hmap
+
+/-- The canonical normal is nonzero exactly at the points where the manifold derivative is
+injective. -/
+@[category API, AMS 53]
+theorem sphereNormal_ne_zero_iff
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+  rw [sphereNormal]
+  exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).trans
+    (sphereNormalRaw_ne_zero_iff F p)
+
+/-- At an immersion point, the canonical normal has unit length. -/
+@[category API, AMS 53]
+theorem norm_sphereNormal_of_injective
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : Function.Injective (sphereAmbientMfderiv F p)) :
+    ‖sphereNormal F p‖ = 1 := by
+  rw [sphereNormal]
+  exact NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
+
+/-- Normalizing a positive multiple of the radial vector recovers the radial vector. -/
+@[category API, AMS 53]
+theorem sphereNormal_eq_of_raw_eq_pos_smul
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
+    (hraw : sphereNormalRaw F p = c • (p : ℝ³)) :
+    sphereNormal F p = (p : ℝ³) := by
+  rw [sphereNormal, hraw, NormedSpace.normalize_smul_of_pos hc,
+    NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -36,7 +36,7 @@ normal is independent of the chart orientation.
 @[expose] public section
 
 open Metric
-open scoped BigOperators EuclideanGeometry Manifold RealInnerProductSpace
+open scoped EuclideanGeometry Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
 
@@ -55,10 +55,10 @@ noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
   unfold TangentSpace
   exact PiLp.basisFun 2 ℝ (Fin 2)
 
-section InclusionDerivative
-
 private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
   ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+
+section InclusionDerivative
 
 private theorem sphereAmbientMfderiv_inclusion_basis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
@@ -122,30 +122,6 @@ theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³)
   rw [orthonormal_iff_ite]
   exact inner_sphereAmbientMfderiv_inclusion_basis p
 
-/-- The derivative of the standard sphere inclusion preserves the coordinate inner product on
-Mathlib's model tangent space. -/
-theorem inner_sphereAmbientMfderiv_inclusion
-    (p : sphere (0 : ℝ³) 1) (v w : TangentSpace (𝓡 2) p) :
-    inner ℝ
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p w) =
-      ∑ i, (sphereTangentBasis p).repr v i * (sphereTangentBasis p).repr w i := by
-  let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  have horth (i j : Fin 2) : inner ℝ (dι (b i)) (dι (b j)) =
-      if i = j then 1 else 0 := by
-    exact inner_sphereAmbientMfderiv_inclusion_basis p i j
-  change inner ℝ (dι v) (dι w) = ∑ i, b.repr v i * b.repr w i
-  calc
-    _ = inner ℝ (dι (∑ i, b.repr v i • b i)) (dι (∑ i, b.repr w i • b i)) := by
-      rw [b.sum_repr, b.sum_repr]
-    _ = _ := by
-      rw [map_sum, map_sum]
-      simp_rw [inner_sum, sum_inner, map_smul, real_inner_smul_left,
-        real_inner_smul_right]
-      simp_rw [horth]
-      simp [Fin.sum_univ_two]
-
 end InclusionDerivative
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
@@ -166,38 +142,59 @@ noncomputable def sphereNormal
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   NormedSpace.normalize (sphereNormalRaw F p)
 
-/-- The orientation factor contributed by the standard sphere inclusion is nonzero. -/
-private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³) 1) :
-    inner ℝ
-      (euclideanCross
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-          (sphereTangentBasis p 0))
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-          (sphereTangentBasis p 1)))
-      (p : ℝ³) ≠ 0 := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+/-- The cross product of the inclusion frame is its radial component. -/
+private theorem sphereInclusionCross_eq_smul (p : sphere (0 : ℝ³) 1) :
+    let b := sphereTangentBasis p
+    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    euclideanCross (dι (b 0)) (dι (b 1)) =
+      inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) • (p : ℝ³) := by
+  dsimp only
+  apply euclideanCross_eq_inner_smul_of_orthogonal
+  · exact norm_eq_of_mem_sphere p
+  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨sphereTangentBasis p 0, rfl⟩
+  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨sphereTangentBasis p 1, rfl⟩
+
+/-- The orientation factor contributed by the standard sphere inclusion has square one. -/
+private theorem sphereInclusionOrientationFactor_sq (p : sphere (0 : ℝ³) 1) :
+    let b := sphereTangentBasis p
+    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ^ 2 = 1 := by
+  dsimp only
   let b := sphereTangentBasis p
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  change inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0
-  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
-  have hιLI : LinearIndependent ℝ ![dι (b 0), dι (b 1)] := by
-    have hmap := b.linearIndependent.map' dι.toLinearMap
-      (LinearMap.ker_eq_bot_of_injective hι)
-    rw [show ![dι (b 0), dι (b 1)] = dι.toLinearMap ∘ b by
-      funext i
-      fin_cases i <;> rfl]
-    exact hmap
-  have hcross : euclideanCross (dι (b 0)) (dι (b 1)) ≠ 0 :=
-    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hιLI
+  have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
+    orthonormal_sphereAmbientMfderiv_inclusion_basis p
+  let c := euclideanCross (dι (b 0)) (dι (b 1))
+  let s := inner ℝ c (p : ℝ³)
   have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
-  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
-    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨b i, rfl⟩
-  intro hfactor
-  apply hcross
-  rw [euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) _ _ hp (horth 0) (horth 1),
-    hfactor, zero_smul]
+  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
+  change s ^ 2 = 1
+  calc
+    s ^ 2 = inner ℝ c c := by
+      simp [hc, norm_smul, hp, pow_two]
+    _ = 1 := by
+      dsimp only [c]
+      rw [inner_euclideanCross_euclideanCross]
+      simp [hON.norm_eq_one, hON.inner_eq_zero]
+
+/-- The raw canonical normal of the standard sphere inclusion is the radial vector. -/
+@[simp]
+theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
+    sphereNormalRaw (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let c := euclideanCross (dι (b 0)) (dι (b 1))
+  let s := inner ℝ c (p : ℝ³)
+  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
+  have hs : s ^ 2 = 1 := sphereInclusionOrientationFactor_sq p
+  rw [sphereNormalRaw]
+  dsimp only
+  change s • c = (p : ℝ³)
+  rw [hc, smul_smul, ← pow_two, hs, one_smul]
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
 @[simp]
@@ -229,8 +226,11 @@ private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormalRaw F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
   let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let dF := sphereAmbientMfderiv F p
-  have hfactor := sphereInclusionOrientationFactor_ne_zero p
+  have hfactor : inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
+    intro h
+    simpa [b, dι, h] using sphereInclusionOrientationFactor_sq p
   rw [sphereNormalRaw]
   dsimp only
   rw [smul_ne_zero_iff, and_iff_right hfactor,
@@ -273,29 +273,86 @@ theorem sphereNormal_eq_of_raw_eq_pos_smul
   rw [sphereNormal, hraw, NormedSpace.normalize_smul_of_pos hc,
     NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
 
+/-- A radially tangent map whose derivative is positively coercive relative to the standard
+sphere inclusion has the outward radial canonical normal. -/
+theorem sphereNormal_eq_radial_of_coercive
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
+    (hnormal : ∀ v, inner ℝ (p : ℝ³) (sphereAmbientMfderiv F p v) = 0)
+    (hcoercive : ∀ v,
+      c * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ (sphereAmbientMfderiv F p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+    sphereNormal F p = (p : ℝ³) := by
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF := sphereAmbientMfderiv F p
+  let u := dι (b 0)
+  let v := dι (b 1)
+  let x := dF (b 0)
+  let y := dF (b 1)
+  let A := inner ℝ x u
+  let D := inner ℝ y v
+  let P := inner ℝ x v
+  let Q := inner ℝ y u
+  have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
+    orthonormal_sphereAmbientMfderiv_inclusion_basis p
+  have hι : Function.Injective dι := by
+    dsimp only [dι, sphereAmbientMfderiv]
+    exact mfderiv_coe_sphere_injective p
+  have hA : c ≤ A := by
+    simpa only [dF, dι, x, u, A, hON.norm_eq_one, one_pow, mul_one] using
+      hcoercive (b 0)
+  have hApos : 0 < A := hc.trans_le hA
+  let s := P + Q
+  let t := s • b 0 - (2 * A) • b 1
+  have ht : t ≠ 0 := by
+    intro ht
+    have htCoord := congrArg (fun z ↦ b.repr z 1) ht
+    dsimp only [t] at htCoord
+    simp at htCoord
+    linarith
+  have hdιt : dι t ≠ 0 := by
+    intro ht'
+    apply ht
+    apply hι
+    simpa only [map_zero] using ht'
+  have hquadpos : 0 < inner ℝ (dF t) (dι t) :=
+    (mul_pos hc (sq_pos_of_pos (norm_pos_iff.mpr hdιt))).trans_le (hcoercive t)
+  dsimp only [t] at hquadpos
+  simp only [map_sub, map_smul] at hquadpos
+  change 0 < inner ℝ (s • x - (2 * A) • y) (s • u - (2 * A) • v) at hquadpos
+  simp only [inner_sub_left, inner_sub_right, real_inner_smul_left,
+    real_inner_smul_right] at hquadpos
+  dsimp only [s, A, D, P, Q] at hquadpos
+  have hdetAux : 0 < 4 * A * D - (P + Q) ^ 2 := by
+    nlinarith
+  have hdet : 0 < A * D - P * Q := by
+    nlinarith [sq_nonneg (P - Q)]
+  have hcrossPos : 0 < inner ℝ (euclideanCross u v) (euclideanCross x y) := by
+    rw [inner_euclideanCross_euclideanCross]
+    rw [← real_inner_comm u x, ← real_inner_comm v y, ← real_inner_comm u y,
+      ← real_inner_comm v x]
+    change 0 < A * D - Q * P
+    nlinarith
+  have hcrossEq : euclideanCross x y =
+      inner ℝ (euclideanCross x y) (p : ℝ³) • (p : ℝ³) :=
+    euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
+      (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1))
+  apply sphereNormal_eq_of_raw_eq_pos_smul F p
+    (inner ℝ (euclideanCross u v) (euclideanCross x y)) hcrossPos
+  rw [sphereNormalRaw]
+  dsimp only
+  change inner ℝ (euclideanCross u v) (p : ℝ³) • euclideanCross x y =
+    inner ℝ (euclideanCross u v) (euclideanCross x y) • (p : ℝ³)
+  rw [hcrossEq, real_inner_smul_right]
+  module
+
 /-- The canonical normal of the standard sphere inclusion points radially outward. -/
 @[simp]
 theorem sphereNormal_inclusion (p : sphere (0 : ℝ³) 1) :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-  let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let c := euclideanCross (dι (b 0)) (dι (b 1))
-  let s := inner ℝ c (p : ℝ³)
-  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
-  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
-    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨b i, rfl⟩
-  have hc : c = s • (p : ℝ³) := by
-    exact euclideanCross_eq_inner_smul_of_orthogonal
-      (p : ℝ³) (dι (b 0)) (dι (b 1)) hp (horth 0) (horth 1)
-  have hs : s ≠ 0 := by
-    exact sphereInclusionOrientationFactor_ne_zero p
-  apply sphereNormal_eq_of_raw_eq_pos_smul _ p (s ^ 2) (sq_pos_of_ne_zero hs)
-  rw [sphereNormalRaw]
-  dsimp only
-  change s • c = s ^ 2 • (p : ℝ³)
-  rw [hc, smul_smul, pow_two]
+  rw [sphereNormal, sphereNormalRaw_inclusion,
+    NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -26,13 +26,9 @@ public import FormalConjecturesForMathlib.Geometry.«3d»
 /-!
 # A canonical normal for immersed two-spheres in three-space
 
-Mathlib represents every tangent space of the sphere by a copy of the fixed model space `ℝ²`.
-The basis below is the standard basis of that model space, not a continuous global tangent frame.
-The preferred sphere charts identify the geometric tangent plane with the model space through a
-possibly orientation-reversing orthonormal map. This file constructs a normal from the corresponding
-cross product and corrects its sign using the standard sphere inclusion. A change of model frame
-therefore occurs in both cross products, so its determinant appears squared and the normalized
-normal is independent of the chart orientation.
+Mathlib models each sphere tangent space on a fixed copy of `ℝ²`. We orient the cross product
+using the standard sphere inclusion; changing the model frame then contributes a squared
+determinant, which disappears after normalization.
 -/
 
 @[expose] public section
@@ -42,10 +38,7 @@ open scoped EuclideanGeometry EuclideanSpace Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
 
-/-- The standard basis of Mathlib's fixed model copy of `ℝ²` for the tangent space at `p`.
-
-This is a coordinate basis used to evaluate the manifold derivative, not a global tangent frame on
-the sphere. -/
+/-- The standard coordinate basis of the model tangent space at `p`, not a global tangent frame. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) :=
   (trivializationAt (EuclideanSpace ℝ (Fin 2)) (TangentSpace (𝓡 2)) p).basisAt
@@ -134,16 +127,13 @@ noncomputable def sphereNormalRaw
   inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
     euclideanCross (dF (b 0)) (dF (b 1))
 
-/-- The canonical unit normal of a map from the unit two-sphere to three-space.
-
-Its orientation is induced by the outward orientation of the domain sphere. Thus it need not be
-the outward normal of the image when `F` reverses orientation. For a non-immersion its raw normal
-can vanish, in which case this definition is zero. -/
+/-- The canonical unit normal, oriented by the outward orientation of the domain sphere.
+It may point inward on the image if `F` reverses orientation and is zero where its raw normal
+vanishes. -/
 noncomputable def sphereNormal
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   NormedSpace.normalize (sphereNormalRaw F p)
 
-/-- The cross product of the inclusion frame is its radial component. -/
 private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
@@ -158,7 +148,6 @@ private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
   · exact Submodule.mem_orthogonal_singleton_iff_inner_right.mp <|
       range_mfderiv_coe_sphere (n := 2) p ▸ ⟨sphereTangentBasis p 1, rfl⟩
 
-/-- The orientation factor contributed by the standard sphere inclusion has square one. -/
 private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
@@ -223,8 +212,6 @@ theorem inner_sphereNormal_mfderiv
   rw [sphereNormal, NormedSpace.normalize, real_inner_smul_left,
     inner_sphereNormalRaw_mfderiv, mul_zero]
 
-/-- The raw canonical normal is nonzero exactly at the points where the manifold derivative is
-injective. -/
 private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormalRaw F p ≠ 0 ↔ Function.Injective

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -24,15 +24,19 @@ public import FormalConjecturesForMathlib.Geometry.«3d»
 /-!
 # A canonical normal for immersed two-spheres in three-space
 
-This file constructs an orientation-compatible normal vector from the cross product of the images
-of the standard basis of the model tangent space. The sign is corrected using the standard sphere
-inclusion, so the result does not depend on whether a sphere chart preserves orientation.
+Mathlib represents every tangent space of the sphere by a copy of the fixed model space `ℝ²`.
+The basis below is the standard basis of that model space, not a continuous global tangent frame.
+The preferred sphere charts identify the geometric tangent plane with the model space through a
+possibly orientation-reversing orthonormal map. This file constructs a normal from the corresponding
+cross product and corrects its sign using the standard sphere inclusion. A change of model frame
+therefore occurs in both cross products, so its determinant appears squared and the normalized
+normal is independent of the chart orientation.
 -/
 
 @[expose] public section
 
 open Metric
-open scoped EuclideanGeometry Manifold RealInnerProductSpace
+open scoped BigOperators EuclideanGeometry Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
 
@@ -42,11 +46,107 @@ noncomputable def sphereAmbientMfderiv
     TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
   mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
 
-/-- The standard basis of the model tangent space at a point of the unit two-sphere. -/
+/-- The standard basis of Mathlib's fixed model copy of `ℝ²` for the tangent space at `p`.
+
+This is a coordinate basis used to evaluate the manifold derivative, not a global tangent frame on
+the sphere. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) := by
   unfold TangentSpace
   exact PiLp.basisFun 2 ℝ (Fin 2)
+
+section InclusionDerivative
+
+private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
+  ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+
+private theorem sphereAmbientMfderiv_inclusion_basis_apply
+    (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
+    sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p i) =
+      let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
+        (ne_zero_of_mem_unit_sphere (-p))).repr
+      ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
+        (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
+  rw [sphereAmbientMfderiv]
+  rw [((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
+  simp only [chartAt, fderivWithin_univ, mfld_simps]
+  let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
+    (ne_zero_of_mem_unit_sphere (-p))).repr
+  change
+    (fderiv ℝ ((stereoInvFunAux (-p : ℝ³) ∘
+      (Subtype.val : (ℝ ∙ (-(p : ℝ³)))ᗮ → ℝ³)) ∘ U.symm)
+        (stereographic' 2 (-p) p)) (PiLp.basisFun 2 ℝ (Fin 2) i) =
+      ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) : (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³)
+  have hp0 : stereographic' 2 (-p) p = 0 := by
+    dsimp [stereographic']
+    simp only [EmbeddingLike.map_eq_zero_iff]
+    apply stereographic_neg_apply
+  rw [hp0]
+  have h :
+      HasFDerivAt (stereoInvFunAux (-p : ℝ³) ∘
+        (Subtype.val : (ℝ ∙ (-(p : ℝ³)))ᗮ → ℝ³))
+        (ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeL (U.symm 0) := by
+    convert hasFDerivAt_stereoInvFunAux_comp_coe (-p : ℝ³)
+    simp
+  rw [(h.comp 0 U.symm.toContinuousLinearEquiv.hasFDerivAt).fderiv]
+  rfl
+
+/-- The standard model basis maps to an orthonormal frame under the derivative of the sphere
+inclusion. -/
+@[simp]
+theorem inner_sphereAmbientMfderiv_inclusion_basis
+    (p : sphere (0 : ℝ³) 1) (i j : Fin 2) :
+    inner ℝ
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p i))
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p j)) =
+      if i = j then 1 else 0 := by
+  rw [sphereAmbientMfderiv_inclusion_basis_apply,
+    sphereAmbientMfderiv_inclusion_basis_apply]
+  let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
+    (ne_zero_of_mem_unit_sphere (-p))).repr
+  change inner ℝ
+    ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) i)))
+    ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) j))) = _
+  rw [LinearIsometry.inner_map_map, U.symm.inner_map_map]
+  exact orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
+
+/-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
+family. -/
+theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³) 1) :
+    Orthonormal ℝ fun i : Fin 2 ↦
+      sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p i) := by
+  rw [orthonormal_iff_ite]
+  exact inner_sphereAmbientMfderiv_inclusion_basis p
+
+/-- The derivative of the standard sphere inclusion preserves the coordinate inner product on
+Mathlib's model tangent space. -/
+theorem inner_sphereAmbientMfderiv_inclusion
+    (p : sphere (0 : ℝ³) 1) (v w : TangentSpace (𝓡 2) p) :
+    inner ℝ
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p w) =
+      ∑ i, (sphereTangentBasis p).repr v i * (sphereTangentBasis p).repr w i := by
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  have horth (i j : Fin 2) : inner ℝ (dι (b i)) (dι (b j)) =
+      if i = j then 1 else 0 := by
+    exact inner_sphereAmbientMfderiv_inclusion_basis p i j
+  change inner ℝ (dι v) (dι w) = ∑ i, b.repr v i * b.repr w i
+  calc
+    _ = inner ℝ (dι (∑ i, b.repr v i • b i)) (dι (∑ i, b.repr w i • b i)) := by
+      rw [b.sum_repr, b.sum_repr]
+    _ = _ := by
+      rw [map_sum, map_sum]
+      simp_rw [inner_sum, sum_inner, map_smul, real_inner_smul_left,
+        real_inner_smul_right]
+      simp_rw [horth]
+      simp [Fin.sum_univ_two]
+
+end InclusionDerivative
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
 noncomputable def sphereNormalRaw
@@ -59,7 +159,9 @@ noncomputable def sphereNormalRaw
 
 /-- The canonical unit normal of a map from the unit two-sphere to three-space.
 
-For a non-immersion its raw normal can vanish, in which case this definition is zero. -/
+Its orientation is induced by the outward orientation of the domain sphere. Thus it need not be
+the outward normal of the image when `F` reverses orientation. For a non-immersion its raw normal
+can vanish, in which case this definition is zero. -/
 noncomputable def sphereNormal
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   NormedSpace.normalize (sphereNormalRaw F p)
@@ -170,5 +272,30 @@ theorem sphereNormal_eq_of_raw_eq_pos_smul
     sphereNormal F p = (p : ℝ³) := by
   rw [sphereNormal, hraw, NormedSpace.normalize_smul_of_pos hc,
     NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
+
+/-- The canonical normal of the standard sphere inclusion points radially outward. -/
+@[simp]
+theorem sphereNormal_inclusion (p : sphere (0 : ℝ³) 1) :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let c := euclideanCross (dι (b 0)) (dι (b 1))
+  let s := inner ℝ c (p : ℝ³)
+  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
+  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
+    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨b i, rfl⟩
+  have hc : c = s • (p : ℝ³) := by
+    exact euclideanCross_eq_inner_smul_of_orthogonal
+      (p : ℝ³) (dι (b 0)) (dι (b 1)) hp (horth 0) (horth 1)
+  have hs : s ≠ 0 := by
+    exact sphereInclusionOrientationFactor_ne_zero p
+  apply sphereNormal_eq_of_raw_eq_pos_smul _ p (s ^ 2) (sq_pos_of_ne_zero hs)
+  rw [sphereNormalRaw]
+  dsimp only
+  change s • c = s ^ 2 • (p : ℝ³)
+  rw [hc, smul_smul, pow_two]
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -58,8 +58,6 @@ noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
 private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
   ⟨by norm_num [finrank_euclideanSpace_fin]⟩
 
-section InclusionDerivative
-
 private theorem sphereAmbientMfderiv_inclusion_basis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
     sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
@@ -68,8 +66,8 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
         (ne_zero_of_mem_unit_sphere (-p))).repr
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
         (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
-  rw [sphereAmbientMfderiv]
-  rw [((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
+  rw [sphereAmbientMfderiv,
+    ((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
   simp only [chartAt, fderivWithin_univ, mfld_simps]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
@@ -80,8 +78,7 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) : (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³)
   have hp0 : stereographic' 2 (-p) p = 0 := by
     dsimp [stereographic']
-    simp only [EmbeddingLike.map_eq_zero_iff]
-    apply stereographic_neg_apply
+    simpa only [EmbeddingLike.map_eq_zero_iff] using stereographic_neg_apply p
   rw [hp0]
   have h :
       HasFDerivAt (stereoInvFunAux (-p : ℝ³) ∘
@@ -103,26 +100,22 @@ theorem inner_sphereAmbientMfderiv_inclusion_basis
       (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
         (sphereTangentBasis p j)) =
       if i = j then 1 else 0 := by
-  rw [sphereAmbientMfderiv_inclusion_basis_apply,
-    sphereAmbientMfderiv_inclusion_basis_apply]
+  simp only [sphereAmbientMfderiv_inclusion_basis_apply]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change inner ℝ
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) i)))
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) j))) = _
-  rw [LinearIsometry.inner_map_map, U.symm.inner_map_map]
-  exact orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
+  simpa only [LinearIsometry.inner_map_map, U.symm.inner_map_map] using
+    orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
 
 /-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
 family. -/
 theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³) 1) :
     Orthonormal ℝ fun i : Fin 2 ↦
       sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p i) := by
-  rw [orthonormal_iff_ite]
-  exact inner_sphereAmbientMfderiv_inclusion_basis p
-
-end InclusionDerivative
+        (sphereTangentBasis p i) :=
+  orthonormal_iff_ite.mpr (inner_sphereAmbientMfderiv_inclusion_basis p)
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
 noncomputable def sphereNormalRaw
@@ -143,7 +136,7 @@ noncomputable def sphereNormal
   NormedSpace.normalize (sphereNormalRaw F p)
 
 /-- The cross product of the inclusion frame is its radial component. -/
-private theorem sphereInclusionCross_eq_smul (p : sphere (0 : ℝ³) 1) :
+private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     euclideanCross (dι (b 0)) (dι (b 1)) =
@@ -159,7 +152,7 @@ private theorem sphereInclusionCross_eq_smul (p : sphere (0 : ℝ³) 1) :
     exact ⟨sphereTangentBasis p 1, rfl⟩
 
 /-- The orientation factor contributed by the standard sphere inclusion has square one. -/
-private theorem sphereInclusionOrientationFactor_sq (p : sphere (0 : ℝ³) 1) :
+private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ^ 2 = 1 := by
@@ -170,12 +163,11 @@ private theorem sphereInclusionOrientationFactor_sq (p : sphere (0 : ℝ³) 1) :
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
-  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
+  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
   change s ^ 2 = 1
   calc
     s ^ 2 = inner ℝ c c := by
-      simp [hc, norm_smul, hp, pow_two]
+      simp [hc, norm_smul, norm_eq_of_mem_sphere p, pow_two]
     _ = 1 := by
       dsimp only [c]
       rw [inner_euclideanCross_euclideanCross]
@@ -189,10 +181,8 @@ theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
-  have hs : s ^ 2 = 1 := sphereInclusionOrientationFactor_sq p
-  rw [sphereNormalRaw]
-  dsimp only
+  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
+  have hs : s ^ 2 = 1 := sphere_inclusion_orientation_factor_sq p
   change s • c = (p : ℝ³)
   rw [hc, smul_smul, ← pow_two, hs, one_smul]
 
@@ -202,12 +192,9 @@ theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
     inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
-  rw [sphereNormalRaw]
-  dsimp only
-  rw [real_inner_smul_left]
+  rw [sphereNormalRaw, real_inner_smul_left]
   apply mul_eq_zero_of_right
-  rw [← (sphereTangentBasis p).sum_repr v]
-  rw [map_sum]
+  rw [← (sphereTangentBasis p).sum_repr v, map_sum]
   simp only [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
     euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
 
@@ -230,10 +217,8 @@ private theorem sphereNormalRaw_ne_zero_iff
   let dF := sphereAmbientMfderiv F p
   have hfactor : inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
     intro h
-    simpa [b, dι, h] using sphereInclusionOrientationFactor_sq p
-  rw [sphereNormalRaw]
-  dsimp only
-  rw [smul_ne_zero_iff, and_iff_right hfactor,
+    simpa [b, dι, h] using sphere_inclusion_orientation_factor_sq p
+  rw [sphereNormalRaw, smul_ne_zero_iff, and_iff_right hfactor,
     euclideanCross_ne_zero_iff_linearIndependent]
   have hfamily : dF.toLinearMap ∘ b = ![dF (b 0), dF (b 1)] := by
     funext i
@@ -297,56 +282,43 @@ theorem sphereNormal_eq_radial_of_coercive
   let Q := inner ℝ y u
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
-  have hι : Function.Injective dι := by
-    dsimp only [dι, sphereAmbientMfderiv]
-    exact mfderiv_coe_sphere_injective p
-  have hA : c ≤ A := by
+  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
+  have hApos : 0 < A := hc.trans_le <| by
     simpa only [dF, dι, x, u, A, hON.norm_eq_one, one_pow, mul_one] using
       hcoercive (b 0)
-  have hApos : 0 < A := hc.trans_le hA
   let s := P + Q
   let t := s • b 0 - (2 * A) • b 1
   have ht : t ≠ 0 := by
     intro ht
     have htCoord := congrArg (fun z ↦ b.repr z 1) ht
-    dsimp only [t] at htCoord
-    simp at htCoord
+    simp [t] at htCoord
     linarith
-  have hdιt : dι t ≠ 0 := by
-    intro ht'
-    apply ht
-    apply hι
-    simpa only [map_zero] using ht'
+  have hdιt : dι t ≠ 0 := (map_ne_zero_iff dι hι).mpr ht
   have hquadpos : 0 < inner ℝ (dF t) (dι t) :=
     (mul_pos hc (sq_pos_of_pos (norm_pos_iff.mpr hdιt))).trans_le (hcoercive t)
-  dsimp only [t] at hquadpos
-  simp only [map_sub, map_smul] at hquadpos
+  simp only [t, map_sub, map_smul] at hquadpos
   change 0 < inner ℝ (s • x - (2 * A) • y) (s • u - (2 * A) • v) at hquadpos
   simp only [inner_sub_left, inner_sub_right, real_inner_smul_left,
-    real_inner_smul_right] at hquadpos
-  dsimp only [s, A, D, P, Q] at hquadpos
+    real_inner_smul_right, s, A, P, Q] at hquadpos
   have hdetAux : 0 < 4 * A * D - (P + Q) ^ 2 := by
     nlinarith
   have hdet : 0 < A * D - P * Q := by
     nlinarith [sq_nonneg (P - Q)]
   have hcrossPos : 0 < inner ℝ (euclideanCross u v) (euclideanCross x y) := by
-    rw [inner_euclideanCross_euclideanCross]
-    rw [← real_inner_comm u x, ← real_inner_comm v y, ← real_inner_comm u y,
+    rw [inner_euclideanCross_euclideanCross, ← real_inner_comm u x,
+      ← real_inner_comm v y, ← real_inner_comm u y,
       ← real_inner_comm v x]
     change 0 < A * D - Q * P
-    nlinarith
+    simpa only [mul_comm Q P] using hdet
   have hcrossEq : euclideanCross x y =
       inner ℝ (euclideanCross x y) (p : ℝ³) • (p : ℝ³) :=
     euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
       (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1))
   apply sphereNormal_eq_of_raw_eq_pos_smul F p
     (inner ℝ (euclideanCross u v) (euclideanCross x y)) hcrossPos
-  rw [sphereNormalRaw]
-  dsimp only
   change inner ℝ (euclideanCross u v) (p : ℝ³) • euclideanCross x y =
     inner ℝ (euclideanCross u v) (euclideanCross x y) • (p : ℝ³)
-  rw [hcrossEq, real_inner_smul_right]
-  module
+  rw [hcrossEq, real_inner_smul_right, smul_smul, mul_comm]
 
 /-- The canonical normal of the standard sphere inclusion points radially outward. -/
 @[simp]

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -20,7 +20,6 @@ public import Mathlib.Analysis.Normed.Module.Normalize
 public import Mathlib.Geometry.Manifold.Instances.Sphere
 
 public import FormalConjecturesForMathlib.Geometry.«3d»
-public meta import FormalConjecturesUtil.Attributes.Basic
 
 /-!
 # A canonical normal for immersed two-spheres in three-space
@@ -95,7 +94,7 @@ private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³)
     hfactor, zero_smul]
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
@@ -110,7 +109,7 @@ theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
 
 /-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem inner_sphereNormal_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
@@ -146,7 +145,6 @@ private theorem sphereNormalRaw_ne_zero_iff
 
 /-- The canonical normal is nonzero exactly at the points where the manifold derivative is
 injective. -/
-@[category API, AMS 53]
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
@@ -155,7 +153,6 @@ theorem sphereNormal_ne_zero_iff
     (sphereNormalRaw_ne_zero_iff F p)
 
 /-- At an immersion point, the canonical normal has unit length. -/
-@[category API, AMS 53]
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : Function.Injective (sphereAmbientMfderiv F p)) :
@@ -164,7 +161,6 @@ theorem norm_sphereNormal_of_injective
   exact NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
 
 /-- Normalizing a positive multiple of the radial vector recovers the radial vector. -/
-@[category API, AMS 53]
 theorem sphereNormal_eq_of_raw_eq_pos_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
     (hraw : sphereNormalRaw F p = c • (p : ℝ³)) :

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -51,21 +51,20 @@ noncomputable def sphereAmbientMfderiv
 This is a coordinate basis used to evaluate the manifold derivative, not a global tangent frame on
 the sphere. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
-    Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) := by
-  unfold TangentSpace
-  exact PiLp.basisFun 2 ℝ (Fin 2)
-
-private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
-  ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+    Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) :=
+  PiLp.basisFun 2 ℝ (Fin 2)
 
 private theorem sphereAmbientMfderiv_inclusion_basis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
+    letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
     sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
         (sphereTangentBasis p i) =
       let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
         (ne_zero_of_mem_unit_sphere (-p))).repr
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
         (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  dsimp only
   rw [sphereAmbientMfderiv,
     ((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
   simp only [chartAt, fderivWithin_univ, mfld_simps]
@@ -78,7 +77,7 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) : (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³)
   have hp0 : stereographic' 2 (-p) p = 0 := by
     dsimp [stereographic']
-    simpa only [EmbeddingLike.map_eq_zero_iff] using stereographic_neg_apply p
+    simpa [EmbeddingLike.map_eq_zero_iff] using stereographic_neg_apply p
   rw [hp0]
   have h :
       HasFDerivAt (stereoInvFunAux (-p : ℝ³) ∘
@@ -100,14 +99,16 @@ theorem inner_sphereAmbientMfderiv_inclusion_basis
       (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
         (sphereTangentBasis p j)) =
       if i = j then 1 else 0 := by
-  simp only [sphereAmbientMfderiv_inclusion_basis_apply]
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  rw [sphereAmbientMfderiv_inclusion_basis_apply p i,
+    sphereAmbientMfderiv_inclusion_basis_apply p j]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change inner ℝ
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) i)))
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) j))) = _
-  simpa only [LinearIsometry.inner_map_map, U.symm.inner_map_map] using
-    orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
+  rw [LinearIsometry.inner_map_map, U.symm.inner_map_map]
+  exact orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
 
 /-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
 family. -/
@@ -141,15 +142,14 @@ private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     euclideanCross (dι (b 0)) (dι (b 1)) =
       inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) • (p : ℝ³) := by
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   dsimp only
-  apply euclideanCross_eq_inner_smul_of_orthogonal
-  · exact norm_eq_of_mem_sphere p
-  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨sphereTangentBasis p 0, rfl⟩
-  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨sphereTangentBasis p 1, rfl⟩
+  refine euclideanCross_eq_inner_smul_of_orthogonal _ _ _
+    (norm_eq_of_mem_sphere p) ?_ ?_
+  · exact Submodule.mem_orthogonal_singleton_iff_inner_right.mp <|
+      range_mfderiv_coe_sphere (n := 2) p ▸ ⟨sphereTangentBasis p 0, rfl⟩
+  · exact Submodule.mem_orthogonal_singleton_iff_inner_right.mp <|
+      range_mfderiv_coe_sphere (n := 2) p ▸ ⟨sphereTangentBasis p 1, rfl⟩
 
 /-- The orientation factor contributed by the standard sphere inclusion has square one. -/
 private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
@@ -163,11 +163,11 @@ private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
   change s ^ 2 = 1
   calc
     s ^ 2 = inner ℝ c c := by
-      simp [hc, norm_smul, norm_eq_of_mem_sphere p, pow_two]
+      simp [show c = s • (p : ℝ³) from sphere_inclusion_cross_eq_smul p,
+        norm_smul, norm_eq_of_mem_sphere p, pow_two]
     _ = 1 := by
       dsimp only [c]
       rw [inner_euclideanCross_euclideanCross]
@@ -181,10 +181,10 @@ theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
-  have hs : s ^ 2 = 1 := sphere_inclusion_orientation_factor_sq p
   change s • c = (p : ℝ³)
-  rw [hc, smul_smul, ← pow_two, hs, one_smul]
+  rw [show c = s • (p : ℝ³) from sphere_inclusion_cross_eq_smul p,
+    smul_smul, ← pow_two,
+    show s ^ 2 = 1 from sphere_inclusion_orientation_factor_sq p, one_smul]
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
 @[simp]
@@ -192,10 +192,8 @@ theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
     inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
-  rw [sphereNormalRaw, real_inner_smul_left]
-  apply mul_eq_zero_of_right
-  rw [← (sphereTangentBasis p).sum_repr v, map_sum]
-  simp only [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
+  rw [sphereNormalRaw, real_inner_smul_left, ← (sphereTangentBasis p).sum_repr v, map_sum]
+  simp [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
     euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
 
 /-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
@@ -224,31 +222,25 @@ private theorem sphereNormalRaw_ne_zero_iff
     funext i
     fin_cases i <;> rfl
   constructor
-  · intro hLI
-    apply LinearMap.injective_of_linearIndependent b.span_eq
-    rw [hfamily]
-    exact hLI
-  · intro hF
-    have hmap := b.linearIndependent.map' dF.toLinearMap
+  · exact fun hLI ↦ LinearMap.injective_of_linearIndependent b.span_eq (hfamily.symm ▸ hLI)
+  · exact fun hF ↦ hfamily ▸ b.linearIndependent.map' dF.toLinearMap
       (LinearMap.ker_eq_bot_of_injective hF)
-    rwa [hfamily] at hmap
 
 /-- The canonical normal is nonzero exactly at the points where the manifold derivative is
 injective. -/
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
-  rw [sphereNormal]
-  exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).trans
-    (sphereNormalRaw_ne_zero_iff F p)
+  simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
+    sphereNormalRaw_ne_zero_iff F p
 
 /-- At an immersion point, the canonical normal has unit length. -/
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : Function.Injective (sphereAmbientMfderiv F p)) :
     ‖sphereNormal F p‖ = 1 := by
-  rw [sphereNormal]
-  exact NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
+  simpa [sphereNormal] using
+    NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
 
 /-- Normalizing a positive multiple of the radial vector recovers the radial vector. -/
 theorem sphereNormal_eq_of_raw_eq_pos_smul
@@ -269,6 +261,7 @@ theorem sphereNormal_eq_radial_of_coercive
         inner ℝ (sphereAmbientMfderiv F p v)
           (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
     sphereNormal F p = (p : ℝ³) := by
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   let b := sphereTangentBasis p
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let dF := sphereAmbientMfderiv F p
@@ -282,9 +275,8 @@ theorem sphereNormal_eq_radial_of_coercive
   let Q := inner ℝ y u
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
-  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
   have hApos : 0 < A := hc.trans_le <| by
-    simpa only [dF, dι, x, u, A, hON.norm_eq_one, one_pow, mul_one] using
+    simpa [dF, dι, x, u, A, hON.norm_eq_one] using
       hcoercive (b 0)
   let s := P + Q
   let t := s • b 0 - (2 * A) • b 1
@@ -293,7 +285,8 @@ theorem sphereNormal_eq_radial_of_coercive
     have htCoord := congrArg (fun z ↦ b.repr z 1) ht
     simp [t] at htCoord
     linarith
-  have hdιt : dι t ≠ 0 := (map_ne_zero_iff dι hι).mpr ht
+  have hdιt : dι t ≠ 0 :=
+    (map_ne_zero_iff dι (mfderiv_coe_sphere_injective p)).mpr ht
   have hquadpos : 0 < inner ℝ (dF t) (dι t) :=
     (mul_pos hc (sq_pos_of_pos (norm_pos_iff.mpr hdιt))).trans_le (hcoercive t)
   simp only [t, map_sub, map_smul] at hquadpos
@@ -309,16 +302,14 @@ theorem sphereNormal_eq_radial_of_coercive
       ← real_inner_comm v y, ← real_inner_comm u y,
       ← real_inner_comm v x]
     change 0 < A * D - Q * P
-    simpa only [mul_comm Q P] using hdet
-  have hcrossEq : euclideanCross x y =
-      inner ℝ (euclideanCross x y) (p : ℝ³) • (p : ℝ³) :=
-    euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
-      (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1))
+    simpa [mul_comm Q P] using hdet
   apply sphereNormal_eq_of_raw_eq_pos_smul F p
     (inner ℝ (euclideanCross u v) (euclideanCross x y)) hcrossPos
   change inner ℝ (euclideanCross u v) (p : ℝ³) • euclideanCross x y =
     inner ℝ (euclideanCross u v) (euclideanCross x y) • (p : ℝ³)
-  rw [hcrossEq, real_inner_smul_right, smul_smul, mul_comm]
+  rw [euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
+      (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1)),
+    real_inner_smul_right, smul_smul, mul_comm]
 
 /-- The canonical normal of the standard sphere inclusion points radially outward. -/
 @[simp]

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -1,0 +1,261 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Calculus
+public import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
+
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+
+/-!
+# Regularity of the canonical normal of a sphere immersion
+
+Although Mathlib's preferred sphere charts do not give a continuous global tangent frame, the
+canonical normal is regular. Locally, `inTangentCoordinates` gives a regular frame for the
+derivative. Changing from that frame to the pointwise model basis scales both cross products in the
+raw normal by the same determinant, so the raw normal scales by its positive square. Normalization
+therefore removes the coordinate dependence. In particular, a `C^(m + 1)` immersion has a `C^m`
+canonical normal.
+-/
+
+@[expose] public section
+
+open Metric Set Function
+open scoped EuclideanGeometry Manifold RealInnerProductSpace
+
+namespace EuclideanHypersurface
+
+private noncomputable def sphereModelBasis (p : sphere (0 : ℝ³) 1) :
+    Module.Basis (Fin 2) ℝ (EuclideanSpace ℝ (Fin 2)) :=
+  sphereTangentBasis p
+
+private noncomputable def basisDet {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (b : Module.Basis (Fin 2) ℝ V) (A : V →L[ℝ] V) : ℝ :=
+  b.repr (A (b 0)) 0 * b.repr (A (b 1)) 1 -
+    b.repr (A (b 0)) 1 * b.repr (A (b 1)) 0
+
+private theorem euclideanCross_comp_basis
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (b : Module.Basis (Fin 2) ℝ V) (L : V →L[ℝ] ℝ³) (A : V →L[ℝ] V) :
+    euclideanCross (L (A (b 0))) (L (A (b 1))) =
+      basisDet b A • euclideanCross (L (b 0)) (L (b 1)) := by
+  rw [← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
+  simp only [Fin.sum_univ_two, map_add, map_smul, ContinuousLinearMap.add_apply,
+    ContinuousLinearMap.smul_apply,
+    euclideanCross_self, smul_zero, add_zero, basisDet]
+  rw [← euclideanCross_anticomm (L (b 0)) (L (b 1))]
+  module
+
+private theorem contMDiffAt_normalize
+    {m : WithTop ℕ∞} {f : sphere (0 : ℝ³) 1 → ℝ³} {p : sphere (0 : ℝ³) 1}
+    (hf : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m f p) (h0 : f p ≠ 0) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (fun q ↦ NormedSpace.normalize (f q)) p := by
+  change ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (fun q ↦ ‖f q‖⁻¹ • f q) p
+  exact (((contDiffAt_norm ℝ h0).inv (norm_ne_zero_iff.mpr h0)).comp_contMDiffAt hf).smul hf
+
+private theorem inTangentCoordinates_sphere_eq_comp
+    (G : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
+    (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id G (sphereAmbientMfderiv G) p q =
+      sphereAmbientMfderiv G q ∘L
+        (tangentCoordChange (𝓡 2) p q q :
+          EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
+  rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp)]
+  simp only [tangentBundleCore_coordChange_model_space, ContinuousLinearMap.id_comp]
+  rfl
+
+private theorem tangentCoordChange_injective
+    (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    Function.Injective (tangentCoordChange (𝓡 2) p q q :
+      EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
+  intro u v huv
+  have hq' : q ∈ (extChartAt (𝓡 2) q).source := mem_extChartAt_source q
+  have hmem : q ∈ (extChartAt (𝓡 2) p).source ∩
+      (extChartAt (𝓡 2) q).source ∩ (extChartAt (𝓡 2) p).source :=
+    ⟨⟨hq, hq'⟩, hq⟩
+  have hu := congrArg (tangentCoordChange (𝓡 2) q p q :
+    EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) huv
+  simpa only [tangentCoordChange_comp hmem, tangentCoordChange_self hq] using hu
+
+private noncomputable def sphereNormalRawInCoordinates
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    sphere (0 : ℝ³) 1 → ℝ³ :=
+  let b := sphereModelBasis p
+  let e0 : EuclideanSpace ℝ (Fin 2) := b 0
+  let e1 : EuclideanSpace ℝ (Fin 2) := b 1
+  let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+    (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
+    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+  let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+    (sphereAmbientMfderiv F) p
+  fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
+    euclideanCross (dF q e0) (dF q e1)
+
+private theorem contMDiffAt_sphereNormalRawInCoordinates
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
+  let b := sphereModelBasis p
+  let e0 : EuclideanSpace ℝ (Fin 2) := b 0
+  let e1 : EuclideanSpace ℝ (Fin 2) := b 1
+  let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+    (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
+    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+  let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+    (sphereAmbientMfderiv F) p
+  have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
+    (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
+  have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
+    (hF p).mfderiv_const le_rfl
+  have hdι0 := hdι.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
+  have hdι1 := hdι.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
+  have hdF0 := hdF.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
+  have hdF1 := hdF.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
+  have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
+  have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
+  have hp : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
+      (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p :=
+    contMDiff_coe_sphere p
+  have hs : ContMDiffAt (𝓡 2) 𝓘(ℝ) m
+      (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³)) p :=
+    contDiff_inner.comp_contMDiffAt (hcι.prodMk_space hp)
+  rw [sphereNormalRawInCoordinates]
+  dsimp only
+  change ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
+    (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
+      euclideanCross (dF q e0) (dF q e1)) p
+  exact hs.smul hcF
+
+private theorem sphereNormalRawInCoordinates_eq_smul
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
+    (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    sphereNormalRawInCoordinates F p q =
+      basisDet (sphereModelBasis p)
+          (tangentCoordChange (𝓡 2) p q q :
+            EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ^ 2 •
+        sphereNormalRaw F q := by
+  let b := sphereModelBasis p
+  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
+    tangentCoordChange (𝓡 2) p q q
+  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
+  let dF := sphereAmbientMfderiv F q
+  have hι := inTangentCoordinates_sphere_eq_comp
+    (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
+  have hF := inTangentCoordinates_sphere_eq_comp F p q hq
+  rw [sphereNormalRawInCoordinates, sphereNormalRaw]
+  dsimp only
+  change inner ℝ
+      (euclideanCross
+        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
+          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 0))
+        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
+          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 1)))
+      (q : ℝ³) •
+        euclideanCross
+          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+            (sphereAmbientMfderiv F) p q) (b 0))
+          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+            (sphereAmbientMfderiv F) p q) (b 1)) =
+      basisDet b A ^ 2 •
+        (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
+          euclideanCross (dF (b 0)) (dF (b 1)))
+  rw [hι, hF]
+  simp only [ContinuousLinearMap.comp_apply]
+  change inner ℝ (euclideanCross (dι (A (b 0))) (dι (A (b 1)))) (q : ℝ³) •
+      euclideanCross (dF (A (b 0))) (dF (A (b 1))) =
+    basisDet b A ^ 2 •
+      (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
+        euclideanCross (dF (b 0)) (dF (b 1)))
+  have hιcross := euclideanCross_comp_basis b dι A
+  have hFcross := euclideanCross_comp_basis b dF A
+  calc
+    _ = inner ℝ (basisDet b A • euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
+        (basisDet b A • euclideanCross (dF (b 0)) (dF (b 1))) :=
+      congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
+        (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
+    _ = _ := by
+      rw [real_inner_smul_left, smul_smul, smul_smul]
+      congr 1
+      ring
+
+private theorem basisDet_tangentCoordChange_ne_zero
+    (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    basisDet (sphereModelBasis p)
+        (tangentCoordChange (𝓡 2) p q q :
+          EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ≠ 0 := by
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
+  let b := sphereModelBasis p
+  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
+    tangentCoordChange (𝓡 2) p q q
+  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
+  have hA : Function.Injective A := tangentCoordChange_injective p q hq
+  have hι : Function.Injective dι := mfderiv_coe_sphere_injective q
+  have hcomp : Function.Injective (dι.comp A) := hι.comp hA
+  have hLI : LinearIndependent ℝ ![(dι.comp A) (b 0), (dι.comp A) (b 1)] := by
+    have hmap := b.linearIndependent.map' (dι.comp A).toLinearMap
+      (LinearMap.ker_eq_bot_of_injective hcomp)
+    rw [show ![(dι.comp A) (b 0), (dι.comp A) (b 1)] =
+        (dι.comp A).toLinearMap ∘ b by
+      funext i
+      fin_cases i <;> rfl]
+    exact hmap
+  have hcross : euclideanCross ((dι.comp A) (b 0)) ((dι.comp A) (b 1)) ≠ 0 :=
+    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hLI
+  intro hdet
+  apply hcross
+  simp only [ContinuousLinearMap.comp_apply]
+  change basisDet b A = 0 at hdet
+  exact (euclideanCross_comp_basis b dι A).trans (by rw [hdet, zero_smul])
+
+private theorem contMDiffAt_sphereNormal
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
+    (himm : ∀ q, Function.Injective (sphereAmbientMfderiv F q)) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
+  have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
+  have hdet := basisDet_tangentCoordChange_ne_zero p p hp
+  have hraw : sphereNormalRaw F p ≠ 0 := by
+    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 (himm p)
+    rw [sphereNormal] at hn
+    exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).mp hn
+  have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
+    rw [sphereNormalRawInCoordinates_eq_smul F p p hp]
+    exact smul_ne_zero (pow_ne_zero 2 hdet) hraw
+  have hsmooth := contMDiffAt_normalize
+    (contMDiffAt_sphereNormalRawInCoordinates F p hF) hlocal
+  apply hsmooth.congr_of_eventuallyEq
+  filter_upwards [extChartAt_source_mem_nhds (I := 𝓡 2) p] with q hq
+  rw [sphereNormal, sphereNormalRawInCoordinates_eq_smul F p q hq,
+    NormedSpace.normalize_smul_of_pos
+      (sq_pos_of_ne_zero (basisDet_tangentCoordChange_ne_zero p q hq))]
+
+/-- A `C^(m + 1)` immersion of the unit two-sphere has a `C^m` canonical unit normal. -/
+theorem contMDiff_sphereNormal
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
+    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
+  fun p ↦ contMDiffAt_sphereNormal F p hF himm
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -48,8 +48,8 @@ private theorem euclideanCross_comp_basis
     (b : Module.Basis (Fin 2) ℝ V) (L : V →L[ℝ] ℝ³) (A : V →L[ℝ] V) :
     euclideanCross (L (A (b 0))) (L (A (b 1))) =
       LinearMap.det A.toLinearMap • euclideanCross (L (b 0)) (L (b 1)) := by
-  rw [← LinearMap.det_toMatrix b, Matrix.det_fin_two]
-  rw [← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
+  rw [← LinearMap.det_toMatrix b, Matrix.det_fin_two,
+    ← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
   simp only [Fin.sum_univ_two, map_add, map_smul, ContinuousLinearMap.add_apply,
     ContinuousLinearMap.smul_apply, euclideanCross_self, smul_zero, add_zero,
     LinearMap.toMatrix_apply]
@@ -134,12 +134,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
   have hs : ContMDiffAt (𝓡 2) 𝓘(ℝ) m
       (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³)) p :=
     contDiff_inner.comp_contMDiffAt (hcι.prodMk_space hp)
-  rw [sphereNormalRawInCoordinates]
-  dsimp only
-  change ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
-    (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
-      euclideanCross (dF q e0) (dF q e1)) p
-  exact hs.smul hcF
+  simpa only [sphereNormalRawInCoordinates] using hs.smul hcF
 
 private theorem sphereNormalRawInCoordinates_eq_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
@@ -160,20 +155,12 @@ private theorem sphereNormalRawInCoordinates_eq_smul
   have hι : dιc = dι.comp A := inTangentCoordinates_sphere_eq_comp
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
   have hF : dFc = dF.comp A := inTangentCoordinates_sphere_eq_comp F p q hq
-  rw [sphereNormalRawInCoordinates, sphereNormalRaw]
-  dsimp only
   change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
       euclideanCross (dFc (b 0)) (dFc (b 1)) =
       LinearMap.det A.toLinearMap ^ 2 •
         (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
           euclideanCross (dF (b 0)) (dF (b 1)))
-  rw [hι, hF]
-  simp only [ContinuousLinearMap.comp_apply]
-  change inner ℝ (euclideanCross (dι (A (b 0))) (dι (A (b 1)))) (q : ℝ³) •
-      euclideanCross (dF (A (b 0))) (dF (A (b 1))) =
-    LinearMap.det A.toLinearMap ^ 2 •
-      (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
-        euclideanCross (dF (b 0)) (dF (b 1)))
+  simp only [hι, hF, ContinuousLinearMap.comp_apply]
   have hιcross := euclideanCross_comp_basis b dι A
   have hFcross := euclideanCross_comp_basis b dF A
   calc
@@ -183,16 +170,15 @@ private theorem sphereNormalRawInCoordinates_eq_smul
       congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
         (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
     _ = _ := by
-      rw [real_inner_smul_left, smul_smul, smul_smul]
-      congr 1
-      ring
+      rw [real_inner_smul_left]
+      module
 
 private theorem det_tangentCoordChange_ne_zero
     (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
     LinearMap.det (tangentCoordChange (𝓡 2) p q q :
       EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ≠ 0 := by
-  rw [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not]
-  exact LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
+  simpa only [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not] using
+    LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
 
 /-- At an immersion point, a locally `C^n` map has a locally `C^m` canonical unit normal when
 `m + 1 ≤ n`. -/

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -84,8 +84,8 @@ private noncomputable def sphereNormalRawInCoordinates
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphere (0 : ℝ³) 1 → ℝ³ :=
   let b := PiLp.basisFun 2 ℝ (Fin 2)
-  let e0 : EuclideanSpace ℝ (Fin 2) := b 0
-  let e1 : EuclideanSpace ℝ (Fin 2) := b 1
+  let e0 := b 0
+  let e1 := b 1
   let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
     (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
@@ -99,25 +99,21 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
   let b := PiLp.basisFun 2 ℝ (Fin 2)
-  let e0 : EuclideanSpace ℝ (Fin 2) := b 0
-  let e1 : EuclideanSpace ℝ (Fin 2) := b 1
+  let e0 := b 0
+  let e1 := b 1
   let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
     (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
   let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
     (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p
   have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
-    (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
+    (contMDiff_coe_sphere (n := 2) (m := ⊤) p).mfderiv_const le_top
   have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
     hF.mfderiv_const hmn
-  have hdι0 := hdι.clm_apply (contMDiffAt_const :
-    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
-  have hdι1 := hdι.clm_apply (contMDiffAt_const :
-    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
-  have hdF0 := hdF.clm_apply (contMDiffAt_const :
-    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
-  have hdF1 := hdF.clm_apply (contMDiffAt_const :
-    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
+  have hdι0 := hdι.clm_apply (contMDiffAt_const (c := e0))
+  have hdι1 := hdι.clm_apply (contMDiffAt_const (c := e1))
+  have hdF0 := hdF.clm_apply (contMDiffAt_const (c := e0))
+  have hdF1 := hdF.clm_apply (contMDiffAt_const (c := e1))
   have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
   have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
   simpa [sphereNormalRawInCoordinates, b, e0, e1, dι, dF] using
@@ -132,8 +128,7 @@ private theorem sphereNormalRawInCoordinates_eq_smul
         EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ^ 2 •
         sphereNormalRaw F q := by
   let b := PiLp.basisFun 2 ℝ (Fin 2)
-  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
-    tangentCoordChange (𝓡 2) p q q
+  let A := tangentCoordChange (𝓡 2) p q q
   let dι : TangentSpace (𝓡 2) q →L[ℝ] ℝ³ :=
     mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
   let dF : TangentSpace (𝓡 2) q →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F q
@@ -175,8 +170,7 @@ private theorem det_tangentCoordChange_ne_zero
 theorem contMDiffAt_sphereNormal_of_le
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n)
-    (himm : Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
+    (himm : Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
@@ -195,8 +189,7 @@ theorem contMDiffAt_sphereNormal_of_le
 theorem contMDiffAt_sphereNormal
     {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F p)
-    (himm : Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
+    (himm : Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p :=
   contMDiffAt_sphereNormal_of_le F p hF le_rfl himm
 
@@ -205,8 +198,7 @@ theorem contMDiffAt_sphereNormal
 theorem contMDiff_sphereNormal_of_le
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) n F) (hmn : m + 1 ≤ n)
-    (himm : ∀ p, Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
+    (himm : ∀ p, Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
   fun p ↦ contMDiffAt_sphereNormal_of_le F p (hF p) hmn (himm p)
 
@@ -214,8 +206,7 @@ theorem contMDiff_sphereNormal_of_le
 theorem contMDiff_sphereNormal
     {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
-    (himm : ∀ p, Function.Injective
-      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
+    (himm : ∀ p, Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
   contMDiff_sphereNormal_of_le F hF le_rfl himm
 

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -24,12 +24,9 @@ public import FormalConjecturesForMathlib.Geometry.SphereImmersion
 /-!
 # Regularity of the canonical normal of a sphere immersion
 
-Although Mathlib's preferred sphere charts do not give a continuous global tangent frame, the
-canonical normal is regular. Locally, `inTangentCoordinates` gives a regular frame for the
-derivative. Changing from that frame to the pointwise model basis scales both cross products in the
-raw normal by the same determinant, so the raw normal scales by its positive square. Normalization
-therefore removes the coordinate dependence. In particular, a `C^(m + 1)` immersion has a `C^m`
-canonical normal.
+Although the sphere charts do not give a continuous global tangent frame, `sphereNormal` is
+regular. In local tangent coordinates, a frame change scales its raw normal by a positive square,
+which normalization removes. Thus a `C^(m + 1)` immersion has a `C^m` canonical normal.
 -/
 
 @[expose] public section

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -70,8 +70,8 @@ private theorem inTangentCoordinates_sphere_eq_comp
       sphereAmbientMfderiv G q ∘L
         (tangentCoordChange (𝓡 2) p q q :
           EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
-  rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp)]
-  simp only [tangentBundleCore_coordChange_model_space, ContinuousLinearMap.id_comp]
+  rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp),
+    tangentBundleCore_coordChange_model_space, ContinuousLinearMap.id_comp]
   rfl
 
 private theorem tangentCoordChange_injective
@@ -79,13 +79,12 @@ private theorem tangentCoordChange_injective
     Function.Injective (tangentCoordChange (𝓡 2) p q q :
       EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
   intro u v huv
-  have hq' : q ∈ (extChartAt (𝓡 2) q).source := mem_extChartAt_source q
   have hmem : q ∈ (extChartAt (𝓡 2) p).source ∩
       (extChartAt (𝓡 2) q).source ∩ (extChartAt (𝓡 2) p).source :=
-    ⟨⟨hq, hq'⟩, hq⟩
-  have hu := congrArg (tangentCoordChange (𝓡 2) q p q :
-    EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) huv
-  simpa only [tangentCoordChange_comp hmem, tangentCoordChange_self hq] using hu
+    ⟨⟨hq, mem_extChartAt_source q⟩, hq⟩
+  simpa only [tangentCoordChange_comp hmem, tangentCoordChange_self hq] using
+    congrArg (tangentCoordChange (𝓡 2) q p q :
+      EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) huv
 
 private noncomputable def sphereNormalRawInCoordinates
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
@@ -105,7 +104,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
   let b := sphereModelBasis p
   let e0 : EuclideanSpace ℝ (Fin 2) := b 0
   let e1 : EuclideanSpace ℝ (Fin 2) := b 1
@@ -128,13 +127,9 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
   have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
   have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
-  have hp : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
-      (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p :=
-    contMDiff_coe_sphere p
-  have hs : ContMDiffAt (𝓡 2) 𝓘(ℝ) m
-      (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³)) p :=
-    contDiff_inner.comp_contMDiffAt (hcι.prodMk_space hp)
-  simpa only [sphereNormalRawInCoordinates] using hs.smul hcF
+  simpa [sphereNormalRawInCoordinates] using
+    (contDiff_inner.comp_contMDiffAt
+      (hcι.prodMk_space (contMDiff_coe_sphere p))).smul hcF
 
 private theorem sphereNormalRawInCoordinates_eq_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
@@ -152,23 +147,21 @@ private theorem sphereNormalRawInCoordinates_eq_smul
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
     (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
   let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F (sphereAmbientMfderiv F) p q
-  have hι : dιc = dι.comp A := inTangentCoordinates_sphere_eq_comp
-    (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
-  have hF : dFc = dF.comp A := inTangentCoordinates_sphere_eq_comp F p q hq
   change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
       euclideanCross (dFc (b 0)) (dFc (b 1)) =
       LinearMap.det A.toLinearMap ^ 2 •
         (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
           euclideanCross (dF (b 0)) (dF (b 1)))
-  simp only [hι, hF, ContinuousLinearMap.comp_apply]
-  have hιcross := euclideanCross_comp_basis b dι A
-  have hFcross := euclideanCross_comp_basis b dF A
+  rw [show dιc = dι.comp A from inTangentCoordinates_sphere_eq_comp
+      (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq,
+    show dFc = dF.comp A from inTangentCoordinates_sphere_eq_comp F p q hq]
   calc
     _ = inner ℝ (LinearMap.det A.toLinearMap • euclideanCross (dι (b 0)) (dι (b 1)))
           (q : ℝ³) •
         (LinearMap.det A.toLinearMap • euclideanCross (dF (b 0)) (dF (b 1))) :=
       congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
-        (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
+        (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) (euclideanCross_comp_basis b dι A))
+        (euclideanCross_comp_basis b dF A)
     _ = _ := by
       rw [real_inner_smul_left]
       module
@@ -177,7 +170,7 @@ private theorem det_tangentCoordChange_ne_zero
     (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
     LinearMap.det (tangentCoordChange (𝓡 2) p q q :
       EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ≠ 0 := by
-  simpa only [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not] using
+  simpa [LinearMap.det_eq_zero_iff_ker_ne_bot] using
     LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
 
 /-- At an immersion point, a locally `C^n` map has a locally `C^m` canonical unit normal when
@@ -188,17 +181,13 @@ theorem contMDiffAt_sphereNormal_of_le
     (himm : Function.Injective (sphereAmbientMfderiv F p)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
-  have hdet := det_tangentCoordChange_ne_zero p p hp
-  have hraw : sphereNormalRaw F p ≠ 0 := by
-    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 himm
-    rw [sphereNormal] at hn
-    exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).mp hn
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
     rw [sphereNormalRawInCoordinates_eq_smul F p p hp]
-    exact smul_ne_zero (pow_ne_zero 2 hdet) hraw
-  have hsmooth := contMDiffAt_normalize
-    (contMDiffAt_sphereNormalRawInCoordinates F p hF hmn) hlocal
-  apply hsmooth.congr_of_eventuallyEq
+    refine smul_ne_zero (pow_ne_zero 2 (det_tangentCoordChange_ne_zero p p hp)) ?_
+    simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
+      (sphereNormal_ne_zero_iff F p).2 himm
+  apply (contMDiffAt_normalize
+    (contMDiffAt_sphereNormalRawInCoordinates F p hF hmn) hlocal).congr_of_eventuallyEq
   filter_upwards [extChartAt_source_mem_nhds (I := 𝓡 2) p] with q hq
   rw [sphereNormal, sphereNormalRawInCoordinates_eq_smul F p q hq,
     NormedSpace.normalize_smul_of_pos

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -34,7 +34,7 @@ canonical normal.
 
 @[expose] public section
 
-open Metric Set Function
+open Metric
 open scoped EuclideanGeometry Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
@@ -43,20 +43,16 @@ private noncomputable def sphereModelBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (EuclideanSpace ℝ (Fin 2)) :=
   sphereTangentBasis p
 
-private noncomputable def basisDet {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
-    (b : Module.Basis (Fin 2) ℝ V) (A : V →L[ℝ] V) : ℝ :=
-  b.repr (A (b 0)) 0 * b.repr (A (b 1)) 1 -
-    b.repr (A (b 0)) 1 * b.repr (A (b 1)) 0
-
 private theorem euclideanCross_comp_basis
     {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (b : Module.Basis (Fin 2) ℝ V) (L : V →L[ℝ] ℝ³) (A : V →L[ℝ] V) :
     euclideanCross (L (A (b 0))) (L (A (b 1))) =
-      basisDet b A • euclideanCross (L (b 0)) (L (b 1)) := by
+      LinearMap.det A.toLinearMap • euclideanCross (L (b 0)) (L (b 1)) := by
+  rw [← LinearMap.det_toMatrix b, Matrix.det_fin_two]
   rw [← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
   simp only [Fin.sum_univ_two, map_add, map_smul, ContinuousLinearMap.add_apply,
-    ContinuousLinearMap.smul_apply,
-    euclideanCross_self, smul_zero, add_zero, basisDet]
+    ContinuousLinearMap.smul_apply, euclideanCross_self, smul_zero, add_zero,
+    LinearMap.toMatrix_apply]
   rw [← euclideanCross_anticomm (L (b 0)) (L (b 1))]
   module
 
@@ -106,8 +102,8 @@ private noncomputable def sphereNormalRawInCoordinates
     euclideanCross (dF q e0) (dF q e1)
 
 private theorem contMDiffAt_sphereNormalRawInCoordinates
-    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F) :
+    {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
   letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
   let b := sphereModelBasis p
@@ -121,7 +117,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
   have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
     (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
   have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
-    (hF p).mfderiv_const le_rfl
+    hF.mfderiv_const hmn
   have hdι0 := hdι.clm_apply (contMDiffAt_const :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
   have hdι1 := hdι.clm_apply (contMDiffAt_const :
@@ -149,49 +145,41 @@ private theorem sphereNormalRawInCoordinates_eq_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
     (hq : q ∈ (extChartAt (𝓡 2) p).source) :
     sphereNormalRawInCoordinates F p q =
-      basisDet (sphereModelBasis p)
-          (tangentCoordChange (𝓡 2) p q q :
-            EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ^ 2 •
+      LinearMap.det (tangentCoordChange (𝓡 2) p q q :
+        EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ^ 2 •
         sphereNormalRaw F q := by
   let b := sphereModelBasis p
   let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
     tangentCoordChange (𝓡 2) p q q
   let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
   let dF := sphereAmbientMfderiv F q
-  have hι := inTangentCoordinates_sphere_eq_comp
+  let dιc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+    (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
+    (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
+  let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F (sphereAmbientMfderiv F) p q
+  have hι : dιc = dι.comp A := inTangentCoordinates_sphere_eq_comp
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
-  have hF := inTangentCoordinates_sphere_eq_comp F p q hq
+  have hF : dFc = dF.comp A := inTangentCoordinates_sphere_eq_comp F p q hq
   rw [sphereNormalRawInCoordinates, sphereNormalRaw]
   dsimp only
-  change inner ℝ
-      (euclideanCross
-        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
-          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
-          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 0))
-        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
-          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
-          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 1)))
-      (q : ℝ³) •
-        euclideanCross
-          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-            (sphereAmbientMfderiv F) p q) (b 0))
-          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-            (sphereAmbientMfderiv F) p q) (b 1)) =
-      basisDet b A ^ 2 •
+  change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
+      euclideanCross (dFc (b 0)) (dFc (b 1)) =
+      LinearMap.det A.toLinearMap ^ 2 •
         (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
           euclideanCross (dF (b 0)) (dF (b 1)))
   rw [hι, hF]
   simp only [ContinuousLinearMap.comp_apply]
   change inner ℝ (euclideanCross (dι (A (b 0))) (dι (A (b 1)))) (q : ℝ³) •
       euclideanCross (dF (A (b 0))) (dF (A (b 1))) =
-    basisDet b A ^ 2 •
+    LinearMap.det A.toLinearMap ^ 2 •
       (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
         euclideanCross (dF (b 0)) (dF (b 1)))
   have hιcross := euclideanCross_comp_basis b dι A
   have hFcross := euclideanCross_comp_basis b dF A
   calc
-    _ = inner ℝ (basisDet b A • euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
-        (basisDet b A • euclideanCross (dF (b 0)) (dF (b 1))) :=
+    _ = inner ℝ (LinearMap.det A.toLinearMap • euclideanCross (dι (b 0)) (dι (b 1)))
+          (q : ℝ³) •
+        (LinearMap.det A.toLinearMap • euclideanCross (dF (b 0)) (dF (b 1))) :=
       congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
         (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
     _ = _ := by
@@ -199,56 +187,53 @@ private theorem sphereNormalRawInCoordinates_eq_smul
       congr 1
       ring
 
-private theorem basisDet_tangentCoordChange_ne_zero
+private theorem det_tangentCoordChange_ne_zero
     (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
-    basisDet (sphereModelBasis p)
-        (tangentCoordChange (𝓡 2) p q q :
-          EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ≠ 0 := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
-  let b := sphereModelBasis p
-  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
-    tangentCoordChange (𝓡 2) p q q
-  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
-  have hA : Function.Injective A := tangentCoordChange_injective p q hq
-  have hι : Function.Injective dι := mfderiv_coe_sphere_injective q
-  have hcomp : Function.Injective (dι.comp A) := hι.comp hA
-  have hLI : LinearIndependent ℝ ![(dι.comp A) (b 0), (dι.comp A) (b 1)] := by
-    have hmap := b.linearIndependent.map' (dι.comp A).toLinearMap
-      (LinearMap.ker_eq_bot_of_injective hcomp)
-    rw [show ![(dι.comp A) (b 0), (dι.comp A) (b 1)] =
-        (dι.comp A).toLinearMap ∘ b by
-      funext i
-      fin_cases i <;> rfl]
-    exact hmap
-  have hcross : euclideanCross ((dι.comp A) (b 0)) ((dι.comp A) (b 1)) ≠ 0 :=
-    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hLI
-  intro hdet
-  apply hcross
-  simp only [ContinuousLinearMap.comp_apply]
-  change basisDet b A = 0 at hdet
-  exact (euclideanCross_comp_basis b dι A).trans (by rw [hdet, zero_smul])
+    LinearMap.det (tangentCoordChange (𝓡 2) p q q :
+      EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ≠ 0 := by
+  rw [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not]
+  exact LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
 
-private theorem contMDiffAt_sphereNormal
-    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
-    (himm : ∀ q, Function.Injective (sphereAmbientMfderiv F q)) :
+/-- At an immersion point, a locally `C^n` map has a locally `C^m` canonical unit normal when
+`m + 1 ≤ n`. -/
+theorem contMDiffAt_sphereNormal_of_le
+    {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n)
+    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
-  have hdet := basisDet_tangentCoordChange_ne_zero p p hp
+  have hdet := det_tangentCoordChange_ne_zero p p hp
   have hraw : sphereNormalRaw F p ≠ 0 := by
-    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 (himm p)
+    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 himm
     rw [sphereNormal] at hn
     exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).mp hn
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
     rw [sphereNormalRawInCoordinates_eq_smul F p p hp]
     exact smul_ne_zero (pow_ne_zero 2 hdet) hraw
   have hsmooth := contMDiffAt_normalize
-    (contMDiffAt_sphereNormalRawInCoordinates F p hF) hlocal
+    (contMDiffAt_sphereNormalRawInCoordinates F p hF hmn) hlocal
   apply hsmooth.congr_of_eventuallyEq
   filter_upwards [extChartAt_source_mem_nhds (I := 𝓡 2) p] with q hq
   rw [sphereNormal, sphereNormalRawInCoordinates_eq_smul F p q hq,
     NormedSpace.normalize_smul_of_pos
-      (sq_pos_of_ne_zero (basisDet_tangentCoordChange_ne_zero p q hq))]
+      (sq_pos_of_ne_zero (det_tangentCoordChange_ne_zero p q hq))]
+
+/-- At an immersion point, a locally `C^(m + 1)` map has a locally `C^m` canonical unit normal. -/
+theorem contMDiffAt_sphereNormal
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F p)
+    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p :=
+  contMDiffAt_sphereNormal_of_le F p hF le_rfl himm
+
+/-- A `C^n` immersion of the unit two-sphere has a `C^m` canonical unit normal when
+`m + 1 ≤ n`. -/
+theorem contMDiff_sphereNormal_of_le
+    {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) n F) (hmn : m + 1 ≤ n)
+    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
+  fun p ↦ contMDiffAt_sphereNormal_of_le F p (hF p) hmn (himm p)
 
 /-- A `C^(m + 1)` immersion of the unit two-sphere has a `C^m` canonical unit normal. -/
 theorem contMDiff_sphereNormal
@@ -256,6 +241,6 @@ theorem contMDiff_sphereNormal
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
     (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
-  fun p ↦ contMDiffAt_sphereNormal F p hF himm
+  contMDiff_sphereNormal_of_le F hF le_rfl himm
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -35,13 +35,9 @@ canonical normal.
 @[expose] public section
 
 open Metric
-open scoped EuclideanGeometry Manifold RealInnerProductSpace
+open scoped EuclideanGeometry EuclideanSpace Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
-
-private noncomputable def sphereModelBasis (p : sphere (0 : ℝ³) 1) :
-    Module.Basis (Fin 2) ℝ (EuclideanSpace ℝ (Fin 2)) :=
-  sphereTangentBasis p
 
 private theorem euclideanCross_comp_basis
     {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
@@ -66,8 +62,9 @@ private theorem contMDiffAt_normalize
 private theorem inTangentCoordinates_sphere_eq_comp
     (G : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
     (hq : q ∈ (extChartAt (𝓡 2) p).source) :
-    inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id G (sphereAmbientMfderiv G) p q =
-      sphereAmbientMfderiv G q ∘L
+    inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id G
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) G) p q =
+      mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) G q ∘L
         (tangentCoordChange (𝓡 2) p q q :
           EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
   rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp),
@@ -89,14 +86,14 @@ private theorem tangentCoordChange_injective
 private noncomputable def sphereNormalRawInCoordinates
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphere (0 : ℝ³) 1 → ℝ³ :=
-  let b := sphereModelBasis p
+  let b := PiLp.basisFun 2 ℝ (Fin 2)
   let e0 : EuclideanSpace ℝ (Fin 2) := b 0
   let e1 : EuclideanSpace ℝ (Fin 2) := b 1
   let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
-    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
   let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-    (sphereAmbientMfderiv F) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p
   fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
     euclideanCross (dF q e0) (dF q e1)
 
@@ -104,15 +101,14 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
-  let b := sphereModelBasis p
+  let b := PiLp.basisFun 2 ℝ (Fin 2)
   let e0 : EuclideanSpace ℝ (Fin 2) := b 0
   let e1 : EuclideanSpace ℝ (Fin 2) := b 1
   let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
-    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
   let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-    (sphereAmbientMfderiv F) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p
   have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
     (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
   have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
@@ -127,7 +123,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
   have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
   have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
-  simpa [sphereNormalRawInCoordinates] using
+  simpa [sphereNormalRawInCoordinates, b, e0, e1, dι, dF] using
     (contDiff_inner.comp_contMDiffAt
       (hcι.prodMk_space (contMDiff_coe_sphere p))).smul hcF
 
@@ -138,15 +134,19 @@ private theorem sphereNormalRawInCoordinates_eq_smul
       LinearMap.det (tangentCoordChange (𝓡 2) p q q :
         EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ^ 2 •
         sphereNormalRaw F q := by
-  let b := sphereModelBasis p
+  let b := PiLp.basisFun 2 ℝ (Fin 2)
   let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
     tangentCoordChange (𝓡 2) p q q
-  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
-  let dF := sphereAmbientMfderiv F q
+  let dι : TangentSpace (𝓡 2) q →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
+  let dF : TangentSpace (𝓡 2) q →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F q
   let dιc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
-    (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
-  let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F (sphereAmbientMfderiv F) p q
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
+  let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p q
+  rw [sphereNormalRaw]
+  rw [sphereTangentBasis_apply q 0, sphereTangentBasis_apply q 1]
   change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
       euclideanCross (dFc (b 0)) (dFc (b 1)) =
       LinearMap.det A.toLinearMap ^ 2 •
@@ -178,7 +178,8 @@ private theorem det_tangentCoordChange_ne_zero
 theorem contMDiffAt_sphereNormal_of_le
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n)
-    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
@@ -197,7 +198,8 @@ theorem contMDiffAt_sphereNormal_of_le
 theorem contMDiffAt_sphereNormal
     {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F p)
-    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p :=
   contMDiffAt_sphereNormal_of_le F p hF le_rfl himm
 
@@ -206,7 +208,8 @@ theorem contMDiffAt_sphereNormal
 theorem contMDiff_sphereNormal_of_le
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) n F) (hmn : m + 1 ≤ n)
-    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : ∀ p, Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
   fun p ↦ contMDiffAt_sphereNormal_of_le F p (hF p) hmn (himm p)
 
@@ -214,7 +217,8 @@ theorem contMDiff_sphereNormal_of_le
 theorem contMDiff_sphereNormal
     {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
-    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : ∀ p, Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
   contMDiff_sphereNormal_of_le F hF le_rfl himm
 

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -36,33 +36,27 @@ open EuclideanHypersurface
 
 private def positiveAxis0 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[1, 0, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis0 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[-1, 0, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis1 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, 1, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis1 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, -1, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis2 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, 0, 1], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, 0, -1], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -1,0 +1,97 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+
+/-!
+# Sanity checks for the canonical sphere normal
+
+The canonical normal of the standard inclusion is checked explicitly at the six signed coordinate
+axes of the unit sphere.
+-/
+
+@[expose] public section
+
+open Metric
+open scoped EuclideanGeometry
+
+namespace SphereImmersionTest
+
+open EuclideanHypersurface
+
+private def positiveAxis0 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![1, 0, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def negativeAxis0 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![-1, 0, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def positiveAxis1 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, 1, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def negativeAxis1 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, -1, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def positiveAxis2 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, 0, 1], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, 0, -1], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =
+      WithLp.toLp 2 ![1, 0, 0] := by
+  simp [positiveAxis0]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis0 =
+      WithLp.toLp 2 ![-1, 0, 0] := by
+  simp [negativeAxis0]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis1 =
+      WithLp.toLp 2 ![0, 1, 0] := by
+  simp [positiveAxis1]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis1 =
+      WithLp.toLp 2 ![0, -1, 0] := by
+  simp [negativeAxis1]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis2 =
+      WithLp.toLp 2 ![0, 0, 1] := by
+  simp [positiveAxis2]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis2 =
+      WithLp.toLp 2 ![0, 0, -1] := by
+  simp [negativeAxis2]
+
+end SphereImmersionTest

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -59,32 +59,32 @@ private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
     norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 example :
-    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =
+    sphereNormal (fun q ↦ (q : ℝ³)) positiveAxis0 =
       !₂[1, 0, 0] := by
   simp [positiveAxis0]
 
 example :
-    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis0 =
+    sphereNormal (fun q ↦ (q : ℝ³)) negativeAxis0 =
       !₂[-1, 0, 0] := by
   simp [negativeAxis0]
 
 example :
-    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis1 =
+    sphereNormal (fun q ↦ (q : ℝ³)) positiveAxis1 =
       !₂[0, 1, 0] := by
   simp [positiveAxis1]
 
 example :
-    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis1 =
+    sphereNormal (fun q ↦ (q : ℝ³)) negativeAxis1 =
       !₂[0, -1, 0] := by
   simp [negativeAxis1]
 
 example :
-    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis2 =
+    sphereNormal (fun q ↦ (q : ℝ³)) positiveAxis2 =
       !₂[0, 0, 1] := by
   simp [positiveAxis2]
 
 example :
-    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis2 =
+    sphereNormal (fun q ↦ (q : ℝ³)) negativeAxis2 =
       !₂[0, 0, -1] := by
   simp [negativeAxis2]
 

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -35,63 +35,63 @@ namespace SphereImmersionTest
 open EuclideanHypersurface
 
 private def positiveAxis0 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![1, 0, 0], by
+  ⟨!₂[1, 0, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis0 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![-1, 0, 0], by
+  ⟨!₂[-1, 0, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis1 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, 1, 0], by
+  ⟨!₂[0, 1, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis1 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, -1, 0], by
+  ⟨!₂[0, -1, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis2 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, 0, 1], by
+  ⟨!₂[0, 0, 1], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, 0, -1], by
+  ⟨!₂[0, 0, -1], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =
-      WithLp.toLp 2 ![1, 0, 0] := by
+      !₂[1, 0, 0] := by
   simp [positiveAxis0]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis0 =
-      WithLp.toLp 2 ![-1, 0, 0] := by
+      !₂[-1, 0, 0] := by
   simp [negativeAxis0]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis1 =
-      WithLp.toLp 2 ![0, 1, 0] := by
+      !₂[0, 1, 0] := by
   simp [positiveAxis1]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis1 =
-      WithLp.toLp 2 ![0, -1, 0] := by
+      !₂[0, -1, 0] := by
   simp [negativeAxis1]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis2 =
-      WithLp.toLp 2 ![0, 0, 1] := by
+      !₂[0, 0, 1] := by
   simp [positiveAxis2]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis2 =
-      WithLp.toLp 2 ![0, 0, -1] := by
+      !₂[0, 0, -1] := by
   simp [negativeAxis2]
 
 end SphereImmersionTest


### PR DESCRIPTION
This PR does the following:
- formalize the smooth and real-analytic Loewner conjectures using the winding number of the trace-free Hessian;
- formalize smooth and real-analytic Carathéodory conjectures for parametrized convex two-spheres;
- formulate Carathéodory umbilics through proportional first and second fundamental forms, with reusable equivalence lemmas;
- record that the smooth Loewner conjecture implies the smooth Carathéodory conjecture.

The classical formulations follow Ghomi’s Problems 8.1 and 8.2, with the analytic results sourced to Titus.

The complete sorry-free counterexample proof is in the dependent draft PR #5070. That PR proves both smooth statements false, pins their `formal_proof` metadata to a kernel-checked commit, and includes the full informal proof.
