### PR TITLE
Prove the smooth Carathéodory and Loewner counterexamples

### DIFF
--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -37,33 +37,34 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- The manifold derivative of a sphere-valued parametrization, with its codomain exposed as the
-ambient Euclidean space. -/
-noncomputable def sphereAmbientMfderiv
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
-  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+/-- A parametrized convex surface whose canonical normal is of class `C^k`.
 
-/-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
-
-The range condition says that the parametrization is the boundary of a convex body. Requiring
-nonempty interior rules out lower-dimensional convex sets. -/
-def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
-  Manifold.IsSmoothEmbedding (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
-    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k n ∧
-    (∀ p, ‖n p‖ = 1) ∧
-    (∀ p v, inner ℝ (n p) (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0) ∧
+The canonical normal is constructed from the derivative of `F` by a globally
+orientation-corrected cross product. Its orthogonality is built into the construction, while the
+injective differential makes it a unit vector. For finite `k`, requiring this normal to be `C^k`
+is stronger than requiring only `F` to be `C^k`. The range condition identifies the surface with
+the boundary of a compact convex body with nonempty interior. -/
+def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
+  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+    Topology.IsEmbedding F ∧
+    (∀ p, Function.Injective (EuclideanHypersurface.sphereAmbientMfderiv F p)) ∧
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
+/-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
+from the derivative of the parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
-  ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
+  ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧
       EuclideanHypersurface.IsUmbilic
-        (sphereAmbientMfderiv F p₁) (sphereAmbientMfderiv n p₁) ∧
+        (EuclideanHypersurface.sphereAmbientMfderiv F p₁)
+        (EuclideanHypersurface.sphereAmbientMfderiv
+          (EuclideanHypersurface.sphereNormal F) p₁) ∧
       EuclideanHypersurface.IsUmbilic
-        (sphereAmbientMfderiv F p₂) (sphereAmbientMfderiv n p₂)
+        (EuclideanHypersurface.sphereAmbientMfderiv F p₂)
+        (EuclideanHypersurface.sphereAmbientMfderiv
+          (EuclideanHypersurface.sphereNormal F) p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -74,7 +74,7 @@ Every smoothly embedded two-sphere which bounds a convex body has at least two d
 umbilic points. Alpöge's smooth support function has exactly one umbilic, so the answer is
 false. -/
 @[category research solved, AMS 52 53,
-  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/150d2159bd37294ac7ad45c4ae7f199fb7dcd871/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/a4677e237082ea8740b8a47d8f5f0086628b11d4/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
 theorem caratheodory_conjecture : answer(False) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -37,12 +37,19 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
+/-- A parametrized convex surface with a `C^k` Gauss parametrization: both the immersion and its
+chosen unit normal are of class `C^k`.
 
-The range condition says that the parametrization is the boundary of a convex body. Requiring
-nonempty interior rules out lower-dimensional convex sets. -/
+The first three conditions spell out the usual finite-dimensional notion of a smooth embedding:
+smoothness, a topological embedding, and an injective differential at every point. The range
+condition says that the parametrization is the boundary of a convex body. Requiring nonempty
+interior rules out lower-dimensional convex sets. For finite `k`, asking the normal itself to be
+`C^k` is stronger than asking only that the immersion be `C^k`; the distinction disappears for
+the smooth and analytic endpoints. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
-  Manifold.IsSmoothEmbedding (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+    Topology.IsEmbedding F ∧
+    (∀ p, Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) ∧
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k n ∧
     (∀ p, ‖n p‖ = 1) ∧
     (∀ p v, inner ℝ (n p) (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0) ∧
@@ -54,7 +61,7 @@ derivative of the immersion, equivalently when its shape operator is scalar. -/
 def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
   ∃ c : ℝ, mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) n p = c • mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
 
-/-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
+/-- Carathéodory's conjecture for convex surfaces with a `C^k` Gauss parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -39,40 +39,34 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- The manifold derivative of a sphere-valued parametrization, with its codomain exposed as the
-ambient Euclidean space. -/
-noncomputable def sphereAmbientMfderiv
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
-  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+/-- A parametrized convex surface whose canonical normal is of class `C^k`.
 
-/-- A parametrized convex surface with a `C^k` Gauss parametrization: both the immersion and its
-chosen unit normal are of class `C^k`.
-
-The first three conditions spell out the usual finite-dimensional notion of a smooth embedding:
-smoothness, a topological embedding, and an injective differential at every point. The range
-condition says that the parametrization is the boundary of a convex body. Requiring nonempty
-interior rules out lower-dimensional convex sets. For finite `k`, asking the normal itself to be
-`C^k` is stronger than asking only that the immersion be `C^k`; the distinction disappears for
-the smooth and analytic endpoints. -/
-def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
+The canonical normal is constructed from the derivative of `F` by a globally
+orientation-corrected cross product. Its orthogonality is built into the construction, while the
+injective differential makes it a unit vector. For finite `k`, requiring this normal to be `C^k`
+is stronger than requiring only `F` to be `C^k`. The range condition identifies the surface with
+the boundary of a compact convex body with nonempty interior. -/
+def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
   ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
     Topology.IsEmbedding F ∧
-    (∀ p, Function.Injective (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p)) ∧
-    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k n ∧
-    (∀ p, ‖n p‖ = 1) ∧
-    (∀ p v, inner ℝ (n p) (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0) ∧
+    (∀ p, Function.Injective (EuclideanHypersurface.sphereAmbientMfderiv F p)) ∧
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- Carathéodory's conjecture for convex surfaces with a `C^k` Gauss parametrization. -/
+/-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
+from the derivative of the parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
-  ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
+  ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧
       EuclideanHypersurface.IsUmbilic
-        (sphereAmbientMfderiv F p₁) (sphereAmbientMfderiv n p₁) ∧
+        (EuclideanHypersurface.sphereAmbientMfderiv F p₁)
+        (EuclideanHypersurface.sphereAmbientMfderiv
+          (EuclideanHypersurface.sphereNormal F) p₁) ∧
       EuclideanHypersurface.IsUmbilic
-        (sphereAmbientMfderiv F p₂) (sphereAmbientMfderiv n p₂)
+        (EuclideanHypersurface.sphereAmbientMfderiv F p₂)
+        (EuclideanHypersurface.sphereAmbientMfderiv
+          (EuclideanHypersurface.sphereNormal F) p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -37,6 +37,13 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
+/-- The manifold derivative of a sphere-valued parametrization, with its codomain exposed as the
+ambient Euclidean space. -/
+noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
 /-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
 
 The range condition says that the parametrization is the boundary of a convex body. Requiring
@@ -49,10 +56,11 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
-derivative of the immersion, equivalently when its shape operator is scalar. -/
+/-- A point is umbilic when its second fundamental form is a scalar multiple of its first.
+The second form uses the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
 def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
-  ∃ c : ℝ, mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) n p = c • mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+  EuclideanHypersurface.IsUmbilicByFundamentalForms
+    (sphereAmbientMfderiv F p) (sphereAmbientMfderiv n p)
 
 /-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
+import FormalConjecturesUtil
 import FormalConjectures.Other.LoewnerConjecture
 
 /-!
@@ -48,12 +49,6 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A smooth parametrized convex surface with a smooth choice of unit normal. -/
-abbrev IsSmoothConvexSphere := IsConvexSphereOfClass ∞
-
-/-- A real-analytic parametrized convex surface with a real-analytic choice of unit normal. -/
-abbrev IsAnalyticConvexSphere := IsConvexSphereOfClass ω
-
 /-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
 derivative of the immersion, equivalently when its shape operator is scalar. -/
 def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
@@ -64,18 +59,12 @@ def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
 
-/-- The smooth Carathéodory conjecture. -/
-abbrev SmoothCaratheodoryConjecture := CaratheodoryConjectureOfClass ∞
-
-/-- The real-analytic Carathéodory conjecture. -/
-abbrev AnalyticCaratheodoryConjecture := CaratheodoryConjectureOfClass ω
-
 /-- **The smooth Carathéodory conjecture.**
 
 Every smoothly embedded two-sphere which bounds a convex body has at least two distinct
 umbilic points. -/
 @[category research open, AMS 52 53]
-theorem caratheodory_conjecture : answer(sorry) ↔ SmoothCaratheodoryConjecture := by
+theorem caratheodory_conjecture : answer(sorry) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Carathéodory conjecture.**
@@ -83,14 +72,14 @@ theorem caratheodory_conjecture : answer(sorry) ↔ SmoothCaratheodoryConjecture
 Every real-analytically embedded two-sphere which bounds a convex body has at least two distinct
 umbilic points. This is the classical theorem of Hamburger. -/
 @[category research solved, AMS 52 53]
-theorem caratheodory_conjecture_analytic : AnalyticCaratheodoryConjecture := by
+theorem caratheodory_conjecture_analytic : CaratheodoryConjectureOfClass ω := by
   sorry
 
 /-- The smooth Loewner conjecture implies the smooth Carathéodory conjecture by the
 Poincaré–Hopf index theorem for principal line fields. -/
 @[category research solved, AMS 52 53 57]
 theorem loewner_implies_caratheodory :
-    LoewnerConjecture.SmoothLoewnerConjecture → SmoothCaratheodoryConjecture := by
+    LoewnerConjecture.LoewnerConjectureOfClass ∞ → CaratheodoryConjectureOfClass ∞ := by
   sorry
 
 end CaratheodoryConjecture

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import Mathlib.Analysis.Convex.Body
-import FormalConjectures.Other.LoewnerConjecture
 import FormalConjecturesUtil
+import FormalConjectures.Other.LoewnerConjecture
 
 /-!
 # Carathéodory's conjecture

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -22,9 +22,8 @@ import FormalConjecturesUtil
 # Carathéodory's conjecture
 
 Carathéodory's conjecture says that every sufficiently smooth closed convex surface in
-three-dimensional Euclidean space has at least two umbilic points. We state the conjecture for
-smooth surfaces and the classical positive result for real-analytic surfaces. We also record
-that Loewner's local index conjecture implies Carathéodory's global conjecture.
+three-dimensional Euclidean space has at least two umbilic points. We record smooth and
+real-analytic versions and the implication from Loewner's local index conjecture.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problems 8.1 and
@@ -38,14 +37,8 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- A parametrized convex surface of class `C^(k + 1)`, whose canonical normal is of class
-`C^k`.
-
-The canonical normal is constructed from the derivative of `F` by a globally
-orientation-corrected cross product. Its orthogonality is built into the construction, while the
-injective differential makes it a unit vector. Its `C^k` regularity follows from the `C^(k + 1)`
-regularity of `F`. The range condition identifies the surface with the boundary of a compact
-convex body with nonempty interior. -/
+/-- A `C^(k + 1)` parametrized convex surface. Its canonical normal is `C^k` by
+`EuclideanHypersurface.contMDiff_sphereNormal`. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
   ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (k + 1) F ∧
     Topology.IsEmbedding F ∧
@@ -61,8 +54,7 @@ theorem IsConvexSphereOfClass.contMDiff_sphereNormal
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) :=
   EuclideanHypersurface.contMDiff_sphereNormal F hF.1 hF.2.2.1
 
-/-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
-from the derivative of the parametrization. -/
+/-- Carathéodory's conjecture for `IsConvexSphereOfClass k` surfaces. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjecturesUtil
+import Mathlib.Analysis.Convex.Body
 import FormalConjectures.Other.LoewnerConjecture
+import FormalConjecturesUtil
 
 /-!
 # Carathéodory's conjecture
@@ -47,10 +48,11 @@ the boundary of a compact convex body with nonempty interior. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
   ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
     Topology.IsEmbedding F ∧
-    (∀ p, Function.Injective (EuclideanHypersurface.sphereAmbientMfderiv F p)) ∧
+    (∀ p, Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) ∧
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
-    ∃ K : Set ℝ³,
-      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
+    ∃ K : ConvexBody ℝ³,
+      (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 
 /-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
 from the derivative of the parametrization. -/
@@ -58,13 +60,15 @@ def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ F : sphere (0 : ℝ³) 1 → ℝ³, IsConvexSphereOfClass k F →
     ∃ p₁ p₂, p₁ ≠ p₂ ∧
       EuclideanHypersurface.IsUmbilic
-        (EuclideanHypersurface.sphereAmbientMfderiv F p₁)
-        (EuclideanHypersurface.sphereAmbientMfderiv
-          (EuclideanHypersurface.sphereNormal F) p₁) ∧
+        (V := TangentSpace (𝓡 2) p₁) (E := ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₁ : TangentSpace (𝓡 2) p₁ →L[ℝ] ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₁ :
+          TangentSpace (𝓡 2) p₁ →L[ℝ] ℝ³) ∧
       EuclideanHypersurface.IsUmbilic
-        (EuclideanHypersurface.sphereAmbientMfderiv F p₂)
-        (EuclideanHypersurface.sphereAmbientMfderiv
-          (EuclideanHypersurface.sphereNormal F) p₂)
+        (V := TangentSpace (𝓡 2) p₂) (E := ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p₂ : TangentSpace (𝓡 2) p₂ →L[ℝ] ℝ³)
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (EuclideanHypersurface.sphereNormal F) p₂ :
+          TangentSpace (𝓡 2) p₂ →L[ℝ] ℝ³)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -54,6 +54,13 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ
     ∃ K : ConvexBody ℝ³,
       (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 
+/-- The canonical normal of an `IsConvexSphereOfClass k` surface is of class `C^k`. -/
+@[category test, AMS 52 53]
+theorem IsConvexSphereOfClass.contMDiff_sphereNormal
+    {k : WithTop ℕ∞} {F : sphere (0 : ℝ³) 1 → ℝ³} (hF : IsConvexSphereOfClass k F) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) :=
+  EuclideanHypersurface.contMDiff_sphereNormal F hF.1 hF.2.2.1
+
 /-- Carathéodory's conjecture for convex surfaces with a `C^k` canonical normal constructed
 from the derivative of the parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -39,6 +39,13 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
+/-- The manifold derivative of a sphere-valued parametrization, with its codomain exposed as the
+ambient Euclidean space. -/
+noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
 /-- A parametrized convex surface with a `C^k` Gauss parametrization: both the immersion and its
 chosen unit normal are of class `C^k`.
 
@@ -58,10 +65,11 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
-derivative of the immersion, equivalently when its shape operator is scalar. -/
+/-- A point is umbilic when its second fundamental form is a scalar multiple of its first.
+The second form uses the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
 def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
-  ∃ c : ℝ, mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) n p = c • mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+  EuclideanHypersurface.IsUmbilicByFundamentalForms
+    (sphereAmbientMfderiv F p) (sphereAmbientMfderiv n p)
 
 /-- Carathéodory's conjecture for convex surfaces with a `C^k` Gauss parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
@@ -74,7 +82,7 @@ Every smoothly embedded two-sphere which bounds a convex body has at least two d
 umbilic points. Alpöge's smooth support function has exactly one umbilic, so the answer is
 false. -/
 @[category research solved, AMS 52 53,
-  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/a4677e237082ea8740b8a47d8f5f0086628b11d4/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/c6d9126429cbcf0ae251191f932a6b7aa3e0276a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
 theorem caratheodory_conjecture : answer(False) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -1,0 +1,96 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Other.LoewnerConjecture
+
+/-!
+# Carathéodory's conjecture
+
+Carathéodory's conjecture says that every sufficiently smooth closed convex surface in
+three-dimensional Euclidean space has at least two umbilic points. We state the conjecture for
+smooth surfaces and the classical positive result for real-analytic surfaces. We also record
+that Loewner's local index conjecture implies Carathéodory's global conjecture.
+
+*References:*
+- [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problems 8.1 and
+  8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
+- [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
+  umbilic points*](https://doi.org/10.1007/BF02392036)
+-/
+
+open Set Metric
+open scoped ContDiff EuclideanGeometry Manifold
+
+namespace CaratheodoryConjecture
+
+/-- A parametrized convex surface of class `C^k`, together with a `C^k` choice of unit normal.
+
+The range condition says that the parametrization is the boundary of a convex body. Requiring
+nonempty interior rules out lower-dimensional convex sets. -/
+def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
+  Manifold.IsSmoothEmbedding (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k n ∧
+    (∀ p, ‖n p‖ = 1) ∧
+    (∀ p v, inner ℝ (n p) (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0) ∧
+    ∃ K : Set ℝ³,
+      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
+
+/-- A smooth parametrized convex surface with a smooth choice of unit normal. -/
+abbrev IsSmoothConvexSphere := IsConvexSphereOfClass ∞
+
+/-- A real-analytic parametrized convex surface with a real-analytic choice of unit normal. -/
+abbrev IsAnalyticConvexSphere := IsConvexSphereOfClass ω
+
+/-- A point is umbilic when the derivative of the unit normal is a scalar multiple of the
+derivative of the immersion, equivalently when its shape operator is scalar. -/
+def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
+  ∃ c : ℝ, mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) n p = c • mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
+/-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
+def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
+  ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
+    ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
+
+/-- The smooth Carathéodory conjecture. -/
+abbrev SmoothCaratheodoryConjecture := CaratheodoryConjectureOfClass ∞
+
+/-- The real-analytic Carathéodory conjecture. -/
+abbrev AnalyticCaratheodoryConjecture := CaratheodoryConjectureOfClass ω
+
+/-- **The smooth Carathéodory conjecture.**
+
+Every smoothly embedded two-sphere which bounds a convex body has at least two distinct
+umbilic points. -/
+@[category research open, AMS 52 53]
+theorem caratheodory_conjecture : answer(sorry) ↔ SmoothCaratheodoryConjecture := by
+  sorry
+
+/-- **The real-analytic Carathéodory conjecture.**
+
+Every real-analytically embedded two-sphere which bounds a convex body has at least two distinct
+umbilic points. This is the classical theorem of Hamburger. -/
+@[category research solved, AMS 52 53]
+theorem caratheodory_conjecture_analytic : AnalyticCaratheodoryConjecture := by
+  sorry
+
+/-- The smooth Loewner conjecture implies the smooth Carathéodory conjecture by the
+Poincaré–Hopf index theorem for principal line fields. -/
+@[category research solved, AMS 52 53 57]
+theorem loewner_implies_caratheodory :
+    LoewnerConjecture.SmoothLoewnerConjecture → SmoothCaratheodoryConjecture := by
+  sorry
+
+end CaratheodoryConjecture

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -82,7 +82,7 @@ Every smoothly embedded two-sphere which bounds a convex body has at least two d
 umbilic points. Alpöge's smooth support function has exactly one umbilic, so the answer is
 false. -/
 @[category research solved, AMS 52 53,
-  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/c6d9126429cbcf0ae251191f932a6b7aa3e0276a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/7aa855bb344450777d9b19fe1cf11f2f5f9fae09/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
 theorem caratheodory_conjecture : answer(False) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -56,16 +56,14 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A point is umbilic when its second fundamental form is a scalar multiple of its first.
-The second form uses the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
-def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
-  EuclideanHypersurface.IsUmbilicByFundamentalForms
-    (sphereAmbientMfderiv F p) (sphereAmbientMfderiv n p)
-
 /-- Carathéodory's conjecture for convex surfaces of class `C^k`. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
-    ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
+    ∃ p₁ p₂, p₁ ≠ p₂ ∧
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p₁) (sphereAmbientMfderiv n p₁) ∧
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p₂) (sphereAmbientMfderiv n p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -65,16 +65,14 @@ def IsConvexSphereOfClass (k : WithTop ℕ∞) (F n : sphere (0 : ℝ³) 1 → �
     ∃ K : Set ℝ³,
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧ range F = frontier K
 
-/-- A point is umbilic when its second fundamental form is a scalar multiple of its first.
-The second form uses the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
-def IsUmbilic (F n : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : Prop :=
-  EuclideanHypersurface.IsUmbilicByFundamentalForms
-    (sphereAmbientMfderiv F p) (sphereAmbientMfderiv n p)
-
 /-- Carathéodory's conjecture for convex surfaces with a `C^k` Gauss parametrization. -/
 def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (F n : sphere (0 : ℝ³) 1 → ℝ³), IsConvexSphereOfClass k F n →
-    ∃ p₁ p₂, p₁ ≠ p₂ ∧ IsUmbilic F n p₁ ∧ IsUmbilic F n p₂
+    ∃ p₁ p₂, p₁ ≠ p₂ ∧
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p₁) (sphereAmbientMfderiv n p₁) ∧
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p₂) (sphereAmbientMfderiv n p₂)
 
 /-- **The smooth Carathéodory conjecture.**
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -38,19 +38,19 @@ open scoped ContDiff EuclideanGeometry Manifold
 
 namespace CaratheodoryConjecture
 
-/-- A parametrized convex surface whose canonical normal is of class `C^k`.
+/-- A parametrized convex surface of class `C^(k + 1)`, whose canonical normal is of class
+`C^k`.
 
 The canonical normal is constructed from the derivative of `F` by a globally
 orientation-corrected cross product. Its orthogonality is built into the construction, while the
-injective differential makes it a unit vector. For finite `k`, requiring this normal to be `C^k`
-is stronger than requiring only `F` to be `C^k`. The range condition identifies the surface with
-the boundary of a compact convex body with nonempty interior. -/
+injective differential makes it a unit vector. Its `C^k` regularity follows from the `C^(k + 1)`
+regularity of `F`. The range condition identifies the surface with the boundary of a compact
+convex body with nonempty interior. -/
 def IsConvexSphereOfClass (k : WithTop ℕ∞) (F : sphere (0 : ℝ³) 1 → ℝ³) : Prop :=
-  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k F ∧
+  ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (k + 1) F ∧
     Topology.IsEmbedding F ∧
     (∀ p, Function.Injective
       (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) ∧
-    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) k (EuclideanHypersurface.sphereNormal F) ∧
     ∃ K : ConvexBody ℝ³,
       (interior (K : Set ℝ³)).Nonempty ∧ range F = frontier (K : Set ℝ³)
 

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -22,14 +22,17 @@ import FormalConjecturesUtil
 # Carathéodory's conjecture
 
 Carathéodory's conjecture says that every sufficiently smooth closed convex surface in
-three-dimensional Euclidean space has at least two umbilic points. We record smooth and
-real-analytic versions and the implication from Loewner's local index conjecture.
+three-dimensional Euclidean space has at least two umbilic points. We state the now-disproved
+smooth version and the classical positive result for real-analytic surfaces. We also record that
+Loewner's local index conjecture implies Carathéodory's global conjecture. Levent Alpöge announced
+the smooth counterexample on 19 August 2026.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problems 8.1 and
   8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
 - [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
   umbilic points*](https://doi.org/10.1007/BF02392036)
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
 -/
 
 open Set Metric
@@ -72,9 +75,11 @@ def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
 /-- **The smooth Carathéodory conjecture.**
 
 Every smoothly embedded two-sphere which bounds a convex body has at least two distinct
-umbilic points. -/
-@[category research open, AMS 52 53]
-theorem caratheodory_conjecture : answer(sorry) ↔ CaratheodoryConjectureOfClass ∞ := by
+umbilic points. Alpöge's smooth support function has exactly one umbilic, so the answer is
+false. -/
+@[category research solved, AMS 52 53,
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/c0591a2d3c3c8fca852865c8ceecfe4dfb083d10/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L74"]
+theorem caratheodory_conjecture : answer(False) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Carathéodory conjecture.**

--- a/FormalConjectures/Other/CaratheodoryConjecture.lean
+++ b/FormalConjectures/Other/CaratheodoryConjecture.lean
@@ -21,15 +21,17 @@ import FormalConjectures.Other.LoewnerConjecture
 # Carathéodory's conjecture
 
 Carathéodory's conjecture says that every sufficiently smooth closed convex surface in
-three-dimensional Euclidean space has at least two umbilic points. We state the conjecture for
-smooth surfaces and the classical positive result for real-analytic surfaces. We also record
-that Loewner's local index conjecture implies Carathéodory's global conjecture.
+three-dimensional Euclidean space has at least two umbilic points. We state the now-disproved
+smooth version and the classical positive result for real-analytic surfaces. We also record that
+Loewner's local index conjecture implies Carathéodory's global conjecture. Levent Alpöge announced
+the smooth counterexample on 19 August 2026.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problems 8.1 and
   8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
 - [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
   umbilic points*](https://doi.org/10.1007/BF02392036)
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
 -/
 
 open Set Metric
@@ -69,9 +71,11 @@ def CaratheodoryConjectureOfClass (k : WithTop ℕ∞) : Prop :=
 /-- **The smooth Carathéodory conjecture.**
 
 Every smoothly embedded two-sphere which bounds a convex body has at least two distinct
-umbilic points. -/
-@[category research open, AMS 52 53]
-theorem caratheodory_conjecture : answer(sorry) ↔ CaratheodoryConjectureOfClass ∞ := by
+umbilic points. Alpöge's smooth support function has exactly one umbilic, so the answer is
+false. -/
+@[category research solved, AMS 52 53,
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/150d2159bd37294ac7ad45c4ae7f199fb7dcd871/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L75"]
+theorem caratheodory_conjecture : answer(False) ↔ CaratheodoryConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Carathéodory conjecture.**

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Other.CaratheodoryLoewner
+import FormalConjectures.Other.CaratheodoryConjecture
 
 /-!
 # The announced smooth counterexamples to the Carathéodory and Loewner conjectures
@@ -34,7 +34,9 @@ informal proof motivating the statements below.
 open scoped ContDiff EuclideanGeometry Manifold
 open Set Metric
 
-namespace CaratheodoryLoewner
+namespace CaratheodoryLoewnerCounterexample
+
+open CaratheodoryConjecture LoewnerConjecture
 
 /-- The periodic real-valued function used in the announced counterexample. -/
 noncomputable def counterexampleSeed (z : ℂ) : ℝ :=
@@ -131,4 +133,4 @@ theorem counterexample_two_is_support_function_with_unique_umbilic :
       ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
   sorry
 
-end CaratheodoryLoewner
+end CaratheodoryLoewnerCounterexample

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
@@ -61,12 +61,11 @@ theorem not_caratheodoryConjectureOfClass_of_le_infty (k : WithTop ℕ∞) (hk :
   intro h
   rcases counterexample_two_is_support_function_with_unique_umbilic with
     ⟨_, F, _, _, _, hsurface, _, _, _, _, _, humbilic, hunique⟩
-  rcases hsurface with ⟨hFsmooth, hFembedding, hFinjective, hnsmooth, hnnorm,
-    hnormal, K, hKconvex, hKcompact, hKinterior, hFrange⟩
-  have hsurfaceOfClass : IsConvexSphereOfClass k F (fun p ↦ (p : ℝ³)) :=
-    ⟨hFsmooth.of_le hk, hFembedding, hFinjective, hnsmooth.of_le hk, hnnorm,
-      hnormal, K, hKconvex, hKcompact, hKinterior, hFrange⟩
-  rcases h F (fun p ↦ (p : ℝ³)) hsurfaceOfClass with
+  rcases hsurface with ⟨hFsmooth, hFembedding, hFinjective, K, hKinterior, hFrange⟩
+  have hsurfaceOfClass : IsConvexSphereOfClass k F :=
+    ⟨hFsmooth.of_le (add_le_add hk le_rfl), hFembedding, hFinjective,
+      K, hKinterior, hFrange⟩
+  rcases h F hsurfaceOfClass with
     ⟨p₁, p₂, hpne, hp₁, hp₂⟩
   exact hpne ((hunique p₁ hp₁).trans (hunique p₂ hp₂).symm)
 

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
@@ -126,7 +126,7 @@ theorem counterexample_two_is_support_function_with_unique_umbilic :
     ∃ (h : sphere (0 : ℝ³) 1 → ℝ) (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
       ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h ∧
       (∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) ∧
-      IsSmoothConvexSphere F (fun p ↦ (p : ℝ³)) ∧
+      IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
       IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
@@ -19,15 +19,20 @@ import FormalConjectures.Other.CaratheodoryLoewner
 /-!
 # The announced smooth counterexamples to the Carathéodory and Loewner conjectures
 
-This file begins the formalisation of the explicit family from the recent announcement quoted
-in the issue or pull request associated with this file. It records the planar formula and states
-its smoothness and index properties. The global interpretation of `counterexample 2` as a support
-function on the two-sphere is left for a subsequent step.
+This file formalises the explicit family announced by Levent Alpöge on 19 August 2026; the
+announcement credits John-Paul Smith and Claude with checking the construction. It records the
+planar formula and states its smoothness and index properties. The global interpretation of
+`counterexample 2` as a support function on the two-sphere is developed from the same formula.
 
-The exact public URL, author, and date of the announcement should be added here before submission.
+The accompanying file `CaratheodoryLoewnerCounterexample.md` gives a formalisation-oriented
+informal proof motivating the statements below.
+
+*Reference:*
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
 -/
 
-open scoped ContDiff
+open scoped ContDiff EuclideanGeometry Manifold
+open Set Metric
 
 namespace CaratheodoryLoewner
 
@@ -46,10 +51,10 @@ noncomputable def counterexample (k : ℕ) (z : ℂ) : ℝ :=
   r ^ 2 * Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) *
       counterexampleSeed w / (1 + r ^ 2) + 10 ^ 10
 
-/-- Each member of the announced family is smooth on the whole complex plane, including at the
-origin. The flat exponential factor is essential at the origin. -/
+/-- Each positive member of the announced family is smooth on the whole complex plane, including
+at the origin. The flat exponential factor is essential at the origin. -/
 @[category research solved, AMS 26 53]
-theorem counterexample_contDiff (k : ℕ) : ContDiff ℝ ∞ (counterexample k) := by
+theorem counterexample_contDiff (k : ℕ) (hk : 0 < k) : ContDiff ℝ ∞ (counterexample k) := by
   sorry
 
 /-- For positive `k`, the origin is an isolated umbilic of principal-line index `1 + k / 2`.
@@ -66,5 +71,64 @@ conjecture. -/
 theorem counterexample_not_loewner_bound (k : ℕ) (hk : 0 < k) :
     ¬ ((2 + k : ℕ) : ℤ) ≤ 2 := by
   omega
+
+/- ## The global counterexample on the sphere -/
+
+/-- The north pole used to fix the stereographic chart for the global counterexample. -/
+noncomputable def counterexampleNorthPole : sphere (0 : ℝ³) 1 :=
+  ⟨EuclideanSpace.single (2 : Fin 3) 1, by
+    rw [mem_sphere, dist_zero_right]
+    simp⟩
+
+/-- The inverse stereographic chart in which the formula `counterexample 2` is written.
+
+Mathlib's stereographic coordinate has a conventional factor of two. Scaling its target
+coordinate by two makes the pullback of the round metric equal to
+`4 / (1 + ‖z‖ ^ 2) ^ 2` times the Euclidean metric, as in the accompanying proof. -/
+noncomputable def counterexampleSphereChart (z : ℂ) : sphere (0 : ℝ³) 1 :=
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨finrank_euclideanSpace_fin⟩
+  (stereographic' 2 counterexampleNorthPole).symm
+    (2 • Complex.orthonormalBasisOneI.repr z)
+
+/-- The origin of the planar chart represents the south pole. This test fixes the scale and sign
+convention in `counterexampleSphereChart`. -/
+@[category test, AMS 53]
+theorem counterexampleSphereChart_zero :
+    counterexampleSphereChart 0 = -counterexampleNorthPole := by
+  apply Subtype.ext
+  simp [counterexampleSphereChart, stereographic'_symm_apply]
+
+/-- `F` parametrizes the supporting point of `K` with outer unit normal `p`, and `h p` is
+the corresponding support value.
+
+The final inequality says that the hyperplane through `F p` perpendicular to `p` supports
+the whole body. Requiring `F p ∈ K` makes the supremum attained and avoids conventions for
+`sSup ∅`. -/
+def IsSupportParametrization (h : sphere (0 : ℝ³) 1 → ℝ)
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³) : Prop :=
+  ∀ p, F p ∈ K ∧ inner ℝ (F p) (p : ℝ³) = h p ∧
+    ∀ x ∈ K, inner ℝ x (p : ℝ³) ≤ h p
+
+/-- **Alpöge's smooth Carathéodory counterexample.**
+
+The function `counterexample 2` extends across the omitted north pole to a smooth function `h`
+on the round two-sphere. It is the support function of a convex body `K`; `F` is its smooth
+Gauss parametrization with outward normal `p`. The corresponding convex surface has exactly one
+umbilic, at the point represented by `z = 0`.
+
+The explicit compactness and nonempty-interior conditions rule out unbounded and
+lower-dimensional convex sets. The range equality ensures that `F` parametrizes the boundary
+of the same body whose support function is `h`. -/
+@[category research solved, AMS 52 53]
+theorem counterexample_two_is_support_function_with_unique_umbilic :
+    ∃ (h : sphere (0 : ℝ³) 1 → ℝ) (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
+      ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h ∧
+      (∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) ∧
+      IsSmoothConvexSphere F (fun p ↦ (p : ℝ³)) ∧
+      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
+      Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
+      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
+      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+  sorry
 
 end CaratheodoryLoewner

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
@@ -1,0 +1,70 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Other.CaratheodoryLoewner
+
+/-!
+# The announced smooth counterexamples to the Carathéodory and Loewner conjectures
+
+This file begins the formalisation of the explicit family from the recent announcement quoted
+in the issue or pull request associated with this file. It records the planar formula and states
+its smoothness and index properties. The global interpretation of `counterexample 2` as a support
+function on the two-sphere is left for a subsequent step.
+
+The exact public URL, author, and date of the announcement should be added here before submission.
+-/
+
+open scoped ContDiff
+
+namespace CaratheodoryLoewner
+
+/-- The periodic real-valued function used in the announced counterexample. -/
+noncomputable def counterexampleSeed (z : ℂ) : ℝ :=
+  -Real.cos (2 * z.re) / 4 + 3 * Real.cos (2 * z.im) / 10 -
+    Real.cos (4 * z.im) / 32 + Real.sin z.re * Real.sin z.im
+
+/-- The announced family `g_k` of smooth functions on the complex plane.
+
+The use of the principal complex power chooses a square-root branch when `k` is odd. The seed is
+even, so the resulting real-valued expression is independent of the sign of that square root. -/
+noncomputable def counterexample (k : ℕ) (z : ℂ) : ℝ :=
+  let r := ‖z‖
+  let w := Complex.cpow (100 / star z) ((k : ℂ) / 2)
+  r ^ 2 * Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) *
+      counterexampleSeed w / (1 + r ^ 2) + 10 ^ 10
+
+/-- Each member of the announced family is smooth on the whole complex plane, including at the
+origin. The flat exponential factor is essential at the origin. -/
+@[category research solved, AMS 26 53]
+theorem counterexample_contDiff (k : ℕ) : ContDiff ℝ ∞ (counterexample k) := by
+  sorry
+
+/-- For positive `k`, the origin is an isolated umbilic of principal-line index `1 + k / 2`.
+
+`HasIsolatedZeroIndex` stores twice the principal-line index, hence the integer `2 + k` here. -/
+@[category research solved, AMS 26 53 57]
+theorem counterexample_hasIsolatedZeroIndex (k : ℕ) (hk : 0 < k) :
+    HasIsolatedZeroIndex (traceFreeHessian (counterexample k)) 0 (2 + k) := by
+  sorry
+
+/-- Every positive member with `k > 0` violates the index bound in the smooth Loewner
+conjecture. -/
+@[category research solved, AMS 53 57]
+theorem counterexample_not_loewner_bound (k : ℕ) (hk : 0 < k) :
+    ¬ ((2 + k : ℕ) : ℤ) ≤ 2 := by
+  omega
+
+end CaratheodoryLoewner

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean
@@ -14,123 +14,65 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import FormalConjectures.Other.CaratheodoryConjecture
+import FormalConjecturesUtil
+import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Global
 
 /-!
 # The announced smooth counterexamples to the Carathéodory and Loewner conjectures
 
-This file formalises the explicit family announced by Levent Alpöge on 19 August 2026; the
-announcement credits John-Paul Smith and Claude with checking the construction. It records the
-planar formula and states its smoothness and index properties. The global interpretation of
-`counterexample 2` as a support function on the two-sphere is developed from the same formula.
-
-The accompanying file `CaratheodoryLoewnerCounterexample.md` gives a formalisation-oriented
-informal proof motivating the statements below.
+This module collects the formalization of the explicit counterexample family announced by Levent
+Alpöge on 19 August 2026; the announcement credits John-Paul Smith and Claude with checking the
+construction. The accompanying file `CaratheodoryLoewnerCounterexample.md` gives the
+formalization-oriented informal proof.
 
 *Reference:*
 - [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
 -/
 
 open scoped ContDiff EuclideanGeometry Manifold
-open Set Metric
 
 namespace CaratheodoryLoewnerCounterexample
 
 open CaratheodoryConjecture LoewnerConjecture
 
-/-- The periodic real-valued function used in the announced counterexample. -/
-noncomputable def counterexampleSeed (z : ℂ) : ℝ :=
-  -Real.cos (2 * z.re) / 4 + 3 * Real.cos (2 * z.im) / 10 -
-    Real.cos (4 * z.im) / 32 + Real.sin z.re * Real.sin z.im
-
-/-- The announced family `g_k` of smooth functions on the complex plane.
-
-The use of the principal complex power chooses a square-root branch when `k` is odd. The seed is
-even, so the resulting real-valued expression is independent of the sign of that square root. -/
-noncomputable def counterexample (k : ℕ) (z : ℂ) : ℝ :=
-  let r := ‖z‖
-  let w := Complex.cpow (100 / star z) ((k : ℂ) / 2)
-  r ^ 2 * Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) *
-      counterexampleSeed w / (1 + r ^ 2) + 10 ^ 10
-
-/-- Each positive member of the announced family is smooth on the whole complex plane, including
-at the origin. The flat exponential factor is essential at the origin. -/
-@[category research solved, AMS 26 53]
-theorem counterexample_contDiff (k : ℕ) (hk : 0 < k) : ContDiff ℝ ∞ (counterexample k) := by
-  sorry
-
-/-- For positive `k`, the origin is an isolated umbilic of principal-line index `1 + k / 2`.
-
-`HasIsolatedZeroIndex` stores twice the principal-line index, hence the integer `2 + k` here. -/
-@[category research solved, AMS 26 53 57]
-theorem counterexample_hasIsolatedZeroIndex (k : ℕ) (hk : 0 < k) :
-    HasIsolatedZeroIndex (traceFreeHessian (counterexample k)) 0 (2 + k) := by
-  sorry
-
-/-- Every positive member with `k > 0` violates the index bound in the smooth Loewner
-conjecture. -/
+/-- Alpöge's family disproves every Loewner conjecture whose regularity is no stronger than
+smoothness: its member with `k = 1` has an isolated trace-free Hessian zero of winding number
+three. -/
 @[category research solved, AMS 53 57]
-theorem counterexample_not_loewner_bound (k : ℕ) (hk : 0 < k) :
-    ¬ ((2 + k : ℕ) : ℤ) ≤ 2 := by
+theorem not_loewnerConjectureOfClass_of_le_infty (k : WithTop ℕ∞) (hk : k ≤ ∞) :
+    ¬ LoewnerConjectureOfClass k := by
+  intro h
+  have hbound : (((2 + 1 : ℕ) : ℤ)) ≤ 2 :=
+    h (counterexample 1) 0 (((2 + 1 : ℕ) : ℤ))
+      ((counterexample_contDiff 1 (by omega)).contDiffAt.of_le hk)
+      (counterexample_hasIsolatedZeroIndex 1 (by omega))
   omega
 
-/- ## The global counterexample on the sphere -/
+/-- In particular, Alpöge's family disproves the smooth Loewner conjecture. -/
+@[category research solved, AMS 53 57]
+theorem not_loewnerConjectureOfClass_infty : ¬ LoewnerConjectureOfClass ∞ :=
+  not_loewnerConjectureOfClass_of_le_infty ∞ le_rfl
 
-/-- The north pole used to fix the stereographic chart for the global counterexample. -/
-noncomputable def counterexampleNorthPole : sphere (0 : ℝ³) 1 :=
-  ⟨EuclideanSpace.single (2 : Fin 3) 1, by
-    rw [mem_sphere, dist_zero_right]
-    simp⟩
-
-/-- The inverse stereographic chart in which the formula `counterexample 2` is written.
-
-Mathlib's stereographic coordinate has a conventional factor of two. Scaling its target
-coordinate by two makes the pullback of the round metric equal to
-`4 / (1 + ‖z‖ ^ 2) ^ 2` times the Euclidean metric, as in the accompanying proof. -/
-noncomputable def counterexampleSphereChart (z : ℂ) : sphere (0 : ℝ³) 1 :=
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨finrank_euclideanSpace_fin⟩
-  (stereographic' 2 counterexampleNorthPole).symm
-    (2 • Complex.orthonormalBasisOneI.repr z)
-
-/-- The origin of the planar chart represents the south pole. This test fixes the scale and sign
-convention in `counterexampleSphereChart`. -/
-@[category test, AMS 53]
-theorem counterexampleSphereChart_zero :
-    counterexampleSphereChart 0 = -counterexampleNorthPole := by
-  apply Subtype.ext
-  simp [counterexampleSphereChart, stereographic'_symm_apply]
-
-/-- `F` parametrizes the supporting point of `K` with outer unit normal `p`, and `h p` is
-the corresponding support value.
-
-The final inequality says that the hyperplane through `F p` perpendicular to `p` supports
-the whole body. Requiring `F p ∈ K` makes the supremum attained and avoids conventions for
-`sSup ∅`. -/
-def IsSupportParametrization (h : sphere (0 : ℝ³) 1 → ℝ)
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³) : Prop :=
-  ∀ p, F p ∈ K ∧ inner ℝ (F p) (p : ℝ³) = h p ∧
-    ∀ x ∈ K, inner ℝ x (p : ℝ³) ≤ h p
-
-/-- **Alpöge's smooth Carathéodory counterexample.**
-
-The function `counterexample 2` extends across the omitted north pole to a smooth function `h`
-on the round two-sphere. It is the support function of a convex body `K`; `F` is its smooth
-Gauss parametrization with outward normal `p`. The corresponding convex surface has exactly one
-umbilic, at the point represented by `z = 0`.
-
-The explicit compactness and nonempty-interior conditions rule out unbounded and
-lower-dimensional convex sets. The range equality ensures that `F` parametrizes the boundary
-of the same body whose support function is `h`. -/
+/-- Alpöge's support function disproves every Carathéodory conjecture whose regularity is no
+stronger than smoothness: its convex sphere has exactly one umbilic point. -/
 @[category research solved, AMS 52 53]
-theorem counterexample_two_is_support_function_with_unique_umbilic :
-    ∃ (h : sphere (0 : ℝ³) 1 → ℝ) (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
-      ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h ∧
-      (∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) ∧
-      IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
-      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
-      Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
-      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
-      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
-  sorry
+theorem not_caratheodoryConjectureOfClass_of_le_infty (k : WithTop ℕ∞) (hk : k ≤ ∞) :
+    ¬ CaratheodoryConjectureOfClass k := by
+  intro h
+  rcases counterexample_two_is_support_function_with_unique_umbilic with
+    ⟨_, F, _, _, _, hsurface, _, _, _, _, _, humbilic, hunique⟩
+  rcases hsurface with ⟨hFsmooth, hFembedding, hFinjective, hnsmooth, hnnorm,
+    hnormal, K, hKconvex, hKcompact, hKinterior, hFrange⟩
+  have hsurfaceOfClass : IsConvexSphereOfClass k F (fun p ↦ (p : ℝ³)) :=
+    ⟨hFsmooth.of_le hk, hFembedding, hFinjective, hnsmooth.of_le hk, hnnorm,
+      hnormal, K, hKconvex, hKcompact, hKinterior, hFrange⟩
+  rcases h F (fun p ↦ (p : ℝ³)) hsurfaceOfClass with
+    ⟨p₁, p₂, hpne, hp₁, hp₂⟩
+  exact hpne ((hunique p₁ hp₁).trans (hunique p₂ hp₂).symm)
+
+/-- In particular, Alpöge's support function disproves the smooth Carathéodory conjecture. -/
+@[category research solved, AMS 52 53]
+theorem not_caratheodoryConjectureOfClass_infty : ¬ CaratheodoryConjectureOfClass ∞ :=
+  not_caratheodoryConjectureOfClass_of_le_infty ∞ le_rfl
 
 end CaratheodoryLoewnerCounterexample

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
@@ -65,13 +65,43 @@ It vanishes exactly when the trace-free spherical Hessian vanishes. Its winding 
 the index of the corresponding principal line field. Multiplication of (3) by a positive scalar
 does not affect its zeros or winding number.
 
+There are two normalizations to keep separate in the Lean development. The repository's
+`traceFreeHessian` is \(q_{\mathrm E}=4u_{\bar z\bar z}\). In a chart whose metric is
+
+\[
+ ds^2=\lambda^2|dw|^2,
+\]
+
+the Lean expression called `sphericalTraceFreeHessian` is
+
+\[
+ q_{\mathrm E}(u)+8\frac{w}{D}u_{\bar w}=4Q_w(u),                       \tag{3a}
+\]
+
+where \(D=1+|w|^2\) in the original chart and \(D=10000+|w|^2\) in the
+reciprocal chart. The anti-linear coefficient of the metric-raised trace-free Hessian is
+
+\[
+ 2\lambda^{-2}Q_w(u)=\frac{\lambda^{-2}}2
+   \operatorname{sphericalTFH}(u).                                      \tag{3b}
+\]
+
+In the reciprocal chart, where \(\lambda^2=40000/D^2\), this coefficient is exactly
+
+\[
+ \frac{D^2}{80000}\operatorname{sphericalTFH}(u).                       \tag{3c}
+\]
+
+Thus the \(Q\)-normalization is convenient for the estimates below, while (3a)--(3c) give the
+literal constants needed to translate them to the current Lean definitions.
+
 We prove the following more explicit result.
 
 **Theorem.**
 
 1. Every \(g_k\) is \(C^\infty\) at the origin.
-2. If \(k>0\), the origin is an isolated zero of both the Euclidean operator (2) and the
-   spherical operator (3), and both have winding number \(k+2\) there.
+2. If \(k>0\), the origin is an isolated zero of the Euclidean operator (2), with winding
+   number \(k+2\) there.
 3. The function \(g_2\) extends smoothly to \(S^2\).
 4. The spherical operator (3) for \(g_2\) has no zero away from the origin.
 5. The tensor \(\nabla^2 g_2+g_2g_{S^2}\) is positive definite. Consequently \(g_2\) is the
@@ -166,12 +196,22 @@ They follow term by term from \(|\sin|,|\cos|\le1\). For example,
 \(|f_x|\le3/2\), \(|f_y|\le69/40\), and
 \(|f_{\bar w}|\le(|f_x|+|f_y|)/2=129/80\).
 
-Finally, \(f(-w)=f(w)\). Differentiating twice gives
-\(f_{ww}(-w)=f_{ww}(w)\). Because \(f_{ww}\) is nonzero on the simply connected plane, it
+Finally, \(f(-w)=f(w)\). Since \(f\) is real valued,
+\(f_{ww}=\overline{f_{\bar w\bar w}}\), so (6) also gives
+
+\[
+ |f_{ww}|\ge \frac7{200}.
+\]
+
+Differentiating the evenness twice gives \(f_{ww}(-w)=f_{ww}(w)\). Because \(f_{ww}\) is
+nonzero on the simply connected plane, it
 has a continuous argument. The evenness forces that argument to be even as well: the possible
 difference between the arguments at \(w\) and \(-w\) is a constant multiple of \(2\pi\), and it
 is zero at \(w=0\). Consequently the image under \(f_{ww}\) of any closed curve has winding
-number zero. This observation handles the half-integral powers occurring for odd \(k\).
+number zero. More particularly, when \(k\) is odd the continuously chosen branch path
+\(w(\theta)\) runs from \(w(0)\) to \(-w(0)\); the even argument has equal endpoint values, so
+its total argument change is still zero. This observation handles the half-integral powers
+occurring for odd \(k\).
 
 ## 3. A reusable exponential domination lemma
 
@@ -229,9 +269,9 @@ We also need a quantitative, global version later. If \(a,b>0\), then
  \sup_{y>0}y^a e^{-by}=\left(\frac{a}{be}\right)^a.                    \tag{10}
 \]
 
-This follows by differentiating \(a\log y-by\). In Lean it should be a standalone lemma for
-`Real.rpow`; all numerical estimates below are rational consequences of (10) and
-\(e>8/3\).
+This follows by differentiating \(a\log y-by\). The development proves the required
+`Real.rpow` inequalities locally in `Global.lean`, since only this numerical certificate uses
+them; all numerical estimates below are rational consequences of (10) and \(e>8/3\).
 
 ## 4. Smoothness of the planar family
 
@@ -273,7 +313,7 @@ expressions agree under \(w\mapsto-w\), the sectorwise smooth extensions glue.
 Work again on a branch sector. The most singular term in two \(\bar z\)-derivatives is
 
 \[
- A(r) f_{ww}(w(z))\,w_{\bar z}(z)^2.                                   \tag{12}
+ L_k(z):=A(r) f_{ww}(w(z))\,w_{\bar z}(z)^2.                            \tag{12}
 \]
 
 Since
@@ -284,29 +324,91 @@ Since
 
 the argument contributed by \(w_{\bar z}^2\) on \(z=re^{i\theta}\) is
 \((k+2)\theta\), up to a constant. The factor \(A(r)\) is positive, and the factor
-\(f_{ww}(w)\) has winding zero by Section 2.
+\(f_{ww}(w)\) has winding zero by Section 2. Changing an odd-\(k\) branch sends both
+\(w\) and \(w_{\bar z}\) to their negatives; evenness of \(f_{ww}\) and the square on
+\(w_{\bar z}\) therefore make \(L_k\) a single-valued function.
 
-All other terms are smaller uniformly on the circle as \(r\to0\). More explicitly, relative
-to (12):
+We now make the domination uniform on one punctured disc. On every branch,
+
+\[
+\begin{aligned}
+ (Af(w))_{\bar z\bar z}
+  &=L_k
+    +A f_w(w)w_{\bar z\bar z}
+    +2A_{\bar z}f_w(w)w_{\bar z}
+    +A_{\bar z\bar z}f(w).                                             \tag{12a}
+\end{aligned}
+\]
+
+For \(0<r\le r_0\), direct differentiation of \(\log A\) gives constants
+\(C_1,C_2>0\), independent of the angle, such that
+
+\[
+ \frac{|A_{\bar z}|}{A}\le C_1r^{-5/4},\qquad
+ \frac{|A_{\bar z\bar z}|}{A}\le C_2r^{-5/2}.                          \tag{12b}
+\]
+
+Also
+
+\[
+\begin{aligned}
+ |w|&=100^{k/2}r^{-k/2},\\
+ |w_{\bar z}|&=\frac{k}{2}\frac{|w|}{r},\\
+ |w_{\bar z\bar z}|&=\frac{k}{2}\left(\frac{k}{2}+1\right)
+                       \frac{|w|}{r^2}.                               \tag{12c}
+\end{aligned}
+\]
+
+Using (6)--(7), (12b), and (12c), there are constants \(C_{j,k}\) such that the
+ratios to \(|L_k|\) have the following uniform asymptotic orders:
 
 \[
 \begin{array}{c|c}
-\text{source of an error term}&\text{upper bound for the relative size}\\ \hline
-w_{\bar z\bar z}f_w&r^{k/2}\\
-(A_{\bar z}/A)w_{\bar z}f_w&r^{k/2-1/4}\\
-(A_{\bar z\bar z}/A)f&r^{k-1/2}\\
-\dfrac{2z}{1+r^2}(A f(w))_{\bar z}&r^{k/2+2}.
+\text{source of an error term}&\text{relative norm}\\ \hline
+A f_w w_{\bar z\bar z}
+  &\dfrac{|A f_w w_{\bar z\bar z}|}{|L_k|}\le C_{1,k}r^{k/2}\\
+2A_{\bar z}f_w w_{\bar z}
+  &\dfrac{|2A_{\bar z}f_w w_{\bar z}|}{|L_k|}\le C_{2,k}r^{k/2-1/4}\\
+A_{\bar z\bar z}f
+  &\dfrac{|A_{\bar z\bar z}f|}{|L_k|}\le C_{3,k}r^{k-1/2}.
 \end{array}                                                            \tag{13}
 \]
 
-The bounded derivatives in the numerators and the lower bound (6) make the estimates uniform.
-Every exponent in (13) is positive when \(k\ge1\). Therefore, on all sufficiently small
-circles, the full Euclidean operator (2), and also the spherical operator (3), are joined to
-(12) by the straight-line homotopy without crossing zero. Their winding number is thus
-\(k+2\), and the principal-line index is \(1+k/2\). This proves part 2.
+The factors \(100^{k/2}\), \(k/2\), and the bounds in (7) are absorbed only in the constants
+\(C_{j,k}\), not in the powers of \(r\). This is the literal meaning of the often-used shorthand
+\(O_k(r^\alpha)\) here. Put
 
-The same domination on a punctured disc shows that the zero at the origin is isolated, rather
-than merely giving the winding on a selected sequence of circles.
+\[
+ \alpha_k=\min\left\{\frac k2,\frac k2-\frac14,k-\frac12\right\}>0.
+\]
+
+After shrinking \(r_0\) to at most one and taking \(C_k\) to be the sum of the three constants,
+the normalized Euclidean error is bounded by \(C_kr^{\alpha_k}|L_k|\):
+
+\[
+ \left|\frac14q_{\mathrm E}(g_k)-L_k\right|
+   \le C_kr^{\alpha_k}|L_k|.                                           \tag{13a}
+\]
+
+Here \(L_k(z)\ne0\) on the punctured plane: \(A(r)>0\), (6) gives
+\(|f_{ww}|\ge7/200\), and \(w_{\bar z}\ne0\) for \(k>0\).
+The factor \(1/4\) is essential: the Euclidean operator (2) has leading term \(4L_k\).
+Choose one \(\delta_k\in(0,r_0)\) with \(C_k\delta_k^{\alpha_k}<1\). Then (13a) holds with
+strict error smaller than the leading norm for every \(0<|z|<\delta_k\), not only on a
+sequence of circles. The straight-line homotopy from \(\frac14q_{\mathrm E}(g_k)\) to \(L_k\)
+therefore never meets zero on any circle of radius \(r<\delta_k\). It also proves nonvanishing
+throughout the punctured disc, so the zero at the origin is isolated.
+
+For completeness, choose a continuous branch \(w_r(\theta)\) on \(0\le\theta\le2\pi\).
+The even continuous argument of \(f_{ww}\) from Section 2 has equal values at the two endpoints,
+even when odd \(k\) makes \(w_r(2\pi)=-w_r(0)\). The remaining nonconstant phase of \(L_k\) is
+the phase of \(w_{\bar z}^2\), so a lift of its normalized argument changes by
+\(2\pi(k+2)\). Extend this lift to all \(\theta\in\mathbb R\) by adding
+\(2\pi(k+2)\) on each period. The normalized straight-line homotopy lifts through the
+exponential covering, and its endpoint difference is constant during the homotopy. The
+Euclidean trace-free Hessian therefore has winding number \(k+2\), and the principal-line index is
+\(1+k/2\). This proves part 2. The spherical calculation needed for the global counterexample
+is carried out separately for \(k=2\) in Sections 6--8.
 
 ## 6. The second chart for \(g_2\)
 
@@ -364,6 +466,13 @@ cancel the Christoffel term exactly, leaving
 \]
 
 This cancellation is the reason for the factor \(|z|^2/(1+|z|^2)\) in (1).
+Multiplying (18) by four gives exactly the normalization used in Lean:
+
+\[
+ \frac{\operatorname{sphericalTFH}(Bf)}B
+ =q_{\mathrm E}(f)-8wp\,\operatorname{complexBarDeriv}(f)
+      +4w^2(p^2-p')f.                                                   \tag{18a}
+\]
 
 It remains to bound the last two terms in (18). Put \(x=s/10000\) and
 \(\phi(x)=x^{1/8}e^{-1/x}\), so that \(\psi(s)=\phi(x)\). Direct differentiation gives
@@ -412,9 +521,20 @@ Combining (6), (7), (18), and (20),
 \end{aligned}
 \]
 
-Since \(B>0\), (21) proves that \(Q_w(h_0)\ne0\) at every finite \(w\). Finite \(w\)
-parametrizes the entire sphere except the point \(z=0\). At that remaining point, Section 4
-shows that \(h_0\) is flat, hence umbilic. This proves part 4: it is the unique umbilic.
+The derivation through \(y=1/x\) applies when \(w\ne0\). At \(w=0\), the smooth extension of
+\(\psi\) is flat, so \(p(0)=p'(0)=0\), while \(B(0)=1\). Formula (18), evaluated using these
+extended derivatives, reduces to
+
+\[
+ Q_0(Bf)=f_{\bar w\bar w}(0)\ne0
+\]
+
+by (6). Thus, since \(B>0\), (21) and this separate origin calculation prove that
+\(Q_w(h_0)\ne0\) at every finite reciprocal coordinate \(w\). Finite \(w\) parametrizes the
+entire sphere except the point \(z=0\) of the original chart. At that remaining point, Section 4
+shows that the nonconstant part is flat, so its spherical trace-free Hessian vanishes. This proves
+part 4 at the level of the spherical Hessian; Section 8 identifies this condition with the
+repository's surface-level IsUmbilic predicate.
 
 ## 8. Convexity and the constant \(10^{10}\)
 
@@ -439,6 +559,9 @@ Here is a certificate for (23). In the \(w\)-chart put
       =2500(1+y^8)e^{-\psi}.                                            \tag{24}
 \]
 
+At \(y=0\), the expression \(y e^{-y^{-8}}\) in (24) means its continuous value zero; all
+subsequent uses of a negative power of \(y\) occur only in the case \(y>0\).
+
 - For \(0\le y\le2\), \(M(y)\le642500\).
 - For \(y\ge2\), the inequality \(e^{-y^{-8}}\ge1-y^{-8}\ge255/256\), followed by
   (10) and \(e>8/3\), gives
@@ -447,8 +570,9 @@ Here is a certificate for (23). In the \(w\)-chart put
       <2500(1+4^8)<1.64\cdot10^8.                                      \tag{25}
   \]
 
-Thus \(M<1.64\cdot10^8\) globally. Equation (18), the sharper upper bound
-\(|f_{\bar w\bar w}|\le47/40\) in (7), and (20) give the deliberately loose estimate
+Thus \(M<1.64\cdot10^8\) throughout the finite reciprocal chart. Equation (18), the sharper
+upper bound \(|f_{\bar w\bar w}|\le47/40\) in (7), and (20) give the deliberately loose
+estimate
 
 \[
  \frac{|Q_w(h_0)|}{B}
@@ -456,9 +580,16 @@ Thus \(M<1.64\cdot10^8\) globally. Equation (18), the sharper upper bound
  \qquad\text{hence}\qquad |Q_w(h_0)|\le5B.                              \tag{26}
 \]
 
-The operator norm of the trace-free spherical Hessian is
-\(2\lambda^{-2}|Q_w(h_0)|\), so (25)–(26) bound it by
-\(1.64\cdot10^9\).
+The operator norm of the metric-raised trace-free spherical Hessian is
+\(2\lambda^{-2}|Q_w(h_0)|\). Equivalently, (3a)--(3c) give
+
+\[
+ \frac{D^2}{80000}|\operatorname{sphericalTFH}(h_0)|
+ =\frac{D^2}{80000}|4Q_w(h_0)|
+ =2\lambda^{-2}|Q_w(h_0)|.
+\]
+
+Thus (25)--(26) bound it by \(1.64\cdot10^9\).
 
 For the trace, radial differentiation gives
 
@@ -495,7 +626,7 @@ Now (7), (20), (28), and \(s/D\le1\) give
 \end{aligned}
 \]
 
-The scalar part of the spherical Hessian has norm
+The scalar part of the metric-raised spherical Hessian has norm
 \(2\lambda^{-2}|(Bf)_{w\bar w}|<4M<6.56\cdot10^8\). Also \(B\le1\), so
 \(|h_0|\le253/160<2\). Consequently
 
@@ -506,7 +637,10 @@ The scalar part of the spherical Hessian has norm
  <3\cdot10^9,
 \]
 
-which proves (23).
+This proves (23) at every point represented by a finite reciprocal coordinate. That chart omits
+the south pole \(z=0\) of the original chart. There the nonconstant part \(h_0\), together with
+its first and second derivatives, vanishes by Section 4. Hence \(R_{h_0}=0\) at the omitted
+point, and (23) is genuinely global.
 
 Now set \(h=10^{10}+h_0\). Since the Hessian of a constant is zero,
 
@@ -517,48 +651,225 @@ Now set \(h=10^{10}+h_0\). Since the Hessian of a constant is zero,
 By (23), every eigenvalue of \(R_h\) is positive. In fact it is greater than
 \(7\cdot10^9\). Thus \(R_h\) is positive definite everywhere.
 
-The standard support-function construction is
+We also have the pointwise lower bound
 
 \[
- X_h(u)=h(u)u+\nabla h(u),\qquad u\in S^2.                              \tag{30}
+ h\ge 10^{10}-\frac{253}{160}>1,                                      \tag{29a}
 \]
 
-Its derivative on \(T_uS^2\) is \(R_h\), and its unit normal is \(u\). Positive definiteness
-of \(R_h\) implies that (30) is the Gauss parametrization of the boundary of the compact strictly
-convex body
+because \(0<B\le1\) in the reciprocal chart, and the same estimate follows directly from (1)
+in the original chart.
+
+We now give the global support-function argument rather than invoking it as a black box. Let
+\(H:\mathbb R^3\to\mathbb R\) be the degree-one radial extension
+
+\[
+ H(0)=0,\qquad H(x)=|x|h(x/|x|)\quad(x\ne0),
+\]
+
+and put
+
+\[
+ X_h(u)=\nabla H(u)=h(u)u+\nabla_{S^2}h(u),\qquad u\in S^2.             \tag{30}
+\]
+
+Euler's identity for the homogeneous function gives
+
+\[
+ \langle X_h(u),u\rangle=h(u).                                        \tag{31}
+\]
+
+After identifying \(T_uS^2\) with its tangent plane in \(\mathbb R^3\), and using the metric to
+identify it with its dual, the derivative of \(X_h\) is the raised radius operator
+
+\[
+ dX_h=R_h^\sharp:=g_{S^2}^{-1}R_h.                                    \tag{32}
+\]
+
+In particular, (23) makes \(dX_h\) injective and tangent to the sphere at \(u\); hence \(u\) is
+the chosen unit normal.
+
+It remains to prove the global supporting inequality. If \(u\ne v\) are not antipodal, the
+chord
+
+\[
+ \gamma(t)=(1-t)u+tv,\qquad 0\le t\le1,
+\]
+
+does not meet the origin. The Hessian of \(H\) has the radial direction as kernel and, on
+tangent directions at \(rp\), is \(r^{-1}R_h^\sharp\). The chord velocity \(v-u\) is never
+radial along this chord unless \(u\) and \(v\) are collinear. Positive definiteness of \(R_h\)
+therefore gives
+
+\[
+ \frac{d^2}{dt^2}H(\gamma(t))>0.
+\]
+
+Strict convexity on the chord and the derivative at \(t=0\) give
+
+\[
+ \langle X_h(u),v-u\rangle<h(v)-h(u),
+\]
+
+and (31) simplifies this to
+
+\[
+ \langle X_h(u),v\rangle<h(v).                                        \tag{33}
+\]
+
+If \(v=-u\), then instead
+
+\[
+ \langle X_h(u),v\rangle=-h(u)<h(-u)
+\]
+
+by (29a). Thus (33) holds for every pair \(u\ne v\), while equality holds for \(u=v\).
+Consequently, for every \(x\ne0\), with \(v=x/|x|\),
+
+\[
+ \langle X_h(u),x\rangle\le |x|h(v)=H(x),
+\]
+
+with equality at \(u=v\). Therefore \(H\) is the supremum of the linear functionals
+\(x\mapsto\langle X_h(u),x\rangle\), and in particular is convex.
+
+Define
 
 \[
  K_h=\{x\in\mathbb R^3:\langle x,u\rangle\le h(u)\text{ for every }u\in S^2\}.
 \]
 
-The shape operator is \(R_h^{-1}\). Therefore a point of this convex surface is umbilic exactly
-when the trace-free part of \(R_h\), equivalently the trace-free part of \(\nabla^2h\), vanishes.
-The constant \(10^{10}\) affects neither this trace-free tensor nor its zeros. Section 7 therefore
-shows that the surface has exactly one umbilic. This proves part 5 and the announced
-Carathéodory counterexample.
+This is an intersection of closed half-spaces, hence is closed and convex. Equation (29a) puts
+the open unit ball in its interior. It is bounded: if \(x\in K_h\) and \(x\ne0\), choosing
+\(u=x/|x|\) gives \(|x|\le h(u)\le\max_{S^2}h\). Thus \(K_h\) is compact and has nonempty
+interior. Equations (31) and (33) show that \(X_h(u)\in K_h\), with its unique contact
+hyperplane having outer normal \(u\).
+
+The range of \(X_h\) is exactly \(\partial K_h\). One inclusion follows because a point
+\(X_h(u)\) lies in \(K_h\) and on a supporting hyperplane, so it cannot be interior. Conversely,
+let \(x\in\partial K_h\). The finite-dimensional supporting-hyperplane theorem gives a unit
+normal \(u\) at \(x\). The defining inequality for \(K_h\), together with
+\(X_h(u)\in K_h\), forces
+
+\[
+ \langle x,u\rangle=h(u).
+\]
+
+Membership in \(K_h\) says that the linear function \(y\mapsto\langle x,y\rangle\) lies below
+the convex homogeneous function \(H\), with equality at \(u\). Since \(H\) is differentiable
+there, its supporting linear functional is unique, and hence \(x=\nabla H(u)=X_h(u)\).
+
+The strict inequality (33) also proves injectivity: if \(X_h(u)=X_h(v)\) for \(u\ne v\), then
+pairing with \(v\) contradicts (31). Since \(S^2\) is compact, the continuous injection \(X_h\)
+is a topological embedding; (32) makes it an immersion. It is therefore a smooth embedding onto
+\(\partial K_h\), with outer unit normal \(n(u)=u\). This supplies all the compactness,
+nonempty-interior, embedding, normal, and range conditions in IsConvexSphereOfClass. Moreover,
+the differentiability argument above makes the contact point for every supporting normal unique,
+so every supporting face is a singleton and \(K_h\) is strictly convex.
+
+We finish by spelling out the umbilic bridge. In a conformal complex chart
+\(\rho:\mathbb C\to S^2\), write \(u=h\circ\rho\). Relative to the chart differential
+\(d\rho\), (32) has the form
+
+\[
+ dX_h=d\rho\circ R_h^\sharp,\qquad dn=d\rho.
+\]
+
+The identity part \(h\,\mathrm{id}\) and the trace part of the Hessian are scalar. By (3b), the
+anti-linear coefficient of the remaining trace-free part is
+\(2\lambda^{-2}Q(u)\), or equivalently
+\(\lambda^{-2}\operatorname{sphericalTFH}(u)/2\). Thus \(R_h^\sharp\) is scalar exactly when
+\(Q(u)=0\). Since \(R_h^\sharp\) is positive and invertible,
+
+\[
+\begin{aligned}
+ \operatorname{IsUmbilic}(X_h,n,\rho(w))
+ &\Longleftrightarrow \exists c,\ dn=c\,dX_h\\
+ &\Longleftrightarrow \exists c,\ \mathrm{id}=cR_h^\sharp\\
+ &\Longleftrightarrow Q_w(u)=0.                                      \tag{34}
+\end{aligned}
+\]
+
+Equivalently, the shape operator is \((R_h^\sharp)^{-1}\), up to the conventional overall sign,
+and it is scalar precisely in (34). In the reciprocal chart, the exact anti-linear coefficient
+is the quantity \(D^2\operatorname{sphericalTFH}(u)/80000\) from (3c), whose prefactor never
+vanishes.
+
+Section 7 shows that this coefficient is nonzero at every finite reciprocal coordinate. At the
+one omitted point \(z=0\), the nonconstant part is flat, so the trace-free Hessian vanishes;
+there \(R_h=10^{10}g_{S^2}\), and the point is umbilic. Hence it is the unique umbilic. This
+proves part 5 and the announced Carathéodory counterexample.
 
 ## 9. Lean decomposition
 
-The Lean development should follow this dependency order.
+The files and declarations are arranged in the following dependency order. This list records the
+current implementation architecture rather than proposing a separate public Wirtinger API.
 
-1. **Wirtinger API.** Define first and second Wirtinger derivatives as real Fréchet derivatives,
-   and prove that `traceFreeHessian = 4 • wirtingerBar (wirtingerBar f)`.
-2. **Seed identities.** Prove (4), evenness, the bounds (7), and the three-case polynomial
-   certificate (6). These are finite `ring_nf`/`nlinarith` arguments after trigonometric bounds.
-3. **Flat functions.** Prove (8)–(10) in a reusable file under `FormalConjecturesForMathlib`.
-   This file must contain no `sorry`.
-4. **Branch-independent power.** Package `f ((100 / star z) ^ (k/2))` as a smooth function on
-   the punctured plane. For odd `k`, glue the two square-root branches using `f (-w) = f w`.
-5. **Smooth extension at zero.** Turn (11) into a general extension lemma and instantiate it.
-6. **Index.** Expand the Hessian, prove the relative estimates (13), and use homotopy invariance
-   of winding number to obtain `2 + k`.
-7. **Sphere charts.** Define the two chart representatives, prove their transition identity,
-   and derive the spherical operators (3) and (17).
-8. **Uniqueness.** Formalize (18)–(21). This part should use only differentiation, rational
-   inequalities, and the seed certificate.
-9. **Support functions.** Define (22) and (30), prove the support-function theorem, formalize
-   the numerical certificate (23), and conclude strict convexity and uniqueness of the umbilic.
+1. **Definitions.** `CaratheodoryLoewnerCounterexample/Defs.lean` contains
+   `counterexampleSeed`, `counterexample`, `counterexampleSphereChart`, and
+   `IsSupportParametrization`. These are the source-facing definitions; short one-use analytic
+   expressions remain local to the proof modules.
 
-The first four analytic estimates should be proved independently of the particular surface; this
-keeps the problem file short and leaves generally useful flatness and support-function API in
-`FormalConjecturesForMathlib`.
+2. **Reusable flatness.**
+   `FormalConjecturesForMathlib/Analysis/SpecialFunctions/FlatRpowExp.lean` defines
+   `Real.flatRpowExp` and proves its smoothness, zero Taylor series, and domination by arbitrary
+   real powers. The general extension lemmas
+   `ContDiff.at_zero_of_iteratedFDeriv_isLittleO` and
+   `ContDiff.isLittleO_norm_pow_of_iteratedFDeriv_zero` turn punctured estimates into smooth,
+   flat extensions. The elementary quantitative bounds corresponding to (10), which are used
+   only for this numerical certificate, remain private in `Global.lean`.
+
+3. **Planar smoothness.** `CaratheodoryLoewnerCounterexample/Smooth.lean` proves
+   `counterexampleSeed_contDiff`, glues the principal and alternate half-power branches using
+   `counterexampleSeed_cpow_eq_alt`, obtains the polynomial derivative estimates behind (11), and
+   concludes `counterexample_contDiff`. Its theorem `counterexample_fderiv_fderiv_zero` records
+   the exact second-derivative vanishing needed at the planar origin.
+
+4. **Seed and index calculation.** `CaratheodoryLoewnerCounterexample/Index.lean` keeps the
+   concrete first-Wirtinger and trace-free-Hessian expressions local as `seedWirtingerModel` and
+   `seedTraceFreeHessianModel`. It proves the public seed bounds
+   `counterexampleSeed_abs_le`, `counterexampleSeed_wirtinger_norm_upper`,
+   `counterexampleSeed_traceFreeHessian_norm_lower`, and
+   `counterexampleSeed_traceFreeHessian_norm_upper`. The identity
+   `traceFreeHessian_counterexampleSeed` connects the local model to the repository definition.
+   The three-case certificate for (6) is a finite ring-normalization and nonlinear-arithmetic
+   proof.
+
+5. **Dominant Hessian and winding.** The same `Index.lean` file defines local
+   `counterexampleHessianLeading` and `counterexampleHessianError` and proves
+   `counterexample_traceFreeHessian_decomposition`. Three positive powers tend to zero on the
+   punctured neighbourhood, giving one radius for both isolation and the normalized
+   straight-line homotopy. The covering-map lift preserves the endpoint argument change
+   \(2\pi(k+2)\), and `counterexample_hasIsolatedZeroIndex` stores the resulting integer
+   \(2+k\), twice the principal-line index.
+
+6. **Sphere charts.** `CaratheodoryLoewnerCounterexample/Global.lean` defines the reciprocal
+   exponent, damping, and chart representative; proves `counterexample_two_reciprocal`; and
+   glues it to the original chart in `counterexample_two_sphere_extension`. The reciprocal
+   origin and the original south pole are treated separately, exactly as in Sections 6--8.
+
+7. **Spherical trace-free calculation.** `Global.lean` uses the private definitions
+   `complexBarDeriv` and `sphericalTraceFreeHessian`. By definition the latter is \(4Q\), as in
+   (3a), not \(Q\). The product and radial differentiation lemmas yield the factorization (18a).
+   The seed perturbation estimate proves nonvanishing at every finite reciprocal coordinate,
+   with a separate proof at \(w=0\). The reciprocal radius formula converts this coordinate
+   expression to the anti-linear coefficient of the raised radius operator using exactly the
+   multiplier \(D^2/80000\) from (3c).
+
+8. **Reusable support geometry.**
+   `FormalConjecturesForMathlib/Geometry/SupportFunctionSphere.lean` supplies `radialExtension`,
+   `homogeneousGradient`, `body`, the contact and supporting inequalities, compactness and
+   interior lemmas, range-equals-frontier results, and injectivity/embedding from strict
+   cross-support. These declarations formalize the general steps following (30), rather than
+   duplicating them as problem-specific abbreviations.
+
+9. **Numerical radius tensor and the surface.** `Global.lean` contains the scalar estimates
+   behind (19)--(29), packages them as a global radius-tensor bound including the separate
+   omitted-south calculation, derives strict convexity on nonantipodal chords, handles antipodal
+   chords using \(h\ge1\), and implements the chart differential equivalence (34). The reusable
+   support API supplies the body and its Gauss parametrization, culminating in
+   `counterexample_two_is_support_function_with_unique_umbilic`.
+
+This decomposition keeps general flat-function and support-function results in
+`FormalConjecturesForMathlib`, while the oscillatory branches, seed certificates, numerical
+constants, and chart normalizations remain in the problem-specific modules.

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
@@ -47,7 +47,8 @@ For a real \(C^2\) function \(u\) on a plane, put
 
 At an isolated zero of (2), our principal-line index is half the winding number of
 \(q_{\mathrm E}(u)\) on a small positively oriented circle. This is the convention used by
-`HasIsolatedZeroIndex` in the Lean statement.
+`HasIsolatedZeroIndex` in the Lean statement. That definition also records continuity on its
+witness ball; the formal proof supplies it from the global continuity of this trace-free Hessian.
 
 On the round sphere, use stereographic coordinates in which
 
@@ -686,8 +687,10 @@ identify it with its dual, the derivative of \(X_h\) is the raised radius operat
  dX_h=R_h^\sharp:=g_{S^2}^{-1}R_h.                                    \tag{32}
 \]
 
-In particular, (23) makes \(dX_h\) injective and tangent to the sphere at \(u\); hence \(u\) is
-the chosen unit normal.
+In particular, (23) makes \(dX_h\) injective and tangent to the sphere at \(u\). The canonical
+normal used in Lean is constructed from the cross product of two differential images. Its sign
+is corrected using the same two model directions under the standard sphere inclusion. Since
+(23) is positively oriented, normalizing this cross product gives precisely \(u\).
 
 It remains to prove the global supporting inequality. If \(u\ne v\) are not antipodal, the
 chord
@@ -762,8 +765,10 @@ there, its supporting linear functional is unique, and hence \(x=\nabla H(u)=X_h
 The strict inequality (33) also proves injectivity: if \(X_h(u)=X_h(v)\) for \(u\ne v\), then
 pairing with \(v\) contradicts (31). Since \(S^2\) is compact, the continuous injection \(X_h\)
 is a topological embedding; (32) makes it an immersion. It is therefore a smooth embedding onto
-\(\partial K_h\), with outer unit normal \(n(u)=u\). This supplies all the compactness,
-nonempty-interior, embedding, normal, and range conditions in IsConvexSphereOfClass. Moreover,
+\(\partial K_h\), and its canonical cross-product normal is the outer unit normal \(n(u)=u\).
+This supplies all the convex-body, nonempty-interior, embedding, immersion, and range conditions
+in `IsConvexSphereOfClass`; regularity of the canonical normal then follows from the general
+sphere-immersion theorem. Moreover,
 the differentiability argument above makes the contact point for every supporting normal unique,
 so every supporting face is a singleton and \(K_h\) is strictly convex.
 
@@ -772,7 +777,7 @@ We finish by spelling out the umbilic bridge. In a conformal complex chart
 \(d\rho\), (32) has the form
 
 \[
- dX_h=d\rho\circ R_h^\sharp,\qquad dn=d\rho.
+ dX_h=d\rho\circ R_h^\sharp,\qquad d n_{X_h}=d\rho,
 \]
 
 The identity part \(h\,\mathrm{id}\) and the trace part of the Hessian are scalar. By (3b), the
@@ -787,8 +792,8 @@ proportionality to \(dn=c\,dX_h\). Since \(R_h^\sharp\) is positive and invertib
 
 \[
 \begin{aligned}
- \operatorname{IsUmbilic}(X_h,n,\rho(w))
- &\Longleftrightarrow \exists c,\ dn=c\,dX_h\\
+ \operatorname{IsUmbilic}(X_h,\rho(w))
+ &\Longleftrightarrow \exists c,\ d n_{X_h}=c\,dX_h\\
  &\Longleftrightarrow \exists c,\ \mathrm{id}=cR_h^\sharp\\
  &\Longleftrightarrow Q_w(u)=0.                                      \tag{34}
 \end{aligned}
@@ -861,6 +866,9 @@ current implementation architecture rather than proposing a separate public Wirt
    multiplier \(D^2/80000\) from (3c).
 
 8. **Reusable support geometry.**
+   `FormalConjecturesForMathlib/Geometry/SphereImmersion.lean` constructs the canonical unit
+   normal of an immersed two-sphere from an orientation-corrected cross product, so the surface
+   and its umbilics require no separately quantified normal field.
    `FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean` packages the first and
    second fundamental forms and proves their umbilicity criterion equivalent to a scalar normal
    differential when the normal derivative's range lies in the immersion derivative's range.

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
@@ -533,8 +533,8 @@ by (6). Thus, since \(B>0\), (21) and this separate origin calculation prove tha
 \(Q_w(h_0)\ne0\) at every finite reciprocal coordinate \(w\). Finite \(w\) parametrizes the
 entire sphere except the point \(z=0\) of the original chart. At that remaining point, Section 4
 shows that the nonconstant part is flat, so its spherical trace-free Hessian vanishes. This proves
-part 4 at the level of the spherical Hessian; Section 8 identifies this condition with the
-repository's surface-level IsUmbilic predicate.
+part 4 at the level of the spherical Hessian; Section 8 identifies this condition with
+`EuclideanHypersurface.IsUmbilic`, the repository's fundamental-form predicate.
 
 ## 8. Convexity and the constant \(10^{10}\)
 
@@ -779,9 +779,10 @@ The identity part \(h\,\mathrm{id}\) and the trace part of the Hessian are scala
 anti-linear coefficient of the remaining trace-free part is
 \(2\lambda^{-2}Q(u)\), or equivalently
 \(\lambda^{-2}\operatorname{sphericalTFH}(u)/2\). Thus \(R_h^\sharp\) is scalar exactly when
-\(Q(u)=0\). In Lean, `IsUmbilic` is stated as proportionality of the second and first
-fundamental forms. Normality puts the range of \(dX_h\) in the tangent plane, while coercivity
-makes \(dX_h\) injective; equality of the two-dimensional ranges then converts that form
+\(Q(u)=0\). In Lean, `EuclideanHypersurface.IsUmbilic` is stated as proportionality of the
+second and first fundamental forms. Normality puts the range of \(dX_h\) in the tangent plane,
+while coercivity makes \(dX_h\) injective; equality of the two-dimensional ranges then converts
+that form
 proportionality to \(dn=c\,dX_h\). Since \(R_h^\sharp\) is positive and invertible,
 
 \[

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
@@ -779,7 +779,10 @@ The identity part \(h\,\mathrm{id}\) and the trace part of the Hessian are scala
 anti-linear coefficient of the remaining trace-free part is
 \(2\lambda^{-2}Q(u)\), or equivalently
 \(\lambda^{-2}\operatorname{sphericalTFH}(u)/2\). Thus \(R_h^\sharp\) is scalar exactly when
-\(Q(u)=0\). Since \(R_h^\sharp\) is positive and invertible,
+\(Q(u)=0\). In Lean, `IsUmbilic` is stated as proportionality of the second and first
+fundamental forms. Normality puts the range of \(dX_h\) in the tangent plane, while coercivity
+makes \(dX_h\) injective; equality of the two-dimensional ranges then converts that form
+proportionality to \(dn=c\,dX_h\). Since \(R_h^\sharp\) is positive and invertible,
 
 \[
 \begin{aligned}
@@ -857,6 +860,9 @@ current implementation architecture rather than proposing a separate public Wirt
    multiplier \(D^2/80000\) from (3c).
 
 8. **Reusable support geometry.**
+   `FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean` packages the first and
+   second fundamental forms and proves their umbilicity criterion equivalent to a scalar normal
+   differential when the normal derivative's range lies in the immersion derivative's range.
    `FormalConjecturesForMathlib/Geometry/SupportFunctionSphere.lean` supplies `radialExtension`,
    `homogeneousGradient`, `body`, the contact and supporting inequalities, compactness and
    interior lemmas, range-equals-frontier results, and injectivity/embedding from strict

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.md
@@ -1,0 +1,564 @@
+# Proof of the smooth Carathéodory–Loewner counterexample
+
+This note is a formalisation-oriented reconstruction of the counterexample announced by
+Levent Alpöge on 19 August 2026:
+
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203).
+
+The post says that, with
+
+\[
+ f(x+iy)=-\frac14\cos(2x)+\frac3{10}\cos(2y)-\frac1{32}\cos(4y)
+          +\sin x\sin y,
+\]
+
+and, for a positive integer \(k\),
+
+\[
+ g_k(z)=10^{10}+\frac{|z|^2}{1+|z|^2}
+ \exp\!\left(-|z|^{-1/4}e^{-|z|^2}\right)
+ f\!\left(\left(\frac{100}{\bar z}\right)^{k/2}\right),                 \tag{1}
+\]
+
+the origin is an umbilic of index \(1+k/2\), and \(g_2\), regarded as a smooth function
+on \(S^2=\mathbb P^1(\mathbb C)\), is the support function of a convex body with exactly
+one umbilic.
+
+The circulated writeup mentioned in the post is not public at the time of writing. Everything
+below is therefore derived directly from (1). The proof is arranged as a sequence of lemmas that
+can be translated to Lean without changing the mathematical decomposition.
+
+## 1. Conventions and the exact theorem
+
+Write \(z=x+iy\), \(r=|z|\), and
+
+\[
+ E(r)=\exp\!\left(-r^{-1/4}e^{-r^2}\right),\qquad
+ A(r)=\frac{r^2}{1+r^2}E(r).
+\]
+
+At \(z=0\), the nonconstant term in (1) is defined to be zero. Thus \(g_k(0)=10^{10}\).
+
+For a real \(C^2\) function \(u\) on a plane, put
+
+\[
+ q_{\mathrm E}(u)=u_{xx}-u_{yy}+2i u_{xy}=4u_{\bar z\bar z}.             \tag{2}
+\]
+
+At an isolated zero of (2), our principal-line index is half the winding number of
+\(q_{\mathrm E}(u)\) on a small positively oriented circle. This is the convention used by
+`HasIsolatedZeroIndex` in the Lean statement.
+
+On the round sphere, use stereographic coordinates in which
+
+\[
+ ds^2=\lambda(z)^2|dz|^2,\qquad \lambda(z)=\frac2{1+|z|^2}.
+\]
+
+The \((0,2)\)-part of the covariant Hessian is
+
+\[
+ Q_z(u)=u_{\bar z\bar z}+\frac{2z}{1+|z|^2}u_{\bar z}.                  \tag{3}
+\]
+
+It vanishes exactly when the trace-free spherical Hessian vanishes. Its winding number is twice
+the index of the corresponding principal line field. Multiplication of (3) by a positive scalar
+does not affect its zeros or winding number.
+
+We prove the following more explicit result.
+
+**Theorem.**
+
+1. Every \(g_k\) is \(C^\infty\) at the origin.
+2. If \(k>0\), the origin is an isolated zero of both the Euclidean operator (2) and the
+   spherical operator (3), and both have winding number \(k+2\) there.
+3. The function \(g_2\) extends smoothly to \(S^2\).
+4. The spherical operator (3) for \(g_2\) has no zero away from the origin.
+5. The tensor \(\nabla^2 g_2+g_2g_{S^2}\) is positive definite. Consequently \(g_2\) is the
+   support function of a smooth strictly convex body, whose unique umbilic is the point \(z=0\).
+
+## 2. The seed function has no umbilics
+
+The important feature of \(f\) is that its trace-free Hessian is uniformly separated from zero.
+Direct differentiation gives
+
+\[
+\begin{aligned}
+ 4f_{\bar w\bar w}
+ &= f_{xx}-f_{yy}+2if_{xy}\\
+ &=\cos(2x)+\frac65\cos(2y)-\frac12\cos(4y)
+      +2i\cos x\cos y.                                                  \tag{4}
+\end{aligned}
+\]
+
+Put \(u=\cos x\), \(v=\cos y\), \(s=u^2\), and \(t=v^2\). Then
+
+\[
+ \operatorname{Re}(4f_{\bar w\bar w})
+ =2s+\frac{32}{5}t-4t^2-\frac{27}{10},qquad
+ |\operatorname{Im}(4f_{\bar w\bar w})|^2=4st.                         \tag{5}
+\]
+
+The following exact bound is the central finite certificate:
+
+\[
+             |4f_{\bar w\bar w}|\ge \frac7{50}.                        \tag{6}
+\]
+
+Here is an elementary verification suitable for `nlinarith`. For fixed \(t\), the square of
+the left side of (6) is the convex quadratic
+
+\[
+ P_t(s)=\left(2s-4t^2+\frac{32}{5}t-\frac{27}{10}\right)^2+4st.
+\]
+
+Its unconstrained minimum occurs at
+
+\[
+ s_*(t)=\frac{4t^2-(37/5)t+27/10}{2}.
+\]
+
+Split \(0\le t\le1\) into the following three rational intervals.
+
+- If \(0\le t\le1/10\), then \(s_*(t)\ge1\), so the minimum on \([0,1]\) occurs at
+  \(s=1\). Write
+  \[
+  A_1(t)=-4t^2+\frac{32}{5}t-\frac7{10},
+  \qquad P_t(1)=A_1(t)^2+4t.
+  \]
+  If \(t\ge1/64\), then \(P_t(1)\ge4t\ge1/16\). If \(t\le1/64\), then
+  \(A_1(t)\le1/10-7/10=-3/5\), so \(P_t(1)\ge9/25\). Thus in either case
+  \(P_t(1)\ge1/16>(7/50)^2\).
+- If \(1/10\le t\le1/2\), substitute \(s=s_*(t)\). The result is
+  \[
+  t\left(8t^2-\frac{69}{5}t+\frac{27}{5}\right)\ge\frac14.
+  \]
+  For a rational certificate, subtract \(1/4\) and factor:
+  \[
+  \left(t-\frac12\right)
+  \left(8t^2-\frac{49}{5}t+\frac12\right).
+  \]
+  Both factors are nonpositive on this interval. For the second one, subtract its value
+  \(-2/5\) at \(t=1/10\) and factor the difference as
+  \[
+  \left(t-\frac1{10}\right)
+  \left(8\left(t+\frac1{10}\right)-\frac{49}{5}\right)\le0.
+  \]
+- If \(1/2\le t\le1\), then \(s_*(t)\le0\), so the minimum occurs at \(s=0\). Moreover
+  \[
+  -4t^2+\frac{32}{5}t-\frac{27}{10}
+   =-4\left(t-\frac45\right)^2-\frac7{50},
+  \]
+  which gives exactly the lower bound \((7/50)^2\).
+
+Thus (6) follows. Notice that the constant is sharp: equality occurs when
+\(u=0\) and \(t=4/5\).
+
+We will also use the deliberately crude bounds
+
+\[
+ |f|\le\frac{253}{160},\qquad |f_{\bar w}|\le\frac{129}{80},qquad
+ |f_{w\bar w}|\le\frac{47}{40},\qquad
+ |f_{\bar w\bar w}|\le\frac{47}{40}<5.                               \tag{7}
+\]
+
+They follow term by term from \(|\sin|,|\cos|\le1\). For example,
+\(|f_x|\le3/2\), \(|f_y|\le69/40\), and
+\(|f_{\bar w}|\le(|f_x|+|f_y|)/2=129/80\).
+
+Finally, \(f(-w)=f(w)\). Differentiating twice gives
+\(f_{ww}(-w)=f_{ww}(w)\). Because \(f_{ww}\) is nonzero on the simply connected plane, it
+has a continuous argument. The evenness forces that argument to be even as well: the possible
+difference between the arguments at \(w\) and \(-w\) is a constant multiple of \(2\pi\), and it
+is zero at \(w=0\). Consequently the image under \(f_{ww}\) of any closed curve has winding
+number zero. This observation handles the half-integral powers occurring for odd \(k\).
+
+## 3. A reusable exponential domination lemma
+
+We use the following standard flatness result.
+
+**Flat exponential lemma.** Let \(a,c>0\), and define
+
+\[
+ F_{a,c}(r)=\begin{cases}e^{-c r^{-a}},&r>0,\\0,&r=0.\end{cases}
+\]
+
+Then \(F_{a,c}\) is \(C^\infty\) on \([0,\infty)\), every derivative at zero is zero, and,
+for every real \(N\),
+
+\[
+                    r^{-N}F_{a,c}(r)\longrightarrow0\quad(r\downarrow0). \tag{8}
+\]
+
+For formalisation, prove (8) first after the substitution \(t=r^{-a}\): exponential decay
+dominates every real power of \(t\). An induction shows that each derivative of \(F_{a,c}\) is
+the original exponential multiplied by a finite sum of real powers of \(r\). Equation (8) then
+extends every derivative continuously by zero.
+
+Here is the induction in the form needed later. For every \(j\ge0\), there is a finite set
+\(S_j\subset\mathbb R\) and constants \(c_{j,\nu}\) such that, for \(r>0\),
+
+\[
+ F_{a,c}^{(j)}(r)=F_{a,c}(r)\sum_{\nu\in S_j}c_{j,\nu}r^\nu.           \tag{8a}
+\]
+
+The assertion for \(j+1\) follows by differentiating: differentiating a monomial lowers its
+exponent by one, while differentiating the exponential introduces the additional factor
+\(ca r^{-a-1}\). Thus every summand in (8a) tends to zero at the origin by (8). Induction using
+the elementary extension lemma
+
+\[
+ u\in C^1((0,\varepsilon)),\quad u(r)\to0,\quad u'(r)\to0
+ \quad\Longrightarrow\quad
+ \bigl(u(0):=0\bigr)\in C^1([0,\varepsilon))
+\]
+
+proves simultaneous smoothness and flatness.
+
+Near zero, \(e^{-r^2}\ge1/2\), and therefore
+
+\[
+ 0<E(r)\le e^{-\frac12 r^{-1/4}}.                                      \tag{9}
+\]
+
+Every derivative of \(E\) is bounded by (9) times a finite sum of negative powers of \(r\).
+
+We also need a quantitative, global version later. If \(a,b>0\), then
+
+\[
+ \sup_{y>0}y^a e^{-by}=\left(\frac{a}{be}\right)^a.                    \tag{10}
+\]
+
+This follows by differentiating \(a\log y-by\). In Lean it should be a standalone lemma for
+`Real.rpow`; all numerical estimates below are rational consequences of (10) and
+\(e>8/3\).
+
+## 4. Smoothness of the planar family
+
+On a simply connected sector in the punctured plane choose a branch
+
+\[
+ w(z)=\left(100/\bar z\right)^{k/2}.
+\]
+
+For odd \(k\), changing the square-root branch replaces \(w\) by \(-w\), and hence does not
+change \(f(w)\). Thus the local expressions glue to a single smooth function on
+\(\mathbb C\setminus\{0\}\). Equivalently one may use the principal `Complex.cpow`; its jump
+across the branch cut is a sign, which disappears after composition with the even function
+\(f\).
+
+For every multi-index \(\alpha\), repeated chain and product rules give
+
+\[
+ |D^\alpha(A(r)f(w(z)))|\le C_\alpha r^{-N_\alpha}
+ e^{-\frac12r^{-1/4}}                                                   \tag{11}
+\]
+
+for suitable constants \(C_\alpha,N_\alpha\). Indeed, all derivatives of \(f\) are bounded,
+derivatives of \(w\) have at most algebraic growth in \(1/r\), and derivatives of \(A\) are
+controlled by (9). Equation (8) makes the right side of (11) tend to zero. Hence the
+nonconstant part of \(g_k\), with value zero at the origin, is smooth and flat there. This proves
+part 1 of the theorem.
+
+More explicitly, on a closed subsector every derivative of \(w\) is a constant times a power of
+\(\bar z\), and hence is \(O(r^{-k/2-j})\) after \(j\) derivatives. Every derivative of \(f\)
+is bounded because it is a finite trigonometric polynomial. Finally, differentiating
+\(\log E=-r^{-1/4}e^{-r^2}\) shows inductively that \(D^jE/E\) is a finite sum of powers of
+\(r\) times bounded smooth functions. These three facts prove (11) term by term through the
+multivariable product and chain rules. Since the estimates agree on overlaps and the odd-\(k\)
+expressions agree under \(w\mapsto-w\), the sectorwise smooth extensions glue.
+
+## 5. The index at the origin
+
+Work again on a branch sector. The most singular term in two \(\bar z\)-derivatives is
+
+\[
+ A(r) f_{ww}(w(z))\,w_{\bar z}(z)^2.                                   \tag{12}
+\]
+
+Since
+
+\[
+ w_{\bar z}=-\frac{k}{2}\frac{w}{\bar z},
+\]
+
+the argument contributed by \(w_{\bar z}^2\) on \(z=re^{i\theta}\) is
+\((k+2)\theta\), up to a constant. The factor \(A(r)\) is positive, and the factor
+\(f_{ww}(w)\) has winding zero by Section 2.
+
+All other terms are smaller uniformly on the circle as \(r\to0\). More explicitly, relative
+to (12):
+
+\[
+\begin{array}{c|c}
+\text{source of an error term}&\text{upper bound for the relative size}\\ \hline
+w_{\bar z\bar z}f_w&r^{k/2}\\
+(A_{\bar z}/A)w_{\bar z}f_w&r^{k/2-1/4}\\
+(A_{\bar z\bar z}/A)f&r^{k-1/2}\\
+\dfrac{2z}{1+r^2}(A f(w))_{\bar z}&r^{k/2+2}.
+\end{array}                                                            \tag{13}
+\]
+
+The bounded derivatives in the numerators and the lower bound (6) make the estimates uniform.
+Every exponent in (13) is positive when \(k\ge1\). Therefore, on all sufficiently small
+circles, the full Euclidean operator (2), and also the spherical operator (3), are joined to
+(12) by the straight-line homotopy without crossing zero. Their winding number is thus
+\(k+2\), and the principal-line index is \(1+k/2\). This proves part 2.
+
+The same domination on a punctured disc shows that the zero at the origin is isolated, rather
+than merely giving the winding on a selected sequence of circles.
+
+## 6. The second chart for \(g_2\)
+
+For \(k=2\), introduce the reciprocal coordinate
+
+\[
+                         w=100/\bar z.
+\]
+
+Writing \(s=|w|^2\), the nonconstant part of \(g_2\) becomes
+
+\[
+ h_0(w)=B(s)f(w),                                                       \tag{14}
+\]
+
+where
+
+\[
+ B(s)=\frac{10000}{s+10000}e^{-\psi(s)},\qquad
+ \psi(s)=\left(\frac{s}{10000}\right)^{1/8}e^{-10000/s}                \tag{15}
+\]
+
+for \(s>0\), and \(\psi(0)=0\). The flat exponential lemma applied to
+\(e^{-10000/s}\) shows that \(\psi\), then \(B\), is smooth at zero, with \(B(0)=1\).
+Thus (14) extends smoothly through \(w=0\), the point \(z=\infty\). Together with Section 4,
+this proves part 3.
+
+In this chart the round metric is
+
+\[
+ ds^2=\frac{40000}{(s+10000)^2}|dw|^2.                                 \tag{16}
+\]
+
+Consequently its spherical umbilic operator is
+
+\[
+ Q_w(h)=h_{\bar w\bar w}+\frac{2w}{s+10000}h_{\bar w}.                 \tag{17}
+\]
+
+## 7. The cancellation proving uniqueness
+
+Let \(D=s+10000\), \(p=\psi'(s)\), and \(L=(\log B)'=-1/D-p\). Radial
+differentiation gives
+
+\[
+ B_{\bar w}=BLw,\qquad B_{\bar w\bar w}=B(L^2+L')w^2.
+\]
+
+Substitute these identities into (17). The derivatives of the rational factor \(10000/D\)
+cancel the Christoffel term exactly, leaving
+
+\[
+ \boxed{\frac{Q_w(Bf)}B
+ =f_{\bar w\bar w}-2wp f_{\bar w}+w^2(p^2-p')f.}                        \tag{18}
+\]
+
+This cancellation is the reason for the factor \(|z|^2/(1+|z|^2)\) in (1).
+
+It remains to bound the last two terms in (18). Put \(x=s/10000\) and
+\(\phi(x)=x^{1/8}e^{-1/x}\), so that \(\psi(s)=\phi(x)\). Direct differentiation gives
+
+\[
+\begin{aligned}
+ \sqrt{x}\,\phi'(x)
+ &=e^{-y}\left(\frac18y^{3/8}+y^{11/8}\right),\\
+ x\phi'(x)^2
+ &=e^{-2y}\left(\frac1{64}y^{3/4}+\frac14y^{7/4}+y^{11/4}\right),\\
+ x\phi''(x)
+ &=e^{-y}\left(-\frac7{64}y^{7/8}-\frac74y^{15/8}+y^{23/8}\right),
+                                                                            \tag{19}
+\end{aligned}
+\]
+
+where \(y=1/x\). Formula (10), with the crude estimate \(e>2\), yields
+
+\[
+ |wp|\le\frac1{100},\qquad |w^2(p^2-p')|\le\frac1{1000}.                \tag{20}
+\]
+
+For clarity, the first numerator in (19) is at most one: the first summand is at most
+\(1/8\), while the second has maximum
+\((11/(8e))^{11/8}<7/8\). For the second estimate, the triangle inequality bounds the sum of
+the six terms in the last two lines of (19) by ten. One completely rational certificate is as
+follows. Using \(e>2\), the three maxima in the line containing \(e^{-2y}\), including their
+coefficients, are respectively less than \(1/64,1/4,1\). The three maxima in the line containing
+\(e^{-y}\) are less than \(7/64,7/4,3\); for the last one use
+\[
+ (23/(8e))^{23/8}<(23/16)^{23/8}<(23/16)^3<3.
+\]
+Their sum is less than \(10\). After restoring the factor \(1/10000\) coming from
+\(s=10000x\), this is the second inequality in (20). These intentionally loose rational bounds
+are convenient in Lean.
+
+Combining (6), (7), (18), and (20),
+
+\[
+\begin{aligned}
+ \left|\frac{Q_w(Bf)}B-f_{\bar w\bar w}\right|
+ &\le 2\cdot\frac1{100}\cdot\frac{129}{80}
+       +\frac1{1000}\cdot\frac{253}{160}\\
+ &=\frac{5413}{160000}<\frac7{200}
+ \le |f_{\bar w\bar w}|.                                               \tag{21}
+\end{aligned}
+\]
+
+Since \(B>0\), (21) proves that \(Q_w(h_0)\ne0\) at every finite \(w\). Finite \(w\)
+parametrizes the entire sphere except the point \(z=0\). At that remaining point, Section 4
+shows that \(h_0\) is flat, hence umbilic. This proves part 4: it is the unique umbilic.
+
+## 8. Convexity and the constant \(10^{10}\)
+
+For a smooth function \(h\) on \(S^2\), define the radius-of-curvature tensor
+
+\[
+                        R_h=\nabla^2h+h g_{S^2}.                         \tag{22}
+\]
+
+We need a numerical upper bound for \(R_{h_0}\), where \(h_0=Bf\). The following coarse bound
+is more than sufficient and is chosen to have a short formal proof:
+
+\[
+                         \|R_{h_0}\|_{\mathrm{op}}<3\cdot10^9.          \tag{23}
+\]
+
+Here is a certificate for (23). In the \(w\)-chart put
+
+\[
+ y=(s/10000)^{1/8},\qquad \psi=y e^{-y^{-8}},\qquad
+ M(y)=\lambda^{-2}B=\frac{s+10000}{4}e^{-\psi}
+      =2500(1+y^8)e^{-\psi}.                                            \tag{24}
+\]
+
+- For \(0\le y\le2\), \(M(y)\le642500\).
+- For \(y\ge2\), the inequality \(e^{-y^{-8}}\ge1-y^{-8}\ge255/256\), followed by
+  (10) and \(e>8/3\), gives
+  \[
+    M(y)\le2500\left(1+\sup_{y>0}y^8e^{-(255/256)y}\right)
+      <2500(1+4^8)<1.64\cdot10^8.                                      \tag{25}
+  \]
+
+Thus \(M<1.64\cdot10^8\) globally. Equation (18), the sharper upper bound
+\(|f_{\bar w\bar w}|\le47/40\) in (7), and (20) give the deliberately loose estimate
+
+\[
+ \frac{|Q_w(h_0)|}{B}
+ \le\frac{47}{40}+\frac{258}{8000}+\frac{253}{160000}<5,
+ \qquad\text{hence}\qquad |Q_w(h_0)|\le5B.                              \tag{26}
+\]
+
+The operator norm of the trace-free spherical Hessian is
+\(2\lambda^{-2}|Q_w(h_0)|\), so (25)–(26) bound it by
+\(1.64\cdot10^9\).
+
+For the trace, radial differentiation gives
+
+\[
+ \frac{(Bf)_{w\bar w}}B
+ =f_{w\bar w}+L(wf_w+\bar w f_{\bar w})
+   +\left(L+s(L^2+L')\right)f.                                         \tag{27}
+\]
+
+Besides (20), formulas (19) and (10) give
+
+\[
+ |p|\le\frac2{10000},\quad
+ \frac{|w|}{D}\le\frac1{200},\quad
+ \frac{s}{D^2}\le\frac1{40000}.                                      \tag{28}
+\]
+
+For completeness, after substituting \(L=-1/D-p\), the last coefficient in (27) is
+
+\[
+ L+s(L^2+L')=-\frac1D-p+s\left(\frac2{D^2}+\frac{2p}{D}+p^2-p'\right).
+\]
+
+Now (7), (20), (28), and \(s/D\le1\) give
+
+\[
+\begin{aligned}
+ \left|\frac{(Bf)_{w\bar w}}B\right|
+ &\le \frac{47}{40}
+   +2\left(\frac1{200}+\frac1{100}\right)\frac{129}{80}\\
+ &\quad+\left(\frac1{10000}+\frac2{10000}+\frac1{20000}
+                    +\frac1{2500}+\frac1{1000}\right)\frac{253}{160}\\
+ &=\frac{784731}{640000}<2.                                           \tag{29}
+\end{aligned}
+\]
+
+The scalar part of the spherical Hessian has norm
+\(2\lambda^{-2}|(Bf)_{w\bar w}|<4M<6.56\cdot10^8\). Also \(B\le1\), so
+\(|h_0|\le253/160<2\). Consequently
+
+\[
+ \|R_{h_0}\|_{\mathrm{op}}
+ <10M+4M+2
+ <2.296\cdot10^9+2
+ <3\cdot10^9,
+\]
+
+which proves (23).
+
+Now set \(h=10^{10}+h_0\). Since the Hessian of a constant is zero,
+
+\[
+ R_h=10^{10}g_{S^2}+R_{h_0}.
+\]
+
+By (23), every eigenvalue of \(R_h\) is positive. In fact it is greater than
+\(7\cdot10^9\). Thus \(R_h\) is positive definite everywhere.
+
+The standard support-function construction is
+
+\[
+ X_h(u)=h(u)u+\nabla h(u),\qquad u\in S^2.                              \tag{30}
+\]
+
+Its derivative on \(T_uS^2\) is \(R_h\), and its unit normal is \(u\). Positive definiteness
+of \(R_h\) implies that (30) is the Gauss parametrization of the boundary of the compact strictly
+convex body
+
+\[
+ K_h=\{x\in\mathbb R^3:\langle x,u\rangle\le h(u)\text{ for every }u\in S^2\}.
+\]
+
+The shape operator is \(R_h^{-1}\). Therefore a point of this convex surface is umbilic exactly
+when the trace-free part of \(R_h\), equivalently the trace-free part of \(\nabla^2h\), vanishes.
+The constant \(10^{10}\) affects neither this trace-free tensor nor its zeros. Section 7 therefore
+shows that the surface has exactly one umbilic. This proves part 5 and the announced
+Carathéodory counterexample.
+
+## 9. Lean decomposition
+
+The Lean development should follow this dependency order.
+
+1. **Wirtinger API.** Define first and second Wirtinger derivatives as real Fréchet derivatives,
+   and prove that `traceFreeHessian = 4 • wirtingerBar (wirtingerBar f)`.
+2. **Seed identities.** Prove (4), evenness, the bounds (7), and the three-case polynomial
+   certificate (6). These are finite `ring_nf`/`nlinarith` arguments after trigonometric bounds.
+3. **Flat functions.** Prove (8)–(10) in a reusable file under `FormalConjecturesForMathlib`.
+   This file must contain no `sorry`.
+4. **Branch-independent power.** Package `f ((100 / star z) ^ (k/2))` as a smooth function on
+   the punctured plane. For odd `k`, glue the two square-root branches using `f (-w) = f w`.
+5. **Smooth extension at zero.** Turn (11) into a general extension lemma and instantiate it.
+6. **Index.** Expand the Hessian, prove the relative estimates (13), and use homotopy invariance
+   of winding number to obtain `2 + k`.
+7. **Sphere charts.** Define the two chart representatives, prove their transition identity,
+   and derive the spherical operators (3) and (17).
+8. **Uniqueness.** Formalize (18)–(21). This part should use only differentiation, rational
+   inequalities, and the seed certificate.
+9. **Support functions.** Define (22) and (30), prove the support-function theorem, formalize
+   the numerical certificate (23), and conclude strict convexity and uniqueness of the umbilic.
+
+The first four analytic estimates should be proved independently of the particular surface; this
+keeps the problem file short and leaves generally useful flatness and support-function API in
+`FormalConjecturesForMathlib`.

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Defs.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Defs.lean
@@ -1,0 +1,97 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+import FormalConjectures.Other.CaratheodoryConjecture
+
+/-!
+# Definitions for the announced smooth Carathéodory–Loewner counterexamples
+
+This file records the explicit planar family, its stereographic chart, and the support-function
+predicate used in the counterexample announced by Levent Alpöge on 19 August 2026.
+
+*Reference:*
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
+-/
+
+open scoped ContDiff EuclideanGeometry Manifold
+open Set Metric
+
+namespace CaratheodoryLoewnerCounterexample
+
+open CaratheodoryConjecture LoewnerConjecture
+
+/-- The periodic real-valued function used in the announced counterexample. -/
+noncomputable def counterexampleSeed (z : ℂ) : ℝ :=
+  -Real.cos (2 * z.re) / 4 + 3 * Real.cos (2 * z.im) / 10 -
+    Real.cos (4 * z.im) / 32 + Real.sin z.re * Real.sin z.im
+
+/-- The seed is invariant under the sign ambiguity of a square root. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_neg (z : ℂ) : counterexampleSeed (-z) = counterexampleSeed z := by
+  simp [counterexampleSeed]
+
+/-- The announced family `g_k` of smooth functions on the complex plane.
+
+The use of the principal complex power chooses a square-root branch when `k` is odd. The seed is
+even, so the resulting real-valued expression is independent of the sign of that square root. -/
+noncomputable def counterexample (k : ℕ) (z : ℂ) : ℝ :=
+  let r := ‖z‖
+  let w := Complex.cpow (100 / star z) ((k : ℂ) / 2)
+  r ^ 2 * Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) *
+      counterexampleSeed w / (1 + r ^ 2) + 10 ^ 10
+
+/-- Every member of the family takes the constant support value at the origin. -/
+@[category API, AMS 26]
+theorem counterexample_zero (k : ℕ) : counterexample k 0 = 10 ^ 10 := by
+  simp [counterexample]
+
+/-- The north pole used to fix the stereographic chart for the global counterexample. -/
+noncomputable def counterexampleNorthPole : sphere (0 : ℝ³) 1 :=
+  ⟨EuclideanSpace.single (2 : Fin 3) 1, by
+    rw [mem_sphere, dist_zero_right]
+    simp⟩
+
+/-- The inverse stereographic chart in which the formula `counterexample 2` is written.
+
+Mathlib's stereographic coordinate has a conventional factor of two. Scaling its target
+coordinate by two makes the pullback of the round metric equal to
+`4 / (1 + ‖z‖ ^ 2) ^ 2` times the Euclidean metric. -/
+noncomputable def counterexampleSphereChart (z : ℂ) : sphere (0 : ℝ³) 1 :=
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨finrank_euclideanSpace_fin⟩
+  (stereographic' 2 counterexampleNorthPole).symm
+    (2 • Complex.orthonormalBasisOneI.repr z)
+
+/-- The origin of the planar chart represents the south pole. This test fixes the scale and sign
+convention in `counterexampleSphereChart`. -/
+@[category test, AMS 53]
+theorem counterexampleSphereChart_zero :
+    counterexampleSphereChart 0 = -counterexampleNorthPole := by
+  apply Subtype.ext
+  simp [counterexampleSphereChart, stereographic'_symm_apply]
+
+/-- `F` parametrizes the supporting point of `K` with outer unit normal `p`, and `h p` is
+the corresponding support value.
+
+The final inequality says that the hyperplane through `F p` perpendicular to `p` supports
+the whole body. Requiring `F p ∈ K` makes the supremum attained and avoids conventions for
+`sSup ∅`. -/
+def IsSupportParametrization (h : sphere (0 : ℝ³) 1 → ℝ)
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³) : Prop :=
+  ∀ p, F p ∈ K ∧ inner ℝ (F p) (p : ℝ³) = h p ∧
+    ∀ x ∈ K, inner ℝ x (p : ℝ³) ≤ h p
+
+end CaratheodoryLoewnerCounterexample

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
@@ -3432,13 +3432,6 @@ private theorem counterexampleTwoReciprocal_radius_error_bound_of_laplacian (w :
   change ‖dF v - (10 ^ 10 : ℝ) • dρ v‖ ≤ 3000000000 * ‖dρ v‖
   exact hnorm.trans (mul_le_mul_of_nonneg_right hcoefficient.le (norm_nonneg _))
 
-/-- The derivative of a sphere-valued map into ambient Euclidean coordinates.  Naming this
-transport keeps the ambient codomain visible to typeclass inference. -/
-private noncomputable def sphereAmbientMfderiv
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
-  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
-
 /-- The reciprocal-chart radius bound transports to the intrinsic tangent space of the sphere.
 No choice of tangent coordinates remains in this statement. -/
 @[category API, AMS 53]
@@ -3763,7 +3756,7 @@ private theorem counterexampleTwoHomogeneousGradient_umbilic_south :
       (SphereSupport.homogeneousGradient
         (SphereSupport.radialExtension counterexampleTwoSphereExtension))
       (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) := by
-  refine ⟨(10 ^ 10 : ℝ)⁻¹, ?_⟩
+  apply EuclideanHypersurface.isUmbilicByFundamentalForms_of_normal_deriv_eq_smul
   change sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
       (counterexampleSphereChart 0) =
     (10 ^ 10 : ℝ)⁻¹ • sphereAmbientMfderiv
@@ -3778,10 +3771,14 @@ coefficient of the chart radius tensor. -/
 @[category API, AMS 53]
 private theorem sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal
     (w : ℂ)
-    (humbilic : IsUmbilic
-      (SphereSupport.homogeneousGradient
-        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (fun p ↦ (p : ℝ³)) (counterexampleTwoReciprocalSphereChart w)) :
+    (humbilic : ∃ c : ℝ,
+      sphereAmbientMfderiv
+        (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+        (counterexampleTwoReciprocalSphereChart w) =
+      c • sphereAmbientMfderiv
+        (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+        (counterexampleTwoReciprocalSphereChart w)) :
     sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w = 0 := by
   let F := SphereSupport.homogeneousGradient
     (SphereSupport.radialExtension counterexampleTwoSphereExtension)
@@ -3834,20 +3831,6 @@ private theorem sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal
       _ = c • dF a := by rw [hchainF]
   exact antiLinearCoefficient_eq_zero_of_umbilic dρ dF hdρ (10 ^ 10) r A L Q
     (by positivity) hformula hchartUmbilic
-
-/-- Every point other than the south pole is nonumbilic, because the reciprocal chart covers it
-and its spherical trace-free Hessian is nowhere zero. -/
-@[category API, AMS 53]
-private theorem counterexampleTwoHomogeneousGradient_not_umbilic_away_south
-    (p : sphere (0 : ℝ³) 1) (hp : p ≠ counterexampleSphereChart 0) :
-    ¬IsUmbilic
-      (SphereSupport.homogeneousGradient
-        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (fun q ↦ (q : ℝ³)) p := by
-  obtain ⟨w, rfl⟩ := exists_reciprocalSphereChart_of_ne_south hp
-  intro humbilic
-  exact sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero_all w
-    (sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal w humbilic)
 
 /-- The reciprocal radius estimate and the exact south-pole identity combine into global
 oriented coercivity. -/
@@ -4243,6 +4226,82 @@ private theorem continuousLinearMap_injective_of_coercive
   rw [map_sub] at this
   exact hN (sub_eq_zero.mp this)
 
+/-- Normality and oriented coercivity identify the differential range of the contact immersion
+with the tangent plane supplied by the Gauss map. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_range_eq_of_coercive
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v))
+    (p : sphere (0 : ℝ³) 1) :
+    (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p).range =
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p).range := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let n : sphere (0 : ℝ³) 1 → ℝ³ := fun q ↦ (q : ℝ³)
+  let dF := sphereAmbientMfderiv F p
+  let dn := sphereAmbientMfderiv n p
+  change dF.range = dn.range
+  have hdnInjective : Function.Injective dn := by
+    dsimp only [dn, n, sphereAmbientMfderiv]
+    exact mfderiv_coe_sphere_injective p
+  have hdFInjective : Function.Injective dF := by
+    apply continuousLinearMap_injective_of_coercive dn dF hdnInjective
+      (c := 7000000000) (by norm_num)
+    intro v
+    simpa only [dF, dn, F, n] using hCoercive p v
+  have hdF_le_dn : dF.range ≤ dn.range := by
+    rw [show dn.range = (ℝ ∙ (p : ℝ³))ᗮ by
+      dsimp only [dn, n, sphereAmbientMfderiv]
+      exact range_mfderiv_coe_sphere p]
+    rintro _ ⟨v, rfl⟩
+    rw [Submodule.mem_orthogonal_singleton_iff_inner_right]
+    simpa only [dF, F] using counterexampleTwoHomogeneousGradient_normal p v
+  apply Submodule.eq_of_le_of_finrank_eq hdF_le_dn
+  calc
+    Module.finrank ℝ dF.range = Module.finrank ℝ (TangentSpace (𝓡 2) p) :=
+      LinearMap.finrank_range_of_inj hdFInjective
+    _ = Module.finrank ℝ dn.range :=
+      (LinearMap.finrank_range_of_inj hdnInjective).symm
+
+/-- Every point other than the south pole is nonumbilic in the fundamental-form sense, because
+the reciprocal chart covers it and its spherical trace-free Hessian is nowhere zero. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_not_umbilic_away_south
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v))
+    (p : sphere (0 : ℝ³) 1) (hp : p ≠ counterexampleSphereChart 0) :
+    ¬IsUmbilic
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (fun q ↦ (q : ℝ³)) p := by
+  intro humbilic
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let n : sphere (0 : ℝ³) 1 → ℝ³ := fun q ↦ (q : ℝ³)
+  let dF := sphereAmbientMfderiv F p
+  let dn := sphereAmbientMfderiv n p
+  change EuclideanHypersurface.IsUmbilicByFundamentalForms dF dn at humbilic
+  have hrange : dn.range ≤ dF.range := by
+    rw [counterexampleTwoHomogeneousGradient_range_eq_of_coercive hCoercive p]
+  have hscalar : ∃ c : ℝ, dn = c • dF :=
+    (EuclideanHypersurface.isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
+      dF dn hrange).mp humbilic
+  obtain ⟨w, rfl⟩ := exists_reciprocalSphereChart_of_ne_south hp
+  exact sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero_all w
+    (sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal w (by
+      simpa only [dF, dn, F, n] using hscalar))
+
 /-- Oriented coercivity of the radius tensor makes the degree-one extension strictly convex
 along every chord that does not pass through the origin. -/
 @[category API, AMS 53]
@@ -4622,7 +4681,7 @@ theorem counterexample_two_support_geometry
   refine ⟨F, K, ?_⟩
   simpa only [F, K] using counterexampleTwoSupport_geometry_of_certificates
     hCoercive hstrict counterexampleTwoHomogeneousGradient_umbilic_south
-      counterexampleTwoHomogeneousGradient_not_umbilic_away_south
+      (counterexampleTwoHomogeneousGradient_not_umbilic_away_south hCoercive)
 
 /-- **Alpöge's smooth Carathéodory counterexample.**
 

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
@@ -3752,11 +3752,14 @@ private theorem counterexampleTwoHomogeneousGradient_mfderiv_south :
 /-- The south pole is an umbilic of the homogeneous-gradient contact map. -/
 @[category API, AMS 53]
 private theorem counterexampleTwoHomogeneousGradient_umbilic_south :
-    IsUmbilic
-      (SphereSupport.homogeneousGradient
-        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) := by
-  apply EuclideanHypersurface.isUmbilicByFundamentalForms_of_normal_deriv_eq_smul
+    EuclideanHypersurface.IsUmbilic
+      (sphereAmbientMfderiv
+        (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+        (counterexampleSphereChart 0))
+      (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+        (counterexampleSphereChart 0)) := by
+  apply EuclideanHypersurface.isUmbilic_of_normal_deriv_eq_smul
   change sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
       (counterexampleSphereChart 0) =
     (10 ^ 10 : ℝ)⁻¹ • sphereAmbientMfderiv
@@ -4281,22 +4284,22 @@ private theorem counterexampleTwoHomogeneousGradient_not_umbilic_away_south
             (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
           (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v))
     (p : sphere (0 : ℝ³) 1) (hp : p ≠ counterexampleSphereChart 0) :
-    ¬IsUmbilic
-      (SphereSupport.homogeneousGradient
-        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (fun q ↦ (q : ℝ³)) p := by
+    ¬EuclideanHypersurface.IsUmbilic
+      (sphereAmbientMfderiv
+        (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p)
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) := by
   intro humbilic
   let F := SphereSupport.homogeneousGradient
     (SphereSupport.radialExtension counterexampleTwoSphereExtension)
   let n : sphere (0 : ℝ³) 1 → ℝ³ := fun q ↦ (q : ℝ³)
   let dF := sphereAmbientMfderiv F p
   let dn := sphereAmbientMfderiv n p
-  change EuclideanHypersurface.IsUmbilicByFundamentalForms dF dn at humbilic
+  change EuclideanHypersurface.IsUmbilic dF dn at humbilic
   have hrange : dn.range ≤ dF.range := by
     rw [counterexampleTwoHomogeneousGradient_range_eq_of_coercive hCoercive p]
   have hscalar : ∃ c : ℝ, dn = c • dF :=
-    (EuclideanHypersurface.isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
-      dF dn hrange).mp humbilic
+    (EuclideanHypersurface.isUmbilic_iff_normal_deriv_eq_smul dF dn hrange).mp humbilic
   obtain ⟨w, rfl⟩ := exists_reciprocalSphereChart_of_ne_south hp
   exact sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero_all w
     (sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal w (by
@@ -4585,14 +4588,17 @@ private theorem counterexampleTwoSupport_geometry_of_certificates
       inner ℝ (SphereSupport.homogeneousGradient
         (SphereSupport.radialExtension counterexampleTwoSphereExtension) p) (q : ℝ³) <
           counterexampleTwoSphereExtension q)
-    (humbilic : IsUmbilic
-      (SphereSupport.homogeneousGradient
+    (humbilic : EuclideanHypersurface.IsUmbilic
+      (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
         (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0))
-    (hnoUmbilic : ∀ p, p ≠ counterexampleSphereChart 0 → ¬IsUmbilic
-      (SphereSupport.homogeneousGradient
-        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (fun q ↦ (q : ℝ³)) p) :
+        (counterexampleSphereChart 0))
+      (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+        (counterexampleSphereChart 0)))
+    (hnoUmbilic : ∀ p, p ≠ counterexampleSphereChart 0 →
+      ¬EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p)) :
     let F := SphereSupport.homogeneousGradient
       (SphereSupport.radialExtension counterexampleTwoSphereExtension)
     let K := SphereSupport.body counterexampleTwoSphereExtension
@@ -4600,8 +4606,14 @@ private theorem counterexampleTwoSupport_geometry_of_certificates
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       range F = frontier K ∧
       IsSupportParametrization counterexampleTwoSphereExtension F K ∧
-      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
-      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F (counterexampleSphereChart 0))
+        (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+          (counterexampleSphereChart 0)) ∧
+      ∀ p, EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+          p = counterexampleSphereChart 0 := by
   let F := SphereSupport.homogeneousGradient
     (SphereSupport.radialExtension counterexampleTwoSphereExtension)
   let K := SphereSupport.body counterexampleTwoSphereExtension
@@ -4620,11 +4632,18 @@ private theorem counterexampleTwoSupport_geometry_of_certificates
       (mfderiv_coe_sphere_injective p) (by norm_num) (hCoercive p)
   change ∀ (p q : sphere (0 : ℝ³) 1), p ≠ q →
     inner ℝ (F p) (q : ℝ³) < counterexampleTwoSphereExtension q at hstrict
-  change IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) at humbilic
+  change EuclideanHypersurface.IsUmbilic
+    (sphereAmbientMfderiv F (counterexampleSphereChart 0))
+    (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+      (counterexampleSphereChart 0)) at humbilic
   change ∀ p, p ≠ counterexampleSphereChart 0 →
-    ¬IsUmbilic F (fun q ↦ (q : ℝ³)) p at hnoUmbilic
-  have hunique : ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p →
-      p = counterexampleSphereChart 0 := by
+    ¬EuclideanHypersurface.IsUmbilic
+      (sphereAmbientMfderiv F p)
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) at hnoUmbilic
+  have hunique : ∀ p, EuclideanHypersurface.IsUmbilic
+      (sphereAmbientMfderiv F p)
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+        p = counterexampleSphereChart 0 := by
     intro p hp
     by_contra hp0
     exact hnoUmbilic p hp0 hp
@@ -4668,8 +4687,14 @@ theorem counterexample_two_support_geometry
       IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
-      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
-      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F (counterexampleSphereChart 0))
+        (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+          (counterexampleSphereChart 0)) ∧
+      ∀ p, EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+          p = counterexampleSphereChart 0 := by
   have hextension := eq_counterexampleTwoSphereExtension h hsmooth hchart
   subst h
   let F := SphereSupport.homogeneousGradient
@@ -4701,8 +4726,14 @@ theorem counterexample_two_is_support_function_with_unique_umbilic :
       IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
-      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
-      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+      EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F (counterexampleSphereChart 0))
+        (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+          (counterexampleSphereChart 0)) ∧
+      ∀ p, EuclideanHypersurface.IsUmbilic
+        (sphereAmbientMfderiv F p)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+          p = counterexampleSphereChart 0 := by
   rcases counterexample_two_sphere_extension with ⟨h, hsmooth, hchart⟩
   rcases counterexample_two_support_geometry h hsmooth hchart with ⟨F, K, hgeometry⟩
   exact ⟨h, F, K, hsmooth, hchart, hgeometry⟩

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
@@ -15,14 +15,8 @@ limitations under the License.
 -/
 
 import FormalConjecturesUtil
-import FormalConjecturesForMathlib.Analysis.SpecialFunctions.FlatRpowExp
-import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
 import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Smooth
 import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Index
-import Mathlib.Analysis.Complex.ExponentialBounds
-import Mathlib.Geometry.Manifold.Algebra.LieGroup
-import Mathlib.Geometry.Manifold.ContMDiff.Atlas
-import Mathlib.Geometry.Manifold.Riemannian.Basic
 
 /-!
 # The global smooth Carathéodory counterexample

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
@@ -1,0 +1,4657 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+import FormalConjecturesForMathlib.Analysis.SpecialFunctions.FlatRpowExp
+import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
+import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Smooth
+import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Index
+import Mathlib.Analysis.Complex.ExponentialBounds
+import Mathlib.Geometry.Manifold.Algebra.LieGroup
+import Mathlib.Geometry.Manifold.ContMDiff.Atlas
+import Mathlib.Geometry.Manifold.Riemannian.Basic
+
+/-!
+# The global smooth Carathéodory counterexample
+
+This file extends `counterexample 2` across the sphere and realizes it as the support function of
+a smooth strictly convex body with a unique umbilic.
+
+*Reference:*
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
+-/
+
+set_option maxHeartbeats 2000000
+set_option maxRecDepth 4000
+
+open scoped ContDiff EuclideanGeometry Manifold
+open Set Metric
+
+namespace CaratheodoryLoewnerCounterexample
+
+open CaratheodoryConjecture LoewnerConjecture
+
+private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
+  ⟨finrank_euclideanSpace_fin⟩
+
+/-- The complex coordinate inverse to `counterexampleSphereChart` away from the north pole. -/
+private noncomputable def counterexampleSphereCoord
+    (p : sphere (0 : ℝ³) 1) : ℂ :=
+  Complex.orthonormalBasisOneI.repr.symm
+    ((2 : ℝ)⁻¹ • (stereographic' 2 counterexampleNorthPole) p)
+
+/-- The chosen complex coordinate is a left inverse to the spherical chart. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereCoord_chart (z : ℂ) :
+    counterexampleSphereCoord (counterexampleSphereChart z) = z := by
+  apply Complex.ext <;> simp [counterexampleSphereCoord, counterexampleSphereChart]
+
+/-- Away from the north pole, the spherical chart is also a left inverse to its chosen complex
+coordinate. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereChart_coord {p : sphere (0 : ℝ³) 1}
+    (hp : p ≠ counterexampleNorthPole) :
+    counterexampleSphereChart (counterexampleSphereCoord p) = p := by
+  have hp_source : p ∈ (stereographic' 2 counterexampleNorthPole).source := by
+    simpa [stereographic'_source] using hp
+  rw [counterexampleSphereChart, counterexampleSphereCoord,
+    ← (stereographic' 2 counterexampleNorthPole).left_inv hp_source]
+  congr 1
+  apply Complex.orthonormalBasisOneI.repr.symm.injective
+  apply Complex.ext <;> simp
+
+/-- The inverse complex coordinate is smooth on the complement of its projection pole. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereCoord_contMDiffOn :
+    ContMDiffOn (𝓡 2) 𝓘(ℝ, ℂ) ∞ counterexampleSphereCoord
+      {counterexampleNorthPole}ᶜ := by
+  let e := stereographic' 2 counterexampleNorthPole
+  have he : e ∈ IsManifold.maximalAtlas (𝓡 2) ∞ (sphere (0 : ℝ³) 1) :=
+    IsManifold.subset_maximalAtlas ⟨counterexampleNorthPole, rfl⟩
+  have hcoord : ContDiff ℝ ∞
+      (fun x : EuclideanSpace ℝ (Fin 2) ↦
+        Complex.orthonormalBasisOneI.repr.symm ((2 : ℝ)⁻¹ • x)) :=
+    Complex.orthonormalBasisOneI.repr.symm.contDiff.comp
+      (contDiff_const_smul (𝕜 := ℝ) (2 : ℝ)⁻¹)
+  rw [← stereographic'_source (n := 2) counterexampleNorthPole]
+  exact hcoord.contMDiff.comp_contMDiffOn (contMDiffOn_of_mem_maximalAtlas he)
+
+/-- The pointwise extension of `counterexample 2` obtained by assigning its limiting value at the
+north pole. Smoothness at that point is the substantive content of the extension theorem. -/
+private noncomputable def counterexampleTwoSphereExtension
+    (p : sphere (0 : ℝ³) 1) : ℝ :=
+  if p = counterexampleNorthPole then 10 ^ 10 + 3 / 160
+  else counterexample 2 (counterexampleSphereCoord p)
+
+/-- The pointwise spherical extension agrees with the announced formula in its finite chart. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_chart (z : ℂ) :
+    counterexampleTwoSphereExtension (counterexampleSphereChart z) = counterexample 2 z := by
+  have hmem : counterexampleSphereChart z ∈
+      (stereographic' 2 counterexampleNorthPole).source := by
+    simpa [counterexampleSphereChart] using
+      (stereographic' 2 counterexampleNorthPole).map_target
+        (show 2 • Complex.orthonormalBasisOneI.repr z ∈
+          (stereographic' 2 counterexampleNorthPole).target by simp)
+  have hne : counterexampleSphereChart z ≠ counterexampleNorthPole := by
+    simpa [stereographic'_source] using hmem
+  simp [counterexampleTwoSphereExtension, hne, counterexampleSphereCoord_chart]
+
+/-- The pointwise extension is smooth away from the north pole. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_contMDiffOn :
+    ContMDiffOn (𝓡 2) 𝓘(ℝ, ℝ) ∞ counterexampleTwoSphereExtension
+      {counterexampleNorthPole}ᶜ := by
+  have hcounterexample : ContDiff ℝ ∞ (counterexample 2) :=
+    counterexample_contDiff 2 (by omega)
+  refine (hcounterexample.contMDiff.comp_contMDiffOn
+    counterexampleSphereCoord_contMDiffOn).congr ?_
+  intro p hp
+  have hpne : p ≠ counterexampleNorthPole := by simpa using hp
+  simp [counterexampleTwoSphereExtension, hpne]
+
+/-- Smoothness at the north pole is the only missing local condition for smoothness of the
+pointwise extension on the whole sphere. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+    (hnorth : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ) ∞ counterexampleTwoSphereExtension
+      counterexampleNorthPole) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ counterexampleTwoSphereExtension := by
+  intro p
+  by_cases hp : p = counterexampleNorthPole
+  · simpa [hp] using hnorth
+  · exact (counterexampleTwoSphereExtension_contMDiffOn p (by simpa)).contMDiffAt
+      (isOpen_compl_singleton.mem_nhds (by simpa))
+
+/-- The flat scalar appearing in the reciprocal chart at the north pole. On the nonnegative
+half-line this is `(s / 10000) ^ (1 / 8) * exp (-10000 / s)`. -/
+private noncomputable def counterexampleTwoReciprocalExponent (s : ℝ) : ℝ :=
+  (10000 : ℝ) ^ (-(1 : ℝ) / 8) *
+    (s ^ ((1 : ℝ) / 8) * Real.flatRpowExp 1 10000 s)
+
+/-- The reciprocal-chart exponent is smooth across `s = 0`. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_contDiff :
+    ContDiff ℝ ∞ counterexampleTwoReciprocalExponent := by
+  exact contDiff_const.mul
+    (Real.flatRpowExp.rpow_mul_contDiff (by norm_num) (by norm_num) ((1 : ℝ) / 8))
+
+/-- On the positive half-line, the smooth flat extension has the reciprocal-chart formula from
+the informal calculation. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_of_pos {s : ℝ} (hs : 0 < s) :
+    counterexampleTwoReciprocalExponent s =
+      (s / 10000) ^ ((1 : ℝ) / 8) * Real.exp (-10000 / s) := by
+  rw [counterexampleTwoReciprocalExponent, Real.flatRpowExp.of_pos 1 10000 hs]
+  have hscale :
+      (10000 : ℝ) ^ (-(1 : ℝ) / 8) * s ^ ((1 : ℝ) / 8) =
+        (s / 10000) ^ ((1 : ℝ) / 8) := by
+    rw [show -(1 : ℝ) / 8 = -((1 : ℝ) / 8) by ring,
+      Real.rpow_neg (by norm_num : (0 : ℝ) ≤ 10000), Real.div_rpow hs.le
+      (by norm_num : (0 : ℝ) ≤ 10000)]
+    field_simp
+  rw [← mul_assoc, hscale]
+  congr 2
+  field_simp [hs.ne']
+  rw [Real.rpow_neg_one, inv_mul_cancel₀ hs.ne']
+
+/-- The positive radial coefficient multiplying the seed in the reciprocal chart. -/
+private noncomputable def counterexampleTwoReciprocalDamping (w : ℂ) : ℝ :=
+  let s := ‖w‖ ^ 2
+  10000 / (s + 10000) * Real.exp (-counterexampleTwoReciprocalExponent s)
+
+/-- The reciprocal-chart damping coefficient is smooth on the whole complex plane. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalDamping_contDiff :
+    ContDiff ℝ ∞ counterexampleTwoReciprocalDamping := by
+  have hs : ContDiff ℝ ∞ (fun w : ℂ ↦ ‖w‖ ^ 2) := contDiff_norm_sq ℝ
+  have hdenom : ∀ w : ℂ, ‖w‖ ^ 2 + 10000 ≠ 0 := by
+    intro w
+    positivity
+  exact (contDiff_const.div (hs.add contDiff_const) hdenom).mul
+    ((counterexampleTwoReciprocalExponent_contDiff.comp hs).neg.exp)
+
+/-- Away from zero, the smooth damping coefficient has the explicit reciprocal-chart formula. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalDamping_of_ne_zero {w : ℂ} (hw : w ≠ 0) :
+    counterexampleTwoReciprocalDamping w =
+      10000 / (‖w‖ ^ 2 + 10000) *
+        Real.exp (-((‖w‖ ^ 2 / 10000) ^ ((1 : ℝ) / 8) *
+          Real.exp (-10000 / ‖w‖ ^ 2))) := by
+  rw [counterexampleTwoReciprocalDamping,
+    counterexampleTwoReciprocalExponent_of_pos (sq_pos_of_pos (norm_pos_iff.mpr hw))]
+
+/-- The smooth representative of `counterexample 2` in its reciprocal chart. -/
+private noncomputable def counterexampleTwoReciprocal (w : ℂ) : ℝ :=
+  10 ^ 10 + counterexampleTwoReciprocalDamping w * counterexampleSeed w
+
+/-- The reciprocal representative is smooth, including at its origin. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocal_contDiff :
+    ContDiff ℝ ∞ counterexampleTwoReciprocal := by
+  exact contDiff_const.add
+    (counterexampleTwoReciprocalDamping_contDiff.mul counterexampleSeed_contDiff)
+
+/-- The reciprocal representative takes the limiting value used in the pointwise spherical
+extension at its origin. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocal_zero :
+    counterexampleTwoReciprocal 0 = 10 ^ 10 + 3 / 160 := by
+  simp [counterexampleTwoReciprocal, counterexampleTwoReciprocalDamping,
+    counterexampleTwoReciprocalExponent, counterexampleSeed]
+  ring
+
+/-- The reciprocal-star transformation used between the two complex charts is an involution. -/
+@[category API, AMS 53]
+private theorem hundred_div_star_involutive (w : ℂ) :
+    (100 : ℂ) / star ((100 : ℂ) / star w) = w := by
+  rw [star_div₀, star_star]
+  norm_num
+
+/-- The original finite-chart formula becomes the smooth reciprocal representative under
+`z = 100 / star w`. -/
+@[category API, AMS 53]
+private theorem counterexample_two_reciprocal {w : ℂ} (hw : w ≠ 0) :
+    counterexample 2 (100 / star w) = counterexampleTwoReciprocal w := by
+  have hnorm : ‖(100 : ℂ) / star w‖ = 100 / ‖w‖ := by
+    simp
+  have hnorm_pos : 0 < ‖w‖ := norm_pos_iff.mpr hw
+  have harg := hundred_div_star_involutive w
+  have hrpow :
+      (100 / ‖w‖) ^ (-((1 : ℝ) / 4)) =
+        (‖w‖ ^ 2 / 10000) ^ ((1 : ℝ) / 8) := by
+    calc
+      (100 / ‖w‖) ^ (-((1 : ℝ) / 4)) = (‖w‖ / 100) ^ ((1 : ℝ) / 4) := by
+        rw [Real.rpow_neg_eq_inv_rpow]
+        congr 2
+        field_simp
+      _ = ((‖w‖ / 100) ^ 2) ^ ((1 : ℝ) / 8) := by
+        rw [← Real.rpow_natCast_mul (div_nonneg (norm_nonneg _) (by norm_num)) 2]
+        norm_num
+      _ = (‖w‖ ^ 2 / 10000) ^ ((1 : ℝ) / 8) := by
+        congr 2
+        ring
+  have hsquare : -(100 / ‖w‖) ^ 2 = -10000 / ‖w‖ ^ 2 := by
+    field_simp [hnorm_pos.ne']
+    ring
+  have hprefactor :
+      (100 / ‖w‖) ^ 2 / (1 + (100 / ‖w‖) ^ 2) =
+        10000 / (‖w‖ ^ 2 + 10000) := by
+    field_simp [hnorm_pos.ne']
+    ring
+  rw [counterexample, counterexampleTwoReciprocal,
+    counterexampleTwoReciprocalDamping_of_ne_zero hw]
+  simp only [hnorm, harg]
+  norm_num [Complex.cpow_one]
+  rw [hrpow, hsquare, ← hprefactor]
+  ring
+
+/-- The real-linear reciprocal coordinate associated to the standard chart at the north pole.
+The two orthonormal bases account for the fixed basis choice in mathlib's opposite
+stereographic charts. -/
+private noncomputable def counterexampleTwoReciprocalLinearCoord
+    (x : EuclideanSpace ℝ (Fin 2)) : ℂ :=
+  let Upos := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere counterexampleNorthPole)).repr
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  50 • Complex.orthonormalBasisOneI.repr.symm
+    (Upos ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection
+      (Uneg.symm x : ℝ³)))
+
+/-- The fixed isometry from the complex reciprocal coordinate to the tangent plane at the
+north pole. -/
+private noncomputable def counterexampleTwoTangentEquiv :
+    ℂ ≃ₗᵢ[ℝ] (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ :=
+  Complex.orthonormalBasisOneI.repr.trans
+    (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+      (ne_zero_of_mem_unit_sphere counterexampleNorthPole)).repr.symm
+
+/-- Ambient rational formula for the finite stereographic chart used in the statement. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereChart_coe (z : ℂ) :
+    (counterexampleSphereChart z : ℝ³) =
+      (‖z‖ ^ 2 + 1)⁻¹ •
+        (2 • (counterexampleTwoTangentEquiv z : ℝ³) +
+          (‖z‖ ^ 2 - 1) • (counterexampleNorthPole : ℝ³)) := by
+  rw [counterexampleSphereChart, stereographic'_symm_apply]
+  simp only [counterexampleTwoTangentEquiv, LinearIsometryEquiv.trans_apply,
+    ← Nat.cast_smul_eq_nsmul ℝ 2, map_smul]
+  simp only [Submodule.norm_coe, norm_smul, Real.norm_eq_abs,
+    LinearIsometryEquiv.norm_map]
+  have habs : |((2 : ℕ) : ℝ)| = 2 := by norm_num
+  rw [habs]
+  rw [show (2 * ‖z‖) ^ 2 = 4 * ‖z‖ ^ 2 by ring]
+  simp only [Submodule.coe_smul, smul_add, smul_smul]
+  have htangent : (4 * ‖z‖ ^ 2 + 4)⁻¹ * 4 * 2 =
+      (‖z‖ ^ 2 + 1)⁻¹ * 2 := by field_simp
+  have hpole : (4 * ‖z‖ ^ 2 + 4)⁻¹ * (4 * ‖z‖ ^ 2 - 4) =
+      (‖z‖ ^ 2 + 1)⁻¹ * (‖z‖ ^ 2 - 1) := by field_simp
+  norm_num only [Nat.cast_ofNat]
+  rw [show (4 * ‖z‖ ^ 2 + 4)⁻¹ * 8 =
+      (‖z‖ ^ 2 + 1)⁻¹ * 2 by
+        calc
+          _ = (4 * ‖z‖ ^ 2 + 4)⁻¹ * 4 * 2 := by ring
+          _ = _ := htangent, hpole]
+
+/-- At the south pole the finite chart differential is twice the fixed tangent-plane
+isometry. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereChart_fderiv_zero_apply (v : ℂ) :
+    fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0 v =
+      2 • (counterexampleTwoTangentEquiv v : ℝ³) := by
+  have heq : (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) =
+      fun z : ℂ ↦ (‖z‖ ^ 2 + 1)⁻¹ •
+        (2 • (counterexampleTwoTangentEquiv z : ℝ³) +
+          (‖z‖ ^ 2 - 1) • (counterexampleNorthPole : ℝ³)) := by
+    funext z
+    exact counterexampleSphereChart_coe z
+  rw [heq]
+  let T : ℂ →L[ℝ] ℝ³ :=
+    (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL.comp
+      counterexampleTwoTangentEquiv.toContinuousLinearEquiv.toContinuousLinearMap
+  have hT : HasFDerivAt (fun z : ℂ ↦ (counterexampleTwoTangentEquiv z : ℝ³)) T 0 :=
+    T.hasFDerivAt
+  have hs : HasFDerivAt (fun z : ℂ ↦ ‖z‖ ^ 2) (0 : ℂ →L[ℝ] ℝ) 0 := by
+    simpa using (hasStrictFDerivAt_norm_sq (0 : ℂ)).hasFDerivAt
+  have hden : HasFDerivAt (fun z : ℂ ↦ (‖z‖ ^ 2 + 1)⁻¹)
+      (0 : ℂ →L[ℝ] ℝ) 0 := by
+    convert (hasDerivAt_inv
+      (by norm_num : ‖(0 : ℂ)‖ ^ 2 + (1 : ℝ) ≠ 0)).hasFDerivAt.comp 0
+      (hs.add_const 1) using 1 ; ext x ; simp
+  have hlinear : HasFDerivAt
+      (fun z : ℂ ↦ 2 • (counterexampleTwoTangentEquiv z : ℝ³)) (T + T) 0 := by
+    simpa only [two_smul] using hT.add hT
+  have hradial : HasFDerivAt
+      (fun z : ℂ ↦ (‖z‖ ^ 2 - 1) • (counterexampleNorthPole : ℝ³))
+      (0 : ℂ →L[ℝ] ℝ³) 0 := by
+    convert (hs.sub_const 1).smul_const (counterexampleNorthPole : ℝ³) using 1 ;
+      ext x ; simp
+  have hnum : HasFDerivAt
+      (fun z : ℂ ↦ 2 • (counterexampleTwoTangentEquiv z : ℝ³) +
+        (‖z‖ ^ 2 - 1) • (counterexampleNorthPole : ℝ³))
+      (T + T) 0 := by
+    simpa using hlinear.add hradial
+  have hprod := hden.smul hnum
+  change (fderiv ℝ (((fun z : ℂ ↦ (‖z‖ ^ 2 + 1)⁻¹) •
+    fun z ↦ 2 • (counterexampleTwoTangentEquiv z : ℝ³) +
+      (‖z‖ ^ 2 - 1) • (counterexampleNorthPole : ℝ³))) 0) v = _
+  rw [hprod.fderiv]
+  simp [T, two_smul]
+
+/-- The finite chart differential at the south pole has the whole tangent plane as its range. -/
+@[category API, AMS 53]
+private theorem range_fderiv_counterexampleSphereChart_zero :
+    (fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0).range =
+      (ℝ ∙ (counterexampleSphereChart 0 : ℝ³))ᗮ := by
+  rw [counterexampleSphereChart_zero]
+  change (fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0).range =
+    (ℝ ∙ (-(counterexampleNorthPole : ℝ³)))ᗮ
+  have hspan : ℝ ∙ (-(counterexampleNorthPole : ℝ³)) =
+      ℝ ∙ (counterexampleNorthPole : ℝ³) := by
+    rw [Submodule.span_singleton_eq_span_singleton]
+    exact ⟨(-1 : ℝˣ), by simp⟩
+  rw [hspan]
+  apply le_antisymm
+  · intro y hy
+    obtain ⟨v, rfl⟩ := hy
+    change fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0 v ∈ _
+    rw [counterexampleSphereChart_fderiv_zero_apply]
+    simpa only [two_nsmul] using
+      Submodule.add_mem _ (counterexampleTwoTangentEquiv v).2
+        (counterexampleTwoTangentEquiv v).2
+  · intro y hy
+    let v : ℂ := counterexampleTwoTangentEquiv.symm ⟨y, hy⟩
+    refine ⟨(2 : ℝ)⁻¹ • v, ?_⟩
+    change fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0
+      ((2 : ℝ)⁻¹ • v) = y
+    rw [counterexampleSphereChart_fderiv_zero_apply]
+    simp only [v, map_smul, LinearIsometryEquiv.apply_symm_apply, Submodule.coe_smul]
+    change (2 : ℕ) • ((2 : ℝ)⁻¹ • y) = y
+    module
+
+/-- The finite stereographic parametrization is smooth as a map into the sphere. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereChart_contMDiff :
+    ContMDiff 𝓘(ℝ, ℂ) (𝓡 2) ∞ counterexampleSphereChart := by
+  apply ContMDiff.codRestrict_sphere
+  · have heq : (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) =
+        fun z : ℂ ↦ (‖z‖ ^ 2 + 1)⁻¹ •
+          (2 • (counterexampleTwoTangentEquiv z : ℝ³) +
+            (‖z‖ ^ 2 - 1) • (counterexampleNorthPole : ℝ³)) := by
+      funext z
+      exact counterexampleSphereChart_coe z
+    exact (show ContDiff ℝ ∞ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) by
+      rw [heq]
+      have hs : ContDiff ℝ ∞ (fun z : ℂ ↦ ‖z‖ ^ 2) := contDiff_norm_sq ℝ
+      have hT : ContDiff ℝ ∞
+          (fun z : ℂ ↦ (counterexampleTwoTangentEquiv z : ℝ³)) :=
+        ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL.contDiff.comp
+          counterexampleTwoTangentEquiv.contDiff)
+      have hone : ContDiff ℝ ∞ (fun _ : ℂ ↦ (1 : ℝ)) := contDiff_const
+      have hnorth : ContDiff ℝ ∞ (fun _ : ℂ ↦ (counterexampleNorthPole : ℝ³)) :=
+        contDiff_const
+      exact ((hs.add contDiff_const).inv (fun z ↦ by positivity)).smul
+        ((hT.const_smul 2).add ((hs.sub hone).smul hnorth))).contMDiff
+
+/-- The reciprocal complex chart on the sphere. Its origin is the north pole and, away from
+the origin, its finite coordinate is `100 / star w`. -/
+private noncomputable def counterexampleTwoReciprocalSphereChart
+    (w : ℂ) : sphere (0 : ℝ³) 1 :=
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  let u : (ℝ ∙ (-(counterexampleNorthPole : ℝ³)))ᗮ :=
+    ⟨(50 : ℝ)⁻¹ • (counterexampleTwoTangentEquiv w : ℝ³), by
+      rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+      have htangent := Submodule.mem_orthogonal_singleton_iff_inner_left.mp
+        (counterexampleTwoTangentEquiv w).2
+      simp only [real_inner_smul_left, inner_neg_right, htangent, mul_zero, neg_zero]⟩
+  (stereographic' 2 (-counterexampleNorthPole)).symm (Uneg u)
+
+/-- The old north-pole chart coordinate of the reciprocal spherical chart is its defining
+complex coordinate. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalLinearCoord_reciprocalSphereChart (w : ℂ) :
+    counterexampleTwoReciprocalLinearCoord
+      ((stereographic' 2 (-counterexampleNorthPole))
+        (counterexampleTwoReciprocalSphereChart w)) = w := by
+  let Upos := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere counterexampleNorthPole)).repr
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  let u : (ℝ ∙ (-(counterexampleNorthPole : ℝ³)))ᗮ :=
+    ⟨(50 : ℝ)⁻¹ • (counterexampleTwoTangentEquiv w : ℝ³), by
+      rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+      have htangent := Submodule.mem_orthogonal_singleton_iff_inner_left.mp
+        (counterexampleTwoTangentEquiv w).2
+      simp only [real_inner_smul_left, inner_neg_right, htangent, mul_zero, neg_zero]⟩
+  have hu : (u : ℝ³) ∈ (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ := by
+    rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+    have hu' := Submodule.mem_orthogonal_singleton_iff_inner_left.mp u.2
+    change inner ℝ (u : ℝ³) (-(counterexampleNorthPole : ℝ³)) = 0 at hu'
+    simpa only [inner_neg_right, neg_eq_zero] using hu'
+  rw [counterexampleTwoReciprocalSphereChart]
+  change counterexampleTwoReciprocalLinearCoord
+    ((stereographic' 2 (-counterexampleNorthPole))
+      ((stereographic' 2 (-counterexampleNorthPole)).symm (Uneg u))) = w
+  rw [(stereographic' 2 (-counterexampleNorthPole)).right_inv (by simp)]
+  rw [counterexampleTwoReciprocalLinearCoord]
+  simp only [u, Uneg, LinearIsometryEquiv.symm_apply_apply]
+  change 50 • Complex.orthonormalBasisOneI.repr.symm
+    (Upos ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection (u : ℝ³))) = w
+  rw [show (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection (u : ℝ³) =
+      ⟨u, hu⟩ by
+    simpa using (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ
+      |>.orthogonalProjection_mem_subspace_eq_self
+        (⟨u, hu⟩ : (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ)]
+  have hu_eq : (⟨u, hu⟩ : (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ) =
+      (50 : ℝ)⁻¹ • counterexampleTwoTangentEquiv w := by
+    apply Subtype.ext
+    rfl
+  rw [hu_eq, map_smul]
+  simp only [counterexampleTwoTangentEquiv, Upos, LinearIsometryEquiv.trans_apply,
+    LinearIsometryEquiv.apply_symm_apply]
+  rw [map_smul, LinearIsometryEquiv.symm_apply_apply]
+  simp only [← Nat.cast_smul_eq_nsmul ℝ, smul_smul]
+  norm_num
+
+/-- The reciprocal coordinate used at the north pole is smooth. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalLinearCoord_contDiff :
+    ContDiff ℝ ∞ counterexampleTwoReciprocalLinearCoord := by
+  let Upos := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere counterexampleNorthPole)).repr
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  let L : EuclideanSpace ℝ (Fin 2) →L[ℝ] ℂ :=
+    (50 • Complex.orthonormalBasisOneI.repr.symm.toContinuousLinearEquiv.toContinuousLinearMap).comp
+      (Upos.toContinuousLinearEquiv.toContinuousLinearMap.comp
+        ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection.comp
+          ((ℝ ∙ (-(counterexampleNorthPole : ℝ³)))ᗮ.subtypeL.comp
+            Uneg.symm.toContinuousLinearEquiv.toContinuousLinearMap)))
+  change ContDiff ℝ ∞ L
+  exact L.contDiff
+
+/-- The reciprocal linear coordinate is a similarity of ratio `50`. -/
+@[category API, AMS 53]
+private theorem norm_counterexampleTwoReciprocalLinearCoord
+    (x : EuclideanSpace ℝ (Fin 2)) :
+    ‖counterexampleTwoReciprocalLinearCoord x‖ = 50 * ‖x‖ := by
+  let Upos := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere counterexampleNorthPole)).repr
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  let u := Uneg.symm x
+  have hu : (u : ℝ³) ∈ (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ := by
+    rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+    have hu' := Submodule.mem_orthogonal_singleton_iff_inner_left.mp u.2
+    change inner ℝ (u : ℝ³) (-(counterexampleNorthPole : ℝ³)) = 0 at hu'
+    simpa only [inner_neg_right, neg_eq_zero] using hu'
+  rw [counterexampleTwoReciprocalLinearCoord]
+  change ‖50 • Complex.orthonormalBasisOneI.repr.symm
+    (Upos ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection (u : ℝ³)))‖ = _
+  rw [show (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection (u : ℝ³) =
+      ⟨u, hu⟩ by
+    simpa using (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ
+      |>.orthogonalProjection_mem_subspace_eq_self
+        (⟨u, hu⟩ : (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ),
+    RCLike.norm_nsmul (K := ℂ), nsmul_eq_mul,
+    LinearIsometryEquiv.norm_map, LinearIsometryEquiv.norm_map]
+  change (50 : ℝ) * ‖(u : ℝ³)‖ = 50 * ‖x‖
+  rw [Submodule.norm_coe, Uneg.symm.norm_map]
+
+/-- The reciprocal linear coordinate is injective. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalLinearCoord_injective :
+    Function.Injective counterexampleTwoReciprocalLinearCoord := by
+  intro x y hxy
+  have hsub : counterexampleTwoReciprocalLinearCoord (x - y) =
+      counterexampleTwoReciprocalLinearCoord x - counterexampleTwoReciprocalLinearCoord y := by
+    simp only [counterexampleTwoReciprocalLinearCoord, map_sub, Submodule.coe_sub, smul_sub]
+  have hnorm := norm_counterexampleTwoReciprocalLinearCoord (x - y)
+  rw [hsub, hxy, sub_self, norm_zero] at hnorm
+  have : x - y = 0 := by
+    rw [← norm_eq_zero]
+    nlinarith [norm_nonneg (x - y)]
+  exact sub_eq_zero.mp this
+
+/-- Every point except the south pole occurs in the reciprocal chart. -/
+@[category API, AMS 53]
+private theorem exists_reciprocalSphereChart_of_ne_south
+    {p : sphere (0 : ℝ³) 1} (hp : p ≠ counterexampleSphereChart 0) :
+    ∃ w : ℂ, counterexampleTwoReciprocalSphereChart w = p := by
+  let e := stereographic' 2 (-counterexampleNorthPole)
+  have hpole : p ∈ e.source := by
+    dsimp only [e]
+    rw [stereographic'_source]
+    simpa [counterexampleSphereChart_zero] using hp
+  let x := e p
+  let w := counterexampleTwoReciprocalLinearCoord x
+  have hrho : counterexampleTwoReciprocalSphereChart w ∈ e.source := by
+    rw [counterexampleTwoReciprocalSphereChart]
+    exact e.map_target (by simp [e])
+  refine ⟨w, e.injOn hrho hpole ?_⟩
+  apply counterexampleTwoReciprocalLinearCoord_injective
+  rw [counterexampleTwoReciprocalLinearCoord_reciprocalSphereChart]
+
+/-- In the chart centered at the north pole, the reciprocal of the original finite coordinate is
+the fixed real-linear coordinate used by the smooth reciprocal representative. -/
+@[category API, AMS 53]
+private theorem counterexampleSphereCoord_oppositeChart_reciprocal
+    {x : EuclideanSpace ℝ (Fin 2)} (hx : x ≠ 0) :
+    100 / star (counterexampleSphereCoord
+        ((stereographic' 2 (-counterexampleNorthPole)).symm x)) =
+          counterexampleTwoReciprocalLinearCoord x ∧
+      counterexampleTwoReciprocalLinearCoord x ≠ 0 := by
+  let Upos := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere counterexampleNorthPole)).repr
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  let u := Uneg.symm x
+  have hu : (u : ℝ³) ∈ (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ := by
+    rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+    have hu_neg := Submodule.mem_orthogonal_singleton_iff_inner_left.mp u.2
+    change inner ℝ (u : ℝ³) (-(counterexampleNorthPole : ℝ³)) = 0 at hu_neg
+    simpa only [inner_neg_right, neg_eq_zero] using hu_neg
+  have hu0 : (u : ℝ³) ≠ 0 := by
+    intro h
+    have hu_zero : u = 0 := Subtype.ext h
+    apply hx
+    rw [← Uneg.apply_symm_apply x]
+    simpa only [u, map_zero] using congrArg Uneg hu_zero
+  have htransition := SphereSupport.stereoToFun_stereoInvFunAux_neg
+    (norm_eq_of_mem_sphere counterexampleNorthPole) hu hu0
+  have hchart :
+      (stereographic' 2 counterexampleNorthPole)
+          ((stereographic' 2 (-counterexampleNorthPole)).symm x) =
+        (4 / ‖x‖ ^ 2) • Upos (⟨u, hu⟩ :
+          (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ) := by
+    change Upos (stereoToFun (counterexampleNorthPole : ℝ³)
+      (stereoInvFunAux (-(counterexampleNorthPole : ℝ³)) (u : ℝ³))) = _
+    have hunorm : ‖(u : ℝ³)‖ = ‖x‖ := by
+      rw [Submodule.norm_coe, Uneg.symm.norm_map]
+    rw [htransition, map_smul, hunorm]
+  let y : ℂ := Complex.orthonormalBasisOneI.repr.symm
+    (Upos (⟨u, hu⟩ : (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ))
+  have hcoord : counterexampleSphereCoord
+      ((stereographic' 2 (-counterexampleNorthPole)).symm x) =
+        (2 / ‖x‖ ^ 2) • y := by
+    rw [counterexampleSphereCoord, hchart]
+    simp only [map_smul, smul_smul]
+    apply congrArg (fun c : ℝ ↦ c • y)
+    field_simp [pow_ne_zero 2 (norm_ne_zero_iff.mpr hx)]
+    ring
+  have hnormy : ‖y‖ = ‖x‖ := by
+    simp only [y, LinearIsometryEquiv.norm_map]
+    change ‖(u : ℝ³)‖ = ‖x‖
+    rw [Submodule.norm_coe, Uneg.symm.norm_map]
+  have hy0 : y ≠ 0 := by
+    rw [← norm_ne_zero_iff, hnormy]
+    exact norm_ne_zero_iff.mpr hx
+  have hsquare : ‖x‖ ^ 2 ≠ 0 := pow_ne_zero 2 (norm_ne_zero_iff.mpr hx)
+  have hstar : star y * y = (‖x‖ ^ 2 : ℂ) := by
+    rw [← starRingEnd_apply, ← Complex.normSq_eq_conj_mul_self,
+      Complex.normSq_eq_norm_sq, hnormy]
+    norm_num
+  have hlinear : counterexampleTwoReciprocalLinearCoord x = 50 • y := by
+    rw [counterexampleTwoReciprocalLinearCoord]
+    change 50 • Complex.orthonormalBasisOneI.repr.symm
+      (Upos ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection (u : ℝ³))) =
+        50 • y
+    rw [show (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.orthogonalProjection (u : ℝ³) =
+        ⟨u, hu⟩ by
+      simpa using (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ
+        |>.orthogonalProjection_mem_subspace_eq_self
+          (⟨u, hu⟩ : (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ)]
+  constructor
+  · rw [hcoord, hlinear]
+    have hdenom : star ((2 / ‖x‖ ^ 2) • y) ≠ 0 := by
+      rw [star_smul]
+      exact smul_ne_zero (div_ne_zero (by norm_num) hsquare) (star_ne_zero.mpr hy0)
+    rw [div_eq_iff hdenom]
+    rw [star_smul]
+    simp only [star_trivial]
+    simp only [nsmul_eq_mul, Complex.real_smul]
+    change (100 : ℂ) = 50 * y * (((2 / ‖x‖ ^ 2 : ℝ) : ℂ) * star y)
+    rw [show 50 * y * (((2 / ‖x‖ ^ 2 : ℝ) : ℂ) * star y) =
+      50 * ((2 / ‖x‖ ^ 2 : ℝ) : ℂ) * (star y * y) by ring, hstar]
+    push_cast
+    field_simp [norm_ne_zero_iff.mpr hx] ; norm_num
+  · rw [hlinear]
+    exact smul_ne_zero (by norm_num) hy0
+
+/-- The inverse stereographic chart based at the south pole sends its origin to the north pole. -/
+@[category API, AMS 53]
+private theorem counterexampleOppositeSphereChart_zero :
+    (stereographic' 2 (-counterexampleNorthPole)).symm 0 = counterexampleNorthPole := by
+  apply Subtype.ext
+  simp [stereographic'_symm_apply]
+
+/-- In the north-pole chart, the pointwise extension is exactly the smooth reciprocal
+representative composed with a fixed real-linear coordinate. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_oppositeChart
+    (x : EuclideanSpace ℝ (Fin 2)) :
+    counterexampleTwoSphereExtension
+        ((stereographic' 2 (-counterexampleNorthPole)).symm x) =
+      counterexampleTwoReciprocal (counterexampleTwoReciprocalLinearCoord x) := by
+  by_cases hx : x = 0
+  · subst x
+    have hlinear : counterexampleTwoReciprocalLinearCoord 0 = 0 := by
+      simp [counterexampleTwoReciprocalLinearCoord]
+    rw [counterexampleOppositeSphereChart_zero, hlinear, counterexampleTwoReciprocal_zero]
+    simp [counterexampleTwoSphereExtension]
+  · have htransition := counterexampleSphereCoord_oppositeChart_reciprocal hx
+    have hpole :
+        (stereographic' 2 (-counterexampleNorthPole)).symm x ≠
+          counterexampleNorthPole := by
+      intro h
+      have hzero := counterexampleOppositeSphereChart_zero
+      exact hx ((stereographic' 2 (-counterexampleNorthPole)).symm.injOn
+        (by simp) (by simp) (h.trans hzero.symm))
+    have hcoord : counterexampleSphereCoord
+        ((stereographic' 2 (-counterexampleNorthPole)).symm x) =
+          100 / star (counterexampleTwoReciprocalLinearCoord x) := by
+      calc
+        counterexampleSphereCoord
+            ((stereographic' 2 (-counterexampleNorthPole)).symm x) =
+            100 / star (100 / star (counterexampleSphereCoord
+              ((stereographic' 2 (-counterexampleNorthPole)).symm x))) :=
+          (hundred_div_star_involutive _).symm
+        _ = 100 / star (counterexampleTwoReciprocalLinearCoord x) := by
+          rw [htransition.1]
+    rw [counterexampleTwoSphereExtension, if_neg hpole, hcoord]
+    exact counterexample_two_reciprocal htransition.2
+
+/-- The reciprocal chart pulls the spherical extension back to the explicit reciprocal
+representative. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_reciprocalSphereChart (w : ℂ) :
+    counterexampleTwoSphereExtension (counterexampleTwoReciprocalSphereChart w) =
+      counterexampleTwoReciprocal w := by
+  let e := stereographic' 2 (-counterexampleNorthPole)
+  have hrho : counterexampleTwoReciprocalSphereChart w ∈ e.source := by
+    rw [counterexampleTwoReciprocalSphereChart]
+    exact e.map_target (by simp [e])
+  calc
+    counterexampleTwoSphereExtension (counterexampleTwoReciprocalSphereChart w) =
+        counterexampleTwoSphereExtension
+          (e.symm (e (counterexampleTwoReciprocalSphereChart w))) := by
+      rw [e.left_inv hrho]
+    _ = counterexampleTwoReciprocal
+        (counterexampleTwoReciprocalLinearCoord
+          (e (counterexampleTwoReciprocalSphereChart w))) := by
+      exact counterexampleTwoSphereExtension_oppositeChart _
+    _ = counterexampleTwoReciprocal w := by
+      rw [counterexampleTwoReciprocalLinearCoord_reciprocalSphereChart]
+
+/-- Ambient rational formula for the reciprocal spherical chart. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalSphereChart_coe (w : ℂ) :
+    (counterexampleTwoReciprocalSphereChart w : ℝ³) =
+      (‖w‖ ^ 2 + 10000)⁻¹ •
+        (200 • (counterexampleTwoTangentEquiv w : ℝ³) +
+          (10000 - ‖w‖ ^ 2) • (counterexampleNorthPole : ℝ³)) := by
+  let Uneg := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) (E := ℝ³) 2
+    (ne_zero_of_mem_unit_sphere (-counterexampleNorthPole))).repr
+  let u : (ℝ ∙ (-(counterexampleNorthPole : ℝ³)))ᗮ :=
+    ⟨(50 : ℝ)⁻¹ • (counterexampleTwoTangentEquiv w : ℝ³), by
+      rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+      have htangent := Submodule.mem_orthogonal_singleton_iff_inner_left.mp
+        (counterexampleTwoTangentEquiv w).2
+      simp only [real_inner_smul_left, inner_neg_right, htangent, mul_zero, neg_zero]⟩
+  rw [counterexampleTwoReciprocalSphereChart, stereographic'_symm_apply]
+  simp only [LinearIsometryEquiv.symm_apply_apply]
+  change (‖(u : ℝ³)‖ ^ 2 + 4)⁻¹ • (4 : ℝ) • (u : ℝ³) +
+      (‖(u : ℝ³)‖ ^ 2 + 4)⁻¹ • (‖(u : ℝ³)‖ ^ 2 - 4) •
+        (-(counterexampleNorthPole : ℝ³)) = _
+  have hunorm : ‖(u : ℝ³)‖ ^ 2 = ‖w‖ ^ 2 / 2500 := by
+    simp only [u, norm_smul, Real.norm_eq_abs, abs_inv, abs_of_pos (by norm_num :
+      (0 : ℝ) < 50), Submodule.norm_coe,
+      counterexampleTwoTangentEquiv.norm_map]
+    ring
+  rw [hunorm]
+  simp only [u, ← Nat.cast_smul_eq_nsmul ℝ 200, smul_smul,
+    smul_neg, smul_add]
+  have htangent : (‖w‖ ^ 2 / 2500 + 4)⁻¹ * (4 * 50⁻¹) =
+      (‖w‖ ^ 2 + 10000)⁻¹ * 200 := by
+    field_simp
+    ring
+  have hpole : -((‖w‖ ^ 2 / 2500 + 4)⁻¹ * (‖w‖ ^ 2 / 2500 - 4)) =
+      (‖w‖ ^ 2 + 10000)⁻¹ * (10000 - ‖w‖ ^ 2) := by
+    field_simp
+    ring
+  rw [← neg_smul, htangent, hpole]
+  norm_num [← Nat.cast_smul_eq_nsmul ℝ 200, smul_smul]
+
+/-- Derivative of the rational reciprocal chart in ambient coordinates. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalSphereChart_fderiv_apply (w v : ℂ) :
+    fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w v =
+      (200 / (‖w‖ ^ 2 + 10000)) • (counterexampleTwoTangentEquiv v : ℝ³) -
+        (400 * inner ℝ w v / (‖w‖ ^ 2 + 10000) ^ 2) •
+          (counterexampleTwoTangentEquiv w : ℝ³) -
+        (40000 * inner ℝ w v / (‖w‖ ^ 2 + 10000) ^ 2) •
+          (counterexampleNorthPole : ℝ³) := by
+  let T : ℂ →L[ℝ] ℝ³ :=
+    (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL.comp
+      counterexampleTwoTangentEquiv.toContinuousLinearEquiv.toContinuousLinearMap
+  have hT : HasFDerivAt (fun z : ℂ ↦ (counterexampleTwoTangentEquiv z : ℝ³)) T w :=
+    T.hasFDerivAt
+  have hs : HasFDerivAt (fun z : ℂ ↦ ‖z‖ ^ 2) ((2 : ℝ) • innerSL ℝ w) w := by
+    simpa only [two_smul] using (hasStrictFDerivAt_norm_sq w).hasFDerivAt
+  have hden : HasFDerivAt (fun z : ℂ ↦ (‖z‖ ^ 2 + 10000)⁻¹)
+      (-((‖w‖ ^ 2 + 10000) ^ 2)⁻¹ • ((2 : ℝ) • innerSL ℝ w)) w := by
+    convert (hasDerivAt_inv (by positivity : ‖w‖ ^ 2 + 10000 ≠ 0)).hasFDerivAt.comp w
+      (hs.add_const 10000) using 1
+    all_goals
+      ext x
+      simp
+      ring
+  have hnum : HasFDerivAt
+      (fun z : ℂ ↦ (200 : ℝ) • (counterexampleTwoTangentEquiv z : ℝ³) +
+        (10000 - ‖z‖ ^ 2) • (counterexampleNorthPole : ℝ³))
+      ((200 : ℝ) • T + (-((2 : ℝ) • innerSL ℝ w)).smulRight
+        (counterexampleNorthPole : ℝ³)) w := by
+    convert (hT.const_smul 200).add
+      ((hasFDerivAt_const (x := w) 10000).sub hs |>.smul_const
+        (counterexampleNorthPole : ℝ³)) using 1
+    all_goals
+      ext x
+      simp
+  have hderiv := hden.smul hnum
+  have heq : (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) =
+      fun z : ℂ ↦ (‖z‖ ^ 2 + 10000)⁻¹ •
+        ((200 : ℝ) • (counterexampleTwoTangentEquiv z : ℝ³) +
+          (10000 - ‖z‖ ^ 2) • (counterexampleNorthPole : ℝ³)) := by
+    funext z
+    simpa only [← Nat.cast_smul_eq_nsmul ℝ 200] using
+      counterexampleTwoReciprocalSphereChart_coe z
+  rw [heq]
+  change (fderiv ℝ
+    (((fun z : ℂ ↦ (‖z‖ ^ 2 + 10000)⁻¹) •
+      fun z ↦ (200 : ℝ) • (counterexampleTwoTangentEquiv z : ℝ³) +
+        (10000 - ‖z‖ ^ 2) • (counterexampleNorthPole : ℝ³))) w) v = _
+  rw [hderiv.fderiv]
+  dsimp only [T]
+  have hTv : (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL
+      (counterexampleTwoTangentEquiv.toContinuousLinearEquiv.toContinuousLinearMap v) =
+        (counterexampleTwoTangentEquiv v : ℝ³) := rfl
+  simp only [ContinuousLinearMap.add_apply,
+    ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.neg_apply, innerSL_apply_apply,
+    smul_add, smul_smul, neg_smul]
+  rw [hTv]
+  change _ = _
+  match_scalars <;> (try simp only [smul_eq_mul]) <;>
+    field_simp [show ‖w‖ ^ 2 + 10000 ≠ 0 by positivity] <;> ring
+
+/-- The reciprocal spherical chart is conformal, with scale `200 / (‖w‖² + 10000)`.
+Both the inner-product and norm forms are recorded because the radius estimates use each. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalSphereChart_conformal (w v t : ℂ) :
+    inner ℝ
+        (fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w v)
+        (fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w t) =
+        40000 / (‖w‖ ^ 2 + 10000) ^ 2 * inner ℝ v t ∧
+      ‖fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w v‖ =
+        200 / (‖w‖ ^ 2 + 10000) * ‖v‖ := by
+  have hT (a b : ℂ) : inner ℝ (counterexampleTwoTangentEquiv a : ℝ³)
+      (counterexampleTwoTangentEquiv b : ℝ³) = inner ℝ a b :=
+    counterexampleTwoTangentEquiv.inner_map_map a b
+  have hTn (a : ℂ) : inner ℝ (counterexampleTwoTangentEquiv a : ℝ³)
+      (counterexampleNorthPole : ℝ³) = 0 :=
+    Submodule.mem_orthogonal_singleton_iff_inner_left.mp
+      (counterexampleTwoTangentEquiv a).2
+  have hnT (a : ℂ) : inner ℝ (counterexampleNorthPole : ℝ³)
+      (counterexampleTwoTangentEquiv a : ℝ³) = 0 := by
+    rw [real_inner_comm, hTn]
+  have hnn : inner ℝ (counterexampleNorthPole : ℝ³)
+      (counterexampleNorthPole : ℝ³) = 1 := by
+    rw [real_inner_self_eq_norm_sq, norm_eq_of_mem_sphere counterexampleNorthPole]
+    norm_num
+  have hinner (a b : ℂ) : inner ℝ
+        (fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w a)
+        (fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w b) =
+      40000 / (‖w‖ ^ 2 + 10000) ^ 2 * inner ℝ a b := by
+    rw [counterexampleTwoReciprocalSphereChart_fderiv_apply,
+      counterexampleTwoReciprocalSphereChart_fderiv_apply]
+    simp only [inner_sub_left, inner_sub_right,
+      real_inner_smul_left,
+      real_inner_smul_right, hT, hTn, hnT, hnn, mul_zero, sub_zero]
+    rw [real_inner_comm a w, real_inner_comm b w]
+    rw [real_inner_self_eq_norm_sq]
+    field_simp
+    ring
+  refine ⟨hinner v t, ?_⟩
+  have hsquare := hinner v v
+  rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq] at hsquare
+  have hden : 0 < ‖w‖ ^ 2 + 10000 := by positivity
+  have hscale : 0 ≤ 200 / (‖w‖ ^ 2 + 10000) := by positivity
+  apply (sq_eq_sq₀ (norm_nonneg _) (mul_nonneg hscale (norm_nonneg _))).mp
+  calc
+    ‖fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w v‖ ^ 2 =
+        40000 / (‖w‖ ^ 2 + 10000) ^ 2 * ‖v‖ ^ 2 := hsquare
+    _ = (200 / (‖w‖ ^ 2 + 10000) * ‖v‖) ^ 2 := by
+      field_simp
+      ring
+
+/-- The ambient differential of the reciprocal chart has exactly the tangent plane as its
+range. -/
+@[category API, AMS 53]
+private theorem range_fderiv_counterexampleTwoReciprocalSphereChart (w : ℂ) :
+    (fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w).range =
+      (ℝ ∙ (counterexampleTwoReciprocalSphereChart w : ℝ³))ᗮ := by
+  let dρ : ℂ →L[ℝ] ℝ³ :=
+    fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w
+  have hdρinj : Function.Injective dρ := by
+    intro v t hvt
+    have hscale := (counterexampleTwoReciprocalSphereChart_conformal w (v - t) (v - t)).2
+    change ‖dρ (v - t)‖ = 200 / (‖w‖ ^ 2 + 10000) * ‖v - t‖ at hscale
+    rw [map_sub, hvt, sub_self, norm_zero] at hscale
+    have hpositive : 0 < 200 / (‖w‖ ^ 2 + 10000) := by positivity
+    have : ‖v - t‖ = 0 := by nlinarith [norm_nonneg (v - t)]
+    exact sub_eq_zero.mp (norm_eq_zero.mp this)
+  have hdρorth (v : ℂ) : inner ℝ (dρ v)
+      (counterexampleTwoReciprocalSphereChart w : ℝ³) = 0 := by
+    have hT (a b : ℂ) : inner ℝ (counterexampleTwoTangentEquiv a : ℝ³)
+        (counterexampleTwoTangentEquiv b : ℝ³) = inner ℝ a b :=
+      counterexampleTwoTangentEquiv.inner_map_map a b
+    have hTn (a : ℂ) : inner ℝ (counterexampleTwoTangentEquiv a : ℝ³)
+        (counterexampleNorthPole : ℝ³) = 0 :=
+      Submodule.mem_orthogonal_singleton_iff_inner_left.mp
+        (counterexampleTwoTangentEquiv a).2
+    have hnT (a : ℂ) : inner ℝ (counterexampleNorthPole : ℝ³)
+        (counterexampleTwoTangentEquiv a : ℝ³) = 0 := by
+      rw [real_inner_comm, hTn]
+    have hnn : inner ℝ (counterexampleNorthPole : ℝ³)
+        (counterexampleNorthPole : ℝ³) = 1 := by
+      rw [real_inner_self_eq_norm_sq, norm_eq_of_mem_sphere counterexampleNorthPole]
+      norm_num
+    change inner ℝ
+      (fderiv ℝ (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w v)
+      (counterexampleTwoReciprocalSphereChart w : ℝ³) = 0
+    rw [counterexampleTwoReciprocalSphereChart_fderiv_apply,
+      counterexampleTwoReciprocalSphereChart_coe]
+    simp only [← Nat.cast_smul_eq_nsmul ℝ 200, inner_sub_left, real_inner_smul_left,
+      real_inner_smul_right,
+      inner_add_right, hT, hTn, hnT, hnn, mul_zero]
+    rw [real_inner_comm v w, real_inner_self_eq_norm_sq]
+    field_simp
+    ring
+  apply Submodule.eq_of_le_of_finrank_eq
+  · intro y hy
+    obtain ⟨v, rfl⟩ := hy
+    exact Submodule.mem_orthogonal_singleton_iff_inner_left.mpr (hdρorth v)
+  · have hker : dρ.ker = ⊥ := LinearMap.ker_eq_bot.mpr hdρinj
+    have hrank := LinearMap.finrank_range_add_finrank_ker dρ.toLinearMap
+    rw [hker, finrank_bot, add_zero, Complex.finrank_real_complex] at hrank
+    rw [hrank, Submodule.finrank_orthogonal_span_singleton (n := 2)
+      (ne_zero_of_mem_unit_sphere (counterexampleTwoReciprocalSphereChart w))]
+
+/-- The reciprocal chart is smooth as a map into the sphere. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalSphereChart_contMDiff :
+    ContMDiff 𝓘(ℝ, ℂ) (𝓡 2) ∞ counterexampleTwoReciprocalSphereChart := by
+  apply ContMDiff.codRestrict_sphere
+  · have heq : (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) =
+        fun z : ℂ ↦ (‖z‖ ^ 2 + 10000)⁻¹ •
+          (200 • (counterexampleTwoTangentEquiv z : ℝ³) +
+            (10000 - ‖z‖ ^ 2) • (counterexampleNorthPole : ℝ³)) := by
+      funext z
+      exact counterexampleTwoReciprocalSphereChart_coe z
+    exact (show ContDiff ℝ ∞
+        (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) by
+      rw [heq]
+      have hs : ContDiff ℝ ∞ (fun z : ℂ ↦ ‖z‖ ^ 2) := contDiff_norm_sq ℝ
+      have hT : ContDiff ℝ ∞
+          (fun z : ℂ ↦ (counterexampleTwoTangentEquiv z : ℝ³)) :=
+        ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL.contDiff.comp
+          counterexampleTwoTangentEquiv.contDiff)
+      have htenThousand : ContDiff ℝ ∞ (fun _ : ℂ ↦ (10000 : ℝ)) := contDiff_const
+      have hnorth : ContDiff ℝ ∞ (fun _ : ℂ ↦ (counterexampleNorthPole : ℝ³)) :=
+        contDiff_const
+      exact ((hs.add contDiff_const).inv (fun z ↦ by positivity)).smul
+        ((hT.const_smul 200).add
+          ((htenThousand.sub hs).smul hnorth))).contMDiff
+
+/-- The pointwise extension is smooth at the north pole in the opposite stereographic chart. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_contMDiffAt_north :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ) ∞ counterexampleTwoSphereExtension
+      counterexampleNorthPole := by
+  let e := stereographic' 2 (-counterexampleNorthPole)
+  have he : e ∈ IsManifold.maximalAtlas (𝓡 2) ∞ (sphere (0 : ℝ³) 1) :=
+    IsManifold.subset_maximalAtlas ⟨-counterexampleNorthPole, rfl⟩
+  have hnorth : counterexampleNorthPole ∈ e.source := by
+    simpa [e, stereographic'_source] using
+      ne_neg_of_mem_unit_sphere ℝ counterexampleNorthPole
+  have he_smooth : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) ∞ e
+      counterexampleNorthPole :=
+    contMDiffAt_of_mem_maximalAtlas he hnorth
+  have hrepresentative : ContMDiff 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) 𝓘(ℝ, ℝ) ∞
+      (fun x ↦ counterexampleTwoReciprocal (counterexampleTwoReciprocalLinearCoord x)) :=
+    (counterexampleTwoReciprocal_contDiff.comp
+      counterexampleTwoReciprocalLinearCoord_contDiff).contMDiff
+  have hcomp : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ) ∞
+      (fun p ↦ counterexampleTwoReciprocal (counterexampleTwoReciprocalLinearCoord (e p)))
+      counterexampleNorthPole :=
+    hrepresentative.contMDiffAt.comp counterexampleNorthPole he_smooth
+  apply hcomp.congr_of_eventuallyEq
+  filter_upwards [e.open_source.mem_nhds hnorth] with p hp
+  simpa [e, e.left_inv hp] using
+    counterexampleTwoSphereExtension_oppositeChart (e p)
+
+/-- The planar expression `counterexample 2` extends smoothly through the missing north pole of
+the stereographic chart. -/
+@[category research solved, AMS 26 53]
+theorem counterexample_two_sphere_extension :
+    ∃ h : sphere (0 : ℝ³) 1 → ℝ,
+      ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h ∧
+      ∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z := by
+  exact ⟨counterexampleTwoSphereExtension,
+    counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+      counterexampleTwoSphereExtension_contMDiffAt_north,
+    counterexampleTwoSphereExtension_chart⟩
+
+/-- The smooth spherical extension is uniquely determined by its values in the finite
+stereographic chart. -/
+@[category API, AMS 53]
+private theorem eq_counterexampleTwoSphereExtension
+    (h : sphere (0 : ℝ³) 1 → ℝ)
+    (hsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h)
+    (hchart : ∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) :
+    h = counterexampleTwoSphereExtension := by
+  funext p
+  by_cases hp : p = counterexampleNorthPole
+  · subst p
+    let e := stereographic' 2 (-counterexampleNorthPole)
+    have hecont : Continuous e.symm := by
+      rw [← continuousOn_univ]
+      simpa [e] using e.symm.continuousOn
+    have heq : (fun x : EuclideanSpace ℝ (Fin 2) ↦ h (e.symm x)) =
+        fun x ↦ counterexampleTwoSphereExtension (e.symm x) := by
+      apply Continuous.ext_on (dense_compl_singleton (0 : EuclideanSpace ℝ (Fin 2)))
+        (hsmooth.continuous.comp hecont)
+        ((counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+          counterexampleTwoSphereExtension_contMDiffAt_north).continuous.comp hecont)
+      intro x hx
+      have hx0 : x ≠ 0 := by simpa using hx
+      have hpole : e.symm x ≠ counterexampleNorthPole := by
+        intro h
+        have hzero : e.symm 0 = counterexampleNorthPole := by
+          simpa [e] using counterexampleOppositeSphereChart_zero
+        exact hx0 (e.symm.injOn (by simp [e]) (by simp [e]) (h.trans hzero.symm))
+      change h (e.symm x) = counterexampleTwoSphereExtension (e.symm x)
+      rw [← counterexampleSphereChart_coord hpole, hchart,
+        counterexampleTwoSphereExtension_chart]
+    simpa [e, counterexampleOppositeSphereChart_zero] using congrFun heq 0
+  · rw [← counterexampleSphereChart_coord hp, hchart,
+      counterexampleTwoSphereExtension_chart]
+
+/-- The constant term dominates the oscillatory term by a vast margin. -/
+@[category API, AMS 53]
+private theorem counterexample_two_lower (z : ℂ) :
+    (1 : ℝ) ≤ counterexample 2 z := by
+  let r := ‖z‖
+  let w := (100 / star z) ^ ((2 : ℂ) / 2)
+  let c := r ^ 2 * Real.exp (-r ^ (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) /
+    (1 + r ^ 2)
+  have hr : 0 ≤ r := norm_nonneg z
+  have hc0 : 0 ≤ c := by
+    dsimp [c]
+    positivity
+  have hexp : Real.exp (-r ^ (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) ≤ 1 := by
+    rw [Real.exp_le_one_iff]
+    exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.mpr (Real.rpow_nonneg hr _))
+      (Real.exp_nonneg _)
+  have hratio : r ^ 2 / (1 + r ^ 2) ≤ 1 := by
+    rw [div_le_one (by positivity : 0 < 1 + r ^ 2)]
+    linarith [sq_nonneg r]
+  have hc1 : c ≤ 1 := by
+    calc
+      c = (r ^ 2 / (1 + r ^ 2)) *
+          Real.exp (-r ^ (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) := by
+        dsimp [c]
+        ring
+      _ ≤ 1 * 1 := mul_le_mul hratio hexp (Real.exp_nonneg _) (by norm_num)
+      _ = 1 := one_mul 1
+  have hseed : -(253 / 160 : ℝ) ≤ counterexampleSeed w :=
+    neg_le_of_abs_le (counterexampleSeed_abs_le w)
+  have hproduct : -(253 / 160 : ℝ) ≤ c * counterexampleSeed w := by
+    calc
+      -(253 / 160 : ℝ) ≤ c * (-(253 / 160 : ℝ)) := by nlinarith
+      _ ≤ c * counterexampleSeed w := mul_le_mul_of_nonneg_left hseed hc0
+  have hproduct' : -(253 / 160 : ℝ) ≤
+      ‖z‖ ^ 2 * Real.exp (-‖z‖ ^ (-(1 : ℝ) / 4) * Real.exp (-(‖z‖ ^ 2))) *
+        counterexampleSeed ((100 / star z) ^ ((2 : ℂ) / 2)) / (1 + ‖z‖ ^ 2) := by
+    calc
+      -(253 / 160 : ℝ) ≤ c * counterexampleSeed w := hproduct
+      _ = _ := by
+        dsimp [c, r, w]
+        ring
+  rw [counterexample]
+  norm_num at hproduct' ⊢
+  linarith
+
+/-- The explicit spherical extension is uniformly positive, so its support body contains a
+unit ball. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSphereExtension_lower
+    (p : sphere (0 : ℝ³) 1) : (1 : ℝ) ≤ counterexampleTwoSphereExtension p := by
+  by_cases hp : p = counterexampleNorthPole
+  · simp [counterexampleTwoSphereExtension, hp]
+    norm_num
+  · rw [counterexampleTwoSphereExtension, if_neg hp]
+    exact counterexample_two_lower _
+
+/-- The homogeneous extension is nonnegative in every ambient direction. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoRadialExtension_nonneg (x : ℝ³) :
+    0 ≤ SphereSupport.radialExtension counterexampleTwoSphereExtension x := by
+  by_cases hx : x = 0
+  · simp [hx, SphereSupport.radialExtension]
+  · rw [SphereSupport.radialExtension, dif_neg hx]
+    exact mul_nonneg (norm_nonneg x)
+      (le_trans zero_le_one (counterexampleTwoSphereExtension_lower _))
+
+/-- A coarse uniform bound for the power-times-exponential terms in the reciprocal-chart
+estimates. The extra `1` lets the proof split at `y = 1` without optimizing a maximum. -/
+@[category API, AMS 53]
+private theorem rpow_mul_exp_neg_le_factorial {y c a : ℝ} (n : ℕ)
+    (hy : 0 ≤ y) (hc : 0 < c) (ha : 0 ≤ a) (han : a ≤ n) :
+    y ^ a * Real.exp (-c * y) ≤ 1 + n.factorial / c ^ n := by
+  by_cases hy1 : y ≤ 1
+  · calc
+      y ^ a * Real.exp (-c * y) ≤ 1 * 1 := by
+        exact mul_le_mul (Real.rpow_le_one hy hy1 ha)
+          (Real.exp_le_one_iff.mpr (mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.mpr hc.le) hy))
+          (Real.exp_nonneg _) zero_le_one
+      _ ≤ 1 + n.factorial / c ^ n := by
+        simpa only [one_mul] using
+          (le_add_of_nonneg_right (show 0 ≤ n.factorial / c ^ n by positivity))
+  · have h1y : 1 ≤ y := le_of_not_ge hy1
+    have hpower : y ^ a ≤ y ^ n := by
+      simpa only [Real.rpow_natCast] using Real.rpow_le_rpow_of_exponent_le h1y han
+    have hfactorial : (0 : ℝ) < n.factorial := by positivity
+    have hexp := Real.pow_div_factorial_le_exp (x := c * y) (mul_nonneg hc.le hy) n
+    have hpowexp : c ^ n * y ^ n ≤ n.factorial * Real.exp (c * y) := by
+      have := (div_le_iff₀ hfactorial).mp hexp
+      simpa only [mul_pow, mul_comm] using this
+    have hquotient : y ^ n / Real.exp (c * y) ≤ n.factorial / c ^ n := by
+      rw [div_le_div_iff₀ (Real.exp_pos _) (pow_pos hc n)]
+      simpa only [mul_comm] using hpowexp
+    calc
+      y ^ a * Real.exp (-c * y) ≤ y ^ n * Real.exp (-c * y) :=
+        mul_le_mul_of_nonneg_right hpower (Real.exp_nonneg _)
+      _ = y ^ n / Real.exp (c * y) := by
+        rw [show -c * y = -(c * y) by ring, Real.exp_neg]
+        rfl
+      _ ≤ n.factorial / c ^ n := hquotient
+      _ ≤ 1 + n.factorial / c ^ n := le_add_of_nonneg_left zero_le_one
+
+/-- The elementary exact maximum estimate for `t ^ a * exp (-t)`. It avoids introducing a
+calculus maximizer into each reciprocal-chart coefficient bound. -/
+@[category API, AMS 53]
+private theorem rpow_mul_exp_neg_le_self {t a : ℝ} (ht : 0 ≤ t) (ha : 0 < a) :
+    t ^ a * Real.exp (-t) ≤ a ^ a * Real.exp (-a) := by
+  obtain rfl | ht := ht.eq_or_lt
+  · simp [Real.zero_rpow ha.ne']
+    positivity
+  · have hlog := Real.log_le_sub_one_of_pos (div_pos ht ha)
+    have hlog' : a * Real.log t - t ≤ a * Real.log a - a := by
+      have h := mul_le_mul_of_nonneg_left hlog ha.le
+      rw [Real.log_div ht.ne' ha.ne'] at h
+      field_simp [ha.ne'] at h
+      linarith
+    rw [Real.rpow_def_of_pos ht, Real.rpow_def_of_pos ha, ← Real.exp_add, ← Real.exp_add]
+    exact Real.exp_le_exp.mpr (by nlinarith)
+
+/-- For the exponents used below, the exact maximum admits a very simple rational upper bound. -/
+@[category API, AMS 53]
+private theorem self_rpow_mul_exp_neg_le_half {a : ℝ} (ha1 : 1 ≤ a) (ha2 : a ≤ 2) :
+    a ^ a * Real.exp (-a) ≤ a / 2 := by
+  have ha : 0 ≤ a := zero_le_one.trans ha1
+  have hquot0 : 0 ≤ a / Real.exp 1 := div_nonneg ha (Real.exp_nonneg _)
+  have hquot1 : a / Real.exp 1 ≤ 1 := by
+    rw [div_le_one (Real.exp_pos _)]
+    exact ha2.trans Real.exp_one_gt_two.le
+  calc
+    a ^ a * Real.exp (-a) = (a / Real.exp 1) ^ a := by
+      rw [show -a = (-1) * a by ring, Real.exp_mul, Real.exp_neg,
+        ← Real.mul_rpow ha (inv_nonneg.mpr (Real.exp_nonneg 1)), div_eq_mul_inv]
+    _ ≤ a / Real.exp 1 := Real.rpow_le_self_of_le_one hquot0 hquot1 ha1
+    _ ≤ a / 2 := div_le_div_of_nonneg_left ha (by norm_num) Real.exp_one_gt_two.le
+
+/-- For exponents at most one, the unscaled power-times-exponential maximum is at most one. -/
+@[category API, AMS 53]
+private theorem rpow_mul_exp_neg_le_one {t a : ℝ} (ht : 0 ≤ t) (ha : 0 < a) (ha1 : a ≤ 1) :
+    t ^ a * Real.exp (-t) ≤ 1 := by
+  refine (rpow_mul_exp_neg_le_self ht ha).trans ?_
+  calc
+    a ^ a * Real.exp (-a) ≤ 1 * 1 := by
+      exact mul_le_mul (Real.rpow_le_one ha.le ha1 ha.le)
+        (Real.exp_le_one_iff.mpr (neg_nonpos.mpr ha.le)) (Real.exp_nonneg _) zero_le_one
+    _ = 1 := one_mul 1
+
+/-- With exponent at most four, doubling the exponential rate makes the same maximum at most
+one. This single loose estimate controls the largest term in the second damping derivative. -/
+@[category API, AMS 53]
+private theorem rpow_mul_exp_neg_two_mul_le_one {t a : ℝ}
+    (ht : 0 ≤ t) (ha : 0 < a) (ha4 : a ≤ 4) :
+    t ^ a * Real.exp (-2 * t) ≤ 1 := by
+  have hmax := rpow_mul_exp_neg_le_self (t := 2 * t) (a := a) (mul_nonneg (by norm_num) ht) ha
+  have hself : a ^ a * Real.exp (-a) ≤ (2 : ℝ) ^ a := by
+    rw [show -a = (-1) * a by ring, Real.exp_mul, Real.exp_neg,
+      ← Real.mul_rpow ha.le (inv_nonneg.mpr (Real.exp_nonneg 1)), ← div_eq_mul_inv]
+    exact Real.rpow_le_rpow (div_nonneg ha.le (Real.exp_nonneg _))
+      (by rw [div_le_iff₀ (Real.exp_pos _)]; nlinarith [Real.exp_one_gt_two]) ha.le
+  have hscaled : (2 : ℝ) ^ a * (t ^ a * Real.exp (-2 * t)) ≤ (2 : ℝ) ^ a := by
+    calc
+      (2 : ℝ) ^ a * (t ^ a * Real.exp (-2 * t)) =
+          (2 * t) ^ a * Real.exp (-(2 * t)) := by
+        rw [Real.mul_rpow (by norm_num) ht]
+        ring
+      _ ≤ a ^ a * Real.exp (-a) := hmax
+      _ ≤ (2 : ℝ) ^ a := hself
+  have hpos : 0 < (2 : ℝ) ^ a := Real.rpow_pos_of_pos (by norm_num) a
+  exact le_of_mul_le_mul_left (by simpa using hscaled) hpos
+
+/-- The first reciprocal damping-derivative numerator is at most one. -/
+@[category API, AMS 53]
+private theorem reciprocalDampingFirstNumerator_bound {t : ℝ} (ht : 0 ≤ t) :
+    Real.exp (-t) * ((1 / 8 : ℝ) * t ^ (3 / 8 : ℝ) + t ^ (11 / 8 : ℝ)) ≤ 1 := by
+  have hsmall : t ^ (3 / 8 : ℝ) * Real.exp (-t) ≤ 1 :=
+    rpow_mul_exp_neg_le_one ht (by norm_num) (by norm_num)
+  have hlarge : t ^ (11 / 8 : ℝ) * Real.exp (-t) ≤ 11 / 16 :=
+    (rpow_mul_exp_neg_le_self ht (by norm_num)).trans
+      ((self_rpow_mul_exp_neg_le_half (a := 11 / 8) (by norm_num) (by norm_num)).trans_eq
+        (by norm_num))
+  calc
+    Real.exp (-t) * ((1 / 8 : ℝ) * t ^ (3 / 8 : ℝ) + t ^ (11 / 8 : ℝ)) =
+        (1 / 8 : ℝ) * (t ^ (3 / 8 : ℝ) * Real.exp (-t)) +
+          t ^ (11 / 8 : ℝ) * Real.exp (-t) := by ring
+    _ ≤ (1 / 8 : ℝ) * 1 + 11 / 16 := by gcongr
+    _ ≤ 1 := by norm_num
+
+/-- The six terms in the second reciprocal damping-derivative numerator admit the rational
+bound used in the global uniqueness and radius estimates. -/
+@[category API, AMS 53]
+private theorem reciprocalDampingSecondNumerator_bound {t : ℝ} (ht : 0 ≤ t) :
+    Real.exp (-2 * t) * ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ) +
+        (1 / 4 : ℝ) * t ^ (7 / 4 : ℝ) + t ^ (11 / 4 : ℝ)) +
+      Real.exp (-t) * ((7 / 64 : ℝ) * t ^ (7 / 8 : ℝ) +
+        (7 / 4 : ℝ) * t ^ (15 / 8 : ℝ) + t ^ (23 / 8 : ℝ)) < 10 := by
+  have hexp_two_le (a : ℝ) :
+      t ^ a * Real.exp (-2 * t) ≤ t ^ a * Real.exp (-t) := by
+    gcongr
+    nlinarith
+  have h₁ : t ^ (3 / 4 : ℝ) * Real.exp (-2 * t) ≤ 1 :=
+    rpow_mul_exp_neg_two_mul_le_one ht (by norm_num) (by norm_num)
+  have h₂ : t ^ (7 / 4 : ℝ) * Real.exp (-2 * t) ≤ 7 / 8 :=
+    (hexp_two_le (7 / 4)).trans <|
+      (rpow_mul_exp_neg_le_self ht (by norm_num)).trans
+        ((self_rpow_mul_exp_neg_le_half (a := 7 / 4) (by norm_num) (by norm_num)).trans_eq
+          (by norm_num))
+  have h₃ : t ^ (11 / 4 : ℝ) * Real.exp (-2 * t) ≤ 1 :=
+    rpow_mul_exp_neg_two_mul_le_one ht (by norm_num) (by norm_num)
+  have h₄ : t ^ (7 / 8 : ℝ) * Real.exp (-t) ≤ 1 :=
+    rpow_mul_exp_neg_le_one ht (by norm_num) (by norm_num)
+  have h₅ : t ^ (15 / 8 : ℝ) * Real.exp (-t) ≤ 15 / 16 :=
+    (rpow_mul_exp_neg_le_self ht (by norm_num)).trans
+      ((self_rpow_mul_exp_neg_le_half (a := 15 / 8) (by norm_num) (by norm_num)).trans_eq
+        (by norm_num))
+  have h₆ : t ^ (23 / 8 : ℝ) * Real.exp (-t) ≤ 7 := by
+    convert rpow_mul_exp_neg_le_factorial 3 ht (by norm_num : (0 : ℝ) < 1)
+      (by norm_num : (0 : ℝ) ≤ 23 / 8) (by norm_num : (23 / 8 : ℝ) ≤ 3) using 1 <;>
+      norm_num [Nat.factorial]
+  calc
+    Real.exp (-2 * t) * ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ) +
+        (1 / 4 : ℝ) * t ^ (7 / 4 : ℝ) + t ^ (11 / 4 : ℝ)) +
+      Real.exp (-t) * ((7 / 64 : ℝ) * t ^ (7 / 8 : ℝ) +
+        (7 / 4 : ℝ) * t ^ (15 / 8 : ℝ) + t ^ (23 / 8 : ℝ)) =
+        (1 / 64 : ℝ) * (t ^ (3 / 4 : ℝ) * Real.exp (-2 * t)) +
+        (1 / 4 : ℝ) * (t ^ (7 / 4 : ℝ) * Real.exp (-2 * t)) +
+        t ^ (11 / 4 : ℝ) * Real.exp (-2 * t) +
+        (7 / 64 : ℝ) * (t ^ (7 / 8 : ℝ) * Real.exp (-t)) +
+        (7 / 4 : ℝ) * (t ^ (15 / 8 : ℝ) * Real.exp (-t)) +
+        t ^ (23 / 8 : ℝ) * Real.exp (-t) := by ring
+    _ ≤ (1 / 64 : ℝ) * 1 + (1 / 4 : ℝ) * (7 / 8) + 1 +
+        (7 / 64 : ℝ) * 1 + (7 / 4 : ℝ) * (15 / 16) + 7 := by gcongr
+    _ < 10 := by norm_num
+
+/-- The reciprocal-chart conformal weight times the damping factor has a deliberately coarse
+global numerical bound. This is the main growth estimate behind the radius-tensor certificate. -/
+@[category API, AMS 53]
+private theorem reciprocalMetricDamping_bound {y : ℝ} (hy : 0 ≤ y) :
+    2500 * (1 + y ^ 8) * Real.exp (-(y * Real.exp (-(y ^ (-(8 : ℝ)))))) <
+      164000000 := by
+  by_cases hy2 : y ≤ 2
+  · have hy8 : y ^ 8 ≤ (2 : ℝ) ^ 8 := pow_le_pow_left₀ hy hy2 8
+    have hpsi : 0 ≤ y * Real.exp (-(y ^ (-(8 : ℝ)))) :=
+      mul_nonneg hy (Real.exp_nonneg _)
+    calc
+      2500 * (1 + y ^ 8) * Real.exp (-(y * Real.exp (-(y ^ (-(8 : ℝ)))))) ≤
+          2500 * (1 + (2 : ℝ) ^ 8) * 1 := by
+        gcongr
+        exact Real.exp_le_one_iff.mpr (neg_nonpos.mpr hpsi)
+      _ < 164000000 := by norm_num
+  · have hy8 : (256 : ℝ) ≤ y ^ 8 := by
+      convert pow_le_pow_left₀ (by norm_num : (0 : ℝ) ≤ 2) (le_of_not_ge hy2) 8 using 1 ;
+        norm_num
+    have hypos : 0 < y := lt_of_lt_of_le (by norm_num) (le_of_not_ge hy2)
+    have hinv : y ^ (-(8 : ℝ)) ≤ 1 / 256 := by
+      rw [Real.rpow_neg hy]
+      have hy8r : y ^ (8 : ℝ) = y ^ (8 : ℕ) := Real.rpow_natCast y 8
+      calc
+        (y ^ (8 : ℝ))⁻¹ = (y ^ (8 : ℕ))⁻¹ := by rw [hy8r]
+        _ ≤ (256 : ℝ)⁻¹ :=
+          (inv_le_inv₀ (pow_pos hypos 8) (by norm_num)).2 hy8
+        _ = 1 / 256 := by norm_num
+    have hdamping : (255 / 256 : ℝ) ≤ Real.exp (-(y ^ (-(8 : ℝ)))) := by
+      calc
+        (255 / 256 : ℝ) = 1 - 1 / 256 := by norm_num
+        _ ≤ 1 - y ^ (-(8 : ℝ)) := sub_le_sub_left hinv 1
+        _ ≤ Real.exp (-(y ^ (-(8 : ℝ)))) := Real.one_sub_le_exp_neg _
+    have hexp : Real.exp (-(y * Real.exp (-(y ^ (-(8 : ℝ)))))) ≤
+        Real.exp (-(255 / 256 : ℝ) * y) := by
+      rw [Real.exp_le_exp]
+      simpa [mul_comm] using neg_le_neg (mul_le_mul_of_nonneg_left hdamping hy)
+    have hpower := rpow_mul_exp_neg_le_factorial 8 hy
+      (by norm_num : (0 : ℝ) < 255 / 256) (by norm_num : (0 : ℝ) ≤ 8)
+      (by norm_num : (8 : ℝ) ≤ 8)
+    have hpower' : y ^ 8 * Real.exp (-(255 / 256 : ℝ) * y) ≤
+        1 + (8 : ℕ).factorial / (255 / 256 : ℝ) ^ 8 := by
+      convert hpower using 1 ; norm_num
+    have hexp_one : Real.exp (-(255 / 256 : ℝ) * y) ≤ 1 := by
+      exact Real.exp_le_one_iff.mpr
+        (mul_nonpos_of_nonpos_of_nonneg (by norm_num) hy)
+    calc
+      2500 * (1 + y ^ 8) * Real.exp (-(y * Real.exp (-(y ^ (-(8 : ℝ)))))) ≤
+          2500 * (1 + y ^ 8) * Real.exp (-(255 / 256 : ℝ) * y) := by
+        gcongr
+      _ = 2500 * (Real.exp (-(255 / 256 : ℝ) * y) +
+          y ^ 8 * Real.exp (-(255 / 256 : ℝ) * y)) := by ring
+      _ ≤ 2500 * (1 + (1 + (8 : ℕ).factorial / (255 / 256 : ℝ) ^ 8)) := by
+        gcongr
+      _ < 164000000 := by norm_num [Nat.factorial]
+
+/-- The preceding one-variable estimate in the exact reciprocal-chart normalization. -/
+@[category API, AMS 53]
+private theorem reciprocalConformalDamping_bound (w : ℂ) :
+    (‖w‖ ^ 2 + 10000) ^ 2 / 40000 * counterexampleTwoReciprocalDamping w <
+      164000000 := by
+  by_cases hw : w = 0
+  · subst w
+    simp [counterexampleTwoReciprocalDamping, counterexampleTwoReciprocalExponent]
+    norm_num
+  · let s := ‖w‖ ^ 2
+    let y := (s / 10000) ^ ((1 : ℝ) / 8)
+    have hs : 0 < s := sq_pos_of_pos (norm_pos_iff.mpr hw)
+    have hy : 0 < y := Real.rpow_pos_of_pos (div_pos hs (by norm_num)) _
+    have hy8 : y ^ 8 = s / 10000 := by
+      dsimp only [y]
+      rw [← Real.rpow_natCast, ← Real.rpow_mul (div_nonneg hs.le (by norm_num))]
+      norm_num
+    have hyneg8 : y ^ (-(8 : ℝ)) = 10000 / s := by
+      calc
+        y ^ (-(8 : ℝ)) = (y ^ (8 : ℝ))⁻¹ := Real.rpow_neg hy.le (8 : ℝ)
+        _ = (y ^ (8 : ℕ))⁻¹ := congrArg Inv.inv (Real.rpow_natCast y 8)
+        _ = 10000 / s := by rw [hy8, inv_div]
+    have hψ : counterexampleTwoReciprocalExponent s =
+        y * Real.exp (-(y ^ (-(8 : ℝ)))) := by
+      rw [counterexampleTwoReciprocalExponent_of_pos hs, hyneg8]
+      dsimp only [y]
+      congr 2 ; ring
+    have hbound := reciprocalMetricDamping_bound hy.le
+    rw [counterexampleTwoReciprocalDamping]
+    change (s + 10000) ^ 2 / 40000 *
+      (10000 / (s + 10000) * Real.exp (-counterexampleTwoReciprocalExponent s)) < _
+    rw [hψ]
+    calc
+      (s + 10000) ^ 2 / 40000 *
+          (10000 / (s + 10000) * Real.exp (-(y * Real.exp (-y ^ (-(8 : ℝ)))))) =
+          2500 * (1 + y ^ 8) * Real.exp (-(y * Real.exp (-y ^ (-(8 : ℝ))))) := by
+        rw [hy8]
+        field_simp [show s + 10000 ≠ 0 by positivity]
+        ring
+      _ < 164000000 := hbound
+
+/-- The degree-one radial extension of a smooth function on the sphere is smooth away from the
+origin. -/
+@[category API, AMS 53]
+private theorem radialExtension_contDiffOn_compl_of_contMDiff
+    (h : sphere (0 : ℝ³) 1 → ℝ)
+    (hsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h) :
+    ContDiffOn ℝ ∞ (SphereSupport.radialExtension h) {0}ᶜ := by
+  let U : TopologicalSpace.Opens ℝ³ := ⟨{0}ᶜ, isOpen_compl_singleton⟩
+  have hnorm : ContMDiff 𝓘(ℝ, ℝ³) 𝓘(ℝ, ℝ) ∞ (fun x : U ↦ ‖(x : ℝ³)‖) := by
+    intro x
+    exact (contDiffAt_norm ℝ x.property).contMDiffAt.comp x
+      contMDiff_subtype_val.contMDiffAt
+  have hnorm_ne : ∀ x : U, ‖(x : ℝ³)‖ ≠ 0 := fun x ↦ norm_ne_zero_iff.mpr x.property
+  have hnorm_inv : ContMDiff 𝓘(ℝ, ℝ³) 𝓘(ℝ, ℝ) ∞
+      (fun x : U ↦ ‖(x : ℝ³)‖⁻¹) := hnorm.inv₀ hnorm_ne
+  have hnormalize_mem (x : U) : ‖(x : ℝ³)‖⁻¹ • (x : ℝ³) ∈ sphere (0 : ℝ³) 1 := by
+    rw [mem_sphere_zero_iff_norm, norm_smul, Real.norm_eq_abs, abs_inv, abs_norm,
+      inv_mul_cancel₀ (hnorm_ne x)]
+  let normalize : U → sphere (0 : ℝ³) 1 := fun x ↦
+    ⟨‖(x : ℝ³)‖⁻¹ • (x : ℝ³), hnormalize_mem x⟩
+  have hnormalize : ContMDiff 𝓘(ℝ, ℝ³) (𝓡 2) ∞ normalize := by
+    exact (hnorm_inv.smul contMDiff_subtype_val).codRestrict_sphere hnormalize_mem
+  have hradial : ContMDiff 𝓘(ℝ, ℝ³) 𝓘(ℝ, ℝ) ∞
+      (fun x : U ↦ SphereSupport.radialExtension h (x : ℝ³)) := by
+    apply (hnorm.mul (hsmooth.comp hnormalize)).congr
+    intro x
+    change SphereSupport.radialExtension h (x : ℝ³) =
+      ‖(x : ℝ³)‖ * h (normalize x)
+    have hx0 : (x : ℝ³) ≠ 0 := by
+      intro hx
+      apply x.property
+      simpa only [Set.mem_singleton_iff] using hx
+    rw [SphereSupport.radialExtension, dif_neg hx0]
+  intro x hx
+  let xU : U := ⟨x, hx⟩
+  have hx_smooth : ContMDiffAt 𝓘(ℝ, ℝ³) 𝓘(ℝ, ℝ) ∞
+      (SphereSupport.radialExtension h) x := by
+    exact contMDiffAt_subtype_iff.mp (hradial.contMDiffAt :
+      ContMDiffAt 𝓘(ℝ, ℝ³) 𝓘(ℝ, ℝ) ∞
+        (fun y : U ↦ SphereSupport.radialExtension h (y : ℝ³)) xU)
+  exact hx_smooth.contDiffAt.contDiffWithinAt
+
+/-- The degree-one radial extension of a smooth function on the sphere is differentiable away
+from the origin. This is applied only on the unit sphere below. -/
+@[category API, AMS 53]
+private theorem radialExtension_differentiableAt_of_contMDiff
+    (h : sphere (0 : ℝ³) 1 → ℝ)
+    (hsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h)
+    (p : sphere (0 : ℝ³) 1) :
+    DifferentiableAt ℝ (SphereSupport.radialExtension h) (p : ℝ³) := by
+  exact (radialExtension_contDiffOn_compl_of_contMDiff h hsmooth
+    (p : ℝ³) (ne_zero_of_mem_unit_sphere p)).differentiableWithinAt (by simp) |>.differentiableAt
+      (isOpen_compl_singleton.mem_nhds (ne_zero_of_mem_unit_sphere p))
+
+/-- The homogeneous extension of the explicit spherical function is differentiable at every
+point of the unit sphere. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoRadialExtension_differentiableAt
+    (p : sphere (0 : ℝ³) 1) :
+    DifferentiableAt ℝ
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) (p : ℝ³) := by
+  exact radialExtension_differentiableAt_of_contMDiff counterexampleTwoSphereExtension
+    (counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+      counterexampleTwoSphereExtension_contMDiffAt_north) p
+
+/-- The contact map obtained from the homogeneous extension of a smooth spherical function is
+smooth. -/
+@[category API, AMS 53]
+private theorem homogeneousGradient_contMDiff_of_contMDiff
+    (h : sphere (0 : ℝ³) 1 → ℝ)
+    (hsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) ∞
+      (SphereSupport.homogeneousGradient (SphereSupport.radialExtension h)) := by
+  let H := SphereSupport.radialExtension h
+  have hH : ContDiffOn ℝ ∞ H {0}ᶜ :=
+    radialExtension_contDiffOn_compl_of_contMDiff h hsmooth
+  have hDf : ContDiffOn ℝ ∞ (fderiv ℝ H) {0}ᶜ :=
+    hH.fderiv_of_isOpen isOpen_compl_singleton (by simp)
+  have hgradient : ContDiffOn ℝ ∞ (gradient H) {0}ᶜ := by
+    simpa only [gradient] using
+      (InnerProductSpace.toDual ℝ ℝ³).symm.contDiff.comp_contDiffOn hDf
+  intro p
+  have hp : (p : ℝ³) ∈ ({0}ᶜ : Set ℝ³) := ne_zero_of_mem_unit_sphere p
+  have hp_gradient : ContDiffAt ℝ ∞ (gradient H) (p : ℝ³) :=
+    (hgradient (p : ℝ³) hp).contDiffAt (isOpen_compl_singleton.mem_nhds hp)
+  exact hp_gradient.contMDiffAt.comp p (contMDiff_coe_sphere p)
+
+/-- The explicit homogeneous-gradient contact map is smooth. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_contMDiff :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) ∞
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension)) := by
+  exact homogeneousGradient_contMDiff_of_contMDiff counterexampleTwoSphereExtension
+    (counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+      counterexampleTwoSphereExtension_contMDiffAt_north)
+
+/-- The first anti-holomorphic derivative, in the normalization for which the repository's
+`traceFreeHessian` is four times its second iterate. -/
+private noncomputable def complexBarDeriv (u : ℂ → ℝ) (w : ℂ) : ℂ :=
+  ((fderiv ℝ u w 1 : ℂ) + (fderiv ℝ u w Complex.I : ℂ) * Complex.I) / 2
+
+/-- The trace-free spherical Hessian in a stereographic chart whose metric denominator is
+`‖w‖² + a`. Its vanishing is the coordinate form of the umbilic equation. -/
+private noncomputable def sphericalTraceFreeHessian (a : ℝ) (u : ℂ → ℝ) (w : ℂ) : ℂ :=
+  traceFreeHessian u w + 8 * w / (‖w‖ ^ 2 + a) * complexBarDeriv u w
+
+/-- The Euclidean chart Laplacian, encoded using the same second Fréchet derivative as the
+trace-free Hessian. -/
+private noncomputable def chartLaplacian (u : ℂ → ℝ) (w : ℂ) : ℝ :=
+  let H := fderiv ℝ (fun z ↦ fderiv ℝ u z) w
+  H 1 1 + H Complex.I Complex.I
+
+/-- In reciprocal coordinates, the homogeneous gradient is the support value in the radial
+direction plus the metric-dual of the first derivative in the tangent direction. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_reciprocalSphereChart (w : ℂ) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    let dρ := fderiv ℝ
+      (fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)) w
+    F (counterexampleTwoReciprocalSphereChart w) =
+      counterexampleTwoReciprocal w • (counterexampleTwoReciprocalSphereChart w : ℝ³) +
+        ((‖w‖ ^ 2 + 10000) ^ 2 / 20000) •
+          dρ (complexBarDeriv counterexampleTwoReciprocal w) := by
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let F := SphereSupport.homogeneousGradient H
+  let ρ : ℂ → ℝ³ := fun z ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ ρ w
+  let p := counterexampleTwoReciprocalSphereChart w
+  let G : ℝ³ := counterexampleTwoReciprocal w • (p : ℝ³) +
+    ((‖w‖ ^ 2 + 10000) ^ 2 / 20000) •
+      dρ (complexBarDeriv counterexampleTwoReciprocal w)
+  have hρdiff : Differentiable ℝ ρ := by
+    exact (contMDiff_coe_sphere.comp counterexampleTwoReciprocalSphereChart_contMDiff).contDiff
+      |>.differentiable (by simp)
+  have hdρrange : dρ.range = (ℝ ∙ (p : ℝ³))ᗮ := by
+    simpa only [dρ, ρ, p] using range_fderiv_counterexampleTwoReciprocalSphereChart w
+  have hdρorth (v : ℂ) : inner ℝ (dρ v) (p : ℝ³) = 0 := by
+    rw [← Submodule.mem_orthogonal_singleton_iff_inner_left, ← hdρrange]
+    exact ⟨v, rfl⟩
+  have hHdiff : DifferentiableAt ℝ H (p : ℝ³) :=
+    counterexampleTwoRadialExtension_differentiableAt p
+  have hcontact : inner ℝ (F p) (p : ℝ³) = counterexampleTwoReciprocal w := by
+    calc
+      inner ℝ (F p) (p : ℝ³) = H p :=
+        SphereSupport.inner_homogeneousGradient H p hHdiff
+          (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+      _ = counterexampleTwoReciprocal w := by
+        dsimp only [H]
+        rw [SphereSupport.radialExtension_coe,
+          counterexampleTwoSphereExtension_reciprocalSphereChart]
+  have hdifferentiate (v : ℂ) :
+      fderiv ℝ counterexampleTwoReciprocal w v =
+        fderiv ℝ H (p : ℝ³) (dρ v) := by
+    have hcomp := hHdiff.hasFDerivAt.comp w hρdiff.differentiableAt.hasFDerivAt
+    have heq : H ∘ ρ = counterexampleTwoReciprocal := by
+      funext z
+      dsimp only [Function.comp_apply, H, ρ]
+      rw [SphereSupport.radialExtension_coe,
+        counterexampleTwoSphereExtension_reciprocalSphereChart]
+    rw [heq] at hcomp
+    exact congr($hcomp.fderiv v)
+  have hfirst (v : ℂ) : fderiv ℝ counterexampleTwoReciprocal w v =
+      2 * inner ℝ (complexBarDeriv counterexampleTwoReciprocal w) v := by
+    have hv : v = v.re • (1 : ℂ) + v.im • Complex.I := by
+      apply Complex.ext <;> simp
+    rw [hv, map_add, map_smul, map_smul, complexBarDeriv]
+    simp only [smul_eq_mul]
+    simp only [Complex.inner, Complex.mul_re, Complex.conj_re, Complex.conj_im,
+      Complex.div_re, Complex.div_im, Complex.add_re, Complex.add_im,
+      Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im,
+      Complex.normSq_apply]
+    norm_num
+    ring
+  have hGcontact : inner ℝ G (p : ℝ³) = counterexampleTwoReciprocal w := by
+    dsimp only [G]
+    rw [inner_add_left, real_inner_smul_left, real_inner_smul_left,
+      hdρorth, mul_zero, add_zero, real_inner_self_eq_norm_sq,
+      norm_eq_of_mem_sphere p]
+    ring
+  have htangent (v : ℂ) : inner ℝ (F p - G) (dρ v) = 0 := by
+    dsimp only [F, SphereSupport.homogeneousGradient]
+    rw [inner_sub_left, inner_gradient_left hHdiff, ← hdifferentiate v, hfirst]
+    have hmetric := (counterexampleTwoReciprocalSphereChart_conformal w
+      (complexBarDeriv counterexampleTwoReciprocal w) v).1
+    change inner ℝ (dρ (complexBarDeriv counterexampleTwoReciprocal w)) (dρ v) =
+      40000 / (‖w‖ ^ 2 + 10000) ^ 2 *
+        inner ℝ (complexBarDeriv counterexampleTwoReciprocal w) v at hmetric
+    dsimp only [G]
+    have hporth : inner ℝ (p : ℝ³) (dρ v) = 0 := by
+      rw [real_inner_comm, hdρorth]
+    rw [inner_add_left, real_inner_smul_left, real_inner_smul_left, hporth,
+      mul_zero, zero_add, hmetric]
+    field_simp
+    ring
+  have hradial : inner ℝ (F p - G) (p : ℝ³) = 0 := by
+    rw [inner_sub_left, hcontact, hGcontact, sub_self]
+  have hdmem : F p - G ∈ dρ.range := by
+    rw [hdρrange, Submodule.mem_orthogonal_singleton_iff_inner_left]
+    exact hradial
+  obtain ⟨v, hv⟩ := hdmem
+  have hzero := htangent v
+  rw [← hv] at hzero
+  change inner ℝ (dρ v) (dρ v) = 0 at hzero
+  rw [real_inner_self_eq_norm_sq] at hzero
+  have hdρzero : dρ v = 0 := norm_eq_zero.mp (sq_eq_zero_iff.mp hzero)
+  have hdiffzero : F p - G = 0 := by
+    have hzero' : (0 : ℝ³) = F p - G := by simpa [hdρzero] using hv
+    exact hzero'.symm
+  exact sub_eq_zero.mp hdiffzero
+
+/-- The real Fréchet derivative expressed through the complex bar derivative. -/
+@[category API, AMS 53]
+private theorem fderiv_eq_two_inner_complexBarDeriv (u : ℂ → ℝ) (w v : ℂ) :
+    fderiv ℝ u w v = 2 * inner ℝ (complexBarDeriv u w) v := by
+  have hv : v = v.re • (1 : ℂ) + v.im • Complex.I := by
+    apply Complex.ext <;> simp
+  rw [hv, map_add, map_smul, map_smul]
+  simp only [complexBarDeriv, smul_eq_mul]
+  simp only [Complex.inner, Complex.mul_re, Complex.conj_re, Complex.conj_im,
+    Complex.div_re, Complex.div_im, Complex.add_re, Complex.add_im,
+    Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im,
+    Complex.normSq_apply]
+  norm_num
+  ring
+
+/-- The derivative of the complex bar derivative in terms of the two Hessian encodings. -/
+@[category API, AMS 53]
+private theorem complexBarDeriv_fderiv_eq (u : ℂ → ℝ) (hu : ContDiff ℝ ∞ u) (w v : ℂ) :
+    fderiv ℝ (complexBarDeriv u) w v =
+      ((((chartLaplacian u w : ℝ) : ℂ) * v +
+        traceFreeHessian u w * star v) / 4) := by
+  let M := fderiv ℝ (fun z ↦ fderiv ℝ u z) w
+  have hDu : DifferentiableAt ℝ (fun z ↦ fderiv ℝ u z) w :=
+    (hu.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero w
+  have hM (t : ℂ) :
+      fderiv ℝ (fun z ↦ (fderiv ℝ u z t : ℂ)) w v = (M v t : ℂ) := by
+    have ht := hDu.hasFDerivAt.clm_apply (hasFDerivAt_const (x := w) t)
+    have hcast := Complex.ofRealCLM.hasFDerivAt.comp w ht
+    simpa [M] using congr($hcast.fderiv v)
+  have hcomponentDiff (t : ℂ) :
+      DifferentiableAt ℝ (fun z ↦ (fderiv ℝ u z t : ℂ)) w := by
+    have ht := hDu.hasFDerivAt.clm_apply (hasFDerivAt_const (x := w) t)
+    exact (Complex.ofRealCLM.hasFDerivAt.comp w ht).differentiableAt
+  rw [show complexBarDeriv u = fun z ↦
+    ((fderiv ℝ u z 1 : ℂ) + (fderiv ℝ u z Complex.I : ℂ) * Complex.I) / 2 by rfl]
+  simp only [div_eq_mul_inv]
+  have hwhole := ((hcomponentDiff 1).hasFDerivAt.add
+    ((hcomponentDiff Complex.I).hasFDerivAt.mul_const Complex.I)).mul_const (2 : ℂ)⁻¹
+  have hwhole' := hwhole.fderiv
+  simp only [Pi.add_apply] at hwhole'
+  rw [hwhole']
+  simp only [ContinuousLinearMap.smul_apply, ContinuousLinearMap.add_apply]
+  rw [hM, hM]
+  · have hsymm (a b : ℂ) : M a b = M b a := by
+      dsimp only [M]
+      exact hu.contDiffAt.isSymmSndFDerivAt
+        (by
+          simpa only [minSmoothness_of_isRCLikeNormedField] using
+            (show (2 : WithTop ℕ∞) ≤ (∞ : WithTop ℕ∞) by
+              exact WithTop.coe_le_coe.mpr le_top)) a b
+    have hv : v = v.re • (1 : ℂ) + v.im • Complex.I := by
+      apply Complex.ext <;> simp
+    have hMv1 : M v 1 = v.re * M 1 1 + v.im * M 1 Complex.I := by
+      nth_rw 1 [hv]
+      simp only [map_add, map_smul, ContinuousLinearMap.add_apply,
+        ContinuousLinearMap.smul_apply, smul_eq_mul]
+      rw [hsymm Complex.I 1]
+    have hMvI : M v Complex.I =
+        v.re * M 1 Complex.I + v.im * M Complex.I Complex.I := by
+      nth_rw 1 [hv]
+      simp only [map_add, map_smul, ContinuousLinearMap.add_apply,
+        ContinuousLinearMap.smul_apply, smul_eq_mul]
+    rw [hMv1, hMvI, chartLaplacian, traceFreeHessian]
+    dsimp only [M]
+    simp only [smul_eq_mul]
+    apply Complex.ext <;>
+      simp [Complex.mul_re, Complex.mul_im] <;> ring
+
+/-- The complex-coordinate algebra in the reciprocal radius formula. -/
+@[category API, AMS 53]
+private theorem reciprocal_radius_source_vector (u : ℂ → ℝ) (w v : ℂ) (D : ℝ) (g : ℂ)
+    (hDdef : D = ‖w‖ ^ 2 + 10000) (hgdef : g = complexBarDeriv u w) :
+        (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+            (D / 5000 * inner ℝ w v) • g +
+            (D ^ 2 / 20000) •
+              ((-2 / D) • (inner ℝ w v • g + inner ℝ w g • v -
+                  inner ℝ v g • w) +
+                ((((chartLaplacian u w : ℝ) : ℂ) * v +
+                    traceFreeHessian u w * star v) / 4)) =
+          (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+            (D ^ 2 / 80000) •
+              (((chartLaplacian u w : ℝ) : ℂ) * v +
+                sphericalTraceFreeHessian 10000 u w * star v) := by
+  have hcomplex : inner ℝ w v • g - inner ℝ w g • v +
+      inner ℝ v g • w = w * g * star v := by
+    apply Complex.ext <;> simp [Complex.inner, add_mul] <;> ring
+  rw [hgdef] at hcomplex
+  have hD : D ≠ 0 := by
+    rw [hDdef]
+    positivity
+  have hDcast : (((‖w‖ : ℝ) : ℂ) ^ 2) + ((10000 : ℝ) : ℂ) = (D : ℂ) := by
+    rw [hDdef]
+    norm_cast
+  have herrorVector :
+      (D / 5000 * inner ℝ w v) • g +
+          (D ^ 2 / 20000) •
+            ((-2 / D) • (inner ℝ w v • g + inner ℝ w g • v -
+              inner ℝ v g • w)) =
+        (D / 10000) • (inner ℝ w v • g - inner ℝ w g • v +
+          inner ℝ v g • w) := by
+    have htwice : D / 5000 = 2 * (D / 10000) := by ring
+    have hnegative : (D ^ 2 / 20000) * (-2 / D) = -(D / 10000) := by
+      field_simp [hD]
+      ring
+    simp only [smul_smul, htwice, hnegative]
+    module
+  calc
+    (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+          (D / 5000 * inner ℝ w v) • g +
+          (D ^ 2 / 20000) •
+            ((-2 / D) • (inner ℝ w v • g + inner ℝ w g • v -
+                inner ℝ v g • w) +
+              ((((chartLaplacian u w : ℝ) : ℂ) * v +
+                traceFreeHessian u w * star v) / 4)) =
+        (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+          ((D / 5000 * inner ℝ w v) • g +
+            (D ^ 2 / 20000) •
+              ((-2 / D) • (inner ℝ w v • g + inner ℝ w g • v -
+                inner ℝ v g • w))) +
+          (D ^ 2 / 20000) •
+            ((((chartLaplacian u w : ℝ) : ℂ) * v +
+              traceFreeHessian u w * star v) / 4) := by module
+    _ = (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+          (D / 10000) • (inner ℝ w v • g - inner ℝ w g • v +
+            inner ℝ v g • w) +
+          (D ^ 2 / 20000) •
+            ((((chartLaplacian u w : ℝ) : ℂ) * v +
+              traceFreeHessian u w * star v) / 4) := by rw [herrorVector]
+    _ = _ := by
+      rw [hgdef, hcomplex, sphericalTraceFreeHessian]
+      rw [hDcast]
+      apply Complex.ext <;> simp [-Complex.ofReal_pow] <;>
+        field_simp [hD] <;> ring
+
+/-- The second derivative of the reciprocal spherical chart in ambient coordinates. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalSphereChart_second_fderiv (w a b : ℂ) :
+    fderiv ℝ (fun z ↦ fderiv ℝ
+      (fun y : ℂ ↦ (counterexampleTwoReciprocalSphereChart y : ℝ³)) z) w a b =
+        fderiv ℝ (fun y : ℂ ↦ (counterexampleTwoReciprocalSphereChart y : ℝ³)) w
+            ((-2 / (‖w‖ ^ 2 + 10000)) •
+              (inner ℝ w a • b + inner ℝ w b • a - inner ℝ a b • w)) -
+          (40000 / (‖w‖ ^ 2 + 10000) ^ 2 * inner ℝ a b) •
+            (counterexampleTwoReciprocalSphereChart w : ℝ³) := by
+  let ρ : ℂ → ℝ³ := fun z ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ ρ w
+  let D : ℝ := ‖w‖ ^ 2 + 10000
+  change fderiv ℝ (fun z ↦ fderiv ℝ ρ z) w a b =
+    dρ ((-2 / D) • (inner ℝ w a • b + inner ℝ w b • a - inner ℝ a b • w)) -
+      (40000 / D ^ 2 * inner ℝ a b) • (ρ w)
+  have hρsmooth : ContDiff ℝ ∞ ρ := by
+    exact (contMDiff_coe_sphere.comp counterexampleTwoReciprocalSphereChart_contMDiff).contDiff
+  have hDρ : DifferentiableAt ℝ (fun z ↦ fderiv ℝ ρ z) w := by
+    exact (hρsmooth.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero w
+  have heval : fderiv ℝ (fun z ↦ fderiv ℝ ρ z b) w a =
+      fderiv ℝ (fun z ↦ fderiv ℝ ρ z) w a b := by
+    have ht := hDρ.hasFDerivAt.clm_apply (hasFDerivAt_const (x := w) b)
+    simpa using congr($ht.fderiv a)
+  rw [← heval]
+  have heq : (fun z ↦ fderiv ℝ ρ z b) = fun z : ℂ ↦
+      (200 / (‖z‖ ^ 2 + 10000)) • (counterexampleTwoTangentEquiv b : ℝ³) -
+        (400 * inner ℝ z b / (‖z‖ ^ 2 + 10000) ^ 2) •
+          (counterexampleTwoTangentEquiv z : ℝ³) -
+        (40000 * inner ℝ z b / (‖z‖ ^ 2 + 10000) ^ 2) •
+          (counterexampleNorthPole : ℝ³) := by
+    funext z
+    exact counterexampleTwoReciprocalSphereChart_fderiv_apply z b
+  rw [heq]
+  let S : ℂ → ℝ := fun z ↦ ‖z‖ ^ 2 + 10000
+  let I : ℂ → ℝ := fun z ↦ inner ℝ z b
+  let T : ℂ →L[ℝ] ℝ³ :=
+    (ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL.comp
+      counterexampleTwoTangentEquiv.toContinuousLinearEquiv.toContinuousLinearMap
+  have hS : HasFDerivAt S (2 • innerSL ℝ w) w := by
+    dsimp only [S]
+    simpa only [two_smul] using
+      (hasStrictFDerivAt_norm_sq w).hasFDerivAt.add_const 10000
+  have hI : HasFDerivAt I (innerSL ℝ b) w := by
+    dsimp only [I]
+    simpa [real_inner_comm] using (innerSL ℝ b).hasFDerivAt
+  have hq : HasFDerivAt (fun z ↦ (S z)⁻¹)
+      (-((S w) ^ 2)⁻¹ • (2 • innerSL ℝ w)) w := by
+    convert (hasDerivAt_inv (by dsimp only [S]; positivity)).hasFDerivAt.comp w hS using 1 ;
+      ext x ; simp ; ring
+  have hT : HasFDerivAt
+      (fun z : ℂ ↦ (counterexampleTwoTangentEquiv z : ℝ³)) T w := T.hasFDerivAt
+  have hR := hI.mul (hq.pow 2)
+  have hE := (((hq.const_mul 200).smul_const
+    (counterexampleTwoTangentEquiv b : ℝ³)).sub
+      ((hR.const_mul 400).smul hT)).sub
+        ((hR.const_mul 40000).smul_const (counterexampleNorthPole : ℝ³))
+  have hsource :
+      (fun z : ℂ ↦
+        (200 / (‖z‖ ^ 2 + 10000)) • (counterexampleTwoTangentEquiv b : ℝ³) -
+          (400 * inner ℝ z b / (‖z‖ ^ 2 + 10000) ^ 2) •
+            (counterexampleTwoTangentEquiv z : ℝ³) -
+          (40000 * inner ℝ z b / (‖z‖ ^ 2 + 10000) ^ 2) •
+            (counterexampleNorthPole : ℝ³)) =
+        fun z ↦
+          (200 * (S z)⁻¹) • (counterexampleTwoTangentEquiv b : ℝ³) -
+            (400 * (I z * (S z)⁻¹ ^ 2)) •
+              (counterexampleTwoTangentEquiv z : ℝ³) -
+            (40000 * (I z * (S z)⁻¹ ^ 2)) •
+              (counterexampleNorthPole : ℝ³) := by
+    funext z
+    dsimp only [S, I]
+    simp only [div_eq_mul_inv, inv_pow]
+    ring
+  rw [hsource]
+  have hfun :
+      (fun z : ℂ ↦
+        (200 * (S z)⁻¹) • (counterexampleTwoTangentEquiv b : ℝ³) -
+          (400 * (I z * (S z)⁻¹ ^ 2)) • (counterexampleTwoTangentEquiv z : ℝ³) -
+          (40000 * (I z * (S z)⁻¹ ^ 2)) • (counterexampleNorthPole : ℝ³)) =
+        (((fun z : ℂ ↦
+            (200 * (S z)⁻¹) • (counterexampleTwoTangentEquiv b : ℝ³)) -
+          ((fun z : ℂ ↦ 400 * (I * fun x ↦ (S x)⁻¹ ^ 2) z) •
+            fun z : ℂ ↦ (counterexampleTwoTangentEquiv z : ℝ³))) -
+          fun z : ℂ ↦
+            (40000 * (I * fun x ↦ (S x)⁻¹ ^ 2) z) •
+              (counterexampleNorthPole : ℝ³)) := by
+    funext z
+    rfl
+  rw [hfun, hE.fderiv]
+  simp only [ContinuousLinearMap.sub_apply, ContinuousLinearMap.add_apply,
+    ContinuousLinearMap.smul_apply, ContinuousLinearMap.smulRight_apply,
+    innerSL_apply_apply]
+  dsimp only [S, I, T]
+  dsimp only [ρ]
+  rw [counterexampleTwoReciprocalSphereChart_coe]
+  dsimp only [D, dρ]
+  rw [counterexampleTwoReciprocalSphereChart_fderiv_apply]
+  have hTa : ((ℝ ∙ (counterexampleNorthPole : ℝ³))ᗮ.subtypeL.comp
+      counterexampleTwoTangentEquiv.toContinuousLinearEquiv.toContinuousLinearMap) a =
+        (counterexampleTwoTangentEquiv a : ℝ³) := rfl
+  rw [hTa]
+  simp only [map_add, map_sub, map_smul, Submodule.coe_add, Submodule.coe_sub,
+    Submodule.coe_smul, smul_add, smul_sub, smul_smul, div_eq_mul_inv,
+    ← inv_pow, Nat.reduceSub, pow_one, inner_add_right, inner_sub_right,
+    real_inner_smul_right, real_inner_self_eq_norm_sq, smul_eq_mul, Pi.mul_apply]
+  rw [real_inner_comm b a]
+  have hdenOrder : ‖w‖ ^ 2 + 10000 = 10000 + ‖w‖ ^ 2 := by ring
+  rw [hdenOrder]
+  have hden : 10000 + ‖w‖ ^ 2 ≠ 0 := by positivity
+  have hcancel (X Y c k : ℝ) :
+      ‖w‖ ^ 2 * X * (10000 + ‖w‖ ^ 2)⁻¹ * Y * k - ‖w‖ ^ 2 * c +
+            (X * (10000 + ‖w‖ ^ 2)⁻¹ * Y * (10000 * k) - c * 10000) =
+          -(‖w‖ ^ 2 * c) + (X * Y * k - c * 10000) := by
+    calc
+      _ = ((10000 + ‖w‖ ^ 2) * (10000 + ‖w‖ ^ 2)⁻¹) * X * Y * k -
+            ‖w‖ ^ 2 * c - c * 10000 := by ring
+      _ = X * Y * k - ‖w‖ ^ 2 * c - c * 10000 := by
+        rw [mul_inv_cancel₀ hden]
+        ring
+      _ = _ := by ring
+  have hcancelFour :
+      ‖w‖ ^ 2 * inner ℝ w b * (10000 + ‖w‖ ^ 2)⁻¹ * inner ℝ w a * 4 -
+            ‖w‖ ^ 2 * inner ℝ b a +
+            (inner ℝ w b * (10000 + ‖w‖ ^ 2)⁻¹ * inner ℝ w a * 40000 -
+              inner ℝ b a * 10000) =
+          -(‖w‖ ^ 2 * inner ℝ b a) +
+            (inner ℝ w b * inner ℝ w a * 4 - inner ℝ b a * 10000) := by
+    convert hcancel (inner ℝ w b) (inner ℝ w a) (inner ℝ b a) 4 using 1
+    all_goals ring
+  have hcancelSixteenHundred :
+      ‖w‖ ^ 2 * inner ℝ w b * (10000 + ‖w‖ ^ 2)⁻¹ * inner ℝ w a * 1600 -
+            ‖w‖ ^ 2 * inner ℝ b a * 400 +
+            (inner ℝ w b * (10000 + ‖w‖ ^ 2)⁻¹ * inner ℝ w a * 16000000 -
+              inner ℝ b a * 4000000) =
+          -(‖w‖ ^ 2 * inner ℝ b a * 400) +
+            (inner ℝ w b * inner ℝ w a * 1600 - inner ℝ b a * 4000000) := by
+    convert hcancel (inner ℝ w b) (inner ℝ w a) (inner ℝ b a * 400) 1600 using 1
+    all_goals ring
+  match_scalars <;> field_simp [hden] <;> try ring
+  all_goals assumption
+
+/- The product-rule part of the radius computation is kept separate from the subsequent
+coordinate algebra.  Apart from making the two mathematical steps explicit, this prevents
+the elaborator from retaining all of the smoothness witnesses while normalizing the final
+complex expression. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_reciprocalSphereChart_fderiv
+    (w v : ℂ) :
+    let u := counterexampleTwoReciprocal
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    let ρ : ℂ → ℝ³ := fun z ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+    let D : ℝ := ‖w‖ ^ 2 + 10000
+    let g : ℂ := complexBarDeriv u w
+    fderiv ℝ (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) w v =
+      (fderiv ℝ u w v) • ρ w + u w • fderiv ℝ ρ w v +
+        (4 * D / 20000 * inner ℝ w v) • fderiv ℝ ρ w g +
+          (D ^ 2 / 20000) •
+            (fderiv ℝ (fun z ↦ fderiv ℝ ρ z) w v g +
+              fderiv ℝ ρ w (fderiv ℝ (complexBarDeriv u) w v)) := by
+  dsimp only
+  let u := counterexampleTwoReciprocal
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let F := SphereSupport.homogeneousGradient H
+  let ρ : ℂ → ℝ³ := fun z ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+  let D : ℝ := ‖w‖ ^ 2 + 10000
+  let g : ℂ := complexBarDeriv u w
+  have hu : ContDiff ℝ ∞ u := counterexampleTwoReciprocal_contDiff
+  have hρsmooth : ContDiff ℝ ∞ ρ := by
+    exact (contMDiff_coe_sphere.comp counterexampleTwoReciprocalSphereChart_contMDiff).contDiff
+  have hρ : Differentiable ℝ ρ := hρsmooth.differentiable (by simp)
+  have hFchart : (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) =
+      fun z : ℂ ↦ u z • ρ z + ((‖z‖ ^ 2 + 10000) ^ 2 / 20000) •
+        fderiv ℝ ρ z (complexBarDeriv u z) := by
+    funext z
+    exact counterexampleTwoHomogeneousGradient_reciprocalSphereChart z
+  have hgdiff : DifferentiableAt ℝ (complexBarDeriv u) w := by
+    have hDu : DifferentiableAt ℝ (fun z ↦ fderiv ℝ u z) w :=
+      (hu.fderiv_right (m := 1)
+        (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+          exact WithTop.coe_le_coe.mpr le_top)).differentiable
+        one_ne_zero w
+    have hcomponent (t : ℂ) :
+        DifferentiableAt ℝ (fun z ↦ (fderiv ℝ u z t : ℂ)) w := by
+      have ht := hDu.hasFDerivAt.clm_apply (hasFDerivAt_const (x := w) t)
+      exact (Complex.ofRealCLM.hasFDerivAt.comp w ht).differentiableAt
+    change DifferentiableAt ℝ (fun z ↦
+      ((fderiv ℝ u z 1 : ℂ) + (fderiv ℝ u z Complex.I : ℂ) * Complex.I) / 2) w
+    simpa only [div_eq_mul_inv] using
+      (((hcomponent 1).add
+        ((hcomponent Complex.I).mul_const Complex.I)).mul_const (2 : ℂ)⁻¹)
+  have hscale : HasFDerivAt (fun z : ℂ ↦ (‖z‖ ^ 2 + 10000) ^ 2 / 20000)
+      (((4 * D / 20000) • innerSL ℝ w)) w := by
+    convert (((hasStrictFDerivAt_norm_sq w).hasFDerivAt.add_const 10000).pow 2).mul_const
+      (20000 : ℝ)⁻¹ using 1
+    all_goals
+      ext x
+      simp [D, div_eq_mul_inv]
+      ring
+  have hDρdiff : DifferentiableAt ℝ (fun z ↦ fderiv ℝ ρ z) w :=
+    (hρsmooth.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero w
+  have hdnApply := hDρdiff.hasFDerivAt.clm_apply hgdiff.hasFDerivAt
+  have huDiff : DifferentiableAt ℝ u w := hu.differentiable (by simp) w
+  have hρDiff : DifferentiableAt ℝ ρ w := hρ w
+  have hscaleDiff := hscale.differentiableAt
+  have hdnDiff := hdnApply.differentiableAt
+  change fderiv ℝ (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) w v =
+    (fderiv ℝ u w v) • ρ w + u w • fderiv ℝ ρ w v +
+      (4 * D / 20000 * inner ℝ w v) • fderiv ℝ ρ w g +
+        (D ^ 2 / 20000) •
+          (fderiv ℝ (fun z ↦ fderiv ℝ ρ z) w v g +
+            fderiv ℝ ρ w (fderiv ℝ (complexBarDeriv u) w v))
+  rw [hFchart]
+  change fderiv ℝ ((fun z : ℂ ↦ u z • ρ z) + fun z : ℂ ↦
+      ((‖z‖ ^ 2 + 10000) ^ 2 / 20000) •
+        fderiv ℝ ρ z (complexBarDeriv u z)) w v = _
+  change fderiv ℝ (fun z : ℂ ↦
+      (u • ρ) z +
+        (((fun y : ℂ ↦ (‖y‖ ^ 2 + 10000) ^ 2 / 20000) •
+          fun y : ℂ ↦ fderiv ℝ ρ y (complexBarDeriv u y)) z)) w v = _
+  rw [fderiv_fun_add (huDiff.smul hρDiff) (hscaleDiff.smul hdnDiff)]
+  change (fderiv ℝ (fun y ↦ u y • ρ y) w +
+    fderiv ℝ (fun y : ℂ ↦ ((‖y‖ ^ 2 + 10000) ^ 2 / 20000) •
+      fderiv ℝ ρ y (complexBarDeriv u y)) w) v = _
+  rw [fderiv_fun_smul huDiff hρDiff, fderiv_fun_smul hscaleDiff hdnDiff]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply]
+  rw [hscale.fderiv, hdnApply.fderiv]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.flip_apply, ContinuousLinearMap.smul_apply, innerSL_apply_apply]
+  dsimp only [D, g]
+  match_scalars <;> try ring
+  change (2 + ‖w‖ ^ 2 * (1 / 5000)) * inner ℝ w v =
+    ‖w‖ ^ 2 * inner ℝ w v * (1 / 5000) + inner ℝ w v * 2
+  ring
+
+/-- Exact radius-tensor formula in the reciprocal chart. The complex-linear coefficient is
+the chart Laplacian, while the anti-linear coefficient is the spherical trace-free Hessian. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocal_radius_formula (w v : ℂ) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    let ρ := fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+    let dρ := fderiv ℝ ρ w
+    fderiv ℝ (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) w v -
+        (10 ^ 10 : ℝ) • dρ v =
+      dρ ((((counterexampleTwoReciprocal w - 10 ^ 10 : ℝ) : ℂ) * v) +
+        ((‖w‖ ^ 2 + 10000) ^ 2 / 80000 : ℝ) •
+          (((chartLaplacian counterexampleTwoReciprocal w : ℝ) : ℂ) * v +
+            sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w * star v)) := by
+  let u := counterexampleTwoReciprocal
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let F := SphereSupport.homogeneousGradient H
+  let ρ : ℂ → ℝ³ := fun z ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ ρ w
+  let D : ℝ := ‖w‖ ^ 2 + 10000
+  let g : ℂ := complexBarDeriv u w
+  have hu : ContDiff ℝ ∞ u := counterexampleTwoReciprocal_contDiff
+  have hdu : fderiv ℝ u w v = 2 * inner ℝ g v := by
+    exact fderiv_eq_two_inner_complexBarDeriv u w v
+  have hdg : fderiv ℝ (complexBarDeriv u) w v =
+      ((((chartLaplacian u w : ℝ) : ℂ) * v +
+        traceFreeHessian u w * star v) / 4) := by
+    exact complexBarDeriv_fderiv_eq u hu w v
+  have hsecond (a b : ℂ) :
+      fderiv ℝ (fun z ↦ fderiv ℝ ρ z) w a b =
+        dρ ((-2 / D) • (inner ℝ w a • b + inner ℝ w b • a -
+          inner ℝ a b • w)) -
+          (40000 / D ^ 2 * inner ℝ a b) • (ρ w) := by
+    simpa only [ρ, dρ, D] using
+      counterexampleTwoReciprocalSphereChart_second_fderiv w a b
+  change fderiv ℝ (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) w v -
+      (10 ^ 10 : ℝ) • dρ v =
+    dρ ((((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+      (D ^ 2 / 80000) •
+        (((chartLaplacian u w : ℝ) : ℂ) * v +
+          sphericalTraceFreeHessian 10000 u w * star v))
+  rw [counterexampleTwoHomogeneousGradient_reciprocalSphereChart_fderiv]
+  rw [hdu]
+  rw [hsecond v g, hdg]
+  have hD : D ≠ 0 := by
+    dsimp only [D]
+    positivity
+  have hsourceVector :
+      (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+          (D / 5000 * inner ℝ w v) • g +
+          (D ^ 2 / 20000) •
+            ((-2 / D) • (inner ℝ w v • g + inner ℝ w g • v -
+                inner ℝ v g • w) +
+              ((((chartLaplacian u w : ℝ) : ℂ) * v +
+                  traceFreeHessian u w * star v) / 4)) =
+        (((u w - 10 ^ 10 : ℝ) : ℂ) * v) +
+          (D ^ 2 / 80000) •
+            (((chartLaplacian u w : ℝ) : ℂ) * v +
+              sphericalTraceFreeHessian 10000 u w * star v) := by
+    exact reciprocal_radius_source_vector u w v D g rfl rfl
+  rw [← hsourceVector]
+  rw [show (((u w - 10 ^ 10 : ℝ) : ℂ) * v) =
+      (u w - 10 ^ 10 : ℝ) • v by exact Complex.real_smul.symm]
+  simp only [map_add, map_sub, map_smul, smul_add, smul_sub, smul_smul]
+  rw [show ‖w‖ ^ 2 + 10000 = D by rfl]
+  have hscaleDerivative : 4 * D / 20000 * inner ℝ w v =
+        D / 5000 * inner ℝ w v := by ring
+  rw [hscaleDerivative]
+  have hradialScalar : (D ^ 2 / 20000) *
+        (40000 / D ^ 2 * inner ℝ v g) = 2 * inner ℝ g v := by
+    rw [real_inner_comm v g]
+    field_simp [hD]
+    ring
+  rw [hradialScalar]
+  rw [real_inner_comm g v]
+  module
+
+/-- Product rule for the complex encoding of the trace-free Hessian. -/
+@[category API, AMS 53]
+private theorem traceFreeHessian_mul (f g : ℂ → ℝ)
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g) (w : ℂ) :
+    traceFreeHessian (fun z ↦ f z * g z) w =
+      (f w : ℂ) * traceFreeHessian g w +
+        (g w : ℂ) * traceFreeHessian f w +
+          8 * complexBarDeriv f w * complexBarDeriv g w := by
+  have hf0 : Differentiable ℝ f := hf.differentiable (by simp)
+  have hg0 : Differentiable ℝ g := hg.differentiable (by simp)
+  have hDf : Differentiable ℝ (fderiv ℝ f) :=
+    (hf.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero
+  have hDg : Differentiable ℝ (fderiv ℝ g) :=
+    (hg.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero
+  have hgradient : fderiv ℝ (fun z ↦ f z * g z) =
+      fun z ↦ f z • fderiv ℝ g z + g z • fderiv ℝ f z := by
+    funext z
+    exact fderiv_fun_mul (hf0 z) (hg0 z)
+  have hfun : (fun z ↦ f z • fderiv ℝ g z + g z • fderiv ℝ f z) =
+      f • fderiv ℝ g + g • fderiv ℝ f := rfl
+  have hsum : fderiv ℝ (f • fderiv ℝ g + g • fderiv ℝ f) w =
+      fderiv ℝ (f • fderiv ℝ g) w + fderiv ℝ (g • fderiv ℝ f) w := by
+    change fderiv ℝ (fun y ↦ (f • fderiv ℝ g) y + (g • fderiv ℝ f) y) w = _
+    exact fderiv_fun_add ((hf0.smul hDg) w) ((hg0.smul hDf) w)
+  have hfprod : fderiv ℝ (f • fderiv ℝ g) w =
+      f w • fderiv ℝ (fderiv ℝ g) w + (fderiv ℝ f w).smulRight (fderiv ℝ g w) := by
+    change fderiv ℝ (fun y ↦ f y • fderiv ℝ g y) w = _
+    exact fderiv_fun_smul (hf0 w) (hDg w)
+  have hgprod : fderiv ℝ (g • fderiv ℝ f) w =
+      g w • fderiv ℝ (fderiv ℝ f) w + (fderiv ℝ g w).smulRight (fderiv ℝ f w) := by
+    change fderiv ℝ (fun y ↦ g y • fderiv ℝ f y) w = _
+    exact fderiv_fun_smul (hg0 w) (hDf w)
+  rw [traceFreeHessian, hgradient, hfun, hsum,
+    hfprod, hgprod]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply, smul_eq_mul]
+  rw [traceFreeHessian, traceFreeHessian, complexBarDeriv, complexBarDeriv]
+  push_cast
+  apply Complex.ext <;> simp [Complex.mul_re, Complex.mul_im] <;> ring
+
+/-- Product rule for the Euclidean chart Laplacian. -/
+@[category API, AMS 53]
+private theorem chartLaplacian_mul (f g : ℂ → ℝ)
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g) (w : ℂ) :
+    chartLaplacian (fun z ↦ f z * g z) w =
+      f w * chartLaplacian g w + g w * chartLaplacian f w +
+        2 * (fderiv ℝ f w 1 * fderiv ℝ g w 1 +
+          fderiv ℝ f w Complex.I * fderiv ℝ g w Complex.I) := by
+  have hf0 : Differentiable ℝ f := hf.differentiable (by simp)
+  have hg0 : Differentiable ℝ g := hg.differentiable (by simp)
+  have hDf : Differentiable ℝ (fderiv ℝ f) :=
+    (hf.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero
+  have hDg : Differentiable ℝ (fderiv ℝ g) :=
+    (hg.fderiv_right (m := 1)
+      (show (1 : WithTop ℕ∞) + 1 ≤ (∞ : WithTop ℕ∞) by
+        exact WithTop.coe_le_coe.mpr le_top)).differentiable
+      one_ne_zero
+  have hgradient : fderiv ℝ (fun z ↦ f z * g z) =
+      fun z ↦ f z • fderiv ℝ g z + g z • fderiv ℝ f z := by
+    funext z
+    exact fderiv_fun_mul (hf0 z) (hg0 z)
+  have hfun : (fun z ↦ f z • fderiv ℝ g z + g z • fderiv ℝ f z) =
+      f • fderiv ℝ g + g • fderiv ℝ f := rfl
+  have hsum : fderiv ℝ (f • fderiv ℝ g + g • fderiv ℝ f) w =
+      fderiv ℝ (f • fderiv ℝ g) w + fderiv ℝ (g • fderiv ℝ f) w := by
+    change fderiv ℝ (fun y ↦ (f • fderiv ℝ g) y + (g • fderiv ℝ f) y) w = _
+    exact fderiv_fun_add ((hf0.smul hDg) w) ((hg0.smul hDf) w)
+  have hfprod : fderiv ℝ (f • fderiv ℝ g) w =
+      f w • fderiv ℝ (fderiv ℝ g) w + (fderiv ℝ f w).smulRight (fderiv ℝ g w) := by
+    change fderiv ℝ (fun y ↦ f y • fderiv ℝ g y) w = _
+    exact fderiv_fun_smul (hf0 w) (hDg w)
+  have hgprod : fderiv ℝ (g • fderiv ℝ f) w =
+      g w • fderiv ℝ (fderiv ℝ f) w + (fderiv ℝ g w).smulRight (fderiv ℝ f w) := by
+    change fderiv ℝ (fun y ↦ g y • fderiv ℝ f y) w = _
+    exact fderiv_fun_smul (hg0 w) (hDf w)
+  rw [chartLaplacian, hgradient, hfun, hsum,
+    hfprod, hgprod]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply, smul_eq_mul]
+  rw [chartLaplacian, chartLaplacian]
+  ring
+
+/-- Product rule for the first anti-holomorphic derivative. -/
+@[category API, AMS 53]
+private theorem complexBarDeriv_mul (f g : ℂ → ℝ)
+    (hf : Differentiable ℝ f) (hg : Differentiable ℝ g) (w : ℂ) :
+    complexBarDeriv (fun z ↦ f z * g z) w =
+      (f w : ℂ) * complexBarDeriv g w + (g w : ℂ) * complexBarDeriv f w := by
+  rw [complexBarDeriv, fderiv_fun_mul (hf w) (hg w)]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply, smul_eq_mul]
+  rw [complexBarDeriv, complexBarDeriv]
+  push_cast
+  ring
+
+/-- Adding a constant does not change the first anti-holomorphic derivative. -/
+@[category API, AMS 53]
+private theorem complexBarDeriv_const_add (c : ℝ) (f : ℂ → ℝ)
+    (hf : Differentiable ℝ f) (w : ℂ) :
+    complexBarDeriv (fun z ↦ c + f z) w = complexBarDeriv f w := by
+  have hsum := (hasFDerivAt_const (x := w) c).add (hf w).hasFDerivAt
+  rw [complexBarDeriv]
+  change (↑((fderiv ℝ (((fun _ : ℂ ↦ c) + f)) w) 1) +
+    ↑((fderiv ℝ (((fun _ : ℂ ↦ c) + f)) w) Complex.I) * Complex.I) / 2 = _
+  rw [hsum.fderiv]
+  simp [complexBarDeriv]
+
+/-- Adding a constant does not change the trace-free Hessian. -/
+@[category API, AMS 53]
+private theorem traceFreeHessian_const_add (c : ℝ) (f : ℂ → ℝ)
+    (hf : ContDiff ℝ ∞ f) (w : ℂ) :
+    traceFreeHessian (fun z ↦ c + f z) w = traceFreeHessian f w := by
+  have hgradient : fderiv ℝ (fun z ↦ c + f z) = fderiv ℝ f := by
+    funext z
+    change fderiv ℝ (((fun _ : ℂ ↦ c) + f)) z = _
+    rw [((hasFDerivAt_const (x := z) c).add
+      (hf.differentiable (by simp) z).hasFDerivAt).fderiv]
+    simp
+  rw [traceFreeHessian, hgradient]
+  rfl
+
+/-- Adding a constant does not change the chart Laplacian. -/
+@[category API, AMS 53]
+private theorem chartLaplacian_const_add (c : ℝ) (f : ℂ → ℝ)
+    (hf : ContDiff ℝ ∞ f) (w : ℂ) :
+    chartLaplacian (fun z ↦ c + f z) w = chartLaplacian f w := by
+  have hgradient : fderiv ℝ (fun z ↦ c + f z) = fderiv ℝ f := by
+    funext z
+    change fderiv ℝ (((fun _ : ℂ ↦ c) + f)) z = _
+    rw [((hasFDerivAt_const (x := z) c).add
+      (hf.differentiable (by simp) z).hasFDerivAt).fderiv]
+    simp
+  rw [chartLaplacian, hgradient]
+  rfl
+
+/-- The first anti-holomorphic derivative of a radial scalar function. -/
+@[category API, AMS 53]
+private theorem complexBarDeriv_comp_norm_sq (β : ℝ → ℝ) (w : ℂ)
+    (hβ : DifferentiableAt ℝ β (‖w‖ ^ 2)) :
+    complexBarDeriv (fun z : ℂ ↦ β (‖z‖ ^ 2)) w =
+      ((deriv β (‖w‖ ^ 2) : ℝ) : ℂ) * w := by
+  have hre : HasFDerivAt (fun z : ℂ ↦ z.re) Complex.reCLM w := Complex.reCLM.hasFDerivAt
+  have him : HasFDerivAt (fun z : ℂ ↦ z.im) Complex.imCLM w := Complex.imCLM.hasFDerivAt
+  have hs : HasFDerivAt (fun z : ℂ ↦ ‖z‖ ^ 2)
+      ((2 * w.re) • Complex.reCLM + (2 * w.im) • Complex.imCLM) w := by
+    convert (hre.pow 2).add (him.pow 2) using 1
+    · funext z
+      simpa only [Complex.normSq_apply, pow_two] using Complex.sq_norm z
+    · ext v
+      simp
+  have hcomp := hβ.hasDerivAt.hasFDerivAt.comp w hs
+  rw [complexBarDeriv]
+  change (↑((fderiv ℝ (β ∘ fun z : ℂ ↦ ‖z‖ ^ 2) w) 1) +
+    ↑((fderiv ℝ (β ∘ fun z : ℂ ↦ ‖z‖ ^ 2) w) Complex.I) * Complex.I) / 2 = _
+  rw [hcomp.fderiv]
+  apply Complex.ext <;> simp <;> ring
+
+/-- The trace-free Hessian of a radial scalar function. -/
+@[category API, AMS 53]
+private theorem traceFreeHessian_comp_norm_sq (β : ℝ → ℝ) (w : ℂ)
+    (hβ : ContDiffAt ℝ 2 β (‖w‖ ^ 2)) :
+    traceFreeHessian (fun z : ℂ ↦ β (‖z‖ ^ 2)) w =
+      4 * ((deriv (fun x ↦ deriv β x) (‖w‖ ^ 2) : ℝ) : ℂ) * w ^ 2 := by
+  have hs (z : ℂ) : HasFDerivAt (fun y : ℂ ↦ ‖y‖ ^ 2)
+      ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM) z := by
+    have hre : HasFDerivAt (fun y : ℂ ↦ y.re) Complex.reCLM z :=
+      Complex.reCLM.hasFDerivAt
+    have him : HasFDerivAt (fun y : ℂ ↦ y.im) Complex.imCLM z :=
+      Complex.imCLM.hasFDerivAt
+    convert (hre.pow 2).add (him.pow 2) using 1
+    · funext y
+      simpa only [Complex.normSq_apply, pow_two] using Complex.sq_norm y
+    · ext v
+      simp
+  have hβnear : ∀ᶠ z in nhds w, ContDiffAt ℝ 2 β (‖z‖ ^ 2) :=
+    (contDiff_norm_sq ℝ : ContDiff ℝ 2 (fun z : ℂ ↦ ‖z‖ ^ 2)).continuous.continuousAt.tendsto
+      (hβ.eventually (by norm_num : (2 : WithTop ℕ∞) ≠ ∞))
+  have hgradient : fderiv ℝ (fun z : ℂ ↦ β (‖z‖ ^ 2)) =ᶠ[nhds w] fun z ↦
+      deriv β (‖z‖ ^ 2) •
+        ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM) := by
+    filter_upwards [hβnear] with z hz
+    have hcomp :=
+      (hz.differentiableAt (by norm_num)).hasDerivAt.hasFDerivAt.comp z (hs z)
+    convert hcomp.fderiv using 1
+    ext a
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.toSpanSingleton_apply,
+      ContinuousLinearMap.smul_apply, smul_eq_mul]
+    ring
+  have hderivβ : ContDiffAt ℝ 1 (fun x ↦ deriv β x) (‖w‖ ^ 2) := by
+    simpa only [fderiv_apply_one_eq_deriv] using
+      ((hβ.fderiv_right (m := 1) (by norm_num)).clm_apply contDiffAt_const)
+  have hscalar : HasFDerivAt (fun z : ℂ ↦ deriv β (‖z‖ ^ 2))
+      (deriv (fun x ↦ deriv β x) (‖w‖ ^ 2) •
+        ((2 * w.re) • Complex.reCLM + (2 * w.im) • Complex.imCLM)) w := by
+    have hcomp :=
+      (hderivβ.differentiableAt (by norm_num)).hasDerivAt.hasFDerivAt.comp w (hs w)
+    convert hcomp using 1
+    ext a
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.toSpanSingleton_apply,
+      ContinuousLinearMap.smul_apply, smul_eq_mul]
+    ring
+  have hre : HasFDerivAt (fun z : ℂ ↦ z.re) Complex.reCLM w := Complex.reCLM.hasFDerivAt
+  have him : HasFDerivAt (fun z : ℂ ↦ z.im) Complex.imCLM w := Complex.imCLM.hasFDerivAt
+  have hmatrix := ((hre.const_mul 2).smul_const Complex.reCLM).add
+    ((him.const_mul 2).smul_const Complex.imCLM)
+  have hsecond := hscalar.smul hmatrix
+  change HasFDerivAt (fun z : ℂ ↦ deriv β (‖z‖ ^ 2) •
+    ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM)) _ w at hsecond
+  rw [traceFreeHessian, hgradient.fderiv_eq, hsecond.fderiv]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply, Pi.add_apply, smul_eq_mul,
+    Complex.reCLM_apply, Complex.imCLM_apply]
+  push_cast
+  apply Complex.ext <;> simp [pow_two, Complex.mul_re, Complex.mul_im] <;> ring
+
+/-- The Euclidean chart Laplacian of a radial scalar function. -/
+@[category API, AMS 53]
+private theorem chartLaplacian_comp_norm_sq (β : ℝ → ℝ) (w : ℂ)
+    (hβ : ContDiffAt ℝ 2 β (‖w‖ ^ 2)) :
+    chartLaplacian (fun z : ℂ ↦ β (‖z‖ ^ 2)) w =
+      4 * (deriv β (‖w‖ ^ 2) + ‖w‖ ^ 2 *
+        deriv (fun x ↦ deriv β x) (‖w‖ ^ 2)) := by
+  have hs (z : ℂ) : HasFDerivAt (fun y : ℂ ↦ ‖y‖ ^ 2)
+      ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM) z := by
+    have hre : HasFDerivAt (fun y : ℂ ↦ y.re) Complex.reCLM z :=
+      Complex.reCLM.hasFDerivAt
+    have him : HasFDerivAt (fun y : ℂ ↦ y.im) Complex.imCLM z :=
+      Complex.imCLM.hasFDerivAt
+    convert (hre.pow 2).add (him.pow 2) using 1
+    · funext y
+      simpa only [Complex.normSq_apply, pow_two] using Complex.sq_norm y
+    · ext v
+      simp
+  have hβnear : ∀ᶠ z in nhds w, ContDiffAt ℝ 2 β (‖z‖ ^ 2) :=
+    (contDiff_norm_sq ℝ : ContDiff ℝ 2 (fun z : ℂ ↦ ‖z‖ ^ 2)).continuous.continuousAt.tendsto
+      (hβ.eventually (by norm_num : (2 : WithTop ℕ∞) ≠ ∞))
+  have hgradient : fderiv ℝ (fun z : ℂ ↦ β (‖z‖ ^ 2)) =ᶠ[nhds w] fun z ↦
+      deriv β (‖z‖ ^ 2) •
+        ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM) := by
+    filter_upwards [hβnear] with z hz
+    have hcomp :=
+      (hz.differentiableAt (by norm_num)).hasDerivAt.hasFDerivAt.comp z (hs z)
+    convert hcomp.fderiv using 1
+    ext a
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.toSpanSingleton_apply,
+      ContinuousLinearMap.smul_apply, smul_eq_mul]
+    ring
+  have hderivβ : ContDiffAt ℝ 1 (fun x ↦ deriv β x) (‖w‖ ^ 2) := by
+    simpa only [fderiv_apply_one_eq_deriv] using
+      ((hβ.fderiv_right (m := 1) (by norm_num)).clm_apply contDiffAt_const)
+  have hscalar : HasFDerivAt (fun z : ℂ ↦ deriv β (‖z‖ ^ 2))
+      (deriv (fun x ↦ deriv β x) (‖w‖ ^ 2) •
+        ((2 * w.re) • Complex.reCLM + (2 * w.im) • Complex.imCLM)) w := by
+    have hcomp :=
+      (hderivβ.differentiableAt (by norm_num)).hasDerivAt.hasFDerivAt.comp w (hs w)
+    convert hcomp using 1
+    ext a
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.toSpanSingleton_apply,
+      ContinuousLinearMap.smul_apply, smul_eq_mul]
+    ring
+  have hre : HasFDerivAt (fun z : ℂ ↦ z.re) Complex.reCLM w := Complex.reCLM.hasFDerivAt
+  have him : HasFDerivAt (fun z : ℂ ↦ z.im) Complex.imCLM w := Complex.imCLM.hasFDerivAt
+  have hmatrix := ((hre.const_mul 2).smul_const Complex.reCLM).add
+    ((him.const_mul 2).smul_const Complex.imCLM)
+  have hsecond := hscalar.smul hmatrix
+  change HasFDerivAt (fun z : ℂ ↦ deriv β (‖z‖ ^ 2) •
+    ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM)) _ w at hsecond
+  rw [chartLaplacian, hgradient.fderiv_eq, hsecond.fderiv]
+  simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+    ContinuousLinearMap.smulRight_apply, Pi.add_apply, smul_eq_mul,
+    Complex.reCLM_apply, Complex.imCLM_apply]
+  rw [Complex.sq_norm, Complex.normSq_apply]
+  norm_num
+  ring
+
+/-- Logarithmic derivative of the one-variable reciprocal damping factor. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalRadialDamping_deriv {s : ℝ} (hs : -10000 < s) :
+    deriv (fun x : ℝ ↦ 10000 / (x + 10000) *
+      Real.exp (-counterexampleTwoReciprocalExponent x)) s =
+        -(10000 / (s + 10000) * Real.exp (-counterexampleTwoReciprocalExponent s)) *
+          (1 / (s + 10000) + deriv counterexampleTwoReciprocalExponent s) := by
+  have hden : s + 10000 ≠ 0 := by linarith
+  have hfrac := (hasDerivAt_const s 10000).div
+    ((hasDerivAt_id s).add_const 10000) hden
+  have hψ := (counterexampleTwoReciprocalExponent_contDiff.differentiable (by simp) s).hasDerivAt
+  have hraw := hfrac.mul hψ.neg.exp
+  change deriv ((((fun _ : ℝ ↦ (10000 : ℝ)) / fun x ↦ id x + 10000) *
+    fun x ↦ Real.exp ((-counterexampleTwoReciprocalExponent) x))) s = _
+  rw [hraw.deriv]
+  dsimp only [id_eq, Pi.div_apply, Pi.mul_apply, Pi.neg_apply]
+  field_simp [hden]
+  ring
+
+/-- The scalar reciprocal damping factor is smooth wherever its rational denominator is
+nonzero. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalRadialDamping_contDiffAt
+    {s : ℝ} (hs : -10000 < s) {n : ℕ∞} :
+    ContDiffAt ℝ n (fun x : ℝ ↦ 10000 / (x + 10000) *
+      Real.exp (-counterexampleTwoReciprocalExponent x)) s := by
+  have hden : s + 10000 ≠ 0 := by linarith
+  exact (contDiffAt_const.div (contDiffAt_id.add contDiffAt_const) hden).mul
+    (counterexampleTwoReciprocalExponent_contDiff.contDiffAt.neg.exp.of_le (by simp))
+
+/-- Second derivative of the one-variable reciprocal damping factor. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalRadialDamping_second_deriv
+    {s : ℝ} (hs : -10000 < s) :
+    deriv (fun y ↦ deriv (fun x : ℝ ↦ 10000 / (x + 10000) *
+      Real.exp (-counterexampleTwoReciprocalExponent x)) y) s =
+        (10000 / (s + 10000) * Real.exp (-counterexampleTwoReciprocalExponent s)) *
+          ((1 / (s + 10000) + deriv counterexampleTwoReciprocalExponent s) ^ 2 +
+            1 / (s + 10000) ^ 2 -
+              deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s) := by
+  let β : ℝ → ℝ := fun x ↦ 10000 / (x + 10000) *
+    Real.exp (-counterexampleTwoReciprocalExponent x)
+  have hden : s + 10000 ≠ 0 := by linarith
+  have hfrac := (hasDerivAt_const s 10000).div
+    ((hasDerivAt_id s).add_const 10000) hden
+  have hψ := (counterexampleTwoReciprocalExponent_contDiff.differentiable (by simp) s).hasDerivAt
+  have hβ := hfrac.mul hψ.neg.exp
+  have hDψ : ContDiff ℝ ∞ (fun x ↦ deriv counterexampleTwoReciprocalExponent x) := by
+    simpa only [fderiv_apply_one_eq_deriv] using
+      ((counterexampleTwoReciprocalExponent_contDiff.fderiv_right (m := ∞) (by simp)).clm_apply
+        (contDiff_const : ContDiff ℝ ∞ (fun _ : ℝ ↦ (1 : ℝ))))
+  have hψ₂ := (hDψ.differentiable (by simp) s).hasDerivAt
+  have hq := (((hasDerivAt_id s).add_const 10000).inv hden).add hψ₂
+  have hright := (hβ.mul hq).neg
+  have hrightFun : (fun y ↦ -β y * (1 / (y + 10000) +
+      deriv counterexampleTwoReciprocalExponent y)) =
+      -((((fun _ : ℝ ↦ (10000 : ℝ)) / fun x ↦ id x + 10000) *
+          fun x ↦ Real.exp ((-counterexampleTwoReciprocalExponent) x)) *
+        ((fun x ↦ id x + 10000)⁻¹ +
+          fun x ↦ deriv counterexampleTwoReciprocalExponent x)) := by
+    funext y
+    dsimp only [β, id_eq, Pi.div_apply, Pi.mul_apply, Pi.neg_apply, Pi.add_apply,
+      Pi.inv_apply]
+    ring
+  have heq : (fun y ↦ deriv (fun x : ℝ ↦ 10000 / (x + 10000) *
+      Real.exp (-counterexampleTwoReciprocalExponent x)) y) =ᶠ[nhds s]
+      fun y ↦ -β y * (1 / (y + 10000) + deriv counterexampleTwoReciprocalExponent y) := by
+    filter_upwards [Ioi_mem_nhds hs] with y hy
+    exact counterexampleTwoReciprocalRadialDamping_deriv hy
+  rw [heq.deriv_eq]
+  rw [hrightFun, hright.deriv]
+  simp only [id_eq, Pi.div_apply, Pi.mul_apply, Pi.neg_apply, Pi.add_apply, Pi.inv_apply]
+  field_simp [hden]
+  ring
+
+/-- The stereographic trace-free Hessian of the reciprocal representative factors into its
+positive damping coefficient and the explicit seed-plus-error model. -/
+@[category API, AMS 53]
+private theorem sphericalTraceFreeHessian_counterexampleTwoReciprocal (w : ℂ) :
+    let p := deriv counterexampleTwoReciprocalExponent (‖w‖ ^ 2)
+    let p' := deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) (‖w‖ ^ 2)
+    sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w =
+      counterexampleTwoReciprocalDamping w *
+        (traceFreeHessian counterexampleSeed w -
+          8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w +
+          4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w) := by
+  let s := ‖w‖ ^ 2
+  let β : ℝ → ℝ := fun x ↦ 10000 / (x + 10000) *
+    Real.exp (-counterexampleTwoReciprocalExponent x)
+  have hs0 : 0 ≤ s := by
+    dsimp only [s]
+    positivity
+  have hs : -10000 < s := by linarith
+  have hβ : ContDiffAt ℝ 2 β s :=
+    counterexampleTwoReciprocalRadialDamping_contDiffAt hs
+  have hB : counterexampleTwoReciprocalDamping = fun z : ℂ ↦ β (‖z‖ ^ 2) := by
+    rfl
+  have hBbar : complexBarDeriv counterexampleTwoReciprocalDamping w =
+      ((deriv β s : ℝ) : ℂ) * w := by
+    rw [hB]
+    exact complexBarDeriv_comp_norm_sq β w (hβ.differentiableAt (by norm_num))
+  have hBtf : traceFreeHessian counterexampleTwoReciprocalDamping w =
+      4 * ((deriv (fun x ↦ deriv β x) s : ℝ) : ℂ) * w ^ 2 := by
+    rw [hB]
+    exact traceFreeHessian_comp_norm_sq β w hβ
+  have hβ' : deriv β s = -β s *
+      (1 / (s + 10000) + deriv counterexampleTwoReciprocalExponent s) :=
+    counterexampleTwoReciprocalRadialDamping_deriv hs
+  have hβ'' : deriv (fun x ↦ deriv β x) s = β s *
+      ((1 / (s + 10000) + deriv counterexampleTwoReciprocalExponent s) ^ 2 +
+        1 / (s + 10000) ^ 2 -
+          deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s) :=
+    counterexampleTwoReciprocalRadialDamping_second_deriv hs
+  have hprodSmooth : ContDiff ℝ ∞
+      (fun z ↦ counterexampleTwoReciprocalDamping z * counterexampleSeed z) :=
+    counterexampleTwoReciprocalDamping_contDiff.mul counterexampleSeed_contDiff
+  have hprodDiff : Differentiable ℝ
+      (fun z ↦ counterexampleTwoReciprocalDamping z * counterexampleSeed z) :=
+    hprodSmooth.differentiable (by simp)
+  change sphericalTraceFreeHessian 10000
+      (fun z ↦ 10 ^ 10 + counterexampleTwoReciprocalDamping z * counterexampleSeed z) w = _
+  rw [sphericalTraceFreeHessian,
+    traceFreeHessian_const_add _ _ hprodSmooth,
+    complexBarDeriv_const_add _ _ hprodDiff,
+    traceFreeHessian_mul _ _ counterexampleTwoReciprocalDamping_contDiff
+      counterexampleSeed_contDiff,
+    complexBarDeriv_mul _ _
+      (counterexampleTwoReciprocalDamping_contDiff.differentiable (by simp))
+      (counterexampleSeed_contDiff.differentiable (by simp)),
+    hBtf, hBbar, hβ', hβ'']
+  rw [hB]
+  dsimp only [s]
+  simp only [div_eq_mul_inv, Complex.ofReal_add, Complex.ofReal_sub,
+    Complex.ofReal_mul, Complex.ofReal_pow, Complex.ofReal_neg,
+    Complex.ofReal_inv, one_mul, ← inv_pow]
+  ring_nf
+
+/-- In a conformal complex chart, a scalar shape operator forces the anti-linear coefficient
+of the radius tensor to vanish. This is the algebraic core of the umbilic criterion. -/
+@[category API, AMS 53]
+private theorem antiLinearCoefficient_eq_zero_of_umbilic
+    (dρ dF : ℂ →L[ℝ] ℝ³) (hdρ : Function.Injective dρ)
+    (C r : ℝ) (A L Q : ℂ) (hr : r ≠ 0)
+    (hformula : ∀ v : ℂ, dF v - C • dρ v =
+      dρ (A * v + r • (L * v + Q * star v)))
+    (humbilic : ∃ c : ℝ, dρ = c • dF) : Q = 0 := by
+  obtain ⟨c, hc⟩ := humbilic
+  have hc0 : c ≠ 0 := by
+    intro hc0
+    subst c
+    have hc' : dρ = 0 := hc.trans (zero_smul ℝ dF)
+    exact one_ne_zero (hdρ (by rw [hc']; rfl))
+  have hdF : dF = c⁻¹ • dρ := by
+    rw [hc, inv_smul_smul₀ hc0]
+  have hcoordinate (v : ℂ) :
+      ((c⁻¹ - C : ℝ) : ℂ) * v = A * v + r • (L * v + Q * star v) := by
+    apply hdρ
+    rw [← hformula v, hdF]
+    change dρ ((c⁻¹ - C) • v) = c⁻¹ • dρ v - C • dρ v
+    rw [map_smul, sub_smul]
+  have h1 := hcoordinate 1
+  have hI := hcoordinate Complex.I
+  have : (2 * r : ℂ) * Complex.I * Q = 0 := by
+    have halgebra : (2 * r : ℂ) * Complex.I * Q =
+        -((A * Complex.I + r • (L * Complex.I + Q * star Complex.I)) -
+          Complex.I * (A * 1 + r • (L * 1 + Q * star (1 : ℂ)))) := by
+      apply Complex.ext <;> simp [Complex.mul_re, Complex.mul_im] <;> ring
+    rw [halgebra, ← hI, ← h1]
+    ring
+  exact (mul_eq_zero.mp this).resolve_left <|
+    mul_ne_zero (by exact_mod_cast (mul_ne_zero (by norm_num : (2 : ℝ) ≠ 0) hr))
+      Complex.I_ne_zero
+
+/-- Norm estimate obtained from the conformal chart radius formula. -/
+@[category API, AMS 53]
+private theorem norm_radiusError_le_of_conformal_formula
+    (dρ dF : ℂ →L[ℝ] ℝ³) (C k r : ℝ) (A L Q : ℂ)
+    (hk : 0 ≤ k) (hr : 0 ≤ r)
+    (hscale : ∀ v : ℂ, ‖dρ v‖ = k * ‖v‖)
+    (hformula : ∀ v : ℂ, dF v - C • dρ v =
+      dρ (A * v + r • (L * v + Q * star v))) :
+    ∀ v : ℂ, ‖dF v - C • dρ v‖ ≤
+      (‖A‖ + r * (‖L‖ + ‖Q‖)) * ‖dρ v‖ := by
+  intro v
+  rw [hformula, hscale]
+  calc
+    k * ‖A * v + r • (L * v + Q * star v)‖ ≤
+        k * ((‖A‖ + r * (‖L‖ + ‖Q‖)) * ‖v‖) := by
+      gcongr
+      calc
+        ‖A * v + r • (L * v + Q * star v)‖ ≤
+            ‖A * v‖ + ‖r • (L * v + Q * star v)‖ := norm_add_le _ _
+        _ = ‖A‖ * ‖v‖ + |r| * ‖L * v + Q * star v‖ := by
+          rw [norm_mul, norm_smul, Real.norm_eq_abs]
+        _ ≤ ‖A‖ * ‖v‖ + r * (‖L * v‖ + ‖Q * star v‖) := by
+          rw [abs_of_nonneg hr]
+          gcongr
+          exact norm_add_le _ _
+        _ = (‖A‖ + r * (‖L‖ + ‖Q‖)) * ‖v‖ := by
+          rw [norm_mul, norm_mul, norm_star]
+          ring
+    _ = (‖A‖ + r * (‖L‖ + ‖Q‖)) * (k * ‖v‖) := by ring
+    _ = (‖A‖ + r * (‖L‖ + ‖Q‖)) * ‖dρ v‖ := by rw [hscale]
+
+/-- The seed's trace-free Hessian cannot be cancelled by error terms having the two bounds
+which arise from differentiating the reciprocal damping factor. -/
+@[category API, AMS 53]
+private theorem seedTraceFreeHessian_perturbation_ne_zero (w : ℂ) (p p' : ℝ)
+    (hp : ‖w‖ * |p| ≤ 1 / 100)
+    (hpp : ‖w‖ ^ 2 * (p ^ 2 + |p'|) ≤ 1 / 1000) :
+    traceFreeHessian counterexampleSeed w -
+        8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w +
+      4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w ≠ 0 := by
+  have hbar : ‖complexBarDeriv counterexampleSeed w‖ ≤ 129 / 80 := by
+    have hnorm : ‖complexBarDeriv counterexampleSeed w‖ =
+        ‖((fderiv ℝ counterexampleSeed w 1 : ℂ) -
+          (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2‖ := by
+      rw [complexBarDeriv, show
+        ((fderiv ℝ counterexampleSeed w 1 : ℂ) +
+            (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2 =
+          star (((fderiv ℝ counterexampleSeed w 1 : ℂ) -
+            (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2) by
+          simp,
+        norm_star]
+    rw [hnorm]
+    exact counterexampleSeed_wirtinger_norm_upper w
+  have hseed : |counterexampleSeed w| ≤ 253 / 160 := counterexampleSeed_abs_le w
+  have hpabs : |p ^ 2 - p'| ≤ p ^ 2 + |p'| := by
+    calc
+      |p ^ 2 - p'| ≤ |p ^ 2| + |p'| := abs_sub _ _
+      _ = p ^ 2 + |p'| := by rw [abs_of_nonneg (sq_nonneg p)]
+  have hpperr : ‖w‖ ^ 2 * |p ^ 2 - p'| ≤ 1 / 1000 :=
+    (mul_le_mul_of_nonneg_left hpabs (sq_nonneg ‖w‖)).trans hpp
+  have hfirst : ‖8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖ ≤
+      129 / 1000 := by
+    calc
+      ‖8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖ =
+          8 * (‖w‖ * |p|) * ‖complexBarDeriv counterexampleSeed w‖ := by
+        simp only [norm_mul, Complex.norm_ofNat, Complex.norm_real, Real.norm_eq_abs]
+        ring
+      _ ≤ 8 * (1 / 100) * (129 / 80) := by gcongr
+      _ = 129 / 1000 := by norm_num
+  have hsecond :
+      ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ ≤
+        253 / 40000 := by
+    calc
+      ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ =
+          4 * (‖w‖ ^ 2 * |p ^ 2 - p'|) * |counterexampleSeed w| := by
+        simp only [norm_mul, norm_pow, Complex.norm_ofNat, Complex.norm_real,
+          Real.norm_eq_abs]
+        ring
+      _ ≤ 4 * (1 / 1000) * (253 / 160) := by gcongr
+      _ = 253 / 40000 := by norm_num
+  have herror :
+      ‖-(8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w) +
+          4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ ≤
+        5413 / 40000 := by
+    calc
+      _ ≤ ‖8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖ +
+          ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ := by
+        simpa only [norm_neg] using norm_add_le
+          (-(8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w))
+          (4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w)
+      _ ≤ 129 / 1000 + 253 / 40000 := add_le_add hfirst hsecond
+      _ = 5413 / 40000 := by norm_num
+  intro hzero
+  have hsum : traceFreeHessian counterexampleSeed w +
+      (-(8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w) +
+        4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w) = 0 := by
+    simpa only [sub_eq_add_neg, add_assoc] using hzero
+  have hnormeq : ‖traceFreeHessian counterexampleSeed w‖ =
+      ‖-(8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w) +
+        4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ := by
+    rw [eq_neg_of_add_eq_zero_left hsum, norm_neg]
+  have hlower := counterexampleSeed_traceFreeHessian_norm_lower w
+  rw [hnormeq] at hlower
+  linarith
+
+/-- A deliberately loose upper bound for the same reciprocal trace-free model. -/
+@[category API, AMS 53]
+private theorem seedTraceFreeHessian_perturbation_norm_upper (w : ℂ) (p p' : ℝ)
+    (hp : ‖w‖ * |p| ≤ 1 / 100)
+    (hpp : ‖w‖ ^ 2 * (p ^ 2 + |p'|) ≤ 1 / 1000) :
+    ‖traceFreeHessian counterexampleSeed w -
+        8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w +
+      4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ ≤ 20 := by
+  have hbar : ‖complexBarDeriv counterexampleSeed w‖ ≤ 129 / 80 := by
+    have hnorm : ‖complexBarDeriv counterexampleSeed w‖ =
+        ‖((fderiv ℝ counterexampleSeed w 1 : ℂ) -
+          (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2‖ := by
+      rw [complexBarDeriv, show
+        ((fderiv ℝ counterexampleSeed w 1 : ℂ) +
+            (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2 =
+          star (((fderiv ℝ counterexampleSeed w 1 : ℂ) -
+            (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2) by
+          simp,
+        norm_star]
+    rw [hnorm]
+    exact counterexampleSeed_wirtinger_norm_upper w
+  have hpabs : |p ^ 2 - p'| ≤ p ^ 2 + |p'| := by
+    exact (abs_sub _ _).trans_eq (by rw [abs_of_nonneg (sq_nonneg p)])
+  have hpperr : ‖w‖ ^ 2 * |p ^ 2 - p'| ≤ 1 / 1000 :=
+    (mul_le_mul_of_nonneg_left hpabs (sq_nonneg ‖w‖)).trans hpp
+  have hfirst : ‖8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖ ≤
+      129 / 1000 := by
+    calc
+      _ = 8 * (‖w‖ * |p|) * ‖complexBarDeriv counterexampleSeed w‖ := by
+        simp only [norm_mul, Complex.norm_ofNat, Complex.norm_real, Real.norm_eq_abs]
+        ring
+      _ ≤ 8 * (1 / 100) * (129 / 80) := by gcongr
+      _ = 129 / 1000 := by norm_num
+  have hsecond :
+      ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ ≤
+        253 / 40000 := by
+    calc
+      _ = 4 * (‖w‖ ^ 2 * |p ^ 2 - p'|) * |counterexampleSeed w| := by
+        simp only [norm_mul, norm_pow, Complex.norm_ofNat, Complex.norm_real,
+          Real.norm_eq_abs]
+        ring
+      _ ≤ 4 * (1 / 1000) * (253 / 160) := by
+        gcongr
+        exact counterexampleSeed_abs_le w
+      _ = 253 / 40000 := by norm_num
+  calc
+    _ ≤ ‖traceFreeHessian counterexampleSeed w‖ +
+        ‖8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖ +
+        ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ := by
+      calc
+        _ ≤ ‖traceFreeHessian counterexampleSeed w -
+              8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖ +
+            ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ :=
+          norm_add_le _ _
+        _ ≤ (‖traceFreeHessian counterexampleSeed w‖ +
+              ‖8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w‖) +
+            ‖4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ :=
+          add_le_add (norm_sub_le _ _) le_rfl
+    _ ≤ 47 / 10 + 129 / 1000 + 253 / 40000 :=
+      add_le_add (add_le_add (counterexampleSeed_traceFreeHessian_norm_upper w) hfirst) hsecond
+    _ ≤ 20 := by norm_num
+
+/-- The first derivative of the reciprocal exponent on the positive half-line. The formula is
+kept in the original radial variable so later estimates may choose their own rescaling. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_deriv_of_pos {s : ℝ} (hs : 0 < s) :
+    deriv counterexampleTwoReciprocalExponent s =
+      ((1 / 8 : ℝ) * (s / 10000) ^ (-(7 : ℝ) / 8) / 10000) *
+          Real.exp (-10000 / s) +
+        (s / 10000) ^ ((1 : ℝ) / 8) * Real.exp (-10000 / s) *
+          (10000 / s ^ 2) := by
+  have heq : counterexampleTwoReciprocalExponent =ᶠ[nhds s]
+      fun x : ℝ ↦ (x / 10000) ^ ((1 : ℝ) / 8) * Real.exp (-10000 / x) := by
+    filter_upwards [Ioi_mem_nhds hs] with x hx
+    exact counterexampleTwoReciprocalExponent_of_pos hx
+  have hpow := ((hasDerivAt_id s).div_const 10000).rpow_const (p := (1 / 8 : ℝ))
+    (Or.inl (div_ne_zero hs.ne' (by norm_num)))
+  have hexp := ((hasDerivAt_const s (-10000)).div (hasDerivAt_id s) hs.ne').exp
+  have hprod := hpow.mul hexp
+  rw [heq.deriv_eq]
+  change deriv ((fun x : ℝ ↦ (x / 10000) ^ ((1 : ℝ) / 8) *
+    Real.exp (-10000 / x))) s = _
+  rw [show deriv ((fun x : ℝ ↦ (x / 10000) ^ ((1 : ℝ) / 8) *
+      Real.exp (-10000 / x))) s = _ by
+    simpa only [id_eq, Pi.div_apply] using hprod.deriv]
+  ring
+
+/-- The same first derivative in the dimensionless variable `t = 10000 / s`. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_deriv_dimensionless {s : ℝ} (hs : 0 < s) :
+    let t := 10000 / s
+    deriv counterexampleTwoReciprocalExponent s =
+      1 / 10000 * Real.exp (-t) *
+        ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ)) := by
+  let t := 10000 / s
+  change deriv counterexampleTwoReciprocalExponent s =
+    1 / 10000 * Real.exp (-t) *
+      ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ))
+  have ht : 0 < t := div_pos (by norm_num) hs
+  have ht_inv : t = (s / 10000)⁻¹ := by
+    dsimp [t]
+    field_simp
+  have hrpow (a : ℝ) : (s / 10000) ^ a = t ^ (-a) := by
+    rw [ht_inv, ← Real.rpow_neg_eq_inv_rpow]
+    congr 1
+    ring
+  have hs_over : 10000 / s ^ 2 = t ^ 2 / 10000 := by
+    dsimp [t]
+    field_simp
+  rw [counterexampleTwoReciprocalExponent_deriv_of_pos hs, hrpow, hrpow, hs_over]
+  have hexp : -10000 / s = -t := by
+    dsimp only [t]
+    ring
+  rw [hexp]
+  norm_num only [neg_div, neg_neg]
+  have hshift : t ^ (-(1 : ℝ) / 8) * t ^ (2 : ℝ) = t ^ (15 / 8 : ℝ) := by
+    rw [← Real.rpow_add ht]
+    congr 1
+    norm_num
+  rw [← Real.rpow_two t]
+  rw [show (-(1 / 8 : ℝ)) = (-(1 : ℝ) / 8) by ring]
+  calc
+    ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) / 10000 * Real.exp (-t) +
+        t ^ (-(1 : ℝ) / 8) * Real.exp (-t) * (t ^ (2 : ℝ) / 10000)) =
+        1 / 10000 * Real.exp (-t) *
+          ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) +
+            t ^ (-(1 : ℝ) / 8) * t ^ (2 : ℝ)) := by ring
+    _ = _ := by rw [hshift]
+
+/-- The second reciprocal-exponent derivative in the same dimensionless variable. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_second_deriv_dimensionless
+    {s : ℝ} (hs : 0 < s) :
+    let t := 10000 / s
+    deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s =
+      -(1 / 100000000 : ℝ) * Real.exp (-t) *
+        ((7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) - t ^ (31 / 8 : ℝ)) := by
+  let t := 10000 / s
+  change deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s =
+    -(1 / 100000000 : ℝ) * Real.exp (-t) *
+      ((7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+        (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) - t ^ (31 / 8 : ℝ))
+  have ht : 0 < t := div_pos (by norm_num) hs
+  let P : ℝ → ℝ := fun x ↦
+    let y := 10000 / x
+    1 / 10000 * Real.exp (-y) *
+      ((1 / 8 : ℝ) * y ^ (7 / 8 : ℝ) + y ^ (15 / 8 : ℝ))
+  have heq : (fun x ↦ deriv counterexampleTwoReciprocalExponent x) =ᶠ[nhds s] P := by
+    filter_upwards [Ioi_mem_nhds hs] with x hx
+    exact counterexampleTwoReciprocalExponent_deriv_dimensionless hx
+  have hT₀ : HasDerivAt (fun x : ℝ ↦ 10000 / x) (-10000 / s ^ 2) s := by
+    convert (hasDerivAt_const s 10000).div (hasDerivAt_id s) hs.ne' using 1
+    all_goals
+      simp only [id_eq]
+      field_simp [hs.ne']
+      ring
+  have hcoef : -10000 / s ^ 2 = -t ^ 2 / 10000 := by
+    dsimp only [t]
+    field_simp [hs.ne']
+  have hT : HasDerivAt (fun x : ℝ ↦ 10000 / x) (-t ^ 2 / 10000) s := by
+    simpa only [hcoef] using hT₀
+  have hA := ((hT.rpow_const (p := (7 / 8 : ℝ)) (Or.inl ht.ne')).const_mul
+    (1 / 8 : ℝ)).add
+      (hT.rpow_const (p := (15 / 8 : ℝ)) (Or.inl ht.ne'))
+  have hP := (hasDerivAt_const s (1 / 10000 : ℝ)).mul (hT.neg.exp.mul hA)
+  calc
+    deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s = deriv P s :=
+      heq.deriv_eq
+    _ = _ := by
+      rw [show deriv P s = _ by
+        simpa only [P, Pi.mul_apply, Pi.add_apply, Pi.neg_apply, Pi.div_apply, id_eq,
+          mul_assoc] using hP.deriv]
+      rw [show 10000 / s = t by rfl]
+      rw [← Real.rpow_two t]
+      ring_nf
+      have h23 : t ^ (7 / 8 : ℝ) * t ^ (2 : ℝ) = t ^ (23 / 8 : ℝ) := by
+        rw [← Real.rpow_add ht]
+        congr 1
+        norm_num
+      have h31 : t ^ (15 / 8 : ℝ) * t ^ (2 : ℝ) = t ^ (31 / 8 : ℝ) := by
+        rw [← Real.rpow_add ht]
+        congr 1
+        norm_num
+      have h15 : t ^ (2 : ℝ) * t ^ (-(1 : ℝ) / 8) = t ^ (15 / 8 : ℝ) := by
+        rw [← Real.rpow_add ht]
+        congr 1
+        norm_num
+      have hterm23 : Real.exp (-t) * t ^ (7 / 8 : ℝ) * t ^ (2 : ℝ) =
+          Real.exp (-t) * t ^ (23 / 8 : ℝ) := by rw [mul_assoc, h23]
+      have hterm31 : Real.exp (-t) * t ^ (15 / 8 : ℝ) * t ^ (2 : ℝ) =
+          Real.exp (-t) * t ^ (31 / 8 : ℝ) := by rw [mul_assoc, h31]
+      have hterm15 : Real.exp (-t) * t ^ (2 : ℝ) * t ^ (-(1 : ℝ) / 8) =
+          Real.exp (-t) * t ^ (15 / 8 : ℝ) := by rw [mul_assoc, h15]
+      rw [hterm23, hterm31, hterm15]
+      ring
+
+/-- After the substitution `t = 10000 / ‖w‖²`, the first reciprocal-exponent derivative is
+exactly the numerator controlled by `reciprocalDampingFirstNumerator_bound`. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_deriv_rescaled {w : ℂ} (hw : w ≠ 0) :
+    let t := 10000 / ‖w‖ ^ 2
+    ‖w‖ * |deriv counterexampleTwoReciprocalExponent (‖w‖ ^ 2)| =
+      1 / 100 * (Real.exp (-t) *
+        ((1 / 8 : ℝ) * t ^ (3 / 8 : ℝ) + t ^ (11 / 8 : ℝ))) := by
+  let r := ‖w‖
+  let s := r ^ 2
+  let t := 10000 / s
+  change r * |deriv counterexampleTwoReciprocalExponent s| =
+    1 / 100 * (Real.exp (-t) *
+      ((1 / 8 : ℝ) * t ^ (3 / 8 : ℝ) + t ^ (11 / 8 : ℝ)))
+  have hr : 0 < r := norm_pos_iff.mpr hw
+  have hs : 0 < s := sq_pos_of_pos hr
+  have ht : 0 < t := div_pos (by norm_num) hs
+  have ht_inv : t = (s / 10000)⁻¹ := by
+    dsimp [t]
+    field_simp
+  have hrpow (a : ℝ) : (s / 10000) ^ a = t ^ (-a) := by
+    rw [ht_inv, ← Real.rpow_neg_eq_inv_rpow]
+    congr 1
+    ring
+  have hs_over : 10000 / s ^ 2 = t ^ 2 / 10000 := by
+    dsimp [t]
+    field_simp
+  have hr_eq : r = 100 * t ^ (-(1 : ℝ) / 2) := by
+    have hsquare : r ^ 2 = (100 * t ^ (-(1 : ℝ) / 2)) ^ 2 := by
+      rw [mul_pow, ← Real.rpow_mul_natCast ht.le (-(1 : ℝ) / 2) 2,
+        show (-(1 : ℝ) / 2) * (2 : ℕ) = -(1 : ℝ) by norm_num,
+        Real.rpow_neg ht.le, Real.rpow_one]
+      dsimp [t, s]
+      field_simp
+      norm_num
+    obtain h | h := eq_or_eq_neg_of_sq_eq_sq r
+      (100 * t ^ (-(1 : ℝ) / 2)) hsquare
+    · exact h
+    · nlinarith [hr, Real.rpow_pos_of_pos ht (-(1 : ℝ) / 2)]
+  rw [counterexampleTwoReciprocalExponent_deriv_of_pos hs, abs_of_nonneg (by positivity),
+    hrpow, hrpow, hs_over, hr_eq]
+  have hexp : -10000 / s = -t := by
+    dsimp only [t]
+    ring
+  rw [hexp]
+  norm_num only [neg_div, neg_neg]
+  have hshift₁ : t ^ (-(1 : ℝ) / 2) * t ^ (7 / 8 : ℝ) = t ^ (3 / 8 : ℝ) := by
+    rw [← Real.rpow_add ht]
+    congr 1
+    norm_num
+  have hshift₂ : t ^ (-(1 : ℝ) / 2) *
+      (t ^ (-(1 : ℝ) / 8) * t ^ (2 : ℝ)) = t ^ (11 / 8 : ℝ) := by
+    rw [← Real.rpow_add ht, ← Real.rpow_add ht]
+    congr 1
+    norm_num
+  rw [← Real.rpow_two t]
+  rw [show (-(1 / 2 : ℝ)) = (-(1 : ℝ) / 2) by ring,
+    show (-(1 / 8 : ℝ)) = (-(1 : ℝ) / 8) by ring]
+  calc
+    100 * t ^ (-(1 : ℝ) / 2) *
+        ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) / 10000 * Real.exp (-t) +
+          t ^ (-(1 : ℝ) / 8) * Real.exp (-t) * (t ^ (2 : ℝ) / 10000)) =
+        1 / 100 * Real.exp (-t) *
+          ((1 / 8 : ℝ) * (t ^ (-(1 : ℝ) / 2) * t ^ (7 / 8 : ℝ)) +
+            t ^ (-(1 : ℝ) / 2) *
+              (t ^ (-(1 : ℝ) / 8) * t ^ (2 : ℝ))) := by ring
+    _ = _ := by
+      rw [hshift₁, hshift₂]
+      ring
+
+/-- Uniform first-derivative bound for the reciprocal exponent away from the reciprocal-chart
+origin. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_first_bound {w : ℂ} (hw : w ≠ 0) :
+    ‖w‖ * |deriv counterexampleTwoReciprocalExponent (‖w‖ ^ 2)| ≤ 1 / 100 := by
+  rw [counterexampleTwoReciprocalExponent_deriv_rescaled hw]
+  have ht : 0 ≤ 10000 / ‖w‖ ^ 2 := by positivity
+  have h := reciprocalDampingFirstNumerator_bound ht
+  nlinarith
+
+/-- Uniform combined first/second derivative bound for the reciprocal exponent. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_second_bound {w : ℂ} (hw : w ≠ 0) :
+    ‖w‖ ^ 2 * (deriv counterexampleTwoReciprocalExponent (‖w‖ ^ 2) ^ 2 +
+      |deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) (‖w‖ ^ 2)|) ≤
+        1 / 1000 := by
+  let s := ‖w‖ ^ 2
+  let t := 10000 / s
+  change s * (deriv counterexampleTwoReciprocalExponent s ^ 2 +
+    |deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s|) ≤ 1 / 1000
+  have hs : 0 < s := sq_pos_of_pos (norm_pos_iff.mpr hw)
+  have ht : 0 < t := div_pos (by norm_num) hs
+  have hs_eq : s = 10000 / t := by
+    dsimp [t]
+    field_simp
+  have hp := counterexampleTwoReciprocalExponent_deriv_dimensionless hs
+  have hpp := counterexampleTwoReciprocalExponent_second_deriv_dimensionless hs
+  have hp' : deriv counterexampleTwoReciprocalExponent s =
+      1 / 10000 * Real.exp (-t) *
+        ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ)) := hp
+  have hpp' : deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s =
+      -(1 / 100000000 : ℝ) * Real.exp (-t) *
+        ((7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) - t ^ (31 / 8 : ℝ)) := hpp
+  have hbracket :
+      |(7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) - t ^ (31 / 8 : ℝ)| ≤
+        (7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) + t ^ (31 / 8 : ℝ) := by
+    calc
+      |(7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) - t ^ (31 / 8 : ℝ)| ≤
+          |(7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+            (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ)| + |t ^ (31 / 8 : ℝ)| := abs_sub _ _
+      _ ≤ |(7 / 64 : ℝ) * t ^ (15 / 8 : ℝ)| +
+          |(7 / 4 : ℝ) * t ^ (23 / 8 : ℝ)| + |t ^ (31 / 8 : ℝ)| := by
+        gcongr
+        exact abs_add_le _ _
+      _ = (7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) + t ^ (31 / 8 : ℝ) := by
+        rw [abs_of_nonneg, abs_of_nonneg, abs_of_nonneg]
+        all_goals positivity
+  have hp_part : s * deriv counterexampleTwoReciprocalExponent s ^ 2 =
+      1 / 10000 * (Real.exp (-2 * t) *
+        ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ) +
+          (1 / 4 : ℝ) * t ^ (7 / 4 : ℝ) + t ^ (11 / 4 : ℝ))) := by
+    rw [hp', hs_eq]
+    have h77 : t ^ (7 / 8 : ℝ) * t ^ (7 / 8 : ℝ) = t ^ (7 / 4 : ℝ) := by
+      rw [← Real.rpow_add ht]
+      congr 1
+      norm_num
+    have h715 : t ^ (7 / 8 : ℝ) * t ^ (15 / 8 : ℝ) = t ^ (11 / 4 : ℝ) := by
+      rw [← Real.rpow_add ht]
+      congr 1
+      norm_num
+    have h1515 : t ^ (15 / 8 : ℝ) * t ^ (15 / 8 : ℝ) = t ^ (15 / 4 : ℝ) := by
+      rw [← Real.rpow_add ht]
+      congr 1
+      norm_num
+    have h13 : t * t ^ (3 / 4 : ℝ) = t ^ (7 / 4 : ℝ) := by
+      nth_rewrite 1 [← Real.rpow_one t]
+      rw [← Real.rpow_add ht]
+      congr 1
+      norm_num
+    have h17 : t * t ^ (7 / 4 : ℝ) = t ^ (11 / 4 : ℝ) := by
+      nth_rewrite 1 [← Real.rpow_one t]
+      rw [← Real.rpow_add ht]
+      congr 1
+      norm_num
+    have h111 : t * t ^ (11 / 4 : ℝ) = t ^ (15 / 4 : ℝ) := by
+      nth_rewrite 1 [← Real.rpow_one t]
+      rw [← Real.rpow_add ht]
+      congr 1
+      norm_num
+    have hc13 : t * ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ)) =
+        (1 / 64 : ℝ) * t ^ (7 / 4 : ℝ) := by
+      calc
+        t * ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ)) =
+            (1 / 64 : ℝ) * (t * t ^ (3 / 4 : ℝ)) := by ring
+        _ = _ := by rw [h13]
+    have hc17 : t * ((1 / 4 : ℝ) * t ^ (7 / 4 : ℝ)) =
+        (1 / 4 : ℝ) * t ^ (11 / 4 : ℝ) := by
+      calc
+        t * ((1 / 4 : ℝ) * t ^ (7 / 4 : ℝ)) =
+            (1 / 4 : ℝ) * (t * t ^ (7 / 4 : ℝ)) := by ring
+        _ = _ := by rw [h17]
+    have hsq :
+        ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ)) ^ 2 =
+          t * ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ) +
+            (1 / 4 : ℝ) * t ^ (7 / 4 : ℝ) + t ^ (11 / 4 : ℝ)) := by
+      calc
+        ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ)) ^ 2 =
+            (1 / 64 : ℝ) * (t ^ (7 / 8 : ℝ) * t ^ (7 / 8 : ℝ)) +
+              (1 / 4 : ℝ) * (t ^ (7 / 8 : ℝ) * t ^ (15 / 8 : ℝ)) +
+              t ^ (15 / 8 : ℝ) * t ^ (15 / 8 : ℝ) := by ring
+        _ = (1 / 64 : ℝ) * t ^ (7 / 4 : ℝ) +
+              (1 / 4 : ℝ) * t ^ (11 / 4 : ℝ) + t ^ (15 / 4 : ℝ) := by
+          rw [h77, h715, h1515]
+        _ = _ := by rw [mul_add, mul_add, hc13, hc17, h111]
+    have hexpSq : Real.exp (-t) ^ 2 = Real.exp (-2 * t) := by
+      rw [pow_two, ← Real.exp_add]
+      congr 1
+      ring
+    calc
+      10000 / t *
+          (1 / 10000 * Real.exp (-t) *
+            ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ))) ^ 2 =
+          10000 / t * ((1 / 10000 : ℝ) ^ 2 * Real.exp (-t) ^ 2 *
+            ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ)) ^ 2) := by
+            ring
+      _ = _ := by
+        rw [hexpSq, hsq]
+        field_simp [ht.ne']
+  have hpp_part : s *
+      |deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s| ≤
+      1 / 10000 * (Real.exp (-t) *
+        ((7 / 64 : ℝ) * t ^ (7 / 8 : ℝ) +
+          (7 / 4 : ℝ) * t ^ (15 / 8 : ℝ) + t ^ (23 / 8 : ℝ))) := by
+    rw [hpp']
+    rw [abs_mul, abs_mul, abs_neg,
+      abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 1 / 100000000),
+      abs_of_nonneg (Real.exp_nonneg _)]
+    calc
+      s * (1 / 100000000 * Real.exp (-t) *
+          |(7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+            (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) - t ^ (31 / 8 : ℝ)|) ≤
+          s * (1 / 100000000 * Real.exp (-t) *
+            ((7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+              (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) + t ^ (31 / 8 : ℝ))) := by
+        gcongr
+      _ = 1 / 10000 * (Real.exp (-t) *
+          ((7 / 64 : ℝ) * t ^ (7 / 8 : ℝ) +
+            (7 / 4 : ℝ) * t ^ (15 / 8 : ℝ) + t ^ (23 / 8 : ℝ))) := by
+        rw [hs_eq]
+        have h7 : t * t ^ (7 / 8 : ℝ) = t ^ (15 / 8 : ℝ) := by
+          nth_rewrite 1 [← Real.rpow_one t]
+          rw [← Real.rpow_add ht]
+          congr 1
+          norm_num
+        have h15 : t * t ^ (15 / 8 : ℝ) = t ^ (23 / 8 : ℝ) := by
+          nth_rewrite 1 [← Real.rpow_one t]
+          rw [← Real.rpow_add ht]
+          congr 1
+          norm_num
+        have h23 : t * t ^ (23 / 8 : ℝ) = t ^ (31 / 8 : ℝ) := by
+          nth_rewrite 1 [← Real.rpow_one t]
+          rw [← Real.rpow_add ht]
+          congr 1
+          norm_num
+        have hshift :
+            (7 / 64 : ℝ) * t ^ (15 / 8 : ℝ) +
+                (7 / 4 : ℝ) * t ^ (23 / 8 : ℝ) + t ^ (31 / 8 : ℝ) =
+              t * ((7 / 64 : ℝ) * t ^ (7 / 8 : ℝ) +
+                (7 / 4 : ℝ) * t ^ (15 / 8 : ℝ) + t ^ (23 / 8 : ℝ)) := by
+          calc
+            _ = (7 / 64 : ℝ) * (t * t ^ (7 / 8 : ℝ)) +
+                (7 / 4 : ℝ) * (t * t ^ (15 / 8 : ℝ)) +
+                t * t ^ (23 / 8 : ℝ) := by rw [h7, h15, h23]
+            _ = _ := by ring
+        rw [hshift]
+        field_simp [ht.ne']
+        ring
+  rw [mul_add, hp_part]
+  calc
+    1 / 10000 * (Real.exp (-2 * t) *
+        ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ) +
+          (1 / 4 : ℝ) * t ^ (7 / 4 : ℝ) + t ^ (11 / 4 : ℝ))) +
+      s * |deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s| ≤
+        1 / 10000 * (Real.exp (-2 * t) *
+          ((1 / 64 : ℝ) * t ^ (3 / 4 : ℝ) +
+            (1 / 4 : ℝ) * t ^ (7 / 4 : ℝ) + t ^ (11 / 4 : ℝ)) +
+          Real.exp (-t) * ((7 / 64 : ℝ) * t ^ (7 / 8 : ℝ) +
+            (7 / 4 : ℝ) * t ^ (15 / 8 : ℝ) + t ^ (23 / 8 : ℝ))) := by
+          nlinarith
+    _ ≤ 1 / 10000 * 10 := by
+      gcongr
+      exact (reciprocalDampingSecondNumerator_bound ht.le).le
+    _ = 1 / 1000 := by norm_num
+
+/-- A direct, deliberately loose bound for the first radial derivative. Unlike the rescaled
+bound above, this remains useful in the Laplacian formula at the reciprocal origin. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalExponent_deriv_abs_le (s : ℝ) (hs : 0 ≤ s) :
+    |deriv counterexampleTwoReciprocalExponent s| ≤ 1 / 1000 := by
+  by_cases hs0 : s = 0
+  · subst s
+    let f : ℝ → ℝ := fun x ↦ x ^ ((1 : ℝ) / 8) * Real.flatRpowExp 1 10000 x
+    have hflat := Real.flatRpowExp.rpow_mul_iteratedFDeriv_zero
+      (by norm_num : (0 : ℝ) < 1) (by norm_num : (0 : ℝ) < 10000) ((1 : ℝ) / 8) 1
+    have hfderiv : fderiv ℝ f 0 = 0 := by
+      apply ContinuousLinearMap.ext
+      intro v
+      have happ := congrArg (fun L : ℝ [×1]→L[ℝ] ℝ ↦ L ![v]) hflat
+      simpa only [f, iteratedFDeriv_one_apply,
+        ContinuousMultilinearMap.zero_apply] using happ
+    have hfcont : ContDiff ℝ ∞ f :=
+      Real.flatRpowExp.rpow_mul_contDiff (by norm_num) (by norm_num) ((1 : ℝ) / 8)
+    have hfDiff : DifferentiableAt ℝ f 0 := hfcont.differentiable (by simp) 0
+    have hderiv : deriv f 0 = 0 := by rw [deriv, hfderiv]; rfl
+    change |deriv (fun x : ℝ ↦ (10000 : ℝ) ^ (-(1 : ℝ) / 8) * f x) 0| ≤ 1 / 1000
+    rw [deriv_const_mul _ hfDiff, hderiv, mul_zero, abs_zero]
+    norm_num
+  · have hspos : 0 < s := lt_of_le_of_ne hs (Ne.symm hs0)
+    let t := 10000 / s
+    have ht : 0 < t := div_pos (by norm_num) hspos
+    rw [counterexampleTwoReciprocalExponent_deriv_dimensionless hspos,
+      abs_of_nonneg (by positivity)]
+    have h₁ : t ^ (7 / 8 : ℝ) * Real.exp (-t) ≤ 1 :=
+      rpow_mul_exp_neg_le_one (a := 7 / 8) ht.le (by norm_num) (by norm_num)
+    have h₂ : t ^ (15 / 8 : ℝ) * Real.exp (-t) ≤ 15 / 16 :=
+      (rpow_mul_exp_neg_le_self (a := 15 / 8) ht.le (by norm_num)).trans
+        ((self_rpow_mul_exp_neg_le_half (a := 15 / 8) (by norm_num) (by norm_num)).trans_eq
+          (by norm_num))
+    calc
+      1 / 10000 * Real.exp (-t) *
+          ((1 / 8 : ℝ) * t ^ (7 / 8 : ℝ) + t ^ (15 / 8 : ℝ)) =
+        1 / 10000 * ((1 / 8 : ℝ) *
+          (t ^ (7 / 8 : ℝ) * Real.exp (-t)) +
+            t ^ (15 / 8 : ℝ) * Real.exp (-t)) := by ring
+      _ ≤ 1 / 10000 * ((1 / 8 : ℝ) * 1 + 15 / 16) := by gcongr
+      _ ≤ 1 / 1000 := by norm_num
+
+/-- The conjugate Wirtinger convention used by the support calculation has the same seed bound
+as the convention used in the planar index calculation. -/
+@[category API, AMS 53]
+private theorem complexBarDeriv_counterexampleSeed_norm_upper (w : ℂ) :
+    ‖complexBarDeriv counterexampleSeed w‖ ≤ 129 / 80 := by
+  have hconj :
+      star (((fderiv ℝ counterexampleSeed w 1 : ℂ) -
+          (fderiv ℝ counterexampleSeed w Complex.I : ℂ) * Complex.I) / 2) =
+        complexBarDeriv counterexampleSeed w := by
+    rw [complexBarDeriv]
+    simp
+  rw [← hconj, norm_star]
+  exact counterexampleSeed_wirtinger_norm_upper w
+
+/-- The Euclidean chart Laplacian of the reciprocal representative is controlled by eight
+times its positive damping factor. The argument deliberately keeps substantial numerical
+slack, since only positivity of the resulting radius tensor matters. -/
+@[category API, AMS 53]
+private theorem chartLaplacian_counterexampleTwoReciprocal_le_of_seed
+    (hSeedLaplacian : ∀ z : ℂ, |chartLaplacian counterexampleSeed z| ≤ 47 / 10)
+    (w : ℂ) :
+    |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w := by
+  let s : ℝ := ‖w‖ ^ 2
+  let D : ℝ := s + 10000
+  let p : ℝ := deriv counterexampleTwoReciprocalExponent s
+  let p' : ℝ := deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) s
+  let q : ℝ := 1 / D + p
+  let β : ℝ → ℝ := fun x ↦ 10000 / (x + 10000) *
+    Real.exp (-counterexampleTwoReciprocalExponent x)
+  let B : ℂ → ℝ := counterexampleTwoReciprocalDamping
+  have hs : 0 ≤ s := sq_nonneg _
+  have hD : 0 < D := by dsimp only [D]; positivity
+  have hBpos : 0 < B w := by
+    dsimp only [B, counterexampleTwoReciprocalDamping]
+    positivity
+  have hβ : ContDiffAt ℝ 2 β s := by
+    exact counterexampleTwoReciprocalRadialDamping_contDiffAt (by linarith [hs])
+  have hβ₁ : deriv β s = -(B w) * q := by
+    rw [counterexampleTwoReciprocalRadialDamping_deriv (by linarith [hs])]
+    rfl
+  have hβ₂ : deriv (fun x ↦ deriv β x) s =
+      B w * (q ^ 2 + 1 / D ^ 2 - p') := by
+    rw [counterexampleTwoReciprocalRadialDamping_second_deriv
+      (by linarith [hs])]
+    rfl
+  have hp : |p| ≤ 1 / 1000 :=
+    counterexampleTwoReciprocalExponent_deriv_abs_le s hs
+  have hrp : ‖w‖ * |p| ≤ 1 / 100 := by
+    by_cases hw : w = 0
+    · simp [hw]
+    · exact counterexampleTwoReciprocalExponent_first_bound hw
+  have hpp : s * (p ^ 2 + |p'|) ≤ 1 / 1000 := by
+    by_cases hw : w = 0
+    · simp [hw, s]
+    · simpa only [s, p, p'] using counterexampleTwoReciprocalExponent_second_bound hw
+  have hrD : ‖w‖ / D ≤ 1 / 200 := by
+    have hsquare := sq_nonneg (‖w‖ - 100)
+    dsimp only [D, s]
+    apply (div_le_iff₀ (by positivity)).2
+    nlinarith
+  have hsD : s / D ^ 2 ≤ 1 / 10000 := by
+    dsimp only [D]
+    apply (div_le_iff₀ (sq_pos_of_pos hD)).2
+    nlinarith [sq_nonneg s]
+  have hq : |q| ≤ 11 / 10000 := by
+    calc
+      |q| ≤ |1 / D| + |p| := by dsimp only [q]; exact abs_add_le ..
+      _ = 1 / D + |p| := by rw [abs_of_pos (one_div_pos.mpr hD)]
+      _ ≤ 1 / 10000 + 1 / 1000 := by
+        gcongr
+        change 10000 ≤ D
+        dsimp only [D]
+        linarith [hs]
+      _ = 11 / 10000 := by norm_num
+  have hrq : ‖w‖ * |q| ≤ 3 / 200 := by
+    calc
+      ‖w‖ * |q| ≤ ‖w‖ * (|1 / D| + |p|) := by
+        gcongr
+        dsimp only [q]
+        exact abs_add_le ..
+      _ = ‖w‖ / D + ‖w‖ * |p| := by
+        rw [abs_of_pos (one_div_pos.mpr hD)]
+        ring
+      _ ≤ 1 / 200 + 1 / 100 := add_le_add hrD hrp
+      _ = 3 / 200 := by norm_num
+  have hinside :
+      |-(q) + s * (q ^ 2 + 1 / D ^ 2 - p')| ≤ 1 / 40 := by
+    calc
+      |-(q) + s * (q ^ 2 + 1 / D ^ 2 - p')| ≤
+          |q| + s * (q ^ 2 + 1 / D ^ 2 + |p'|) := by
+        calc
+          _ ≤ |-q| + |s * (q ^ 2 + 1 / D ^ 2 - p')| := abs_add_le ..
+          _ = |q| + s * |q ^ 2 + 1 / D ^ 2 - p'| := by
+            rw [abs_neg, abs_mul, abs_of_nonneg hs]
+          _ ≤ |q| + s * (q ^ 2 + 1 / D ^ 2 + |p'|) := by
+            gcongr
+            calc
+              |q ^ 2 + 1 / D ^ 2 - p'| ≤
+                  |q ^ 2 + 1 / D ^ 2| + |p'| := abs_sub ..
+              _ = q ^ 2 + 1 / D ^ 2 + |p'| := by
+                rw [abs_of_nonneg]
+                positivity
+      _ ≤ 11 / 10000 +
+          s * (2 * (1 / D ^ 2 + p ^ 2) + 1 / D ^ 2 + |p'|) := by
+        gcongr
+        dsimp only [q]
+        have hdivsq : (1 / D) ^ 2 = 1 / D ^ 2 := by ring
+        rw [← hdivsq]
+        nlinarith [sq_nonneg (1 / D - p)]
+      _ ≤ 11 / 10000 + 3 * (1 / 10000) + 2 * (1 / 1000) := by
+        have hrewrite : s * (2 * (1 / D ^ 2 + p ^ 2) + 1 / D ^ 2 + |p'|) =
+            3 * (s / D ^ 2) + 2 * (s * (p ^ 2 + |p'|)) - s * |p'| := by
+          ring
+        rw [hrewrite]
+        nlinarith [hsD, hpp, mul_nonneg hs (abs_nonneg p')]
+      _ ≤ 1 / 40 := by norm_num
+  have hLaplacianB : |chartLaplacian B w| ≤ B w / 10 := by
+    have hBrep : B = fun z : ℂ ↦ β (‖z‖ ^ 2) := by rfl
+    rw [hBrep, chartLaplacian_comp_norm_sq β w hβ, hβ₁, hβ₂]
+    rw [abs_mul, abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 4)]
+    change 4 * |-B w * q + ‖w‖ ^ 2 * (B w * (q ^ 2 + 1 / D ^ 2 - p'))| ≤
+      β (‖w‖ ^ 2) / 10
+    change 4 * |-B w * q + s * (B w * (q ^ 2 + 1 / D ^ 2 - p'))| ≤ β s / 10
+    rw [show β s = B w by rfl]
+    rw [show -B w * q + s * (B w * (q ^ 2 + 1 / D ^ 2 - p')) =
+      B w * (-q + s * (q ^ 2 + 1 / D ^ 2 - p')) by ring,
+      abs_mul, abs_of_pos hBpos]
+    calc
+      4 * (B w * |-(q) + s * (q ^ 2 + 1 / D ^ 2 - p')|) ≤
+          4 * (B w * (1 / 40)) := by gcongr
+      _ = B w / 10 := by ring
+  have hDB (v : ℂ) : fderiv ℝ B w v =
+      -2 * B w * q * inner ℝ w v := by
+    have hβderiv : HasDerivAt β (-(B w) * q) s := by
+      convert (hβ.differentiableAt (by norm_num)).hasDerivAt using 1
+      exact hβ₁.symm
+    have hsderiv : HasFDerivAt (fun z : ℂ ↦ ‖z‖ ^ 2) (2 • innerSL ℝ w) w := by
+      simpa only [two_smul] using (hasStrictFDerivAt_norm_sq w).hasFDerivAt
+    have hcomp := hβderiv.hasFDerivAt.comp w hsderiv
+    have hBrep : B = fun z : ℂ ↦ β (‖z‖ ^ 2) := by rfl
+    rw [hBrep]
+    change fderiv ℝ (β ∘ fun z : ℂ ↦ ‖z‖ ^ 2) w v =
+      -2 * β s * q * inner ℝ w v
+    rw [hcomp.fderiv]
+    simp
+    rw [show β s = B w by rfl]
+    ring
+  have hcross :
+      |2 * (fderiv ℝ B w 1 * fderiv ℝ counterexampleSeed w 1 +
+        fderiv ℝ B w Complex.I * fderiv ℝ counterexampleSeed w Complex.I)| ≤
+          B w / 2 := by
+    let g := complexBarDeriv counterexampleSeed w
+    have hg : ‖g‖ ≤ 129 / 80 := complexBarDeriv_counterexampleSeed_norm_upper w
+    have hidentity :
+        2 * (fderiv ℝ B w 1 * fderiv ℝ counterexampleSeed w 1 +
+          fderiv ℝ B w Complex.I * fderiv ℝ counterexampleSeed w Complex.I) =
+            -8 * B w * q * (w * star g).re := by
+      rw [hDB, hDB]
+      dsimp only [g, complexBarDeriv]
+      simp [Complex.inner, Complex.mul_re, Complex.mul_im]
+      ring
+    rw [hidentity, abs_mul, abs_mul, abs_mul, abs_of_pos hBpos]
+    have hre : |(w * star g).re| ≤ ‖w‖ * ‖g‖ := by
+      calc
+        |(w * star g).re| ≤ ‖w * star g‖ := Complex.abs_re_le_norm _
+        _ = ‖w‖ * ‖g‖ := by rw [norm_mul, norm_star]
+    calc
+      |(-8 : ℝ)| * B w * |q| * |(w * star g).re| ≤
+        8 * B w * |q| * (‖w‖ * ‖g‖) := by
+          norm_num
+          exact mul_le_mul_of_nonneg_left
+            (show |w.re * g.re + w.im * g.im| ≤ ‖w‖ * ‖g‖ by
+              simpa [Complex.mul_re] using hre)
+            (mul_nonneg (mul_nonneg (by norm_num) hBpos.le) (abs_nonneg q))
+      _ = B w * (8 * (‖w‖ * |q|) * ‖g‖) := by ring
+      _ ≤ B w * (8 * (3 / 200) * (129 / 80)) := by
+        gcongr
+      _ ≤ B w / 2 := by nlinarith [hBpos]
+  have hproduct := chartLaplacian_mul B counterexampleSeed
+    counterexampleTwoReciprocalDamping_contDiff counterexampleSeed_contDiff w
+  have hsum : |chartLaplacian (fun z ↦ B z * counterexampleSeed z) w| ≤
+      B w * (47 / 10) + (253 / 160) * (B w / 10) + B w / 2 := by
+    rw [hproduct]
+    calc
+      |B w * chartLaplacian counterexampleSeed w +
+          counterexampleSeed w * chartLaplacian B w +
+            2 * (fderiv ℝ B w 1 * fderiv ℝ counterexampleSeed w 1 +
+              fderiv ℝ B w Complex.I * fderiv ℝ counterexampleSeed w Complex.I)| ≤
+          |B w * chartLaplacian counterexampleSeed w| +
+            |counterexampleSeed w * chartLaplacian B w| +
+              |2 * (fderiv ℝ B w 1 * fderiv ℝ counterexampleSeed w 1 +
+                fderiv ℝ B w Complex.I * fderiv ℝ counterexampleSeed w Complex.I)| := by
+        exact (abs_add_le ..).trans (add_le_add (abs_add_le ..) le_rfl)
+      _ ≤ B w * (47 / 10) + (253 / 160) * (B w / 10) + B w / 2 := by
+        rw [abs_mul, abs_mul, abs_of_pos hBpos]
+        exact add_le_add
+          (add_le_add (mul_le_mul_of_nonneg_left (hSeedLaplacian w) hBpos.le)
+            (mul_le_mul (counterexampleSeed_abs_le w) hLaplacianB
+              (abs_nonneg _) (by positivity))) hcross
+  change |chartLaplacian
+    (fun z ↦ 10 ^ 10 + B z * counterexampleSeed z) w| ≤ 8 * B w
+  rw [chartLaplacian_const_add]
+  · calc
+      _ ≤ B w * (47 / 10) + (253 / 160) * (B w / 10) + B w / 2 := hsum
+      _ ≤ 8 * B w := by nlinarith [le_of_lt hBpos]
+  · exact counterexampleTwoReciprocalDamping_contDiff.mul counterexampleSeed_contDiff
+
+/-- The explicit reciprocal trace-free model is nonzero away from the reciprocal origin. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocalTraceFreeModel_ne_zero {w : ℂ} (hw : w ≠ 0) :
+    let p := deriv counterexampleTwoReciprocalExponent (‖w‖ ^ 2)
+    let p' := deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) (‖w‖ ^ 2)
+    traceFreeHessian counterexampleSeed w -
+        8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w +
+      4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w ≠ 0 := by
+  exact seedTraceFreeHessian_perturbation_ne_zero w _ _
+    (counterexampleTwoReciprocalExponent_first_bound hw)
+    (counterexampleTwoReciprocalExponent_second_bound hw)
+
+/-- The spherical trace-free Hessian of the reciprocal representative is nonzero away from
+the reciprocal origin. -/
+@[category API, AMS 53]
+private theorem sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero
+    {w : ℂ} (hw : w ≠ 0) :
+    sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w ≠ 0 := by
+  rw [sphericalTraceFreeHessian_counterexampleTwoReciprocal]
+  apply mul_ne_zero
+  · change (counterexampleTwoReciprocalDamping w : ℂ) ≠ 0
+    exact_mod_cast (by
+      rw [counterexampleTwoReciprocalDamping]
+      positivity : counterexampleTwoReciprocalDamping w ≠ 0)
+  · exact counterexampleTwoReciprocalTraceFreeModel_ne_zero hw
+
+/-- The spherical trace-free Hessian of the reciprocal representative is nowhere zero,
+including at the reciprocal origin (the north pole of the sphere). -/
+@[category API, AMS 53]
+private theorem sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero_all (w : ℂ) :
+    sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w ≠ 0 := by
+  by_cases hw : w = 0
+  · subst w
+    rw [sphericalTraceFreeHessian_counterexampleTwoReciprocal]
+    apply mul_ne_zero
+    · change (counterexampleTwoReciprocalDamping 0 : ℂ) ≠ 0
+      exact_mod_cast (by
+        rw [counterexampleTwoReciprocalDamping]
+        positivity : counterexampleTwoReciprocalDamping 0 ≠ 0)
+    · have hseed : traceFreeHessian counterexampleSeed 0 ≠ 0 := by
+        rw [← norm_pos_iff]
+        exact (by norm_num : (0 : ℝ) < 7 / 50).trans_le
+          (counterexampleSeed_traceFreeHessian_norm_lower 0)
+      simpa using hseed
+  · exact sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero hw
+
+/-- Uniform trace-free spherical-Hessian bound in the reciprocal chart. -/
+@[category API, AMS 53]
+private theorem sphericalTraceFreeHessian_counterexampleTwoReciprocal_norm_upper (w : ℂ) :
+    ‖sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w‖ ≤
+      20 * counterexampleTwoReciprocalDamping w := by
+  let p := deriv counterexampleTwoReciprocalExponent (‖w‖ ^ 2)
+  let p' := deriv (fun x ↦ deriv counterexampleTwoReciprocalExponent x) (‖w‖ ^ 2)
+  have hp : ‖w‖ * |p| ≤ 1 / 100 := by
+    by_cases hw : w = 0
+    · simp [hw]
+    · exact counterexampleTwoReciprocalExponent_first_bound hw
+  have hpp : ‖w‖ ^ 2 * (p ^ 2 + |p'|) ≤ 1 / 1000 := by
+    by_cases hw : w = 0
+    · simp [hw]
+    · exact counterexampleTwoReciprocalExponent_second_bound hw
+  have hBpos : 0 < counterexampleTwoReciprocalDamping w := by
+    rw [counterexampleTwoReciprocalDamping]
+    positivity
+  rw [sphericalTraceFreeHessian_counterexampleTwoReciprocal, norm_mul,
+    Complex.norm_real, Real.norm_eq_abs,
+    abs_of_pos hBpos]
+  change counterexampleTwoReciprocalDamping w *
+      ‖traceFreeHessian counterexampleSeed w -
+          8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w +
+        4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ ≤
+    20 * counterexampleTwoReciprocalDamping w
+  calc
+    counterexampleTwoReciprocalDamping w *
+        ‖traceFreeHessian counterexampleSeed w -
+            8 * w * (p : ℂ) * complexBarDeriv counterexampleSeed w +
+          4 * w ^ 2 * ((p ^ 2 - p' : ℝ) : ℂ) * counterexampleSeed w‖ ≤
+        counterexampleTwoReciprocalDamping w * 20 :=
+      mul_le_mul_of_nonneg_left
+        (seedTraceFreeHessian_perturbation_norm_upper w p p' hp hpp) hBpos.le
+    _ = 20 * counterexampleTwoReciprocalDamping w := by ring
+
+/-- The numerical coefficient in the reciprocal radius formula is below `3 · 10⁹` once the
+Laplacian bound is supplied. The exact intermediate value is `2,296,000,002`. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocal_radius_coefficient_lt (w : ℂ)
+    (hL : |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w) :
+    ‖((counterexampleTwoReciprocal w - 10 ^ 10 : ℝ) : ℂ)‖ +
+        ((‖w‖ ^ 2 + 10000) ^ 2 / 80000) *
+          (‖((chartLaplacian counterexampleTwoReciprocal w : ℝ) : ℂ)‖ +
+            ‖sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w‖) <
+      3000000000 := by
+  have hψ : 0 ≤ counterexampleTwoReciprocalExponent (‖w‖ ^ 2) := by
+    rw [counterexampleTwoReciprocalExponent]
+    apply mul_nonneg (Real.rpow_nonneg (by norm_num) _)
+    apply mul_nonneg (Real.rpow_nonneg (sq_nonneg ‖w‖) _)
+    rw [Real.flatRpowExp]
+    split <;> positivity
+  have hBpos : 0 < counterexampleTwoReciprocalDamping w := by
+    rw [counterexampleTwoReciprocalDamping]
+    positivity
+  have hBle : counterexampleTwoReciprocalDamping w ≤ 1 := by
+    rw [counterexampleTwoReciprocalDamping]
+    have hfrac : 10000 / (‖w‖ ^ 2 + 10000) ≤ 1 := by
+      apply (div_le_one₀ (by positivity)).2
+      nlinarith [sq_nonneg ‖w‖]
+    exact mul_le_one₀ hfrac (Real.exp_nonneg _)
+      (Real.exp_le_one_iff.mpr (neg_nonpos.mpr hψ))
+  have hA : ‖((counterexampleTwoReciprocal w - 10 ^ 10 : ℝ) : ℂ)‖ ≤ 2 := by
+    rw [counterexampleTwoReciprocal, add_sub_cancel_left, Complex.norm_real,
+      Real.norm_eq_abs, abs_mul, abs_of_pos hBpos]
+    calc
+      counterexampleTwoReciprocalDamping w * |counterexampleSeed w| ≤
+          1 * (253 / 160) := mul_le_mul hBle (counterexampleSeed_abs_le w)
+            (abs_nonneg _) zero_le_one
+      _ ≤ 2 := by norm_num
+  have hQ := sphericalTraceFreeHessian_counterexampleTwoReciprocal_norm_upper w
+  have hM := reciprocalConformalDamping_bound w
+  have hsum :
+      ‖((chartLaplacian counterexampleTwoReciprocal w : ℝ) : ℂ)‖ +
+          ‖sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w‖ ≤
+        28 * counterexampleTwoReciprocalDamping w := by
+    rw [Complex.norm_real, Real.norm_eq_abs]
+    linarith
+  calc
+    ‖((counterexampleTwoReciprocal w - 10 ^ 10 : ℝ) : ℂ)‖ +
+        ((‖w‖ ^ 2 + 10000) ^ 2 / 80000) *
+          (‖((chartLaplacian counterexampleTwoReciprocal w : ℝ) : ℂ)‖ +
+            ‖sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w‖) ≤
+      2 + ((‖w‖ ^ 2 + 10000) ^ 2 / 80000) *
+        (28 * counterexampleTwoReciprocalDamping w) := by gcongr
+    _ = 2 + 14 * (((‖w‖ ^ 2 + 10000) ^ 2 / 40000) *
+        counterexampleTwoReciprocalDamping w) := by ring
+    _ < 2 + 14 * 164000000 := by gcongr
+    _ < 3000000000 := by norm_num
+
+/-- The exact chart formula and numerical coefficient imply the invariant radius-error bound. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocal_radius_error_bound_of_laplacian (w : ℂ)
+    (hL : |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w) (v : ℂ) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    let ρ := fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+    ‖fderiv ℝ (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) w v -
+        (10 ^ 10 : ℝ) • fderiv ℝ ρ w v‖ ≤
+      3000000000 * ‖fderiv ℝ ρ w v‖ := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let ρ := fun z : ℂ ↦ (counterexampleTwoReciprocalSphereChart z : ℝ³)
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ ρ w
+  let dF : ℂ →L[ℝ] ℝ³ :=
+    fderiv ℝ (fun z : ℂ ↦ F (counterexampleTwoReciprocalSphereChart z)) w
+  let A : ℂ := (counterexampleTwoReciprocal w - 10 ^ 10 : ℝ)
+  let L : ℂ := chartLaplacian counterexampleTwoReciprocal w
+  let Q : ℂ := sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w
+  let r : ℝ := (‖w‖ ^ 2 + 10000) ^ 2 / 80000
+  have hscale (t : ℂ) : ‖dρ t‖ =
+      200 / (‖w‖ ^ 2 + 10000) * ‖t‖ := by
+    exact (counterexampleTwoReciprocalSphereChart_conformal w t t).2
+  have hformula (t : ℂ) : dF t - (10 ^ 10 : ℝ) • dρ t =
+      dρ (A * t + r • (L * t + Q * star t)) := by
+    exact counterexampleTwoReciprocal_radius_formula w t
+  have hnorm := norm_radiusError_le_of_conformal_formula dρ dF (10 ^ 10)
+    (200 / (‖w‖ ^ 2 + 10000)) r A L Q (by positivity) (by positivity) hscale hformula v
+  have hcoefficient := counterexampleTwoReciprocal_radius_coefficient_lt w hL
+  change ‖dF v - (10 ^ 10 : ℝ) • dρ v‖ ≤ 3000000000 * ‖dρ v‖
+  exact hnorm.trans (mul_le_mul_of_nonneg_right hcoefficient.le (norm_nonneg _))
+
+/-- The derivative of a sphere-valued map into ambient Euclidean coordinates.  Naming this
+transport keeps the ambient codomain visible to typeclass inference. -/
+private noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
+/-- The reciprocal-chart radius bound transports to the intrinsic tangent space of the sphere.
+No choice of tangent coordinates remains in this statement. -/
+@[category API, AMS 53]
+private theorem counterexampleTwo_radius_error_bound_away_south_of_laplacian
+    (hL : ∀ w : ℂ, |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w)
+    {p : sphere (0 : ℝ³) 1} (hp : p ≠ counterexampleSphereChart 0)
+    (v : TangentSpace (𝓡 2) p) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    ‖sphereAmbientMfderiv F p v - (10 ^ 10 : ℝ) •
+        sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ≤
+      3000000000 *
+        ‖sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  obtain ⟨w, rfl⟩ := exists_reciprocalSphereChart_of_ne_south hp
+  let ρ := counterexampleTwoReciprocalSphereChart
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ (fun z : ℂ ↦ (ρ z : ℝ³)) w
+  let dn : TangentSpace (𝓡 2) (ρ w) →L[ℝ] ℝ³ :=
+    sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) (ρ w)
+  let dF : TangentSpace (𝓡 2) (ρ w) →L[ℝ] ℝ³ :=
+    sphereAmbientMfderiv F (ρ w)
+  have hyv : dn v ∈ (ℝ ∙ (ρ w : ℝ³))ᗮ := by
+    rw [← range_mfderiv_coe_sphere (n := 2) (ρ w)]
+    exact ⟨v, rfl⟩
+  rw [← range_fderiv_counterexampleTwoReciprocalSphereChart w] at hyv
+  obtain ⟨a, ha⟩ := hyv
+  have hρmd : MDifferentiableAt 𝓘(ℝ, ℂ) (𝓡 2) ρ w :=
+    counterexampleTwoReciprocalSphereChart_contMDiff.mdifferentiableAt (by simp)
+  have hNmd : MDifferentiableAt (𝓡 2) 𝓘(ℝ, ℝ³)
+      (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) (ρ w) :=
+    (contMDiff_coe_sphere (m := ∞)).mdifferentiableAt (by simp)
+  have hFmd : MDifferentiableAt (𝓡 2) 𝓘(ℝ, ℝ³) F (ρ w) :=
+    counterexampleTwoHomogeneousGradient_contMDiff.mdifferentiableAt (by simp)
+  have hchainN := mfderiv_comp_apply w hNmd hρmd a
+  have hchainF := mfderiv_comp_apply w hFmd hρmd a
+  rw [mfderiv_eq_fderiv] at hchainN hchainF
+  change dρ a = dn (mfderiv 𝓘(ℝ, ℂ) (𝓡 2) ρ w a) at hchainN
+  change fderiv ℝ (fun z : ℂ ↦ F (ρ z)) w a =
+    dF (mfderiv 𝓘(ℝ, ℂ) (𝓡 2) ρ w a) at hchainF
+  have ha_tangent : mfderiv 𝓘(ℝ, ℂ) (𝓡 2) ρ w a = v := by
+    apply mfderiv_coe_sphere_injective (ρ w)
+    change dn (mfderiv 𝓘(ℝ, ℂ) (𝓡 2) ρ w a) = dn v
+    rw [← hchainN]
+    simpa only [dρ, ρ] using ha
+  have hchart := counterexampleTwoReciprocal_radius_error_bound_of_laplacian w (hL w) a
+  change ‖fderiv ℝ (fun z : ℂ ↦ F (ρ z)) w a -
+      (10 ^ 10 : ℝ) • dρ a‖ ≤ 3000000000 * ‖dρ a‖ at hchart
+  change ‖dF v - (10 ^ 10 : ℝ) • dn v‖ ≤ 3000000000 * ‖dn v‖
+  simpa only [hchainF, hchainN, ha_tangent] using hchart
+
+/-- The reciprocal radius estimate gives a positive oriented radius tensor at every point away
+from the south pole. This is the invariant form used for immersion and chord convexity. -/
+@[category API, AMS 53]
+private theorem counterexampleTwo_radius_coercive_away_south_of_laplacian
+    (hL : ∀ w : ℂ, |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w)
+    {p : sphere (0 : ℝ³) 1} (hp : p ≠ counterexampleSphereChart 0)
+    (v : TangentSpace (𝓡 2) p) :
+    7000000000 * ‖sphereAmbientMfderiv
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+      inner ℝ
+        (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v) := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let dFv : ℝ³ := sphereAmbientMfderiv F p v
+  let dnv : ℝ³ := sphereAmbientMfderiv
+    (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v
+  have herror : ‖dFv - (10 ^ 10 : ℝ) • dnv‖ ≤ 3000000000 * ‖dnv‖ :=
+    counterexampleTwo_radius_error_bound_away_south_of_laplacian hL hp v
+  have hcauchy : -‖dFv - (10 ^ 10 : ℝ) • dnv‖ * ‖dnv‖ ≤
+      inner ℝ (dFv - (10 ^ 10 : ℝ) • dnv) dnv :=
+    by
+      convert neg_le_of_abs_le
+        (abs_real_inner_le_norm (dFv - (10 ^ 10 : ℝ) • dnv) dnv) using 1
+      all_goals ring
+  have hdecompose : dFv =
+      (10 ^ 10 : ℝ) • dnv + (dFv - (10 ^ 10 : ℝ) • dnv) := by module
+  change 7000000000 * ‖dnv‖ ^ 2 ≤ inner ℝ dFv dnv
+  rw [hdecompose, inner_add_left, real_inner_smul_left,
+    real_inner_self_eq_norm_sq]
+  nlinarith [norm_nonneg dnv]
+
+/-- At the south pole, flatness of the original planar representative makes the contact-map
+differential exactly the constant support value times the Gauss-map differential. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_fderiv_south :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    fderiv ℝ (fun z : ℂ ↦ F (counterexampleSphereChart z)) 0 =
+      (10 ^ 10 : ℝ) •
+        fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0 := by
+  let u := counterexample 2
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let F := SphereSupport.homogeneousGradient H
+  let ρs := counterexampleSphereChart
+  let ρ : ℂ → ℝ³ := fun z ↦ (ρs z : ℝ³)
+  let p := ρs 0
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ ρ 0
+  let dF : ℂ →L[ℝ] ℝ³ := fderiv ℝ (fun z ↦ F (ρs z)) 0
+  have hρsmooth : ContDiff ℝ ∞ ρ := by
+    exact (contMDiff_coe_sphere.comp counterexampleSphereChart_contMDiff).contDiff
+  have hFchartSmooth : ContDiff ℝ ∞ (fun z ↦ F (ρs z)) := by
+    exact (counterexampleTwoHomogeneousGradient_contMDiff.comp
+      counterexampleSphereChart_contMDiff).contDiff
+  have hDρsmooth : ContDiff ℝ ∞ (fun z ↦ fderiv ℝ ρ z) :=
+    hρsmooth.fderiv_right (m := ∞) (by simp)
+  have huSmooth : ContDiff ℝ ∞ u := counterexample_contDiff 2 (by omega)
+  have hDuSmooth : ContDiff ℝ ∞ (fun z ↦ fderiv ℝ u z) :=
+    huSmooth.fderiv_right (m := ∞) (by simp)
+  have hρrange : dρ.range = (ℝ ∙ (p : ℝ³))ᗮ := by
+    simpa only [ρ, ρs, p, dρ] using range_fderiv_counterexampleSphereChart_zero
+  have hpH : DifferentiableAt ℝ H (p : ℝ³) :=
+    counterexampleTwoRadialExtension_differentiableAt p
+  have hpcontact : inner ℝ (F p) (p : ℝ³) = (10 : ℝ) ^ 10 := by
+    calc
+      inner ℝ (F p) (p : ℝ³) = H p :=
+        SphereSupport.inner_homogeneousGradient H p hpH
+          (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+      _ = counterexampleTwoSphereExtension p := SphereSupport.radialExtension_coe _ _
+      _ = u 0 := by
+        dsimp only [p, ρs, u]
+        rw [counterexampleTwoSphereExtension_chart]
+      _ = (10 : ℝ) ^ 10 := counterexample_zero 2
+  have hpullback : H ∘ ρ = u := by
+    funext z
+    dsimp only [Function.comp_apply, H, ρ, ρs, u]
+    rw [SphereSupport.radialExtension_coe, counterexampleTwoSphereExtension_chart]
+  have hfirstIdentity (z b : ℂ) :
+      inner ℝ (F (ρs z)) (fderiv ℝ ρ z b) = fderiv ℝ u z b := by
+    have hHz : DifferentiableAt ℝ H (ρ z) := by
+      simpa only [ρ] using counterexampleTwoRadialExtension_differentiableAt (ρs z)
+    have hchain := hHz.hasFDerivAt.comp z
+      (hρsmooth.differentiable (by simp) z).hasFDerivAt
+    rw [hpullback] at hchain
+    calc
+      inner ℝ (F (ρs z)) (fderiv ℝ ρ z b) =
+          fderiv ℝ H (ρ z) (fderiv ℝ ρ z b) := by
+        dsimp only [F]
+        rw [SphereSupport.homogeneousGradient, inner_gradient_left hHz]
+      _ = fderiv ℝ u z b := congr($hchain.fderiv b).symm
+  have hnormalIdentity (z b : ℂ) :
+      inner ℝ (ρ z) (fderiv ℝ ρ z b) = 0 := by
+    have hnorm : (fun y : ℂ ↦ ‖ρ y‖ ^ 2) = fun _ ↦ (1 : ℝ) := by
+      funext y
+      rw [norm_eq_of_mem_sphere (ρs y)]
+      norm_num
+    have hderiv : fderiv ℝ (fun y : ℂ ↦ ‖ρ y‖ ^ 2) z b = 0 := by
+      rw [hnorm]
+      simp
+    have hformula :=
+      ((hρsmooth.differentiable (by simp) z).hasFDerivAt.norm_sq).fderiv
+    rw [hformula] at hderiv
+    simp only [ContinuousLinearMap.smul_apply, ContinuousLinearMap.comp_apply,
+      innerSL_apply_apply] at hderiv
+    rw [two_smul] at hderiv
+    linarith
+  have hdu0 : fderiv ℝ u 0 = 0 := counterexample_fderiv_zero 2 (by omega)
+  have hnormalP (a : ℂ) : inner ℝ (p : ℝ³) (dρ a) = 0 := by
+    simpa only [p, ρ, ρs, dρ] using hnormalIdentity 0 a
+  have hFp : F p = (10 ^ 10 : ℝ) • (p : ℝ³) := by
+    let G : ℝ³ := (10 ^ 10 : ℝ) • (p : ℝ³)
+    have hradial : inner ℝ (F p - G) (p : ℝ³) = 0 := by
+      dsimp only [G]
+      rw [inner_sub_left, hpcontact, real_inner_smul_left,
+        real_inner_self_eq_norm_sq, norm_eq_of_mem_sphere p]
+      norm_num
+    have hmem : F p - G ∈ dρ.range := by
+      rw [hρrange, Submodule.mem_orthogonal_singleton_iff_inner_left]
+      exact hradial
+    obtain ⟨a, ha⟩ := hmem
+    have htangent : inner ℝ (F p - G) (dρ a) = 0 := by
+      dsimp only [G]
+      rw [inner_sub_left, real_inner_smul_left]
+      have hfirst := hfirstIdentity 0 a
+      change inner ℝ (F p) (dρ a) - (10 ^ 10 : ℝ) * inner ℝ (p : ℝ³) (dρ a) = 0
+      rw [hfirst, hdu0]
+      simp [hnormalP]
+    rw [← ha] at htangent
+    have htangent' : inner ℝ (dρ a) (dρ a) = 0 := htangent
+    rw [real_inner_self_eq_norm_sq] at htangent'
+    have haZero : dρ a = 0 := norm_eq_zero.mp (sq_eq_zero_iff.mp htangent')
+    have hzero : F p - G = 0 := by
+      rw [← ha]
+      exact haZero
+    exact sub_eq_zero.mp hzero
+  have hsecondU : fderiv ℝ (fun z ↦ fderiv ℝ u z) 0 = 0 :=
+    counterexample_fderiv_fderiv_zero 2 (by omega)
+  apply ContinuousLinearMap.ext
+  intro a
+  have hradial : inner ℝ (dF a - (10 ^ 10 : ℝ) • dρ a) (p : ℝ³) = 0 := by
+    have hcontactFunction : (fun z ↦ inner ℝ (F (ρs z)) (ρ z)) = u := by
+      funext z
+      calc
+        inner ℝ (F (ρs z)) (ρ z) = H (ρs z) :=
+          SphereSupport.inner_homogeneousGradient H (ρs z)
+            (counterexampleTwoRadialExtension_differentiableAt (ρs z))
+            (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+        _ = u z := by
+          dsimp only [H, u]
+          rw [SphereSupport.radialExtension_coe, counterexampleTwoSphereExtension_chart]
+    have hderiv : fderiv ℝ (fun z ↦ inner ℝ (F (ρs z)) (ρ z)) 0 a = 0 := by
+      rw [hcontactFunction, hdu0]
+      simp
+    rw [fderiv_inner_apply ℝ (hFchartSmooth.differentiable (by simp) 0)
+      (hρsmooth.differentiable (by simp) 0) a] at hderiv
+    change inner ℝ (F p) (dρ a) + inner ℝ (dF a) (p : ℝ³) = 0 at hderiv
+    rw [hFp, real_inner_smul_left, hnormalIdentity 0 a, mul_zero, zero_add] at hderiv
+    have hnormalRight : inner ℝ (dρ a) (p : ℝ³) = 0 := by
+      rw [real_inner_comm]
+      exact hnormalP a
+    rw [inner_sub_left, real_inner_smul_left, hnormalRight, mul_zero, sub_zero]
+    exact hderiv
+  have hmem : dF a - (10 ^ 10 : ℝ) • dρ a ∈ dρ.range := by
+    rw [hρrange, Submodule.mem_orthogonal_singleton_iff_inner_left]
+    exact hradial
+  obtain ⟨b, hb⟩ := hmem
+  have htangent : inner ℝ (dF a - (10 ^ 10 : ℝ) • dρ a) (dρ b) = 0 := by
+    have hidentity : (fun z ↦ inner ℝ (F (ρs z)) (fderiv ℝ ρ z b)) =
+        fun z ↦ fderiv ℝ u z b := by
+      funext z
+      exact hfirstIdentity z b
+    have hDρb : ContDiff ℝ ∞ (fun z ↦ fderiv ℝ ρ z b) :=
+      hDρsmooth.clm_apply (show ContDiff ℝ ∞ (fun _ : ℂ ↦ b) from contDiff_const)
+    have hleft := fderiv_inner_apply ℝ
+      (hFchartSmooth.differentiable (by simp) 0)
+      (hDρb.differentiable (by simp) 0) a
+    have hright : fderiv ℝ (fun z ↦ fderiv ℝ u z b) 0 a = 0 := by
+      rw [fderiv_clm_apply (hDuSmooth.differentiable (by simp) 0)
+        (differentiableAt_const b : DifferentiableAt ℝ (fun _ : ℂ ↦ b) 0)]
+      rw [hsecondU]
+      simp
+    have hderivIdentity :
+        fderiv ℝ (fun z ↦ inner ℝ (F (ρs z)) (fderiv ℝ ρ z b)) 0 a = 0 := by
+      rw [hidentity, hright]
+    rw [hleft] at hderivIdentity
+    have hnormalFunction : (fun z ↦ inner ℝ (ρ z) (fderiv ℝ ρ z b)) = fun _ ↦ 0 := by
+      funext z
+      exact hnormalIdentity z b
+    have hnormalDerivative :
+        inner ℝ (p : ℝ³) (fderiv ℝ (fun z ↦ fderiv ℝ ρ z b) 0 a) +
+          inner ℝ (dρ a) (dρ b) = 0 := by
+      have hzero : fderiv ℝ (fun z ↦ inner ℝ (ρ z) (fderiv ℝ ρ z b)) 0 a = 0 := by
+        rw [hnormalFunction]
+        simp
+      rw [fderiv_inner_apply ℝ (hρsmooth.differentiable (by simp) 0)
+        (hDρb.differentiable (by simp) 0) a] at hzero
+      exact hzero
+    change inner ℝ (F p) (fderiv ℝ (fun z ↦ fderiv ℝ ρ z b) 0 a) +
+      inner ℝ (dF a) (dρ b) = 0 at hderivIdentity
+    rw [hFp, real_inner_smul_left] at hderivIdentity
+    rw [inner_sub_left, real_inner_smul_left]
+    linarith
+  rw [← hb] at htangent
+  have htangent' : inner ℝ (dρ b) (dρ b) = 0 := htangent
+  rw [real_inner_self_eq_norm_sq] at htangent'
+  have hbZero : dρ b = 0 := norm_eq_zero.mp (sq_eq_zero_iff.mp htangent')
+  have hzero : dF a - (10 ^ 10 : ℝ) • dρ a = 0 := by
+    rw [← hb]
+    exact hbZero
+  exact sub_eq_zero.mp hzero
+
+/-- Intrinsic form of the exact south-pole radius identity. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_mfderiv_south :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    sphereAmbientMfderiv F (counterexampleSphereChart 0) =
+      (10 ^ 10 : ℝ) • sphereAmbientMfderiv
+        (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³)) (counterexampleSphereChart 0) := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let n : sphere (0 : ℝ³) 1 → ℝ³ := fun p ↦ (p : ℝ³)
+  let dρ := mfderiv 𝓘(ℝ, ℂ) (𝓡 2) counterexampleSphereChart 0
+  let dn : TangentSpace (𝓡 2) (counterexampleSphereChart 0) →L[ℝ] ℝ³ :=
+    sphereAmbientMfderiv n (counterexampleSphereChart 0)
+  let dF : TangentSpace (𝓡 2) (counterexampleSphereChart 0) →L[ℝ] ℝ³ :=
+    sphereAmbientMfderiv F (counterexampleSphereChart 0)
+  apply ContinuousLinearMap.ext
+  intro v
+  change dF v = (10 ^ 10 : ℝ) • dn v
+  have hvRange : dn v ∈
+      (fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0).range := by
+    rw [range_fderiv_counterexampleSphereChart_zero,
+      ← range_mfderiv_coe_sphere (n := 2) (counterexampleSphereChart 0)]
+    exact ⟨v, rfl⟩
+  obtain ⟨a, ha⟩ := hvRange
+  have hρmd : MDifferentiableAt 𝓘(ℝ, ℂ) (𝓡 2) counterexampleSphereChart 0 :=
+    counterexampleSphereChart_contMDiff.mdifferentiableAt (by simp)
+  have hNmd : MDifferentiableAt (𝓡 2) 𝓘(ℝ, ℝ³) n
+      (counterexampleSphereChart 0) :=
+    (contMDiff_coe_sphere (m := ∞)).mdifferentiableAt (by simp)
+  have hFmd : MDifferentiableAt (𝓡 2) 𝓘(ℝ, ℝ³) F
+      (counterexampleSphereChart 0) :=
+    counterexampleTwoHomogeneousGradient_contMDiff.mdifferentiableAt (by simp)
+  have hchainN := mfderiv_comp_apply 0 hNmd hρmd a
+  have hchainF := mfderiv_comp_apply 0 hFmd hρmd a
+  rw [mfderiv_eq_fderiv] at hchainN hchainF
+  change fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0 a =
+    dn (dρ a) at hchainN
+  change fderiv ℝ (fun z : ℂ ↦ F (counterexampleSphereChart z)) 0 a =
+    dF (dρ a) at hchainF
+  have haTangent : dρ a = v := by
+    apply mfderiv_coe_sphere_injective (counterexampleSphereChart 0)
+    change dn (dρ a) = dn v
+    rw [← hchainN]
+    simpa only using ha
+  have hsouth := congr($counterexampleTwoHomogeneousGradient_fderiv_south a)
+  change fderiv ℝ (fun z : ℂ ↦ F (counterexampleSphereChart z)) 0 a =
+      (10 ^ 10 : ℝ) •
+        fderiv ℝ (fun z : ℂ ↦ (counterexampleSphereChart z : ℝ³)) 0 a at hsouth
+  rw [← haTangent, ← hchainN, ← hchainF]
+  exact hsouth
+
+/-- The south pole is an umbilic of the homogeneous-gradient contact map. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_umbilic_south :
+    IsUmbilic
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) := by
+  refine ⟨(10 ^ 10 : ℝ)⁻¹, ?_⟩
+  change sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+      (counterexampleSphereChart 0) =
+    (10 ^ 10 : ℝ)⁻¹ • sphereAmbientMfderiv
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (counterexampleSphereChart 0)
+  rw [counterexampleTwoHomogeneousGradient_mfderiv_south]
+  rw [smul_smul, inv_mul_cancel₀ (by norm_num : (10 ^ 10 : ℝ) ≠ 0), one_smul]
+
+/-- Pulling an intrinsic umbilic equation through the reciprocal chart kills the anti-linear
+coefficient of the chart radius tensor. -/
+@[category API, AMS 53]
+private theorem sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal
+    (w : ℂ)
+    (humbilic : IsUmbilic
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (fun p ↦ (p : ℝ³)) (counterexampleTwoReciprocalSphereChart w)) :
+    sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w = 0 := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let ρ := counterexampleTwoReciprocalSphereChart
+  let dρ : ℂ →L[ℝ] ℝ³ := fderiv ℝ (fun z : ℂ ↦ (ρ z : ℝ³)) w
+  let dF : ℂ →L[ℝ] ℝ³ := fderiv ℝ (fun z : ℂ ↦ F (ρ z)) w
+  let A : ℂ := (counterexampleTwoReciprocal w - 10 ^ 10 : ℝ)
+  let L : ℂ := chartLaplacian counterexampleTwoReciprocal w
+  let Q : ℂ := sphericalTraceFreeHessian 10000 counterexampleTwoReciprocal w
+  let r : ℝ := (‖w‖ ^ 2 + 10000) ^ 2 / 80000
+  have hdρ : Function.Injective dρ := by
+    intro a b hab
+    have hscale := (counterexampleTwoReciprocalSphereChart_conformal w (a - b) (a - b)).2
+    change ‖dρ (a - b)‖ = 200 / (‖w‖ ^ 2 + 10000) * ‖a - b‖ at hscale
+    rw [map_sub, hab, sub_self, norm_zero] at hscale
+    have hpositive : 0 < 200 / (‖w‖ ^ 2 + 10000) := by positivity
+    have hnormzero : ‖a - b‖ = 0 := by nlinarith [norm_nonneg (a - b)]
+    exact sub_eq_zero.mp (norm_eq_zero.mp hnormzero)
+  have hformula (a : ℂ) : dF a - (10 ^ 10 : ℝ) • dρ a =
+      dρ (A * a + r • (L * a + Q * star a)) := by
+    exact counterexampleTwoReciprocal_radius_formula w a
+  have hchartUmbilic : ∃ c : ℝ, dρ = c • dF := by
+    obtain ⟨c, hc⟩ := humbilic
+    refine ⟨c, ?_⟩
+    apply ContinuousLinearMap.ext
+    intro a
+    let dchart := mfderiv 𝓘(ℝ, ℂ) (𝓡 2) ρ w
+    let dn : TangentSpace (𝓡 2) (ρ w) →L[ℝ] ℝ³ :=
+      sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³)) (ρ w)
+    let dFintrinsic : TangentSpace (𝓡 2) (ρ w) →L[ℝ] ℝ³ :=
+      sphereAmbientMfderiv F (ρ w)
+    have hρmd : MDifferentiableAt 𝓘(ℝ, ℂ) (𝓡 2) ρ w :=
+      counterexampleTwoReciprocalSphereChart_contMDiff.mdifferentiableAt (by simp)
+    have hNmd : MDifferentiableAt (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³)) (ρ w) :=
+      (contMDiff_coe_sphere (m := ∞)).mdifferentiableAt (by simp)
+    have hFmd : MDifferentiableAt (𝓡 2) 𝓘(ℝ, ℝ³) F (ρ w) :=
+      counterexampleTwoHomogeneousGradient_contMDiff.mdifferentiableAt (by simp)
+    have hchainN := mfderiv_comp_apply w hNmd hρmd a
+    have hchainF := mfderiv_comp_apply w hFmd hρmd a
+    rw [mfderiv_eq_fderiv] at hchainN hchainF
+    change dρ a = dn (dchart a) at hchainN
+    change dF a = dFintrinsic (dchart a) at hchainF
+    have hcApply := congr($hc (dchart a))
+    change dn (dchart a) = c • dFintrinsic (dchart a) at hcApply
+    rw [ContinuousLinearMap.smul_apply]
+    calc
+      dρ a = dn (dchart a) := hchainN
+      _ = c • dFintrinsic (dchart a) := hcApply
+      _ = c • dF a := by rw [hchainF]
+  exact antiLinearCoefficient_eq_zero_of_umbilic dρ dF hdρ (10 ^ 10) r A L Q
+    (by positivity) hformula hchartUmbilic
+
+/-- Every point other than the south pole is nonumbilic, because the reciprocal chart covers it
+and its spherical trace-free Hessian is nowhere zero. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_not_umbilic_away_south
+    (p : sphere (0 : ℝ³) 1) (hp : p ≠ counterexampleSphereChart 0) :
+    ¬IsUmbilic
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (fun q ↦ (q : ℝ³)) p := by
+  obtain ⟨w, rfl⟩ := exists_reciprocalSphereChart_of_ne_south hp
+  intro humbilic
+  exact sphericalTraceFreeHessian_counterexampleTwoReciprocal_ne_zero_all w
+    (sphericalTraceFreeHessian_eq_zero_of_umbilic_reciprocal w humbilic)
+
+/-- The reciprocal radius estimate and the exact south-pole identity combine into global
+oriented coercivity. -/
+@[category API, AMS 53]
+private theorem counterexampleTwo_radius_coercive_of_laplacian
+    (hL : ∀ w : ℂ, |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w) :
+    ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v) := by
+  intro p v
+  by_cases hp : p = counterexampleSphereChart 0
+  · subst p
+    have hsouth := congr($counterexampleTwoHomogeneousGradient_mfderiv_south v)
+    rw [hsouth]
+    simp only [ContinuousLinearMap.smul_apply, real_inner_smul_left,
+      real_inner_self_eq_norm_sq]
+    nlinarith [sq_nonneg
+      ‖sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
+        (counterexampleSphereChart 0) v‖]
+  · exact counterexampleTwo_radius_coercive_away_south_of_laplacian hL hp v
+
+/-- The half-space body cut out by the explicit extension is compact, convex, and
+three-dimensional. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoBody_geometry :
+    Convex ℝ (SphereSupport.body counterexampleTwoSphereExtension) ∧
+      IsCompact (SphereSupport.body counterexampleTwoSphereExtension) ∧
+      (interior (SphereSupport.body counterexampleTwoSphereExtension)).Nonempty := by
+  refine ⟨SphereSupport.body_convex _,
+    SphereSupport.body_isCompact_of_continuous _
+      (counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+        counterexampleTwoSphereExtension_contMDiffAt_north).continuous,
+    SphereSupport.body_interior_nonempty _ zero_lt_one ?_⟩
+  exact counterexampleTwoSphereExtension_lower
+
+/-- Membership in the half-space body gives the homogeneous support inequality in every ambient
+direction. -/
+@[category API, AMS 53]
+private theorem inner_le_counterexampleTwoRadialExtension_of_mem_body
+    {x : ℝ³} (hx : x ∈ SphereSupport.body counterexampleTwoSphereExtension) (y : ℝ³) :
+    inner ℝ x y ≤ SphereSupport.radialExtension counterexampleTwoSphereExtension y := by
+  by_cases hy : y = 0
+  · simp [hy, SphereSupport.radialExtension]
+  · let q : sphere (0 : ℝ³) 1 := ⟨‖y‖⁻¹ • y, by simp [norm_smul, hy]⟩
+    have hq : inner ℝ (q : ℝ³) x ≤ counterexampleTwoSphereExtension q := hx q
+    have hscale : ‖y‖ * inner ℝ (q : ℝ³) x = inner ℝ x y := by
+      change ‖y‖ * inner ℝ (‖y‖⁻¹ • y) x = inner ℝ x y
+      rw [real_inner_smul_left, real_inner_comm]
+      field_simp [norm_ne_zero_iff.mpr hy]
+    calc
+      inner ℝ x y = ‖y‖ * inner ℝ (q : ℝ³) x := hscale.symm
+      _ ≤ ‖y‖ * counterexampleTwoSphereExtension q :=
+        mul_le_mul_of_nonneg_left hq (norm_nonneg y)
+      _ = SphereSupport.radialExtension counterexampleTwoSphereExtension y := by
+        rw [SphereSupport.radialExtension, dif_neg hy]
+
+/-- Differentiability of the homogeneous extension makes each exposed contact face a singleton. -/
+@[category API, AMS 53]
+private theorem eq_counterexampleTwoSupportPoint
+    {p : sphere (0 : ℝ³) 1} {x : ℝ³}
+    (hx : x ∈ SphereSupport.body counterexampleTwoSphereExtension)
+    (hface : inner ℝ (p : ℝ³) x = counterexampleTwoSphereExtension p)
+    (hH : DifferentiableAt ℝ
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) (p : ℝ³)) :
+    x = SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) p := by
+  apply SphereSupport.eq_homogeneousGradient_of_global_support _ p x hH
+    (inner_le_counterexampleTwoRadialExtension_of_mem_body hx)
+  simpa [real_inner_comm] using hface
+
+/-- Convexity and differentiability of the degree-one extension supply the complete
+set-theoretic support parametrization. The remaining geometric work is to verify these analytic
+hypotheses and the differential properties of the resulting gradient map. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSupport_body_of_convex_radialExtension
+    (hHdiff : ∀ p : sphere (0 : ℝ³) 1, DifferentiableAt ℝ
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) (p : ℝ³))
+    (hconvex : ConvexOn ℝ univ
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    range F = frontier (SphereSupport.body counterexampleTwoSphereExtension) ∧
+      IsSupportParametrization counterexampleTwoSphereExtension F
+        (SphereSupport.body counterexampleTwoSphereExtension) := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  have hcontact : ∀ p, inner ℝ (F p) (p : ℝ³) = counterexampleTwoSphereExtension p := by
+    intro p
+    simpa [F] using SphereSupport.inner_homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) p (hHdiff p)
+      (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+  have hcross : ∀ (p q : sphere (0 : ℝ³) 1),
+      inner ℝ (F p) (q : ℝ³) ≤ counterexampleTwoSphereExtension q := by
+    intro p q
+    simpa [F] using SphereSupport.inner_homogeneousGradient_le
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) p (q : ℝ³)
+      hconvex (hHdiff p)
+      (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+  have hstationary : ∀ (p : sphere (0 : ℝ³) 1) (x : ℝ³),
+      x ∈ SphereSupport.body counterexampleTwoSphereExtension →
+      inner ℝ (p : ℝ³) x = counterexampleTwoSphereExtension p →
+      ∀ v : ℝ³, v ∈ (ℝ ∙ (p : ℝ³))ᗮ → inner ℝ (x - F p) v = 0 := by
+    intro p x hx hface v _
+    rw [eq_counterexampleTwoSupportPoint hx hface (hHdiff p)]
+    simp [F]
+  exact ⟨SphereSupport.range_eq_frontier_of_first_variation _ F hcontact hcross
+      counterexampleTwoBody_geometry.2.2 hstationary,
+    SphereSupport.contact_mem_body _ F hcontact hcross⟩
+
+/-- For the explicit radial extension, the homogeneous-gradient differential is tangent to the
+sphere. This follows directly by differentiating Euler's identity and does not use support
+convexity. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_normal :
+    ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      inner ℝ (p : ℝ³)
+        (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v) = 0 := by
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let G : ℝ³ → ℝ³ := gradient H
+  let F := SphereSupport.homogeneousGradient H
+  have hHsmooth : ContDiffOn ℝ ∞ H {0}ᶜ :=
+    radialExtension_contDiffOn_compl_of_contMDiff counterexampleTwoSphereExtension
+      (counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+        counterexampleTwoSphereExtension_contMDiffAt_north)
+  have hGsmooth : ContDiffOn ℝ ∞ G {0}ᶜ := by
+    have hDf : ContDiffOn ℝ ∞ (fderiv ℝ H) {0}ᶜ :=
+      hHsmooth.fderiv_of_isOpen isOpen_compl_singleton (by simp)
+    simpa only [G, gradient] using
+      (InnerProductSpace.toDual ℝ ℝ³).symm.contDiff.comp_contDiffOn hDf
+  have hEuler (x : ℝ³) (hx : x ≠ 0) : inner ℝ (G x) x = H x := by
+    have hHdiff : DifferentiableAt ℝ H x :=
+      (hHsmooth x hx).differentiableWithinAt (by simp) |>.differentiableAt
+        (isOpen_compl_singleton.mem_nhds hx)
+    dsimp only [G]
+    rw [inner_gradient_left hHdiff]
+    have hline : HasDerivAt (fun t : ℝ ↦ H (x + t • x)) (fderiv ℝ H x x) 0 := by
+      have harg : HasDerivAt (fun t : ℝ ↦ x + t • x) x 0 := by
+        simpa only [Pi.add_apply, id_eq, zero_add, one_smul] using
+          (hasDerivAt_const (x := (0 : ℝ)) x).add
+            ((hasDerivAt_id (𝕜 := ℝ) 0).smul_const x)
+      simpa [Function.comp_def] using
+        hHdiff.hasFDerivAt.comp_hasDerivAt_of_eq (x := (0 : ℝ)) harg (by simp)
+    have heq : (fun t : ℝ ↦ H (x + t • x)) =ᶠ[nhds 0]
+        fun t ↦ (1 + t) * H x := by
+      filter_upwards [Metric.ball_mem_nhds (0 : ℝ) (by norm_num : (0 : ℝ) < 1)] with t ht
+      rw [mem_ball, dist_zero_right, Real.norm_eq_abs] at ht
+      calc
+        H (x + t • x) = H ((1 + t) • x) := by rw [add_smul, one_smul]
+        _ = (1 + t) * H x := SphereSupport.radialExtension_smul_of_pos _ _
+          (by linarith [(abs_lt.mp ht).1])
+    have hright : HasDerivAt (fun t : ℝ ↦ (1 + t) * H x) (H x) 0 := by
+      convert (hasDerivAt_id (𝕜 := ℝ) 0).const_add 1 |>.mul_const (H x) using 1
+      all_goals ring
+    exact (hline.congr_of_eventuallyEq heq.symm).unique hright
+  intro p v
+  have hp : (p : ℝ³) ≠ 0 := ne_zero_of_mem_unit_sphere p
+  have hpG : DifferentiableAt ℝ G (p : ℝ³) :=
+    (hGsmooth (p : ℝ³) hp).differentiableWithinAt (by simp) |>.differentiableAt
+      (isOpen_compl_singleton.mem_nhds hp)
+  have hpH : DifferentiableAt ℝ H (p : ℝ³) :=
+    (hHsmooth (p : ℝ³) hp).differentiableWithinAt (by simp) |>.differentiableAt
+      (isOpen_compl_singleton.mem_nhds hp)
+  have hEulerEventually : (fun x : ℝ³ ↦ inner ℝ (G x) x) =ᶠ[nhds (p : ℝ³)] H := by
+    filter_upwards [eventually_ne_nhds hp] with x hx
+    exact hEuler x hx
+  have hnormalAmbient (a : ℝ³) :
+      inner ℝ (p : ℝ³) (fderiv ℝ G (p : ℝ³) a) = 0 := by
+    have hderivEq := hEulerEventually.fderiv_eq (𝕜 := ℝ)
+    have happ := congr($hderivEq a)
+    change (fderiv ℝ (fun t : ℝ³ ↦ inner ℝ (G t) (id t)) (p : ℝ³)) a =
+      (fderiv ℝ H (p : ℝ³)) a at happ
+    rw [fderiv_inner_apply ℝ hpG differentiableAt_id a,
+      inner_gradient_left hpH] at happ
+    simp only [fderiv_id, ContinuousLinearMap.id_apply, id_eq] at happ
+    rw [real_inner_comm]
+    linarith
+  have hchain := mfderiv_comp_apply p
+    (hpG.mdifferentiableAt)
+    ((contMDiff_coe_sphere (m := ∞) p).mdifferentiableAt (by simp)) v
+  rw [mfderiv_eq_fderiv] at hchain
+  change sphereAmbientMfderiv F p v =
+      fderiv ℝ G (p : ℝ³)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v) at hchain
+  rw [hchain]
+  exact hnormalAmbient _
+
+/-- Intrinsic radius-tensor coercivity is the ambient Hessian lower bound for the degree-one
+radial extension. Only the tangential component of the ambient direction contributes. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoRadialExtension_hessian_coercive
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v))
+    {x d : ℝ³} (hx : x ≠ 0) :
+    let p : sphere (0 : ℝ³) 1 := ⟨‖x‖⁻¹ • x, by simp [norm_smul, hx]⟩
+    let τ := d - inner ℝ d (p : ℝ³) • (p : ℝ³)
+    7000000000 / ‖x‖ * ‖τ‖ ^ 2 ≤
+      inner ℝ
+        (fderiv ℝ
+          (gradient (SphereSupport.radialExtension counterexampleTwoSphereExtension)) x d) d := by
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let G : ℝ³ → ℝ³ := gradient H
+  let F := SphereSupport.homogeneousGradient H
+  let r := ‖x‖
+  let p : sphere (0 : ℝ³) 1 := ⟨r⁻¹ • x, by simp [r, norm_smul, hx]⟩
+  let τ : ℝ³ := d - inner ℝ d (p : ℝ³) • (p : ℝ³)
+  have hr : 0 < r := norm_pos_iff.mpr hx
+  have hHsmooth : ContDiffOn ℝ ∞ H {0}ᶜ :=
+    radialExtension_contDiffOn_compl_of_contMDiff counterexampleTwoSphereExtension
+      (counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+        counterexampleTwoSphereExtension_contMDiffAt_north)
+  have hGsmooth : ContDiffOn ℝ ∞ G {0}ᶜ := by
+    have hDf : ContDiffOn ℝ ∞ (fderiv ℝ H) {0}ᶜ :=
+      hHsmooth.fderiv_of_isOpen isOpen_compl_singleton (by simp)
+    simpa only [G, gradient] using
+      (InnerProductSpace.toDual ℝ ℝ³).symm.contDiff.comp_contDiffOn hDf
+  have hGscale (y : ℝ³) (hy : y ≠ 0) (a : ℝ) (ha : 0 < a) :
+      G (a • y) = G y := by
+    have hay : a • y ≠ 0 := smul_ne_zero ha.ne' hy
+    have hyH : DifferentiableAt ℝ H y :=
+      (hHsmooth y hy).differentiableWithinAt (by simp) |>.differentiableAt
+        (isOpen_compl_singleton.mem_nhds hy)
+    have hayH : DifferentiableAt ℝ H (a • y) :=
+      (hHsmooth (a • y) hay).differentiableWithinAt (by simp) |>.differentiableAt
+        (isOpen_compl_singleton.mem_nhds hay)
+    apply ext_inner_right ℝ
+    intro z
+    dsimp only [G]
+    rw [inner_gradient_left hayH, inner_gradient_left hyH]
+    have harg : HasFDerivAt (fun z : ℝ³ ↦ a • z)
+        (a • ContinuousLinearMap.id ℝ ℝ³) y := by fun_prop
+    have hleft := hayH.hasFDerivAt.comp y harg
+    change HasFDerivAt (fun z : ℝ³ ↦ H (a • z))
+      ((fderiv ℝ H (a • y)).comp (a • ContinuousLinearMap.id ℝ ℝ³)) y at hleft
+    have hright := hyH.hasFDerivAt.const_smul a
+    have heq : (fun z : ℝ³ ↦ H (a • z)) = fun z ↦ a • H z := by
+      funext z
+      simpa only [smul_eq_mul] using SphereSupport.radialExtension_smul_of_pos
+        counterexampleTwoSphereExtension z ha
+    rw [heq] at hleft
+    have hderivEq := hleft.unique hright
+    have happ := congr($hderivEq z)
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smul_apply,
+      ContinuousLinearMap.id_apply, map_smul, smul_eq_mul] at happ
+    exact (mul_left_cancel₀ ha.ne' happ)
+  have hp0 : (p : ℝ³) ≠ 0 := ne_zero_of_mem_unit_sphere p
+  have hpG : DifferentiableAt ℝ G (p : ℝ³) :=
+    (hGsmooth (p : ℝ³) hp0).differentiableWithinAt (by simp) |>.differentiableAt
+      (isOpen_compl_singleton.mem_nhds hp0)
+  have hxG : DifferentiableAt ℝ G x :=
+    (hGsmooth x hx).differentiableWithinAt (by simp) |>.differentiableAt
+      (isOpen_compl_singleton.mem_nhds hx)
+  have hradialKernel : fderiv ℝ G (p : ℝ³) (p : ℝ³) = 0 := by
+    have hline : HasDerivAt (fun t : ℝ ↦ G ((p : ℝ³) + t • (p : ℝ³)))
+        (fderiv ℝ G (p : ℝ³) (p : ℝ³)) 0 := by
+      have harg : HasDerivAt (fun t : ℝ ↦ (p : ℝ³) + t • (p : ℝ³))
+          (p : ℝ³) 0 := by
+        simpa only [Pi.add_apply, id_eq, zero_add, one_smul] using
+          (hasDerivAt_const (x := (0 : ℝ)) (p : ℝ³)).add
+            ((hasDerivAt_id (𝕜 := ℝ) 0).smul_const (p : ℝ³))
+      simpa [Function.comp_def] using
+        hpG.hasFDerivAt.comp_hasDerivAt_of_eq (x := (0 : ℝ)) harg (by simp)
+    have heq : (fun t : ℝ ↦ G ((p : ℝ³) + t • (p : ℝ³))) =ᶠ[nhds 0]
+        fun _ ↦ G (p : ℝ³) := by
+      filter_upwards [Metric.ball_mem_nhds (0 : ℝ) (by norm_num : (0 : ℝ) < 1)] with t ht
+      rw [mem_ball, dist_zero_right, Real.norm_eq_abs] at ht
+      rw [show (p : ℝ³) + t • (p : ℝ³) = (1 + t) • (p : ℝ³) by
+        rw [add_smul, one_smul]]
+      exact hGscale (p : ℝ³) hp0 (1 + t) (by linarith [(abs_lt.mp ht).1])
+    have hzero : HasDerivAt (fun _ : ℝ ↦ G (p : ℝ³)) 0 0 := hasDerivAt_const 0 _
+    exact (hline.congr_of_eventuallyEq heq.symm).unique hzero
+  have hscaleHessian (z : ℝ³) :
+      fderiv ℝ G x z = r⁻¹ • fderiv ℝ G (p : ℝ³) z := by
+    have hrp : r • (p : ℝ³) = x := by
+      dsimp only [p]
+      rw [smul_smul, mul_inv_cancel₀ hr.ne', one_smul]
+    have hxG' : DifferentiableAt ℝ G (r • (p : ℝ³)) := by
+      simpa only [hrp] using hxG
+    have harg : HasFDerivAt (fun y : ℝ³ ↦ r • y)
+        (r • ContinuousLinearMap.id ℝ ℝ³) (p : ℝ³) := by fun_prop
+    have hleft := hxG'.hasFDerivAt.comp (p : ℝ³) harg
+    have heq : (fun y : ℝ³ ↦ G (r • y)) =ᶠ[nhds (p : ℝ³)] G := by
+      filter_upwards [isOpen_compl_singleton.mem_nhds hp0] with y hy
+      exact hGscale y hy r hr
+    have hderivEq := (hleft.congr_of_eventuallyEq heq.symm).unique hpG.hasFDerivAt
+    have happ := congr($hderivEq (r⁻¹ • z))
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smul_apply,
+      ContinuousLinearMap.id_apply, smul_smul, inv_mul_cancel₀ hr.ne', one_smul,
+      map_smul] at happ
+    simpa only [hrp] using happ
+  have hτ : τ ∈ (ℝ ∙ (p : ℝ³))ᗮ := by
+    rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
+    dsimp only [τ]
+    rw [inner_sub_left, real_inner_smul_left, real_inner_self_eq_norm_sq,
+      norm_eq_of_mem_sphere p]
+    ring
+  rw [← range_mfderiv_coe_sphere (n := 2) p] at hτ
+  obtain ⟨v, hv⟩ := hτ
+  let dn : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    sphereAmbientMfderiv F p
+  have hchain := mfderiv_comp_apply p hpG.mdifferentiableAt
+    ((contMDiff_coe_sphere (m := ∞) p).mdifferentiableAt (by simp)) v
+  rw [mfderiv_eq_fderiv] at hchain
+  change dF v = fderiv ℝ G (p : ℝ³) (dn v) at hchain
+  have hv' : dn v = τ := by
+    simpa only [dn, sphereAmbientMfderiv] using hv
+  have hddecomp : d = inner ℝ d (p : ℝ³) • (p : ℝ³) + τ := by
+    dsimp only [τ]
+    module
+  have hGp_d : fderiv ℝ G (p : ℝ³) d = dF v := by
+    rw [hddecomp, map_add, map_smul, hradialKernel, smul_zero, zero_add, ← hv', ← hchain]
+  have hnormal : inner ℝ (dF v) (p : ℝ³) = 0 := by
+    rw [real_inner_comm]
+    exact counterexampleTwoHomogeneousGradient_normal p v
+  have hinner : inner ℝ (fderiv ℝ G x d) d =
+      r⁻¹ * inner ℝ (dF v) (dn v) := by
+    rw [hscaleHessian, hGp_d, hddecomp, inner_add_right]
+    simp only [real_inner_smul_left, real_inner_smul_right, hnormal, mul_zero, zero_add]
+    rw [← hv']
+  rw [hinner]
+  have hbase := hCoercive p v
+  have hrinv : 0 ≤ r⁻¹ := inv_nonneg.mpr hr.le
+  calc
+    7000000000 / ‖x‖ * ‖τ‖ ^ 2 =
+        r⁻¹ * (7000000000 * ‖dn v‖ ^ 2) := by rw [← hv']; dsimp only [r]; ring
+    _ ≤ r⁻¹ * inner ℝ (dF v) (dn v) := mul_le_mul_of_nonneg_left hbase hrinv
+
+/-- Contact and cross-support represent the homogeneous extension as a supremum of linear
+functionals, and therefore make it convex. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoRadialExtension_convex_of_cross
+    (F : sphere (0 : ℝ³) 1 → ℝ³)
+    (hcontact : ∀ p : sphere (0 : ℝ³) 1,
+      inner ℝ (F p) (p : ℝ³) = counterexampleTwoSphereExtension p)
+    (hcross : ∀ (p q : sphere (0 : ℝ³) 1),
+      inner ℝ (F p) (q : ℝ³) ≤ counterexampleTwoSphereExtension q) :
+    ConvexOn ℝ univ (SphereSupport.radialExtension counterexampleTwoSphereExtension) := by
+  have hFbody : ∀ p, F p ∈ SphereSupport.body counterexampleTwoSphereExtension := fun p ↦
+    (SphereSupport.contact_mem_body counterexampleTwoSphereExtension F hcontact hcross p).1
+  refine ⟨convex_univ, ?_⟩
+  intro x _ y _ a b ha hb hab
+  by_cases hz : a • x + b • y = 0
+  · rw [hz]
+    simp only [SphereSupport.radialExtension, smul_eq_mul]
+    exact add_nonneg (mul_nonneg ha (counterexampleTwoRadialExtension_nonneg x))
+      (mul_nonneg hb (counterexampleTwoRadialExtension_nonneg y))
+  · let q : sphere (0 : ℝ³) 1 :=
+      ⟨‖a • x + b • y‖⁻¹ • (a • x + b • y), by
+        rw [mem_sphere]
+        simp only [dist_zero_right, norm_smul, Real.norm_eq_abs, abs_inv, abs_norm,
+          inv_mul_cancel₀ (norm_ne_zero_iff.mpr hz)]⟩
+    have hrepresentation :
+        SphereSupport.radialExtension counterexampleTwoSphereExtension (a • x + b • y) =
+          inner ℝ (F q) (a • x + b • y) := by
+      rw [SphereSupport.radialExtension, dif_neg hz]
+      change ‖a • x + b • y‖ * counterexampleTwoSphereExtension q = _
+      rw [← hcontact q, real_inner_smul_right]
+      field_simp [norm_ne_zero_iff.mpr hz]
+    rw [hrepresentation, inner_add_right, real_inner_smul_right, real_inner_smul_right,
+      smul_eq_mul]
+    exact add_le_add
+      (mul_le_mul_of_nonneg_left
+        (inner_le_counterexampleTwoRadialExtension_of_mem_body (hFbody q) x) ha)
+      (mul_le_mul_of_nonneg_left
+        (inner_le_counterexampleTwoRadialExtension_of_mem_body (hFbody q) y) hb)
+
+/-- Positive oriented coercivity relative to an injective reference map implies injectivity. -/
+@[category API, AMS 53]
+private theorem continuousLinearMap_injective_of_coercive
+    {E F : Type*} [TopologicalSpace E] [AddCommGroup E] [Module ℝ E]
+    [NormedAddCommGroup F] [InnerProductSpace ℝ F] (N L : E →L[ℝ] F)
+    (hN : Function.Injective N) {c : ℝ} (hc : 0 < c)
+    (hL : ∀ v, c * ‖N v‖ ^ 2 ≤ inner ℝ (L v) (N v)) : Function.Injective L := by
+  intro v w hvw
+  have hzero : L (v - w) = 0 := by rw [map_sub, hvw, sub_self]
+  have hbound := hL (v - w)
+  rw [hzero, inner_zero_left] at hbound
+  have hnormsq : ‖N (v - w)‖ ^ 2 = 0 := by
+    nlinarith [sq_nonneg ‖N (v - w)‖]
+  have : N (v - w) = 0 := norm_eq_zero.mp (sq_eq_zero_iff.mp hnormsq)
+  rw [map_sub] at this
+  exact hN (sub_eq_zero.mp this)
+
+/-- Oriented coercivity of the radius tensor makes the degree-one extension strictly convex
+along every chord that does not pass through the origin. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoRadialExtension_strictConvexOn_chord
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v))
+    (p q : sphere (0 : ℝ³) 1) (hpq : p ≠ q)
+    (hantipodal : (q : ℝ³) ≠ -(p : ℝ³)) :
+    StrictConvexOn ℝ (Icc 0 1) (fun t : ℝ ↦
+      SphereSupport.radialExtension counterexampleTwoSphereExtension
+        ((p : ℝ³) + t • ((q : ℝ³) - (p : ℝ³)))) := by
+  let H := SphereSupport.radialExtension counterexampleTwoSphereExtension
+  let G : ℝ³ → ℝ³ := gradient H
+  let d : ℝ³ := (q : ℝ³) - (p : ℝ³)
+  let line : ℝ → ℝ³ := fun t ↦ (p : ℝ³) + t • d
+  let f : ℝ → ℝ := fun t ↦ H (line t)
+  have hline_ne (t : ℝ) (ht : t ∈ Icc (0 : ℝ) 1) : line t ≠ 0 := by
+    intro hzero
+    have heq : t • (q : ℝ³) = -(1 - t) • (p : ℝ³) := by
+      dsimp only [line, d] at hzero
+      have hzero' : (1 - t) • (p : ℝ³) + t • (q : ℝ³) = 0 := by
+        calc
+          (1 - t) • (p : ℝ³) + t • (q : ℝ³) =
+              (p : ℝ³) + t • ((q : ℝ³) - (p : ℝ³)) := by module
+          _ = 0 := hzero
+      simpa only [neg_smul] using eq_neg_of_add_eq_zero_right hzero'
+    have hnorm := congrArg norm heq
+    simp only [norm_smul, norm_eq_of_mem_sphere p, norm_eq_of_mem_sphere q, mul_one,
+      Real.norm_eq_abs, abs_neg, abs_of_nonneg ht.1,
+      abs_of_nonneg (sub_nonneg.mpr ht.2)] at hnorm
+    have htHalf : t = 1 / 2 := by linarith
+    apply hantipodal
+    rw [htHalf] at heq
+    norm_num at heq
+    have heq' : (1 / 2 : ℝ) • (q : ℝ³) = (1 / 2 : ℝ) • (-(p : ℝ³)) := by
+      simpa only [smul_neg] using heq
+    have h := congrArg (fun z : ℝ³ ↦ (2 : ℝ) • z) heq'
+    norm_num [smul_smul] at h
+    exact h
+  have hHsmooth : ContDiffOn ℝ ∞ H {0}ᶜ :=
+    radialExtension_contDiffOn_compl_of_contMDiff counterexampleTwoSphereExtension
+      (counterexampleTwoSphereExtension_contMDiff_of_contMDiffAt_north
+        counterexampleTwoSphereExtension_contMDiffAt_north)
+  have hGsmooth : ContDiffOn ℝ ∞ G {0}ᶜ := by
+    have hDf : ContDiffOn ℝ ∞ (fderiv ℝ H) {0}ᶜ :=
+      hHsmooth.fderiv_of_isOpen isOpen_compl_singleton (by simp)
+    simpa only [G, gradient] using
+      (InnerProductSpace.toDual ℝ ℝ³).symm.contDiff.comp_contDiffOn hDf
+  apply strictConvexOn_of_deriv2_pos' (convex_Icc 0 1)
+  · intro t ht
+    have hlineCont : ContinuousAt line t := by fun_prop
+    exact ((hHsmooth (line t) (hline_ne t ht)).contDiffAt
+      (isOpen_compl_singleton.mem_nhds (hline_ne t ht))).continuousAt
+      |>.comp_continuousWithinAt hlineCont.continuousWithinAt
+  · intro t ht
+    let x := line t
+    let r := ‖x‖
+    let s : sphere (0 : ℝ³) 1 := ⟨r⁻¹ • x, by
+      simp only [mem_sphere, dist_zero_right, norm_smul, Real.norm_eq_abs,
+        abs_inv, abs_norm, r]
+      exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr (hline_ne t ht))⟩
+    let τ : ℝ³ := d - inner ℝ d (s : ℝ³) • (s : ℝ³)
+    have hx : x ≠ 0 := hline_ne t ht
+    have hr : 0 < r := norm_pos_iff.mpr hx
+    let c : ℝ := inner ℝ (p : ℝ³) (q : ℝ³)
+    have hcUpper : c ≤ 1 :=
+      real_inner_le_one_of_norm_eq_one (norm_eq_of_mem_sphere p) (norm_eq_of_mem_sphere q)
+    have hcLower : -1 ≤ c := by
+      have := real_inner_le_one_of_norm_eq_one (norm_eq_of_mem_sphere p)
+        (norm_neg (q : ℝ³) ▸ norm_eq_of_mem_sphere q)
+      rw [inner_neg_right] at this
+      dsimp only [c]
+      linarith
+    have hcneOne : c ≠ 1 := by
+      dsimp only [c]
+      intro h
+      have hpq' : (p : ℝ³) = (q : ℝ³) :=
+        (inner_eq_one_iff_of_norm_eq_one (norm_eq_of_mem_sphere p)
+          (norm_eq_of_mem_sphere q)).mp h
+      exact hpq (Subtype.ext hpq')
+    have hcneNegOne : c ≠ -1 := by
+      dsimp only [c]
+      intro h
+      have hpnegq : (p : ℝ³) = -(q : ℝ³) :=
+        (inner_eq_neg_one_iff_of_norm_eq_one (norm_eq_of_mem_sphere p)
+          (norm_eq_of_mem_sphere q)).mp h
+      apply hantipodal
+      have h' := congrArg Neg.neg hpnegq
+      simpa using h'.symm
+    have hcpos : 0 < 1 - c ^ 2 := by
+      rcases lt_or_eq_of_le hcUpper with hc | hc
+      · rcases lt_or_eq_of_le hcLower with hc' | hc'
+        · nlinarith
+        · exact (hcneNegOne hc'.symm).elim
+      · exact (hcneOne hc).elim
+    have hgram : r ^ 2 * ‖τ‖ ^ 2 = 1 - c ^ 2 := by
+      have hxexpr : x = (1 - t) • (p : ℝ³) + t • (q : ℝ³) := by
+        dsimp only [x, line, d]
+        module
+      have hrsq : r ^ 2 = (1 - t) ^ 2 + t ^ 2 +
+          2 * t * (1 - t) * c := by
+        dsimp only [r]
+        rw [← real_inner_self_eq_norm_sq x, hxexpr]
+        dsimp only [c]
+        simp only [inner_add_left, inner_add_right, real_inner_smul_left,
+          real_inner_smul_right, real_inner_self_eq_norm_sq,
+          norm_smul, Real.norm_eq_abs, abs_of_nonneg (sub_nonneg.mpr ht.2),
+          abs_of_nonneg ht.1, norm_eq_of_mem_sphere p, norm_eq_of_mem_sphere q, mul_one]
+        rw [real_inner_comm (q : ℝ³) (p : ℝ³)]
+        ring
+      have hdsq : ‖d‖ ^ 2 = 2 - 2 * c := by
+        rw [← real_inner_self_eq_norm_sq d]
+        dsimp only [d, c]
+        simp only [inner_sub_left, inner_sub_right, real_inner_self_eq_norm_sq,
+          norm_eq_of_mem_sphere p, norm_eq_of_mem_sphere q]
+        rw [real_inner_comm (q : ℝ³) (p : ℝ³)]
+        ring
+      have hdx : inner ℝ d x = (2 * t - 1) * (1 - c) := by
+        rw [hxexpr]
+        dsimp only [d, c]
+        simp only [inner_sub_left, inner_add_right, real_inner_smul_right,
+          real_inner_self_eq_norm_sq, norm_eq_of_mem_sphere p,
+          norm_eq_of_mem_sphere q]
+        rw [real_inner_comm (q : ℝ³) (p : ℝ³)]
+        ring
+      have hds : inner ℝ d (s : ℝ³) = r⁻¹ * inner ℝ d x := by
+        dsimp only [s]
+        rw [real_inner_smul_right]
+      have hτsq : ‖τ‖ ^ 2 = ‖d‖ ^ 2 - inner ℝ d (s : ℝ³) ^ 2 := by
+        rw [← real_inner_self_eq_norm_sq τ]
+        dsimp only [τ]
+        simp only [inner_sub_left, inner_sub_right, real_inner_smul_left,
+          real_inner_smul_right, real_inner_self_eq_norm_sq]
+        rw [real_inner_comm (s : ℝ³) d, norm_smul, norm_eq_of_mem_sphere s,
+          mul_one, Real.norm_eq_abs, sq_abs]
+        ring
+      rw [hτsq, hds, hdsq, hdx]
+      field_simp [hr.ne']
+      nlinarith [hrsq]
+    have hτ : τ ≠ 0 := by
+      intro hτzero
+      rw [hτzero, norm_zero] at hgram
+      nlinarith
+    have hsecond : (deriv^[2] f) t = inner ℝ (fderiv ℝ G x d) d := by
+      have hlineDeriv : HasDerivAt line d t := by
+        dsimp only [line]
+        simpa only [Pi.add_apply, id_eq, zero_add, one_smul] using
+          (hasDerivAt_const (x := t) (p : ℝ³)).add
+            ((hasDerivAt_id (𝕜 := ℝ) t).smul_const d)
+      have hxH : DifferentiableAt ℝ H x :=
+        (hHsmooth x hx).differentiableWithinAt (by simp) |>.differentiableAt
+          (isOpen_compl_singleton.mem_nhds hx)
+      have hxG : DifferentiableAt ℝ G x :=
+        (hGsmooth x hx).differentiableWithinAt (by simp) |>.differentiableAt
+          (isOpen_compl_singleton.mem_nhds hx)
+      have hfirst : deriv f =ᶠ[nhds t] fun y ↦ inner ℝ (G (line y)) d := by
+        have hlineEvent : ∀ᶠ y in nhds t, line y ≠ 0 := by
+          exact (by fun_prop : ContinuousAt line t).eventually_ne (by simpa [x] using hx)
+        filter_upwards [hlineEvent] with y hy
+        have hyH : DifferentiableAt ℝ H (line y) :=
+          (hHsmooth (line y) hy).differentiableWithinAt (by simp) |>.differentiableAt
+            (isOpen_compl_singleton.mem_nhds hy)
+        have hyline : HasDerivAt line d y := by
+          dsimp only [line]
+          simpa only [Pi.add_apply, id_eq, zero_add, one_smul] using
+            (hasDerivAt_const (x := y) (p : ℝ³)).add
+              ((hasDerivAt_id (𝕜 := ℝ) y).smul_const d)
+        rw [(by simpa [Function.comp_def] using
+          hyH.hasFDerivAt.comp_hasDerivAt_of_eq (x := y) hyline rfl :
+            HasDerivAt f (fderiv ℝ H (line y) d) y).deriv]
+        dsimp only [G]
+        rw [inner_gradient_left hyH]
+      change deriv (deriv f) t = inner ℝ (fderiv ℝ G x d) d
+      rw [hfirst.deriv_eq]
+      have hGline : HasDerivAt (fun y ↦ G (line y)) (fderiv ℝ G x d) t := by
+        simpa [Function.comp_def, x] using
+          hxG.hasFDerivAt.comp_hasDerivAt_of_eq (x := t) hlineDeriv rfl
+      simpa using (hGline.inner ℝ (hasDerivAt_const t d)).deriv
+    rw [hsecond]
+    have hbound := counterexampleTwoRadialExtension_hessian_coercive
+      (x := x) (d := d) hCoercive hx
+    change 7000000000 / ‖x‖ * ‖τ‖ ^ 2 ≤ inner ℝ (fderiv ℝ G x d) d at hbound
+    exact lt_of_lt_of_le
+      (mul_pos (div_pos (by norm_num) hr) (sq_pos_of_pos (norm_pos_iff.mpr hτ))) hbound
+
+/-- Strict convexity of the homogeneous extension on each nonradial chord gives strict
+cross-support. The antipodal chord is handled directly by positivity of the support values. -/
+@[category API, AMS 53]
+private theorem strictCross_of_strictConvex_chords
+    (h : sphere (0 : ℝ³) 1 → ℝ) (F : sphere (0 : ℝ³) 1 → ℝ³)
+    (hHdiff : ∀ p : sphere (0 : ℝ³) 1,
+      DifferentiableAt ℝ (SphereSupport.radialExtension h) (p : ℝ³))
+    (hF : F = SphereSupport.homogeneousGradient (SphereSupport.radialExtension h))
+    (hlower : ∀ p, 1 ≤ h p)
+    (hchord : ∀ (p q : sphere (0 : ℝ³) 1), p ≠ q → (q : ℝ³) ≠ -(p : ℝ³) →
+      StrictConvexOn ℝ (Icc 0 1) (fun t : ℝ ↦
+        SphereSupport.radialExtension h ((p : ℝ³) + t • ((q : ℝ³) - (p : ℝ³))))) :
+    ∀ (p q : sphere (0 : ℝ³) 1), p ≠ q → inner ℝ (F p) (q : ℝ³) < h q := by
+  subst F
+  intro p q hpq
+  have hcontact : inner ℝ
+      (SphereSupport.homogeneousGradient (SphereSupport.radialExtension h) p)
+      (p : ℝ³) = h p := by
+    simpa using SphereSupport.inner_homogeneousGradient
+      (SphereSupport.radialExtension h) p (hHdiff p)
+        (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+  by_cases hantipodal : (q : ℝ³) = -(p : ℝ³)
+  · rw [hantipodal, inner_neg_right, hcontact]
+    linarith [hlower p, hlower q]
+  · let line : ℝ → ℝ³ := fun t ↦ (p : ℝ³) + t • ((q : ℝ³) - (p : ℝ³))
+    let f : ℝ → ℝ := fun t ↦ SphereSupport.radialExtension h (line t)
+    have hline : HasDerivAt f
+        (fderiv ℝ (SphereSupport.radialExtension h) (p : ℝ³)
+          ((q : ℝ³) - (p : ℝ³))) 0 := by
+      have harg : HasDerivAt line ((q : ℝ³) - (p : ℝ³)) 0 := by
+        simpa only [line, Pi.add_apply, id_eq, zero_add, one_smul] using
+          (hasDerivAt_const (x := (0 : ℝ)) (p : ℝ³)).add
+            ((hasDerivAt_id (𝕜 := ℝ) 0).smul_const ((q : ℝ³) - (p : ℝ³)))
+      simpa [f, Function.comp_def] using
+        (hHdiff p).hasFDerivAt.comp_hasDerivAt_of_eq (x := (0 : ℝ)) harg (by simp [line])
+    have hslope := (hchord p q hpq hantipodal).deriv_lt_slope
+      (by simp) (by simp) zero_lt_one hline.differentiableAt
+    rw [hline.deriv] at hslope
+    have hslope' : fderiv ℝ (SphereSupport.radialExtension h) (p : ℝ³)
+        ((q : ℝ³) - (p : ℝ³)) < h q - h p := by
+      simpa [f, line, slope] using hslope
+    rw [← inner_gradient_left (hHdiff p)] at hslope'
+    change inner ℝ
+      (SphereSupport.homogeneousGradient (SphereSupport.radialExtension h) p)
+        ((q : ℝ³) - (p : ℝ³)) < h q - h p at hslope'
+    rw [inner_sub_right, hcontact] at hslope'
+    linarith
+
+/-- Global oriented coercivity yields the strict support inequality for distinct normals. -/
+@[category API, AMS 53]
+private theorem counterexampleTwo_strictCross_of_coercive
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+    ∀ (p q : sphere (0 : ℝ³) 1), p ≠ q →
+      inner ℝ
+        (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension) p)
+        (q : ℝ³) < counterexampleTwoSphereExtension q := by
+  exact strictCross_of_strictConvex_chords counterexampleTwoSphereExtension
+    (SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+    counterexampleTwoRadialExtension_differentiableAt rfl
+    counterexampleTwoSphereExtension_lower
+    (fun p q hpq hantipodal ↦
+      counterexampleTwoRadialExtension_strictConvexOn_chord
+        hCoercive p q hpq hantipodal)
+
+/-- The explicit seed Laplacian estimate closes the reciprocal radius certificate. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoReciprocal_chartLaplacian_bound (w : ℂ) :
+    |chartLaplacian counterexampleTwoReciprocal w| ≤
+      8 * counterexampleTwoReciprocalDamping w := by
+  exact chartLaplacian_counterexampleTwoReciprocal_le_of_seed
+    counterexampleSeed_chartLaplacian_abs_le w
+
+/-- The exact analytic certificate needed to finish the support geometry once the explicit
+radius-tensor estimates have been established. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoSupport_geometry_of_certificates
+    (hCoercive : ∀ p v, 7000000000 *
+      ‖sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+      inner ℝ (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v))
+    (hstrict : ∀ (p q : sphere (0 : ℝ³) 1), p ≠ q →
+      inner ℝ (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension) p) (q : ℝ³) <
+          counterexampleTwoSphereExtension q)
+    (humbilic : IsUmbilic
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0))
+    (hnoUmbilic : ∀ p, p ≠ counterexampleSphereChart 0 → ¬IsUmbilic
+      (SphereSupport.homogeneousGradient
+        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
+      (fun q ↦ (q : ℝ³)) p) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    let K := SphereSupport.body counterexampleTwoSphereExtension
+    IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
+      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
+      range F = frontier K ∧
+      IsSupportParametrization counterexampleTwoSphereExtension F K ∧
+      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
+      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let K := SphereSupport.body counterexampleTwoSphereExtension
+  have hHdiff : ∀ p : sphere (0 : ℝ³) 1, DifferentiableAt ℝ
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) (p : ℝ³) :=
+    counterexampleTwoRadialExtension_differentiableAt
+  have hFsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) ∞ F := by
+    exact counterexampleTwoHomogeneousGradient_contMDiff
+  change ∀ p v, 7000000000 *
+      ‖sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+      inner ℝ (sphereAmbientMfderiv F p v)
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v) at hCoercive
+  have hFinjective : ∀ p : sphere (0 : ℝ³) 1, Function.Injective
+      (sphereAmbientMfderiv F p) := fun p ↦
+    continuousLinearMap_injective_of_coercive _ _
+      (mfderiv_coe_sphere_injective p) (by norm_num) (hCoercive p)
+  change ∀ (p q : sphere (0 : ℝ³) 1), p ≠ q →
+    inner ℝ (F p) (q : ℝ³) < counterexampleTwoSphereExtension q at hstrict
+  change IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) at humbilic
+  change ∀ p, p ≠ counterexampleSphereChart 0 →
+    ¬IsUmbilic F (fun q ↦ (q : ℝ³)) p at hnoUmbilic
+  have hunique : ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p →
+      p = counterexampleSphereChart 0 := by
+    intro p hp
+    by_contra hp0
+    exact hnoUmbilic p hp0 hp
+  have hcontact : ∀ p : sphere (0 : ℝ³) 1,
+      inner ℝ (F p) (p : ℝ³) = counterexampleTwoSphereExtension p := by
+    intro p
+    simpa [F] using SphereSupport.inner_homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) p (hHdiff p)
+      (fun t ht ↦ SphereSupport.radialExtension_smul_of_pos _ _ ht)
+  have hcross : ∀ p q : sphere (0 : ℝ³) 1,
+      inner ℝ (F p) (q : ℝ³) ≤ counterexampleTwoSphereExtension q := by
+    intro p q
+    by_cases hpq : p = q
+    · subst q
+      exact (hcontact p).le
+    · exact (hstrict p q hpq).le
+  have hconvex : ConvexOn ℝ univ
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension) :=
+    counterexampleTwoRadialExtension_convex_of_cross F hcontact hcross
+  have hbody := counterexampleTwoSupport_body_of_convex_radialExtension hHdiff hconvex
+  change range F = frontier K ∧
+    IsSupportParametrization counterexampleTwoSphereExtension F K at hbody
+  have hnormal : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      inner ℝ (p : ℝ³) (sphereAmbientMfderiv F p v) = 0 :=
+    counterexampleTwoHomogeneousGradient_normal
+  have hK := counterexampleTwoBody_geometry
+  refine ⟨⟨hFsmooth,
+      SphereSupport.isEmbedding_of_strictCross _ F hFsmooth.continuous hcontact hstrict,
+      hFinjective, contMDiff_coe_sphere, (fun p ↦ norm_eq_of_mem_sphere p), hnormal,
+      ⟨K, hK.1, hK.2.1, hK.2.2, hbody.1⟩⟩,
+    hK.1, hK.2.1, hK.2.2, hbody.1, hbody.2, humbilic, hunique⟩
+
+/-- A smooth spherical extension of `counterexample 2` is the support function of a
+convex body whose Gauss parametrization has exactly one umbilic. -/
+@[category research solved, AMS 52 53]
+theorem counterexample_two_support_geometry
+    (h : sphere (0 : ℝ³) 1 → ℝ)
+    (hsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h)
+    (hchart : ∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) :
+    ∃ (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
+      IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
+      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
+      Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
+      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
+      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+  have hextension := eq_counterexampleTwoSphereExtension h hsmooth hchart
+  subst h
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  let K := SphereSupport.body counterexampleTwoSphereExtension
+  have hCoercive := counterexampleTwo_radius_coercive_of_laplacian
+    counterexampleTwoReciprocal_chartLaplacian_bound
+  have hstrict := counterexampleTwo_strictCross_of_coercive hCoercive
+  refine ⟨F, K, ?_⟩
+  simpa only [F, K] using counterexampleTwoSupport_geometry_of_certificates
+    hCoercive hstrict counterexampleTwoHomogeneousGradient_umbilic_south
+      counterexampleTwoHomogeneousGradient_not_umbilic_away_south
+
+/-- **Alpöge's smooth Carathéodory counterexample.**
+
+The function `counterexample 2` extends across the omitted north pole to a smooth function `h`
+on the round two-sphere. It is the support function of a convex body `K`; `F` is its smooth
+Gauss parametrization with outward normal `p`. The corresponding convex surface has exactly one
+umbilic, at the point represented by `z = 0`.
+
+The explicit compactness and nonempty-interior conditions rule out unbounded and
+lower-dimensional convex sets. The range equality ensures that `F` parametrizes the boundary
+of the same body whose support function is `h`. -/
+@[category research solved, AMS 52 53]
+theorem counterexample_two_is_support_function_with_unique_umbilic :
+    ∃ (h : sphere (0 : ℝ³) 1 → ℝ) (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
+      ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h ∧
+      (∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) ∧
+      IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
+      Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
+      Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
+      IsUmbilic F (fun p ↦ (p : ℝ³)) (counterexampleSphereChart 0) ∧
+      ∀ p, IsUmbilic F (fun q ↦ (q : ℝ³)) p → p = counterexampleSphereChart 0 := by
+  rcases counterexample_two_sphere_extension with ⟨h, hsmooth, hchart⟩
+  rcases counterexample_two_support_geometry h hsmooth hchart with ⟨F, K, hgeometry⟩
+  exact ⟨h, F, K, hsmooth, hchart, hgeometry⟩
+
+end CaratheodoryLoewnerCounterexample

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Global.lean
@@ -36,10 +36,24 @@ open Set Metric
 
 namespace CaratheodoryLoewnerCounterexample
 
-open CaratheodoryConjecture LoewnerConjecture
+open CaratheodoryConjecture EuclideanHypersurface LoewnerConjecture
 
 private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
   ⟨finrank_euclideanSpace_fin⟩
+
+/-- The ambient-codomain manifold derivative used throughout this proof file. -/
+private noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
+@[category API, AMS 26]
+private theorem traceFreeHessian_eq_second_fderiv (f : ℂ → ℝ) (z : ℂ) :
+    traceFreeHessian f z =
+      let H := fderiv ℝ (fun w ↦ fderiv ℝ f w) z
+      (H 1 1 - H Complex.I Complex.I : ℝ) +
+        (2 * H 1 Complex.I : ℝ) * Complex.I := by
+  simp [traceFreeHessian, iteratedFDeriv_two_apply]
 
 /-- The complex coordinate inverse to `counterexampleSphereChart` away from the north pole. -/
 private noncomputable def counterexampleSphereCoord
@@ -1602,7 +1616,7 @@ private theorem complexBarDeriv_fderiv_eq (u : ℂ → ℝ) (hu : ContDiff ℝ �
       nth_rw 1 [hv]
       simp only [map_add, map_smul, ContinuousLinearMap.add_apply,
         ContinuousLinearMap.smul_apply, smul_eq_mul]
-    rw [hMv1, hMvI, chartLaplacian, traceFreeHessian]
+    rw [hMv1, hMvI, chartLaplacian, traceFreeHessian_eq_second_fderiv]
     dsimp only [M]
     simp only [smul_eq_mul]
     apply Complex.ext <;>
@@ -2032,11 +2046,12 @@ private theorem traceFreeHessian_mul (f g : ℂ → ℝ)
       g w • fderiv ℝ (fderiv ℝ f) w + (fderiv ℝ g w).smulRight (fderiv ℝ f w) := by
     change fderiv ℝ (fun y ↦ g y • fderiv ℝ f y) w = _
     exact fderiv_fun_smul (hg0 w) (hDf w)
-  rw [traceFreeHessian, hgradient, hfun, hsum,
+  rw [traceFreeHessian_eq_second_fderiv, hgradient, hfun, hsum,
     hfprod, hgprod]
   simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
     ContinuousLinearMap.smulRight_apply, smul_eq_mul]
-  rw [traceFreeHessian, traceFreeHessian, complexBarDeriv, complexBarDeriv]
+  rw [traceFreeHessian_eq_second_fderiv, traceFreeHessian_eq_second_fderiv,
+    complexBarDeriv, complexBarDeriv]
   push_cast
   apply Complex.ext <;> simp [Complex.mul_re, Complex.mul_im] <;> ring
 
@@ -2120,8 +2135,8 @@ private theorem traceFreeHessian_const_add (c : ℝ) (f : ℂ → ℝ)
     rw [((hasFDerivAt_const (x := z) c).add
       (hf.differentiable (by simp) z).hasFDerivAt).fderiv]
     simp
-  rw [traceFreeHessian, hgradient]
-  rfl
+  rw [traceFreeHessian_eq_second_fderiv, hgradient,
+    traceFreeHessian_eq_second_fderiv]
 
 /-- Adding a constant does not change the chart Laplacian. -/
 @[category API, AMS 53]
@@ -2210,7 +2225,7 @@ private theorem traceFreeHessian_comp_norm_sq (β : ℝ → ℝ) (w : ℂ)
   have hsecond := hscalar.smul hmatrix
   change HasFDerivAt (fun z : ℂ ↦ deriv β (‖z‖ ^ 2) •
     ((2 * z.re) • Complex.reCLM + (2 * z.im) • Complex.imCLM)) _ w at hsecond
-  rw [traceFreeHessian, hgradient.fderiv_eq, hsecond.fderiv]
+  rw [traceFreeHessian_eq_second_fderiv, hgradient.fderiv_eq, hsecond.fderiv]
   simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
     ContinuousLinearMap.smulRight_apply, Pi.add_apply, smul_eq_mul,
     Complex.reCLM_apply, Complex.imCLM_apply]
@@ -3749,26 +3764,6 @@ private theorem counterexampleTwoHomogeneousGradient_mfderiv_south :
   rw [← haTangent, ← hchainN, ← hchainF]
   exact hsouth
 
-/-- The south pole is an umbilic of the homogeneous-gradient contact map. -/
-@[category API, AMS 53]
-private theorem counterexampleTwoHomogeneousGradient_umbilic_south :
-    EuclideanHypersurface.IsUmbilic
-      (sphereAmbientMfderiv
-        (SphereSupport.homogeneousGradient
-          (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-        (counterexampleSphereChart 0))
-      (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
-        (counterexampleSphereChart 0)) := by
-  apply EuclideanHypersurface.isUmbilic_of_normal_deriv_eq_smul
-  change sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
-      (counterexampleSphereChart 0) =
-    (10 ^ 10 : ℝ)⁻¹ • sphereAmbientMfderiv
-      (SphereSupport.homogeneousGradient
-        (SphereSupport.radialExtension counterexampleTwoSphereExtension))
-      (counterexampleSphereChart 0)
-  rw [counterexampleTwoHomogeneousGradient_mfderiv_south]
-  rw [smul_smul, inv_mul_cancel₀ (by norm_num : (10 ^ 10 : ℝ) ≠ 0), one_smul]
-
 /-- Pulling an intrinsic umbilic equation through the reciprocal chart kills the anti-linear
 coefficient of the chart radius tensor. -/
 @[category API, AMS 53]
@@ -4272,6 +4267,56 @@ private theorem counterexampleTwoHomogeneousGradient_range_eq_of_coercive
     _ = Module.finrank ℝ dn.range :=
       (LinearMap.finrank_range_of_inj hdnInjective).symm
 
+/-- Positive oriented coercivity makes the canonical cross-product normal of the support
+parametrization equal to its radial normal. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_sphereNormal_of_coercive
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    sphereNormal F = fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³) := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  funext p
+  apply sphereNormal_eq_radial_of_coercive F p 7000000000 (by norm_num)
+  · intro v
+    simpa only [F] using counterexampleTwoHomogeneousGradient_normal p v
+  · intro v
+    simpa only [F] using hCoercive p v
+
+/-- The south pole is an umbilic for the canonical cross-product normal. -/
+@[category API, AMS 53]
+private theorem counterexampleTwoHomogeneousGradient_umbilic_south_of_coercive
+    (hCoercive : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
+      7000000000 * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ
+          (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+    let F := SphereSupport.homogeneousGradient
+      (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+    EuclideanHypersurface.IsUmbilic
+      (sphereAmbientMfderiv F (counterexampleSphereChart 0))
+      (sphereAmbientMfderiv (sphereNormal F) (counterexampleSphereChart 0)) := by
+  let F := SphereSupport.homogeneousGradient
+    (SphereSupport.radialExtension counterexampleTwoSphereExtension)
+  have hnormal := counterexampleTwoHomogeneousGradient_sphereNormal_of_coercive hCoercive
+  change sphereNormal F = fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³) at hnormal
+  apply EuclideanHypersurface.isUmbilic_of_normal_deriv_eq_smul
+  rw [hnormal]
+  change sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+      (counterexampleSphereChart 0) =
+    (10 ^ 10 : ℝ)⁻¹ • sphereAmbientMfderiv F (counterexampleSphereChart 0)
+  rw [counterexampleTwoHomogeneousGradient_mfderiv_south]
+  rw [smul_smul, inv_mul_cancel₀ (by norm_num : (10 ^ 10 : ℝ) ≠ 0), one_smul]
+
 /-- Every point other than the south pole is nonumbilic in the fundamental-form sense, because
 the reciprocal chart covers it and its spherical trace-free Hessian is nowhere zero. -/
 @[category API, AMS 53]
@@ -4288,13 +4333,18 @@ private theorem counterexampleTwoHomogeneousGradient_not_umbilic_away_south
       (sphereAmbientMfderiv
         (SphereSupport.homogeneousGradient
           (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p)
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) := by
+      (sphereAmbientMfderiv
+        (sphereNormal (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension))) p) := by
   intro humbilic
   let F := SphereSupport.homogeneousGradient
     (SphereSupport.radialExtension counterexampleTwoSphereExtension)
   let n : sphere (0 : ℝ³) 1 → ℝ³ := fun q ↦ (q : ℝ³)
   let dF := sphereAmbientMfderiv F p
   let dn := sphereAmbientMfderiv n p
+  have hnormal := counterexampleTwoHomogeneousGradient_sphereNormal_of_coercive hCoercive
+  change sphereNormal F = n at hnormal
+  rw [hnormal] at humbilic
   change EuclideanHypersurface.IsUmbilic dF dn at humbilic
   have hrange : dn.range ≤ dF.range := by
     rw [counterexampleTwoHomogeneousGradient_range_eq_of_coercive hCoercive p]
@@ -4592,27 +4642,30 @@ private theorem counterexampleTwoSupport_geometry_of_certificates
       (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
         (SphereSupport.radialExtension counterexampleTwoSphereExtension))
         (counterexampleSphereChart 0))
-      (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
+      (sphereAmbientMfderiv
+        (sphereNormal (SphereSupport.homogeneousGradient
+          (SphereSupport.radialExtension counterexampleTwoSphereExtension)))
         (counterexampleSphereChart 0)))
     (hnoUmbilic : ∀ p, p ≠ counterexampleSphereChart 0 →
       ¬EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv (SphereSupport.homogeneousGradient
           (SphereSupport.radialExtension counterexampleTwoSphereExtension)) p)
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p)) :
+        (sphereAmbientMfderiv
+          (sphereNormal (SphereSupport.homogeneousGradient
+            (SphereSupport.radialExtension counterexampleTwoSphereExtension))) p)) :
     let F := SphereSupport.homogeneousGradient
       (SphereSupport.radialExtension counterexampleTwoSphereExtension)
     let K := SphereSupport.body counterexampleTwoSphereExtension
-    IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
+    IsConvexSphereOfClass ∞ F ∧
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       range F = frontier K ∧
       IsSupportParametrization counterexampleTwoSphereExtension F K ∧
       EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv F (counterexampleSphereChart 0))
-        (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
-          (counterexampleSphereChart 0)) ∧
+        (sphereAmbientMfderiv (sphereNormal F) (counterexampleSphereChart 0)) ∧
       ∀ p, EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv F p)
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+        (sphereAmbientMfderiv (sphereNormal F) p) →
           p = counterexampleSphereChart 0 := by
   let F := SphereSupport.homogeneousGradient
     (SphereSupport.radialExtension counterexampleTwoSphereExtension)
@@ -4634,15 +4687,14 @@ private theorem counterexampleTwoSupport_geometry_of_certificates
     inner ℝ (F p) (q : ℝ³) < counterexampleTwoSphereExtension q at hstrict
   change EuclideanHypersurface.IsUmbilic
     (sphereAmbientMfderiv F (counterexampleSphereChart 0))
-    (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
-      (counterexampleSphereChart 0)) at humbilic
+    (sphereAmbientMfderiv (sphereNormal F) (counterexampleSphereChart 0)) at humbilic
   change ∀ p, p ≠ counterexampleSphereChart 0 →
     ¬EuclideanHypersurface.IsUmbilic
       (sphereAmbientMfderiv F p)
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) at hnoUmbilic
+      (sphereAmbientMfderiv (sphereNormal F) p) at hnoUmbilic
   have hunique : ∀ p, EuclideanHypersurface.IsUmbilic
       (sphereAmbientMfderiv F p)
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+      (sphereAmbientMfderiv (sphereNormal F) p) →
         p = counterexampleSphereChart 0 := by
     intro p hp
     by_contra hp0
@@ -4666,14 +4718,11 @@ private theorem counterexampleTwoSupport_geometry_of_certificates
   have hbody := counterexampleTwoSupport_body_of_convex_radialExtension hHdiff hconvex
   change range F = frontier K ∧
     IsSupportParametrization counterexampleTwoSphereExtension F K at hbody
-  have hnormal : ∀ (p : sphere (0 : ℝ³) 1) (v : TangentSpace (𝓡 2) p),
-      inner ℝ (p : ℝ³) (sphereAmbientMfderiv F p v) = 0 :=
-    counterexampleTwoHomogeneousGradient_normal
   have hK := counterexampleTwoBody_geometry
   refine ⟨⟨hFsmooth,
       SphereSupport.isEmbedding_of_strictCross _ F hFsmooth.continuous hcontact hstrict,
-      hFinjective, contMDiff_coe_sphere, (fun p ↦ norm_eq_of_mem_sphere p), hnormal,
-      ⟨K, hK.1, hK.2.1, hK.2.2, hbody.1⟩⟩,
+      hFinjective,
+      ⟨⟨K, hK.1, hK.2.1, hK.2.2.mono interior_subset⟩, hK.2.2, hbody.1⟩⟩,
     hK.1, hK.2.1, hK.2.2, hbody.1, hbody.2, humbilic, hunique⟩
 
 /-- A smooth spherical extension of `counterexample 2` is the support function of a
@@ -4684,16 +4733,15 @@ theorem counterexample_two_support_geometry
     (hsmooth : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h)
     (hchart : ∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) :
     ∃ (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
-      IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
+      IsConvexSphereOfClass ∞ F ∧
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
       EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv F (counterexampleSphereChart 0))
-        (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
-          (counterexampleSphereChart 0)) ∧
+        (sphereAmbientMfderiv (sphereNormal F) (counterexampleSphereChart 0)) ∧
       ∀ p, EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv F p)
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+        (sphereAmbientMfderiv (sphereNormal F) p) →
           p = counterexampleSphereChart 0 := by
   have hextension := eq_counterexampleTwoSphereExtension h hsmooth hchart
   subst h
@@ -4705,7 +4753,7 @@ theorem counterexample_two_support_geometry
   have hstrict := counterexampleTwo_strictCross_of_coercive hCoercive
   refine ⟨F, K, ?_⟩
   simpa only [F, K] using counterexampleTwoSupport_geometry_of_certificates
-    hCoercive hstrict counterexampleTwoHomogeneousGradient_umbilic_south
+    hCoercive hstrict (counterexampleTwoHomogeneousGradient_umbilic_south_of_coercive hCoercive)
       (counterexampleTwoHomogeneousGradient_not_umbilic_away_south hCoercive)
 
 /-- **Alpöge's smooth Carathéodory counterexample.**
@@ -4723,16 +4771,15 @@ theorem counterexample_two_is_support_function_with_unique_umbilic :
     ∃ (h : sphere (0 : ℝ³) 1 → ℝ) (F : sphere (0 : ℝ³) 1 → ℝ³) (K : Set ℝ³),
       ContMDiff (𝓡 2) 𝓘(ℝ, ℝ) ∞ h ∧
       (∀ z : ℂ, h (counterexampleSphereChart z) = counterexample 2 z) ∧
-      IsConvexSphereOfClass ∞ F (fun p ↦ (p : ℝ³)) ∧
+      IsConvexSphereOfClass ∞ F ∧
       Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
       Set.range F = frontier K ∧ IsSupportParametrization h F K ∧
       EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv F (counterexampleSphereChart 0))
-        (sphereAmbientMfderiv (fun p : sphere (0 : ℝ³) 1 ↦ (p : ℝ³))
-          (counterexampleSphereChart 0)) ∧
+        (sphereAmbientMfderiv (sphereNormal F) (counterexampleSphereChart 0)) ∧
       ∀ p, EuclideanHypersurface.IsUmbilic
         (sphereAmbientMfderiv F p)
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p) →
+        (sphereAmbientMfderiv (sphereNormal F) p) →
           p = counterexampleSphereChart 0 := by
   rcases counterexample_two_sphere_extension with ⟨h, hsmooth, hchart⟩
   rcases counterexample_two_support_geometry h hsmooth hchart with ⟨F, K, hgeometry⟩

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Index.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Index.lean
@@ -16,7 +16,6 @@ limitations under the License.
 
 import FormalConjecturesUtil
 import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Smooth
-import Mathlib.Topology.Homotopy.Lifting
 
 /-!
 # Index of the announced Carathéodory–Loewner counterexamples

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Index.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Index.lean
@@ -1,0 +1,2415 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Smooth
+import Mathlib.Topology.Homotopy.Lifting
+
+/-!
+# Index of the announced Carathéodory–Loewner counterexamples
+
+This file computes the winding number of the trace-free Hessian near the origin.
+
+*Reference:*
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
+-/
+
+open Metric
+open Filter
+open scoped ContDiff Topology unitInterval
+
+namespace CaratheodoryLoewnerCounterexample
+
+open LoewnerConjecture
+
+@[category API, AMS 26]
+private theorem traceFreeHessian_eq_zero_of_second_fderiv_eq_zero (f : ℂ → ℝ) (z : ℂ)
+    (h : fderiv ℝ (fun w ↦ fderiv ℝ f w) z = 0) :
+    traceFreeHessian f z = 0 := by
+  simp [traceFreeHessian, h]
+
+/-- The explicit trace-free Hessian of the seed. Keeping this local avoids adding another
+public synonym for a one-line expression. -/
+private noncomputable def seedTraceFreeHessianModel (z : ℂ) : ℂ :=
+  ((Real.cos (2 * z.re) + 6 / 5 * Real.cos (2 * z.im) -
+      1 / 2 * Real.cos (4 * z.im) : ℝ) : ℂ) +
+    ((2 * Real.cos z.re * Real.cos z.im : ℝ) : ℂ) * Complex.I
+
+private noncomputable def seedGradient (z : ℂ) : ℂ →L[ℝ] ℝ :=
+  (Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im) • Complex.reCLM +
+    (-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+      Real.sin z.re * Real.cos z.im) • Complex.imCLM
+
+private noncomputable def seedHessian (z : ℂ) : ℂ →L[ℝ] ℂ →L[ℝ] ℝ :=
+  ((Real.cos (2 * z.re) - Real.sin z.re * Real.sin z.im) • Complex.reCLM +
+      (Real.cos z.re * Real.cos z.im) • Complex.imCLM).smulRight Complex.reCLM +
+    ((Real.cos z.re * Real.cos z.im) • Complex.reCLM +
+      (-6 / 5 * Real.cos (2 * z.im) + 1 / 2 * Real.cos (4 * z.im) -
+        Real.sin z.re * Real.sin z.im) • Complex.imCLM).smulRight Complex.imCLM
+
+private noncomputable def seedWirtingerModel (z : ℂ) : ℂ :=
+  (((Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im : ℝ) : ℂ) -
+    ((-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+      Real.sin z.re * Real.cos z.im : ℝ) : ℂ) * Complex.I) / 2
+
+@[category API, AMS 26]
+private theorem seedTraceFreeHessianModel_neg (z : ℂ) :
+    seedTraceFreeHessianModel (-z) = seedTraceFreeHessianModel z := by
+  simp [seedTraceFreeHessianModel]
+
+@[category API, AMS 26]
+private theorem seedWirtingerModel_neg (z : ℂ) :
+    seedWirtingerModel (-z) = -seedWirtingerModel z := by
+  simp [seedWirtingerModel]
+  ring
+
+@[category API, AMS 26]
+private theorem seedWirtingerModel_eq_gradient (z : ℂ) :
+    seedWirtingerModel z =
+      ((seedGradient z 1 : ℂ) - (seedGradient z Complex.I : ℂ) * Complex.I) / 2 := by
+  simp [seedWirtingerModel, seedGradient]
+
+@[category API, AMS 26]
+private theorem norm_seedWirtingerModel_le (z : ℂ) : ‖seedWirtingerModel z‖ ≤ 129 / 80 := by
+  have hfx : |Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im| ≤ 3 / 2 := by
+    calc
+      _ ≤ |Real.sin (2 * z.re) / 2| + |Real.cos z.re * Real.sin z.im| := abs_add_le ..
+      _ = |Real.sin (2 * z.re)| / 2 + |Real.cos z.re| * |Real.sin z.im| := by
+        rw [abs_div, abs_mul]
+        norm_num
+      _ ≤ 1 / 2 + 1 := by
+        exact add_le_add
+          (div_le_div_of_nonneg_right (Real.abs_sin_le_one _) (by norm_num))
+          (mul_le_one₀ (Real.abs_cos_le_one _) (abs_nonneg _) (Real.abs_sin_le_one _))
+      _ = 3 / 2 := by norm_num
+  have hfy : |-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+      Real.sin z.re * Real.cos z.im| ≤ 69 / 40 := by
+    calc
+      _ ≤ |-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8| +
+          |Real.sin z.re * Real.cos z.im| := abs_add_le ..
+      _ ≤ |-3 * Real.sin (2 * z.im) / 5| + |Real.sin (4 * z.im) / 8| +
+          |Real.sin z.re * Real.cos z.im| := by gcongr; exact abs_add_le ..
+      _ = 3 / 5 * |Real.sin (2 * z.im)| + |Real.sin (4 * z.im)| / 8 +
+          |Real.sin z.re| * |Real.cos z.im| := by
+        rw [abs_div, abs_mul, abs_div, abs_mul]
+        norm_num
+        ring
+      _ ≤ 3 / 5 + 1 / 8 + 1 := by
+        exact add_le_add
+          (add_le_add
+            (by simpa only [mul_one] using
+              (mul_le_mul_of_nonneg_left (Real.abs_sin_le_one (2 * z.im))
+                (by norm_num : (0 : ℝ) ≤ 3 / 5)))
+            (div_le_div_of_nonneg_right (Real.abs_sin_le_one _) (by norm_num)))
+          (mul_le_one₀ (Real.abs_sin_le_one _) (abs_nonneg (Real.cos z.im))
+            (Real.abs_cos_le_one _))
+      _ = 69 / 40 := by norm_num
+  calc
+    ‖seedWirtingerModel z‖ ≤
+        (|Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im| +
+          |-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+            Real.sin z.re * Real.cos z.im|) / 2 := by
+      have hmodel : seedWirtingerModel z =
+          (((Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im : ℝ) : ℂ) -
+            (((-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+              Real.sin z.re * Real.cos z.im : ℝ) : ℂ) * Complex.I)) / 2 := rfl
+      have htwo : ‖(2 : ℂ)‖ = 2 := by norm_num
+      rw [hmodel, norm_div, htwo]
+      apply div_le_div_of_nonneg_right _ (by norm_num)
+      calc
+        _ ≤ ‖((Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im : ℝ) : ℂ)‖ +
+            ‖(((-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+              Real.sin z.re * Real.cos z.im : ℝ) : ℂ) * Complex.I)‖ := norm_sub_le _ _
+        _ = |Real.sin (2 * z.re) / 2 + Real.cos z.re * Real.sin z.im| +
+            |-3 * Real.sin (2 * z.im) / 5 + Real.sin (4 * z.im) / 8 +
+              Real.sin z.re * Real.cos z.im| := by
+          rw [Complex.norm_real, norm_mul, Complex.norm_real]
+          simp only [Complex.norm_I, mul_one, Real.norm_eq_abs]
+    _ ≤ (3 / 2 + 69 / 40) / 2 := div_le_div_of_nonneg_right (add_le_add hfx hfy) (by norm_num)
+    _ = 129 / 80 := by norm_num
+
+/-- The seed has the uniform absolute-value bound used in the global Hessian estimates. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_abs_le (z : ℂ) : |counterexampleSeed z| ≤ 253 / 160 := by
+  calc
+    _ ≤ |-Real.cos (2 * z.re) / 4 + 3 * Real.cos (2 * z.im) / 10 -
+          Real.cos (4 * z.im) / 32| + |Real.sin z.re * Real.sin z.im| := by
+      simpa [counterexampleSeed] using abs_add_le
+        (-Real.cos (2 * z.re) / 4 + 3 * Real.cos (2 * z.im) / 10 -
+          Real.cos (4 * z.im) / 32) (Real.sin z.re * Real.sin z.im)
+    _ ≤ |-Real.cos (2 * z.re) / 4 + 3 * Real.cos (2 * z.im) / 10| +
+          |Real.cos (4 * z.im) / 32| + |Real.sin z.re * Real.sin z.im| := by
+      exact add_le_add (abs_sub (-Real.cos (2 * z.re) / 4 +
+        3 * Real.cos (2 * z.im) / 10) (Real.cos (4 * z.im) / 32)) le_rfl
+    _ ≤ |-Real.cos (2 * z.re) / 4| + |3 * Real.cos (2 * z.im) / 10| +
+          |Real.cos (4 * z.im) / 32| + |Real.sin z.re * Real.sin z.im| := by
+      exact add_le_add (add_le_add (abs_add_le _ _) le_rfl) le_rfl
+    _ = |Real.cos (2 * z.re)| / 4 + 3 / 10 * |Real.cos (2 * z.im)| +
+          |Real.cos (4 * z.im)| / 32 + |Real.sin z.re| * |Real.sin z.im| := by
+      rw [abs_div, abs_neg, abs_div, abs_mul, abs_div, abs_mul]
+      norm_num
+      ring
+    _ ≤ 1 / 4 + 3 / 10 + 1 / 32 + 1 := by
+      exact add_le_add
+        (add_le_add
+          (add_le_add
+            (div_le_div_of_nonneg_right (Real.abs_cos_le_one _) (by norm_num))
+            (by simpa only [mul_one] using
+              (mul_le_mul_of_nonneg_left (Real.abs_cos_le_one (2 * z.im))
+                (by norm_num : (0 : ℝ) ≤ 3 / 10))))
+          (div_le_div_of_nonneg_right (Real.abs_cos_le_one _) (by norm_num)))
+        (mul_le_one₀ (Real.abs_sin_le_one _) (abs_nonneg (Real.sin z.im))
+          (Real.abs_sin_le_one _))
+    _ = 253 / 160 := by norm_num
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_counterexampleSeed (z : ℂ) :
+    HasFDerivAt counterexampleSeed (seedGradient z) z := by
+  let hx : HasFDerivAt (fun u : ℂ ↦ u.re) Complex.reCLM z := Complex.reCLM.hasFDerivAt
+  let hy : HasFDerivAt (fun u : ℂ ↦ u.im) Complex.imCLM z := Complex.imCLM.hasFDerivAt
+  have hraw := (((hx.const_mul 2).cos.neg.mul_const (4 : ℝ)⁻¹).add
+    (((hy.const_mul 2).cos.const_mul 3).mul_const (10 : ℝ)⁻¹)).add
+    (((hy.const_mul 4).cos.neg).mul_const (32 : ℝ)⁻¹) |>.add (hx.sin.mul hy.sin)
+  convert hraw using 1
+  · funext u
+    simp [counterexampleSeed, sub_eq_add_neg, div_eq_mul_inv]
+  · ext v
+    simp [seedGradient]
+    ring
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_seedGradient (z : ℂ) :
+    HasFDerivAt seedGradient (seedHessian z) z := by
+  let hx : HasFDerivAt (fun u : ℂ ↦ u.re) Complex.reCLM z := Complex.reCLM.hasFDerivAt
+  let hy : HasFDerivAt (fun u : ℂ ↦ u.im) Complex.imCLM z := Complex.imCLM.hasFDerivAt
+  have hfx := ((hx.const_mul 2).sin.mul_const (2 : ℝ)⁻¹).add (hx.cos.mul hy.sin)
+  have hfy := (((hy.const_mul 2).sin.const_mul (-3)).mul_const (5 : ℝ)⁻¹).add
+    ((hy.const_mul 4).sin.mul_const (8 : ℝ)⁻¹) |>.add (hx.sin.mul hy.cos)
+  have hraw := (hfx.smul_const Complex.reCLM).add (hfy.smul_const Complex.imCLM)
+  let G : ℂ → (ℂ →L[ℝ] ℝ) :=
+    (fun y ↦ (((fun y : ℂ ↦ Real.sin (2 * y.re) * (2 : ℝ)⁻¹) +
+      (fun x : ℂ ↦ Real.cos x.re) * fun x : ℂ ↦ Real.sin x.im) y) • Complex.reCLM) +
+    fun y ↦ ((((fun y : ℂ ↦ -3 * Real.sin (2 * y.im) * (5 : ℝ)⁻¹) +
+      fun y : ℂ ↦ Real.sin (4 * y.im) * (8 : ℝ)⁻¹) +
+      (fun x : ℂ ↦ Real.sin x.re) * fun x : ℂ ↦ Real.cos x.im) y) • Complex.imCLM
+  have hfun : G = seedGradient := by
+    funext u
+    simp [G, seedGradient, div_eq_mul_inv]
+  have hdiff : DifferentiableAt ℝ seedGradient z := by
+    rw [← hfun]
+    dsimp only [G]
+    exact hraw.differentiableAt
+  have hD : fderiv ℝ seedGradient z = seedHessian z := by
+    rw [← hfun]
+    dsimp only [G]
+    rw [hraw.fderiv]
+    apply DFunLike.coe_injective
+    funext v
+    apply DFunLike.coe_injective
+    funext w
+    simp [seedHessian]
+    ring
+  exact hdiff.hasFDerivAt.congr_fderiv hD
+
+/-- Direct differentiation identifies the finite trigonometric Hessian model with the
+repository's Fréchet-derivative encoding. -/
+@[category API, AMS 26]
+private theorem traceFreeHessian_counterexampleSeed (z : ℂ) :
+    traceFreeHessian counterexampleSeed z = seedTraceFreeHessianModel z := by
+  rw [traceFreeHessian]
+  change (let H := fderiv ℝ (fun w ↦ fderiv ℝ counterexampleSeed w) z
+    (H 1 1 - H Complex.I Complex.I : ℝ) + (2 * H 1 Complex.I : ℝ) * Complex.I) = _
+  rw [show (fun w ↦ fderiv ℝ counterexampleSeed w) = seedGradient by
+    funext w
+    exact (hasFDerivAt_counterexampleSeed w).fderiv]
+  rw [(hasFDerivAt_seedGradient z).fderiv]
+  simp [seedHessian, seedTraceFreeHessianModel]
+  ring
+
+/-- The only part of the derivative of the seed's first Wirtinger derivative needed by the
+anti-holomorphic chain rule. -/
+@[category API, AMS 26]
+private theorem exists_seedWirtingerModel_fderiv (z : ℂ) :
+    ∃ Q : ℂ →L[ℝ] ℂ, HasFDerivAt seedWirtingerModel Q z ∧ ∀ b : ℂ,
+      Q b + Complex.I * Q (-Complex.I * b) =
+        b * star (seedTraceFreeHessianModel z) / 2 := by
+  have hx := (hasFDerivAt_seedGradient z).clm_apply (hasFDerivAt_const (1 : ℂ) z)
+  have hy := (hasFDerivAt_seedGradient z).clm_apply
+    (hasFDerivAt_const Complex.I z)
+  have hx' := Complex.ofRealCLM.hasFDerivAt.comp z hx
+  have hy' := Complex.ofRealCLM.hasFDerivAt.comp z hy
+  have hraw := (hx'.sub (hy'.mul_const Complex.I)).mul_const ((2 : ℂ)⁻¹)
+  have heq : seedWirtingerModel = fun w ↦
+      (((seedGradient w 1 : ℂ) - (seedGradient w Complex.I : ℂ) * Complex.I) / 2) := by
+    funext w
+    exact seedWirtingerModel_eq_gradient w
+  let Q : ℂ →L[ℝ] ℂ := (2 : ℂ)⁻¹ •
+    (Complex.ofRealCLM.comp ((seedHessian z).flip 1) -
+      Complex.I • Complex.ofRealCLM.comp ((seedHessian z).flip Complex.I))
+  have hqRaw : HasFDerivAt (fun w ↦
+      (((seedGradient w 1 : ℂ) - (seedGradient w Complex.I : ℂ) * Complex.I) / 2)) Q z := by
+    apply hraw.congr_fderiv
+    ext b
+    simp [Q]
+  have hq : HasFDerivAt seedWirtingerModel Q z := by
+    rw [heq]
+    exact hqRaw
+  refine ⟨Q, hq, fun b ↦ ?_⟩
+  have hx2 : (2 : ℂ) * (z.re : ℂ) = ((2 * z.re : ℝ) : ℂ) := by
+    push_cast
+    ring
+  have hy2 : (2 : ℂ) * (z.im : ℂ) = ((2 * z.im : ℝ) : ℂ) := by
+    push_cast
+    ring
+  have hy4 : (4 : ℂ) * (z.im : ℂ) = ((4 * z.im : ℝ) : ℂ) := by
+    push_cast
+    ring
+  apply Complex.ext
+  · simp [Q, seedHessian, seedTraceFreeHessianModel, Complex.mul_re, Complex.mul_im]
+    rw [hx2, hy2, hy4]
+    simp only [Complex.cos_ofReal_re, Complex.cos_ofReal_im]
+    ring
+  · simp [Q, seedHessian, seedTraceFreeHessianModel, Complex.mul_re, Complex.mul_im]
+    rw [hx2, hy2, hy4]
+    simp only [Complex.cos_ofReal_re, Complex.cos_ofReal_im]
+    ring
+
+/-- The exact uniform nonvanishing certificate behind the index computation. -/
+@[category API, AMS 26]
+private theorem seven_div_fifty_le_norm_seedTraceFreeHessianModel (z : ℂ) :
+    7 / 50 ≤ ‖seedTraceFreeHessianModel z‖ := by
+  let s := Real.cos z.re ^ 2
+  let t := Real.cos z.im ^ 2
+  let a := -4 * t ^ 2 + 32 / 5 * t - 27 / 10
+  let sstar := (4 * t ^ 2 - 37 / 5 * t + 27 / 10) / 2
+  have hs0 : 0 ≤ s := by positivity
+  have ht0 : 0 ≤ t := by positivity
+  have hs1 : s ≤ 1 := by
+    have hplus : 0 ≤ 1 + Real.cos z.re := by linarith [Real.neg_one_le_cos z.re]
+    have h := mul_nonneg (sub_nonneg.mpr (Real.cos_le_one z.re))
+      hplus
+    dsimp [s]
+    nlinarith only [h]
+  have ht1 : t ≤ 1 := by
+    have hplus : 0 ≤ 1 + Real.cos z.im := by linarith [Real.neg_one_le_cos z.im]
+    have h := mul_nonneg (sub_nonneg.mpr (Real.cos_le_one z.im))
+      hplus
+    dsimp [t]
+    nlinarith only [h]
+  have hcos4y : Real.cos (4 * z.im) =
+      8 * Real.cos z.im ^ 4 - 8 * Real.cos z.im ^ 2 + 1 := by
+    rw [show 4 * z.im = 2 * (2 * z.im) by ring, Real.cos_two_mul, Real.cos_two_mul]
+    ring
+  have hnorm : ‖seedTraceFreeHessianModel z‖ ^ 2 = (2 * s + a) ^ 2 + 4 * s * t := by
+    rw [Complex.sq_norm, Complex.normSq_apply]
+    rw [seedTraceFreeHessianModel]
+    simp only [Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+      Complex.ofReal_re, Complex.ofReal_im, Complex.I_re, Complex.I_im, mul_zero,
+      sub_zero, add_zero, mul_one]
+    have hreSq (x : ℝ) : x * x = x ^ 2 := by ring
+    rw [hreSq, show (0 + 2 * Real.cos z.re * Real.cos z.im) *
+        (0 + 2 * Real.cos z.re * Real.cos z.im) =
+          (2 * Real.cos z.re * Real.cos z.im) ^ 2 by ring]
+    rw [Real.cos_two_mul, Real.cos_two_mul, hcos4y]
+    dsimp [s, t, a]
+    ring
+  have hcomplete : (2 * s + a) ^ 2 + 4 * s * t =
+      4 * (s - sstar) ^ 2 + t * (8 * t ^ 2 - 69 / 5 * t + 27 / 5) := by
+    dsimp [a, sstar]
+    ring
+  rw [← sq_le_sq₀ (by positivity) (norm_nonneg _), hnorm]
+  by_cases htlow : t ≤ 1 / 10
+  · have hfactor : 0 ≤ (t - 1 / 10) * (4 * t - 7) :=
+      mul_nonneg_of_nonpos_of_nonpos (by linarith) (by linarith)
+    have hstar : 1 ≤ sstar := by
+      dsimp [sstar]
+      nlinarith only [ht0, htlow, sq_nonneg t]
+    have hdist : (1 - sstar) ^ 2 ≤ (s - sstar) ^ 2 := by
+      have hprod : 0 ≤ (s - 1) * (s + 1 - 2 * sstar) :=
+        mul_nonneg_of_nonpos_of_nonpos (by linarith) (by linarith)
+      nlinarith only [hprod]
+    have hP1 : (2 + a) ^ 2 + 4 * t ≤ (2 * s + a) ^ 2 + 4 * s * t := by
+      dsimp [a, sstar] at hdist ⊢
+      nlinarith only [hdist]
+    by_cases ht64 : 1 / 64 ≤ t
+    · nlinarith only [hP1, ht64, sq_nonneg (2 + a)]
+    · have hA : 2 + a ≤ -3 / 5 := by
+        dsimp [a]
+        nlinarith only [ht0, ht64, sq_nonneg t]
+      have hneg : 0 ≤ -(2 + a) := by linarith only [hA]
+      have hsq : (7 / 50) ^ 2 ≤ (2 + a) ^ 2 := by
+        rw [show (2 + a) ^ 2 = (-(2 + a)) ^ 2 by ring]
+        exact (sq_le_sq₀ (by norm_num) hneg).2 (by linarith only [hA])
+      nlinarith only [hP1, hsq, ht0]
+  · have htlo : 1 / 10 ≤ t := by linarith only [htlow]
+    by_cases htmid : t ≤ 1 / 2
+    · have hquad : 8 * t ^ 2 - 49 / 5 * t + 1 / 2 ≤ 0 := by
+        have hfactor : (t - 1 / 10) * (8 * (t + 1 / 10) - 49 / 5) ≤ 0 :=
+          mul_nonpos_of_nonneg_of_nonpos (by linarith) (by linarith)
+        nlinarith only [hfactor]
+      have hfactor : 0 ≤
+          (t - 1 / 2) * (8 * t ^ 2 - 49 / 5 * t + 1 / 2) :=
+        mul_nonneg_of_nonpos_of_nonpos (by linarith) hquad
+      have hminimum : 1 / 4 ≤ t * (8 * t ^ 2 - 69 / 5 * t + 27 / 5) := by
+        nlinarith only [hfactor]
+      rw [hcomplete]
+      nlinarith only [hminimum, sq_nonneg (s - sstar)]
+    · have hthi : 1 / 2 ≤ t := by linarith only [htmid]
+      have hfactor : (t - 1 / 2) * (4 * (t + 1 / 2) - 37 / 5) ≤ 0 :=
+        mul_nonpos_of_nonneg_of_nonpos (by linarith) (by linarith)
+      have hstar : sstar ≤ 0 := by
+        dsimp [sstar]
+        nlinarith only [hfactor]
+      have hdist : (-sstar) ^ 2 ≤ (s - sstar) ^ 2 := by
+        have hprod : 0 ≤ s * (s - 2 * sstar) := mul_nonneg hs0 (by linarith)
+        nlinarith only [hprod]
+      have hP0 : a ^ 2 ≤ (2 * s + a) ^ 2 + 4 * s * t := by
+        dsimp [a, sstar] at hdist ⊢
+        nlinarith only [hdist]
+      have hA : a ≤ -7 / 50 := by
+        dsimp [a]
+        nlinarith only [hthi, ht1, sq_nonneg (t - 4 / 5)]
+      have hneg : 0 ≤ -a := by linarith only [hA]
+      have hsq : (7 / 50) ^ 2 ≤ a ^ 2 := by
+        rw [show a ^ 2 = (-a) ^ 2 by ring]
+        exact (sq_le_sq₀ (by norm_num) hneg).2 (by linarith only [hA])
+      nlinarith only [hP0, hsq]
+
+/-- The trace-free Hessian of the seed is uniformly separated from zero. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_traceFreeHessian_norm_lower (z : ℂ) :
+    7 / 50 ≤ ‖traceFreeHessian counterexampleSeed z‖ := by
+  rw [traceFreeHessian_counterexampleSeed]
+  exact seven_div_fifty_le_norm_seedTraceFreeHessianModel z
+
+/-- A deliberately crude uniform upper bound for the seed's trace-free Hessian. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_traceFreeHessian_norm_upper (z : ℂ) :
+    ‖traceFreeHessian counterexampleSeed z‖ ≤ 47 / 10 := by
+  rw [traceFreeHessian_counterexampleSeed]
+  have hre : |Real.cos (2 * z.re) + 6 / 5 * Real.cos (2 * z.im) -
+      1 / 2 * Real.cos (4 * z.im)| ≤ 1 + 6 / 5 + 1 / 2 := by
+    calc
+      _ ≤ |Real.cos (2 * z.re)| + |6 / 5 * Real.cos (2 * z.im)| +
+          |1 / 2 * Real.cos (4 * z.im)| := by
+        exact (abs_sub _ _).trans (add_le_add (abs_add_le _ _) le_rfl)
+      _ = |Real.cos (2 * z.re)| + 6 / 5 * |Real.cos (2 * z.im)| +
+          1 / 2 * |Real.cos (4 * z.im)| := by
+        rw [abs_mul, abs_mul]
+        norm_num
+      _ ≤ 1 + 6 / 5 + 1 / 2 := by
+        exact add_le_add
+          (add_le_add (Real.abs_cos_le_one _)
+            (by simpa only [mul_one] using
+              (mul_le_mul_of_nonneg_left (Real.abs_cos_le_one (2 * z.im))
+                (by norm_num : (0 : ℝ) ≤ 6 / 5))))
+          (by simpa only [mul_one] using
+            (mul_le_mul_of_nonneg_left (Real.abs_cos_le_one (4 * z.im))
+              (by norm_num : (0 : ℝ) ≤ 1 / 2)))
+  have him : |2 * Real.cos z.re * Real.cos z.im| ≤ 2 := by
+    rw [abs_mul, abs_mul]
+    rw [abs_of_nonneg (by norm_num : (0 : ℝ) ≤ 2)]
+    calc
+      2 * |Real.cos z.re| * |Real.cos z.im| ≤ 2 * 1 * 1 := by
+        exact mul_le_mul
+          (mul_le_mul_of_nonneg_left (Real.abs_cos_le_one _)
+            (by norm_num : (0 : ℝ) ≤ 2))
+          (Real.abs_cos_le_one _) (abs_nonneg (Real.cos z.im))
+          (by norm_num)
+      _ = 2 := by norm_num
+  calc
+    ‖seedTraceFreeHessianModel z‖ ≤
+        |Real.cos (2 * z.re) + 6 / 5 * Real.cos (2 * z.im) -
+          1 / 2 * Real.cos (4 * z.im)| +
+        |2 * Real.cos z.re * Real.cos z.im| := by
+      rw [seedTraceFreeHessianModel]
+      calc
+        _ ≤ ‖((Real.cos (2 * z.re) + 6 / 5 * Real.cos (2 * z.im) -
+              1 / 2 * Real.cos (4 * z.im) : ℝ) : ℂ)‖ +
+            ‖((2 * Real.cos z.re * Real.cos z.im : ℝ) : ℂ) * Complex.I‖ :=
+          norm_add_le _ _
+        _ = _ := by rw [Complex.norm_real, norm_mul, Complex.norm_real, Complex.norm_I,
+          mul_one, Real.norm_eq_abs, Real.norm_eq_abs]
+    _ ≤ (1 + 6 / 5 + 1 / 2) + 2 := add_le_add hre him
+    _ = 47 / 10 := by norm_num
+
+/-- The scalar trace of the seed Hessian has a uniform absolute-value bound. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_chartLaplacian_abs_le (z : ℂ) :
+    |let H := fderiv ℝ (fun w ↦ fderiv ℝ counterexampleSeed w) z;
+      H 1 1 + H Complex.I Complex.I| ≤ 47 / 10 := by
+  rw [show (fun w ↦ fderiv ℝ counterexampleSeed w) = seedGradient by
+    funext w
+    exact (hasFDerivAt_counterexampleSeed w).fderiv]
+  rw [(hasFDerivAt_seedGradient z).fderiv]
+  have hformula : seedHessian z 1 1 + seedHessian z Complex.I Complex.I =
+      Real.cos (2 * z.re) - 6 / 5 * Real.cos (2 * z.im) +
+        1 / 2 * Real.cos (4 * z.im) - 2 * Real.sin z.re * Real.sin z.im := by
+    simp [seedHessian]
+    ring
+  rw [hformula]
+  have htriangle :
+      |Real.cos (2 * z.re) - 6 / 5 * Real.cos (2 * z.im) +
+          1 / 2 * Real.cos (4 * z.im) - 2 * Real.sin z.re * Real.sin z.im| ≤
+        |Real.cos (2 * z.re)| + |-6 / 5 * Real.cos (2 * z.im)| +
+          |1 / 2 * Real.cos (4 * z.im)| + |-2 * Real.sin z.re * Real.sin z.im| := by
+    rw [sub_eq_add_neg, sub_eq_add_neg]
+    rw [show -(6 / 5 * Real.cos (2 * z.im)) =
+        -6 / 5 * Real.cos (2 * z.im) by ring,
+      show -(2 * Real.sin z.re * Real.sin z.im) =
+        -2 * Real.sin z.re * Real.sin z.im by ring]
+    calc
+      _ ≤ |Real.cos (2 * z.re) + -6 / 5 * Real.cos (2 * z.im) +
+            1 / 2 * Real.cos (4 * z.im)| +
+          |-2 * Real.sin z.re * Real.sin z.im| := abs_add_le ..
+      _ ≤ (|Real.cos (2 * z.re) + -6 / 5 * Real.cos (2 * z.im)| +
+            |1 / 2 * Real.cos (4 * z.im)|) +
+          |-2 * Real.sin z.re * Real.sin z.im| := by
+        simpa [add_assoc, add_comm, add_left_comm] using
+          add_le_add_right
+            (abs_add_le
+              (Real.cos (2 * z.re) + -6 / 5 * Real.cos (2 * z.im))
+              (1 / 2 * Real.cos (4 * z.im)))
+            |-2 * Real.sin z.re * Real.sin z.im|
+      _ ≤ ((|Real.cos (2 * z.re)| + |-6 / 5 * Real.cos (2 * z.im)|) +
+            |1 / 2 * Real.cos (4 * z.im)|) +
+          |-2 * Real.sin z.re * Real.sin z.im| := by
+        simpa [add_assoc, add_comm, add_left_comm] using
+          add_le_add_right
+            (add_le_add_right
+              (abs_add_le (Real.cos (2 * z.re))
+                (-6 / 5 * Real.cos (2 * z.im)))
+              |1 / 2 * Real.cos (4 * z.im)|)
+            |-2 * Real.sin z.re * Real.sin z.im|
+  refine htriangle.trans ?_
+  simp only [abs_mul]
+  norm_num
+  have hsin : |Real.sin z.re| * |Real.sin z.im| ≤ 1 :=
+    mul_le_one₀ (Real.abs_sin_le_one _) (abs_nonneg _) (Real.abs_sin_le_one _)
+  nlinarith only [Real.abs_cos_le_one (2 * z.re),
+    Real.abs_cos_le_one (2 * z.im), Real.abs_cos_le_one (4 * z.im), hsin]
+
+/-- The first Wirtinger derivative of the seed has a uniform norm bound. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_wirtinger_norm_upper (z : ℂ) :
+    ‖((fderiv ℝ counterexampleSeed z 1 : ℂ) -
+        (fderiv ℝ counterexampleSeed z Complex.I : ℂ) * Complex.I) / 2‖ ≤ 129 / 80 := by
+  rw [(hasFDerivAt_counterexampleSeed z).fderiv]
+  rw [← seedWirtingerModel_eq_gradient]
+  exact norm_seedWirtingerModel_le z
+
+/-- The normalized seed Hessian has a global continuous argument, chosen evenly under
+`z ↦ -z`. This is what makes the half-integral powers for odd `k` contribute no extra winding. -/
+@[category API, AMS 26]
+private theorem exists_even_continuous_seed_argument :
+    ∃ θ : ℂ → ℝ, Continuous θ ∧
+      (∀ z, Complex.exp ((θ z : ℂ) * Complex.I) =
+        seedTraceFreeHessianModel z / ‖seedTraceFreeHessianModel z‖) ∧
+      ∀ z, θ (-z) = θ z := by
+  have hmodel0 (z : ℂ) : seedTraceFreeHessianModel z ≠ 0 := by
+    rw [← norm_pos_iff]
+    exact (by norm_num : (0 : ℝ) < 7 / 50).trans_le
+      (seven_div_fifty_le_norm_seedTraceFreeHessianModel z)
+  have hmodel_cont : Continuous seedTraceFreeHessianModel := by
+    unfold seedTraceFreeHessianModel
+    fun_prop
+  have hmodel_even := seedTraceFreeHessianModel_neg
+  let qCircle : C(ℂ, Circle) :=
+    ⟨fun z ↦ ⟨seedTraceFreeHessianModel z / ‖seedTraceFreeHessianModel z‖,
+      mem_sphere_zero_iff_norm.2 <| by
+        rw [norm_div]
+        simp [hmodel0 z]⟩,
+      (hmodel_cont.div (Complex.continuous_ofReal.comp hmodel_cont.norm)
+        (fun z ↦ Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr (hmodel0 z)))).subtype_mk _⟩
+  let θ0 := Complex.arg (qCircle 0 : ℂ)
+  rcases Circle.isCoveringMap_exp.existsUnique_continuousMap_lifts qCircle 0 θ0
+      (Circle.exp_arg (qCircle 0)) with ⟨θ, ⟨-, hθ⟩, -⟩
+  have hθ' (z : ℂ) : Circle.exp (θ z) = qCircle z := congrFun hθ z
+  have hθeven : (fun z : ℂ ↦ θ (-z)) = θ := by
+    refine Circle.isCoveringMap_exp.eq_of_comp_eq
+      (θ.continuous.comp continuous_neg) θ.continuous ?_ (0 : ℂ) ?_
+    · funext z
+      simp only [Function.comp_apply]
+      rw [hθ', hθ']
+      apply Subtype.ext
+      simp [qCircle, hmodel_even]
+    · simp
+  refine ⟨θ, θ.continuous, ?_, fun z ↦ congrFun hθeven z⟩
+  intro z
+  have hz := congrArg (fun w : Circle ↦ (w : ℂ)) (hθ' z)
+  simpa [qCircle] using hz
+
+/-- The lifted leading Hessian model on a circle has argument change `2π(2+k)`. The path in
+the seed variable is chosen continuously, rather than by the discontinuous principal branch. -/
+@[category API, AMS 26]
+private theorem exists_seed_leading_argument (k : ℕ) (a c : ℝ) :
+    ∃ θ : ℝ → ℝ, Continuous θ ∧
+      (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
+        Complex.exp (((c + (2 + k : ℕ) * t : ℝ) : ℂ) * Complex.I) *
+          star (seedTraceFreeHessianModel
+            ((a : ℂ) * Complex.exp (((k / 2 * t : ℝ) : ℂ) * Complex.I))) /
+          ‖seedTraceFreeHessianModel
+            ((a : ℂ) * Complex.exp (((k / 2 * t : ℝ) : ℂ) * Complex.I))‖) ∧
+      θ (2 * Real.pi) - θ 0 = 2 * Real.pi * ((2 + k : ℕ) : ℤ) := by
+  rcases exists_even_continuous_seed_argument with ⟨φ, hφcont, hφ, hφeven⟩
+  let w : ℝ → ℂ := fun t ↦
+    (a : ℂ) * Complex.exp (((k / 2 * t : ℝ) : ℂ) * Complex.I)
+  let θ : ℝ → ℝ := fun t ↦ c + (2 + k : ℕ) * t - φ (w t)
+  have hwcont : Continuous w := by
+    fun_prop
+  have hθcont : Continuous θ := by
+    fun_prop
+  have hphase (t : ℝ) : Complex.exp ((θ t : ℂ) * Complex.I) =
+      Complex.exp (((c + (2 + k : ℕ) * t : ℝ) : ℂ) * Complex.I) *
+        star (seedTraceFreeHessianModel (w t)) / ‖seedTraceFreeHessianModel (w t)‖ := by
+    have hs := congrArg star (hφ (w t))
+    rw [show ((θ t : ℂ) * Complex.I) =
+      (((c + (2 + k : ℕ) * t : ℝ) : ℂ) * Complex.I) +
+        -((φ (w t) : ℂ) * Complex.I) by simp [θ]; ring, Complex.exp_add]
+    have hs' : Complex.exp (-((φ (w t) : ℂ) * Complex.I)) =
+        star (seedTraceFreeHessianModel (w t)) /
+          ‖seedTraceFreeHessianModel (w t)‖ := by
+      calc
+        _ = star (Complex.exp ((φ (w t) : ℂ) * Complex.I)) := by
+          change Complex.exp (-((φ (w t) : ℂ) * Complex.I)) =
+            (starRingEnd ℂ) (Complex.exp ((φ (w t) : ℂ) * Complex.I))
+          rw [← Complex.exp_conj]
+          congr 1
+          simp
+        _ = star (seedTraceFreeHessianModel (w t) /
+            ‖seedTraceFreeHessianModel (w t)‖) := hs
+        _ = _ := by simp
+    rw [hs']
+    ring
+  have hexp : Complex.exp ((((k : ℝ) * Real.pi : ℂ) * Complex.I)) = (-1 : ℂ) ^ k := by
+    rw [show (((k : ℝ) * Real.pi : ℂ) * Complex.I) =
+      (k : ℂ) * ((Real.pi : ℂ) * Complex.I) by push_cast; ring,
+      Complex.exp_nat_mul, Complex.exp_pi_mul_I]
+  have hwendpoint : φ (w (2 * Real.pi)) = φ (w 0) := by
+    have hwvalue : w (2 * Real.pi) = (a : ℂ) * (-1 : ℂ) ^ k := by
+      simp only [w]
+      rw [show k / 2 * (2 * Real.pi) = (k : ℝ) * Real.pi by ring]
+      congr 1
+      simpa only [Complex.ofReal_mul] using hexp
+    rcases neg_one_pow_eq_or ℂ k with hk | hk
+    · rw [hwvalue, hk]
+      simp [w]
+    · rw [hwvalue, hk]
+      simpa [w] using hφeven (a : ℂ)
+  refine ⟨θ, hθcont, fun t ↦ by simpa [w] using hphase t, ?_⟩
+  dsimp [θ]
+  rw [hwendpoint]
+  have hcast : ((2 + k : ℕ) : ℝ) = ((2 + (k : ℤ) : ℤ) : ℝ) := by
+    norm_num
+  rw [hcast]
+  ring
+
+/-- Lifting a homotopy through the exponential covering preserves the total argument change
+when every stage has matching endpoints. -/
+@[category API, AMS 26]
+private theorem homotopy_preserves_argument_change (H : C(I × ℝ, Circle))
+    (θ0 : C(ℝ, ℝ)) (T C : ℝ) (hH0 : ∀ t, H (0, t) = Circle.exp (θ0 t))
+    (hperiodic : ∀ s, H (s, T) = H (s, 0)) (hchange : θ0 T - θ0 0 = C)
+    (hC : Circle.exp C = 1) :
+    ∃ θ : ℝ → ℝ, Continuous θ ∧ (∀ t, Circle.exp (θ t) = H (1, t)) ∧
+      θ T - θ 0 = C := by
+  let Θ := Circle.isCoveringMap_exp.liftHomotopy H θ0 hH0
+  have hΘ (s : I) (t : ℝ) : Circle.exp (Θ (s, t)) = H (s, t) := by
+    exact congrFun (Circle.isCoveringMap_exp.liftHomotopy_lifts H θ0 hH0) (s, t)
+  have hendpoint : (fun s : I ↦ Θ (s, T)) = fun s ↦ Θ (s, 0) + C := by
+    refine Circle.isCoveringMap_exp.eq_of_comp_eq
+      (Θ.continuous.comp (continuous_id.prodMk continuous_const))
+      ((Θ.continuous.comp (continuous_id.prodMk continuous_const)).add continuous_const)
+      ?_ (0 : I) ?_
+    · funext s
+      simp only [Function.comp_apply]
+      rw [Circle.exp_add, hC, mul_one, hΘ, hΘ, hperiodic]
+    · change Θ (0, T) = Θ (0, 0) + C
+      rw [Circle.isCoveringMap_exp.liftHomotopy_zero,
+        Circle.isCoveringMap_exp.liftHomotopy_zero]
+      linarith
+  refine ⟨fun t ↦ Θ (1, t),
+    Θ.continuous.comp (continuous_const.prodMk continuous_id), fun t ↦ hΘ 1 t, ?_⟩
+  have := congrFun hendpoint 1
+  change Θ (1, T) = Θ (1, 0) + C at this
+  linarith
+
+/-- A positive real power of the radius tends to zero on the punctured complex plane. -/
+@[category API, AMS 26]
+private theorem tendsto_norm_rpow_nhdsWithin_zero {p : ℝ} (hp : 0 < p) :
+    Tendsto (fun z : ℂ ↦ ‖z‖ ^ p) (𝓝[≠] 0) (𝓝 0) := by
+  have hrpow := (Real.continuousAt_rpow_const 0 p (.inr hp.le)).tendsto
+  have hnormAt : ContinuousAt (fun z : ℂ ↦ ‖z‖) 0 := continuous_norm.continuousAt
+  have hnorm : Tendsto (fun z : ℂ ↦ ‖z‖) (𝓝[≠] 0) (𝓝 0) := by
+    simpa using hnormAt.tendsto.mono_left
+      (show 𝓝[≠] (0 : ℂ) ≤ 𝓝 0 from inf_le_left)
+  simpa only [Function.comp_apply, Real.zero_rpow hp.ne'] using hrpow.comp hnorm
+
+/-- The three powers occurring in the Hessian error-to-leading ratios all tend to zero for
+positive `k`. -/
+@[category API, AMS 26]
+private theorem counterexample_error_powers_tendsto_zero (k : ℕ) (hk : 0 < k) :
+    Tendsto (fun z : ℂ ↦ ‖z‖ ^ ((k : ℝ) / 2)) (𝓝[≠] 0) (𝓝 0) ∧
+    Tendsto (fun z : ℂ ↦ ‖z‖ ^ ((k : ℝ) / 2 - 1 / 4)) (𝓝[≠] 0) (𝓝 0) ∧
+    Tendsto (fun z : ℂ ↦ ‖z‖ ^ ((k : ℝ) - 1 / 2)) (𝓝[≠] 0) (𝓝 0) := by
+  have hk' : (1 : ℝ) ≤ k := by exact_mod_cast hk
+  refine ⟨tendsto_norm_rpow_nhdsWithin_zero (by positivity),
+    tendsto_norm_rpow_nhdsWithin_zero (by linarith),
+    tendsto_norm_rpow_nhdsWithin_zero (by linarith)⟩
+
+/-- A perturbation smaller in norm than a nonvanishing leading term has the same argument
+change. The proof uses the normalized straight-line homotopy. -/
+@[category API, AMS 26]
+private theorem exists_argument_of_norm_error_lt (leading error : ℝ → ℂ) (T C : ℝ)
+    (hleading : Continuous leading) (herror : Continuous error)
+    (hsmall : ∀ t, ‖error t‖ < ‖leading t‖)
+    (hperiodicLeading : leading T = leading 0) (hperiodicError : error T = error 0)
+    (θ0 : ℝ → ℝ) (hθ0 : Continuous θ0)
+    (hphase0 : ∀ t, Complex.exp ((θ0 t : ℂ) * Complex.I) = leading t / ‖leading t‖)
+    (hchange : θ0 T - θ0 0 = C) (hC : Circle.exp C = 1) :
+    ∃ θ : ℝ → ℝ, Continuous θ ∧
+      (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
+        (leading t + error t) / ‖leading t + error t‖) ∧
+      θ T - θ 0 = C := by
+  have hne (s : I) (t : ℝ) : leading t + (s : ℝ) • error t ≠ 0 := by
+    intro hzero
+    have heq : leading t = -((s : ℝ) • error t) := eq_neg_of_add_eq_zero_left hzero
+    have hle : ‖leading t‖ ≤ ‖error t‖ := by
+      rw [heq, norm_neg, norm_smul, Real.norm_of_nonneg s.2.1]
+      exact mul_le_of_le_one_left (norm_nonneg _) s.2.2
+    exact (not_lt_of_ge hle) (hsmall t)
+  have hscalar : Continuous (fun st : I × ℝ ↦ (st.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  have herror' : Continuous (fun st : I × ℝ ↦ error st.2) :=
+    herror.comp continuous_snd
+  have htotal : Continuous (fun st : I × ℝ ↦
+      leading st.2 + (st.1 : ℝ) • error st.2) :=
+    (hleading.comp continuous_snd).add (hscalar.smul herror')
+  let H : C(I × ℝ, Circle) :=
+    ⟨fun st ↦ ⟨(leading st.2 + (st.1 : ℝ) • error st.2) /
+          ‖leading st.2 + (st.1 : ℝ) • error st.2‖, mem_sphere_zero_iff_norm.2 <| by
+        rw [norm_div]
+        simp only [Complex.norm_real, Real.norm_eq_abs, abs_norm]
+        exact div_self (norm_ne_zero_iff.mpr (hne st.1 st.2))⟩,
+      (htotal.div
+          (Complex.continuous_ofReal.comp htotal.norm)
+          (fun st ↦ Complex.ofReal_ne_zero.mpr
+            (norm_ne_zero_iff.mpr (hne st.1 st.2)))).subtype_mk _⟩
+  let θ0Map : C(ℝ, ℝ) := ⟨θ0, hθ0⟩
+  have hH0 (t : ℝ) : H (0, t) = Circle.exp (θ0Map t) := by
+    apply Subtype.ext
+    simpa [H, θ0Map] using (hphase0 t).symm
+  have hHperiodic (s : I) : H (s, T) = H (s, 0) := by
+    apply Subtype.ext
+    simp [H, hperiodicLeading, hperiodicError]
+  rcases homotopy_preserves_argument_change H θ0Map T C hH0 hHperiodic hchange hC with
+    ⟨θ, hθ, hphase, hθchange⟩
+  refine ⟨θ, hθ, ?_, hθchange⟩
+  intro t
+  have ht := congrArg (fun w : Circle ↦ (w : ℂ)) (hphase t)
+  simpa [H] using ht
+
+/-- The radial amplitude in the counterexample, separated from the oscillatory seed. -/
+private noncomputable def counterexampleRadialAmplitude (r : ℝ) : ℝ :=
+  r ^ 2 * Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) /
+    (1 + r ^ 2)
+
+/-- The logarithmic derivative of the radial amplitude on the positive real axis. -/
+private noncomputable def counterexampleRadialLogDerivOne (r : ℝ) : ℝ :=
+  2 / r - 2 * r / (1 + r ^ 2) + Real.exp (-(r ^ 2)) *
+    (1 / 4 * Real.rpow r (-(5 : ℝ) / 4) + 2 * Real.rpow r (3 / 4))
+
+/-- The derivative of `counterexampleRadialLogDerivOne` on the positive real axis. -/
+private noncomputable def counterexampleRadialLogDerivTwo (r : ℝ) : ℝ :=
+  -2 / r ^ 2 + 2 * (r ^ 2 - 1) / (1 + r ^ 2) ^ 2 + Real.exp (-(r ^ 2)) *
+    (Real.rpow r (-(1 : ℝ) / 4) - 5 / 16 * Real.rpow r (-(9 : ℝ) / 4) -
+      4 * Real.rpow r (7 / 4))
+
+/-- Crude radial logarithmic-derivative bounds, sufficient for the Hessian error estimate. -/
+@[category API, AMS 26]
+private theorem counterexampleRadialLogDeriv_bounds {r : ℝ} (hr : 0 < r) (hr1 : r ≤ 1) :
+    |counterexampleRadialLogDerivOne r| ≤ 7 * r ^ (-(5 : ℝ) / 4) ∧
+      |counterexampleRadialLogDerivTwo r| ≤ 10 * r ^ (-(9 : ℝ) / 4) := by
+  have hexp0 : 0 ≤ Real.exp (-(r ^ 2)) := (Real.exp_pos _).le
+  have hexp1 : Real.exp (-(r ^ 2)) ≤ 1 :=
+    Real.exp_le_one_iff.mpr (neg_nonpos.mpr (sq_nonneg r))
+  have hpFive : 0 < r ^ (-(5 : ℝ) / 4) := Real.rpow_pos_of_pos hr _
+  have hpNine : 0 < r ^ (-(9 : ℝ) / 4) := Real.rpow_pos_of_pos hr _
+  have hFiveOne : 1 ≤ r ^ (-(5 : ℝ) / 4) :=
+    Real.one_le_rpow_of_pos_of_le_one_of_nonpos hr hr1 (by norm_num)
+  have hNineOne : 1 ≤ r ^ (-(9 : ℝ) / 4) :=
+    Real.one_le_rpow_of_pos_of_le_one_of_nonpos hr hr1 (by norm_num)
+  have hNegOneFive : r ^ (-(1 : ℝ)) ≤ r ^ (-(5 : ℝ) / 4) :=
+    Real.rpow_le_rpow_of_exponent_ge hr hr1 (by norm_num)
+  have hNegTwoNine : r ^ (-(2 : ℝ)) ≤ r ^ (-(9 : ℝ) / 4) :=
+    Real.rpow_le_rpow_of_exponent_ge hr hr1 (by norm_num)
+  have hThreeFive : r ^ ((3 : ℝ) / 4) ≤ r ^ (-(5 : ℝ) / 4) :=
+    Real.rpow_le_rpow_of_exponent_ge hr hr1 (by norm_num)
+  have hOneNine : r ^ (-(1 : ℝ) / 4) ≤ r ^ (-(9 : ℝ) / 4) :=
+    Real.rpow_le_rpow_of_exponent_ge hr hr1 (by norm_num)
+  have hSevenNine : r ^ ((7 : ℝ) / 4) ≤ r ^ (-(9 : ℝ) / 4) :=
+    Real.rpow_le_rpow_of_exponent_ge hr hr1 (by norm_num)
+  have hfirst : |2 / r| ≤ 2 * r ^ (-(5 : ℝ) / 4) := by
+    rw [abs_div, abs_of_nonneg (by norm_num), abs_of_pos hr]
+    rw [div_eq_mul_inv, ← Real.rpow_neg_one]
+    gcongr
+  have hsecond : |2 * r / (1 + r ^ 2)| ≤ 2 := by
+    rw [abs_div, abs_mul, abs_of_nonneg (by norm_num), abs_of_pos hr,
+      abs_of_pos (by positivity : 0 < 1 + r ^ 2)]
+    apply (div_le_iff₀ (by positivity : 0 < 1 + r ^ 2)).2
+    nlinarith
+  have hexpTerm : Real.exp (-(r ^ 2)) *
+      (1 / 4 * r ^ (-(5 : ℝ) / 4) + 2 * r ^ ((3 : ℝ) / 4)) ≤
+      9 / 4 * r ^ (-(5 : ℝ) / 4) := by
+    calc
+      _ ≤ 1 * (1 / 4 * r ^ (-(5 : ℝ) / 4) +
+          2 * r ^ ((3 : ℝ) / 4)) := by gcongr
+      _ ≤ _ := by nlinarith only [hThreeFive, hpFive]
+  constructor
+  · rw [counterexampleRadialLogDerivOne]
+    calc
+      |2 / r - 2 * r / (1 + r ^ 2) + Real.exp (-(r ^ 2)) *
+          (1 / 4 * r ^ (-(5 : ℝ) / 4) + 2 * r ^ ((3 : ℝ) / 4))| ≤
+          |2 / r| + |2 * r / (1 + r ^ 2)| +
+            |Real.exp (-(r ^ 2)) *
+              (1 / 4 * r ^ (-(5 : ℝ) / 4) + 2 * r ^ ((3 : ℝ) / 4))| := by
+        exact (abs_add_le _ _).trans (add_le_add (abs_sub _ _) le_rfl)
+      _ ≤ 2 * r ^ (-(5 : ℝ) / 4) + 2 +
+          9 / 4 * r ^ (-(5 : ℝ) / 4) := by
+        gcongr
+        rw [abs_of_nonneg (mul_nonneg hexp0 (by positivity))]
+        exact hexpTerm
+      _ ≤ 7 * r ^ (-(5 : ℝ) / 4) := by nlinarith only [hFiveOne]
+  · have hmiddle : |2 * (r ^ 2 - 1) / (1 + r ^ 2) ^ 2| ≤ 2 := by
+      rw [abs_div, abs_mul, abs_of_nonneg (by norm_num),
+        abs_of_pos (by positivity : 0 < (1 + r ^ 2) ^ 2)]
+      have hrsq : r ^ 2 ≤ 1 := by nlinarith
+      have habs : |r ^ 2 - 1| ≤ 1 := abs_le.2 ⟨by nlinarith, by nlinarith⟩
+      apply (div_le_iff₀ (by positivity : 0 < (1 + r ^ 2) ^ 2)).2
+      nlinarith [sq_nonneg (r ^ 2)]
+    have hexpTermTwo : |Real.exp (-(r ^ 2)) *
+        (r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+          4 * r ^ ((7 : ℝ) / 4))| ≤ 85 / 16 * r ^ (-(9 : ℝ) / 4) := by
+      rw [abs_mul, abs_of_nonneg hexp0]
+      have hinside :
+          |r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+              4 * r ^ ((7 : ℝ) / 4)| ≤
+            r ^ (-(1 : ℝ) / 4) + 5 / 16 * r ^ (-(9 : ℝ) / 4) +
+              4 * r ^ ((7 : ℝ) / 4) := by
+        calc
+          _ ≤ |r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4)| +
+              |4 * r ^ ((7 : ℝ) / 4)| := abs_sub ..
+          _ ≤ |r ^ (-(1 : ℝ) / 4)| + |5 / 16 * r ^ (-(9 : ℝ) / 4)| +
+              |4 * r ^ ((7 : ℝ) / 4)| := add_le_add (abs_sub _ _) le_rfl
+          _ = _ := by
+            rw [abs_mul, abs_mul, abs_of_nonneg, abs_of_nonneg, abs_of_nonneg,
+              abs_of_nonneg, abs_of_nonneg]
+            all_goals positivity
+      calc
+        Real.exp (-(r ^ 2)) *
+            |r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+              4 * r ^ ((7 : ℝ) / 4)| ≤
+            1 * (r ^ (-(1 : ℝ) / 4) + 5 / 16 * r ^ (-(9 : ℝ) / 4) +
+              4 * r ^ ((7 : ℝ) / 4)) := by gcongr
+        _ ≤ _ := by nlinarith only [hOneNine, hSevenNine, hpNine]
+    rw [counterexampleRadialLogDerivTwo]
+    calc
+      |-2 / r ^ 2 + 2 * (r ^ 2 - 1) / (1 + r ^ 2) ^ 2 +
+          Real.exp (-(r ^ 2)) *
+            (r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+              4 * r ^ ((7 : ℝ) / 4))| ≤
+          |2 / r ^ 2| + |2 * (r ^ 2 - 1) / (1 + r ^ 2) ^ 2| +
+            |Real.exp (-(r ^ 2)) *
+              (r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+                4 * r ^ ((7 : ℝ) / 4))| := by
+        calc
+          _ ≤ |-2 / r ^ 2 + 2 * (r ^ 2 - 1) / (1 + r ^ 2) ^ 2| +
+              |Real.exp (-(r ^ 2)) *
+                (r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+                  4 * r ^ ((7 : ℝ) / 4))| := abs_add_le ..
+          _ ≤ (|-2 / r ^ 2| + |2 * (r ^ 2 - 1) / (1 + r ^ 2) ^ 2|) +
+              |Real.exp (-(r ^ 2)) *
+                (r ^ (-(1 : ℝ) / 4) - 5 / 16 * r ^ (-(9 : ℝ) / 4) -
+                  4 * r ^ ((7 : ℝ) / 4))| :=
+            add_le_add (abs_add_le _ _) le_rfl
+          _ = _ := by
+            rw [show -2 / r ^ 2 = -(2 / r ^ 2) by ring, abs_neg]
+      _ ≤ 2 * r ^ (-(9 : ℝ) / 4) + 2 +
+          85 / 16 * r ^ (-(9 : ℝ) / 4) := by
+        gcongr
+        have hinv : (r ^ 2)⁻¹ = r ^ (-(2 : ℝ)) := by
+          calc
+            (r ^ 2)⁻¹ = (r ^ (2 : ℝ))⁻¹ :=
+              congrArg Inv.inv (Real.rpow_natCast r 2).symm
+            _ = r ^ (-(2 : ℝ)) := (Real.rpow_neg hr.le (2 : ℝ)).symm
+        rw [abs_div, abs_of_nonneg (by norm_num), abs_of_pos (sq_pos_of_pos hr),
+          div_eq_mul_inv, hinv]
+        exact mul_le_mul_of_nonneg_left hNegTwoNine (by norm_num)
+      _ ≤ 10 * r ^ (-(9 : ℝ) / 4) := by nlinarith only [hNineOne]
+
+@[category API, AMS 26]
+private theorem hasDerivAt_counterexampleRadialExponent {r : ℝ} (hr : 0 < r) :
+    HasDerivAt
+      (fun x : ℝ ↦ -Real.rpow x (-(1 : ℝ) / 4) * Real.exp (-(x ^ 2)))
+      (Real.exp (-(r ^ 2)) *
+        (1 / 4 * Real.rpow r (-(5 : ℝ) / 4) + 2 * Real.rpow r (3 / 4))) r := by
+  have hpow :=
+    (Real.hasDerivAt_rpow_const (x := r) (p := -(1 : ℝ) / 4) (Or.inl hr.ne')).neg
+  have hexp := ((hasDerivAt_id r).pow 2).neg.exp
+  have hpow' : HasDerivAt (fun x : ℝ ↦ -Real.rpow x (-(1 : ℝ) / 4))
+      (1 / 4 * Real.rpow r (-(5 : ℝ) / 4)) r := by
+    convert hpow using 1
+    simp only [Real.rpow_eq_pow]
+    rw [show -(1 : ℝ) / 4 - 1 = -5 / 4 by ring]
+    ring
+  have hexp' : HasDerivAt (fun x : ℝ ↦ Real.exp (-(x ^ 2)))
+      (-2 * r * Real.exp (-(r ^ 2))) r := by
+    convert hexp using 1
+    simp only [Pi.neg_apply, Pi.pow_apply, id_eq, Nat.cast_ofNat]
+    ring
+  have hrpow : r * Real.rpow r (-(1 : ℝ) / 4) = Real.rpow r (3 / 4) := by
+    calc
+      r * Real.rpow r (-(1 : ℝ) / 4) =
+          Real.rpow r 1 * Real.rpow r (-(1 : ℝ) / 4) :=
+        congrArg (fun x ↦ x * Real.rpow r (-(1 : ℝ) / 4)) (Real.rpow_one r).symm
+      _ = Real.rpow r (1 + (-(1 : ℝ) / 4)) := (Real.rpow_add hr _ _).symm
+      _ = Real.rpow r (3 / 4) := by
+        congr 1
+        ring
+  convert hpow'.mul hexp' using 1
+  calc
+    Real.exp (-(r ^ 2)) *
+          (1 / 4 * Real.rpow r (-(5 : ℝ) / 4) + 2 * Real.rpow r (3 / 4)) =
+        1 / 4 * Real.rpow r (-(5 : ℝ) / 4) * Real.exp (-(r ^ 2)) +
+          2 * Real.rpow r (3 / 4) * Real.exp (-(r ^ 2)) := by ring
+    _ = 1 / 4 * Real.rpow r (-(5 : ℝ) / 4) * Real.exp (-(r ^ 2)) +
+          2 * (r * Real.rpow r (-(1 : ℝ) / 4)) * Real.exp (-(r ^ 2)) := by rw [hrpow]
+    _ = 1 / 4 * Real.rpow r (-(5 : ℝ) / 4) * Real.exp (-(r ^ 2)) +
+          -Real.rpow r (-(1 : ℝ) / 4) * (-2 * r * Real.exp (-(r ^ 2))) := by ring
+
+@[category API, AMS 26]
+private theorem hasDerivAt_counterexampleRadialAmplitude {r : ℝ} (hr : 0 < r) :
+    HasDerivAt counterexampleRadialAmplitude
+      (counterexampleRadialAmplitude r * counterexampleRadialLogDerivOne r) r := by
+  have hE := (hasDerivAt_counterexampleRadialExponent hr).exp
+  have hnum := ((hasDerivAt_id r).pow 2).mul hE
+  have hden := (hasDerivAt_const r 1).add ((hasDerivAt_id r).pow 2)
+  have hnum' : HasDerivAt (fun x : ℝ ↦ x ^ 2 *
+      Real.exp (-Real.rpow x (-(1 : ℝ) / 4) * Real.exp (-(x ^ 2))))
+      (2 * r * Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) +
+        r ^ 2 * (Real.exp (-Real.rpow r (-(1 : ℝ) / 4) * Real.exp (-(r ^ 2))) *
+          (Real.exp (-(r ^ 2)) *
+            (1 / 4 * Real.rpow r (-(5 : ℝ) / 4) + 2 * Real.rpow r (3 / 4))))) r := by
+    simpa [Pi.mul_apply, Pi.pow_apply, Pi.neg_apply, id_eq] using hnum
+  have hden' : HasDerivAt (fun x : ℝ ↦ 1 + x ^ 2) (2 * r) r := by
+    convert hden using 1
+    norm_num [Pi.add_apply, Pi.pow_apply, id_eq]
+  convert hnum'.div hden' (by positivity) using 1
+  simp only [counterexampleRadialAmplitude, counterexampleRadialLogDerivOne]
+  field_simp [hr.ne']
+  ring
+
+@[category API, AMS 26]
+private theorem hasDerivAt_counterexampleRadialLogDerivOne {r : ℝ} (hr : 0 < r) :
+    HasDerivAt counterexampleRadialLogDerivOne (counterexampleRadialLogDerivTwo r) r := by
+  have hr0 : r ≠ 0 := hr.ne'
+  have hfirst := (hasDerivAt_const r 2).div (hasDerivAt_id r) hr0
+  have hmiddle := ((hasDerivAt_const r 2).mul (hasDerivAt_id r)).div
+    ((hasDerivAt_const r 1).add ((hasDerivAt_id r).pow 2)) (by dsimp; positivity)
+  have hexp := ((hasDerivAt_id r).pow 2).neg.exp
+  have hpFive := Real.hasDerivAt_rpow_const (x := r) (p := -(5 : ℝ) / 4) (Or.inl hr0)
+  have hpThree := Real.hasDerivAt_rpow_const (x := r) (p := (3 : ℝ) / 4) (Or.inl hr0)
+  have hlast := hexp.mul
+    ((hasDerivAt_const r (1 / 4)).mul hpFive |>.add
+      ((hasDerivAt_const r 2).mul hpThree))
+  have hseven : r * Real.rpow r (3 / 4) = Real.rpow r (7 / 4) := by
+    calc
+      r * Real.rpow r (3 / 4) = Real.rpow r 1 * Real.rpow r (3 / 4) :=
+        congrArg (fun x ↦ x * Real.rpow r (3 / 4)) (Real.rpow_one r).symm
+      _ = Real.rpow r (1 + 3 / 4) := (Real.rpow_add hr _ _).symm
+      _ = Real.rpow r (7 / 4) := by
+        congr 1
+        ring
+  have hminus : r * Real.rpow r (-(5 : ℝ) / 4) = Real.rpow r (-(1 : ℝ) / 4) := by
+    calc
+      r * Real.rpow r (-(5 : ℝ) / 4) =
+          Real.rpow r 1 * Real.rpow r (-(5 : ℝ) / 4) :=
+        congrArg (fun x ↦ x * Real.rpow r (-(5 : ℝ) / 4)) (Real.rpow_one r).symm
+      _ = Real.rpow r (1 + (-(5 : ℝ) / 4)) := (Real.rpow_add hr _ _).symm
+      _ = Real.rpow r (-(1 : ℝ) / 4) := by
+        congr 1
+        ring
+  have hfirst' : HasDerivAt (fun x : ℝ ↦ 2 / x) (-2 / r ^ 2) r := by
+    convert hfirst using 1
+    simp only [id_eq, zero_mul]
+    field_simp [hr0]
+    ring
+  have hmiddle' : HasDerivAt (fun x : ℝ ↦ 2 * x / (1 + x ^ 2))
+      (2 * (1 - r ^ 2) / (1 + r ^ 2) ^ 2) r := by
+    convert hmiddle using 1
+    simp only [Pi.mul_apply, Pi.add_apply, Pi.pow_apply, id_eq,
+      Nat.cast_ofNat, zero_mul, zero_add]
+    field_simp
+    ring
+  have hlast' : HasDerivAt (fun x : ℝ ↦ Real.exp (-(x ^ 2)) *
+      (1 / 4 * Real.rpow x (-(5 : ℝ) / 4) + 2 * Real.rpow x (3 / 4)))
+      (Real.exp (-(r ^ 2)) *
+        (Real.rpow r (-(1 : ℝ) / 4) - 5 / 16 * Real.rpow r (-(9 : ℝ) / 4) -
+          4 * Real.rpow r (7 / 4))) r := by
+    convert hlast using 1
+    simp only [Pi.mul_apply, Pi.add_apply, Pi.neg_apply, Pi.pow_apply, id_eq,
+      Nat.cast_ofNat, zero_mul, zero_add, Real.rpow_eq_pow]
+    norm_num only [Nat.reduceSub, pow_one, mul_one, one_mul]
+    have hseven' : r * r ^ ((3 : ℝ) / 4) = r ^ ((7 : ℝ) / 4) := by
+      simpa only [← Real.rpow_eq_pow] using hseven
+    have hminus' : r * r ^ (-(5 : ℝ) / 4) = r ^ (-(1 : ℝ) / 4) := by
+      simpa only [← Real.rpow_eq_pow] using hminus
+    have hminus'' : r * r ^ (-(5 / 4 : ℝ)) = r ^ (-(1 / 4 : ℝ)) := by
+      convert hminus' using 1 <;> ring
+    rw [← hseven', ← hminus'']
+    ring
+  convert hfirst'.sub hmiddle' |>.add hlast' using 1
+  simp only [counterexampleRadialLogDerivTwo]
+  ring
+
+@[category API, AMS 26]
+private theorem hasDerivAt_counterexampleRadialAmplitude_deriv {r : ℝ} (hr : 0 < r) :
+    HasDerivAt (fun x ↦ counterexampleRadialAmplitude x *
+      counterexampleRadialLogDerivOne x)
+      (counterexampleRadialAmplitude r *
+        (counterexampleRadialLogDerivOne r ^ 2 + counterexampleRadialLogDerivTwo r)) r := by
+  convert (hasDerivAt_counterexampleRadialAmplitude hr).mul
+    (hasDerivAt_counterexampleRadialLogDerivOne hr) using 1
+  ring
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_norm_complex {z : ℂ} (hz : z ≠ 0) :
+    HasFDerivAt (fun w : ℂ ↦ ‖w‖)
+      ((z.re / ‖z‖) • Complex.reCLM + (z.im / ‖z‖) • Complex.imCLM) z := by
+  have hsquare := ((Complex.reCLM.hasFDerivAt (x := z)).pow 2).add
+    ((Complex.imCLM.hasFDerivAt (x := z)).pow 2)
+  have hsquare_ne : z.re ^ 2 + z.im ^ 2 ≠ 0 := by
+    rw [show z.re ^ 2 + z.im ^ 2 = ‖z‖ ^ 2 by
+      rw [Complex.sq_norm, Complex.normSq_apply]
+      ring]
+    positivity
+  have hsqrt := (Real.hasDerivAt_sqrt hsquare_ne).comp_hasFDerivAt z hsquare
+  convert hsqrt using 1
+  · ext w
+    simp only [Function.comp_apply, Pi.add_apply, Complex.reCLM_apply, Complex.imCLM_apply]
+    rw [Complex.norm_def, Complex.normSq_apply]
+    ring
+  · ext v
+    simp [Complex.norm_def, Complex.normSq_apply]
+    field_simp [norm_ne_zero_iff.mpr hz]
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_counterexampleRadialAmplitude_norm {z : ℂ} (hz : z ≠ 0) :
+    HasFDerivAt (fun w : ℂ ↦ counterexampleRadialAmplitude ‖w‖)
+      (((counterexampleRadialAmplitude ‖z‖ * counterexampleRadialLogDerivOne ‖z‖) *
+          z.re / ‖z‖) • Complex.reCLM +
+        ((counterexampleRadialAmplitude ‖z‖ * counterexampleRadialLogDerivOne ‖z‖) *
+          z.im / ‖z‖) • Complex.imCLM) z := by
+  have hr : 0 < ‖z‖ := norm_pos_iff.mpr hz
+  have h := (hasDerivAt_counterexampleRadialAmplitude hr).comp_hasFDerivAt z
+    (hasFDerivAt_norm_complex hz)
+  apply h.congr_fderiv
+  ext v
+  simp
+  ring
+
+@[category API, AMS 26]
+private theorem exists_counterexampleRadialGradient_fderiv {z : ℂ} (hz : z ≠ 0) :
+    ∃ R : ℂ →L[ℝ] ℂ,
+      HasFDerivAt (fun w : ℂ ↦
+        (counterexampleRadialAmplitude ‖w‖ * counterexampleRadialLogDerivOne ‖w‖ : ℂ) *
+          w / ‖w‖) R z ∧
+      R 1 + Complex.I * R Complex.I =
+        (counterexampleRadialAmplitude ‖z‖ *
+          (counterexampleRadialLogDerivOne ‖z‖ ^ 2 +
+            counterexampleRadialLogDerivTwo ‖z‖) : ℂ) * z ^ 2 / ‖z‖ ^ 2 -
+          (counterexampleRadialAmplitude ‖z‖ *
+            counterexampleRadialLogDerivOne ‖z‖ : ℂ) * z ^ 2 / ‖z‖ ^ 3 := by
+  have hr : 0 < ‖z‖ := norm_pos_iff.mpr hz
+  have hnorm := hasFDerivAt_norm_complex hz
+  have hnorm' := Complex.ofRealCLM.hasFDerivAt.comp z hnorm
+  have hAprime := (hasDerivAt_counterexampleRadialAmplitude_deriv hr).comp_hasFDerivAt z hnorm
+  have hAprime' := Complex.ofRealCLM.hasFDerivAt.comp z hAprime
+  have hnormInv := (hasFDerivAt_inv' (𝕜 := ℝ)
+    (Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr hz))).comp z hnorm'
+  have hquotient := (hasFDerivAt_id z).mul hnormInv
+  have hgradient := hAprime'.mul hquotient
+  let Fraw : ℂ → ℂ :=
+    (⇑Complex.ofRealCLM ∘
+      (fun x ↦ counterexampleRadialAmplitude x * counterexampleRadialLogDerivOne x) ∘ norm) *
+      (id * Inv.inv ∘ ⇑Complex.ofRealCLM ∘ fun w : ℂ ↦ ‖w‖)
+  let F : ℂ → ℂ := fun w ↦
+      (counterexampleRadialAmplitude ‖w‖ * counterexampleRadialLogDerivOne ‖w‖ : ℂ) *
+        w / ‖w‖
+  have hF : Fraw = F := by
+    funext w
+    simp [Fraw, F, div_eq_mul_inv]
+    ring
+  have hgradient' : HasFDerivAt Fraw
+      (fderiv ℝ Fraw z) z := by
+    have hdiffRaw : DifferentiableAt ℝ Fraw z := by
+      simpa only [Fraw] using hgradient.differentiableAt
+    exact hdiffRaw.hasFDerivAt
+  have hdiff : DifferentiableAt ℝ F z := by
+    rw [← hF]
+    exact hgradient'.differentiableAt
+  let R : ℂ →L[ℝ] ℂ := fderiv ℝ F z
+  have hR : HasFDerivAt F R z := hdiff.hasFDerivAt
+  refine ⟨R, hR, ?_⟩
+  dsimp only [R]
+  rw [← hF]
+  dsimp only [Fraw]
+  rw [hgradient.fderiv]
+  simp [div_eq_mul_inv]
+  field_simp [norm_ne_zero_iff.mpr hz]
+  apply Complex.ext <;>
+    simp [pow_two, Complex.mul_re, Complex.mul_im] <;>
+    ring
+
+@[category API, AMS 26]
+private theorem counterexamplePrincipalBranch_sq (k : ℕ) (u : ℂ) :
+    (Complex.cpow u ((k : ℂ) / 2)) ^ 2 = u ^ k := by
+  change (u ^ ((k : ℂ) / 2)) ^ (2 : ℕ) = u ^ k
+  rw [← Complex.cpow_mul_nat, ← Complex.cpow_natCast]
+  congr 1
+  push_cast
+  ring
+
+@[category API, AMS 26]
+private theorem counterexampleAlternateBranch_sq (k : ℕ) (u : ℂ) :
+    ((Complex.I ^ k) * Complex.cpow (-u) ((k : ℂ) / 2)) ^ 2 = u ^ k := by
+  rw [mul_pow, counterexamplePrincipalBranch_sq, ← pow_mul]
+  conv_lhs => lhs; rw [show k * 2 = 2 * k by omega]
+  rw [pow_mul, Complex.I_sq, neg_pow u k]
+  have hsign : (-1 : ℂ) ^ k * (-1 : ℂ) ^ k = 1 := by
+    rw [← mul_pow]
+    simp
+  rw [← mul_assoc, hsign, one_mul]
+
+@[category API, AMS 26]
+private theorem cpow_half_nat_eq_or_eq_neg_alt (k : ℕ) (u : ℂ) :
+    Complex.cpow u ((k : ℂ) / 2) =
+        (Complex.I ^ k) * Complex.cpow (-u) ((k : ℂ) / 2) ∨
+      Complex.cpow u ((k : ℂ) / 2) =
+        -((Complex.I ^ k) * Complex.cpow (-u) ((k : ℂ) / 2)) := by
+  apply eq_or_eq_neg_of_sq_eq_sq
+  exact (counterexamplePrincipalBranch_sq k u).trans
+    (counterexampleAlternateBranch_sq k u).symm
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_counterexamplePrincipalBranch (k : ℕ) {z : ℂ} (hz : z ≠ 0)
+    (hslit : 100 / star z ∈ Complex.slitPlane) :
+    HasFDerivAt (fun y : ℂ ↦ Complex.cpow (100 / star y) ((k : ℂ) / 2))
+      ((-((k : ℂ) / 2) * Complex.cpow (100 / star z) ((k : ℂ) / 2) / star z) •
+        (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+  have hstar : HasFDerivAt (fun y : ℂ ↦ star y)
+      (Complex.conjCLE : ℂ →L[ℝ] ℂ) z := by
+    simpa [Complex.conjCLE_apply] using Complex.conjCLE.hasFDerivAt
+  have hstar0 : star z ≠ 0 := (map_ne_zero (starRingEnd ℂ)).mpr hz
+  have hinvComplex : HasDerivAt (fun u : ℂ ↦ 100 / u) (-100 / (star z) ^ 2) (star z) := by
+    convert (hasDerivAt_const (star z) 100).div (hasDerivAt_id (star z)) hstar0 using 1
+    simp only [id_eq, zero_mul]
+    field_simp
+    ring
+  have hinv : HasFDerivAt (fun y : ℂ ↦ 100 / star y)
+      ((-100 / (star z) ^ 2) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+    simpa only [Function.comp_apply] using hinvComplex.comp_hasFDerivAt z hstar
+  have hpowerComplex :=
+    (hasDerivAt_id (100 / star z)).cpow_const (c := (k : ℂ) / 2) hslit
+  let D : ℂ →L[ℝ] ℂ :=
+    ((((k : ℂ) / 2) * Complex.cpow (100 / star z) ((k : ℂ) / 2 - 1)) *
+      (-100 / (star z) ^ 2)) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)
+  have hpower : HasFDerivAt
+      (fun y : ℂ ↦ Complex.cpow (100 / star y) ((k : ℂ) / 2)) D z := by
+    simpa only [D, Function.comp_apply, id_eq, mul_one, smul_smul] using
+      hpowerComplex.comp_hasFDerivAt z hinv
+  apply hpower.congr_fderiv
+  ext v
+  have hu0 : 100 / star z ≠ 0 := div_ne_zero (by norm_num) hstar0
+  dsimp only [D]
+  have hcpow : Complex.cpow (100 / star z) ((k : ℂ) / 2 - 1) =
+      Complex.cpow (100 / star z) ((k : ℂ) / 2) /
+        Complex.cpow (100 / star z) 1 := Complex.cpow_sub _ _ hu0
+  rw [hcpow]
+  simp [Complex.conjCLE_apply]
+  field_simp
+  ring
+  exact Or.inl trivial
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_counterexamplePrincipalBranch_barDeriv (k : ℕ) {z : ℂ}
+    (hz : z ≠ 0) (hslit : 100 / star z ∈ Complex.slitPlane) :
+    HasFDerivAt (fun y : ℂ ↦
+      -((k : ℂ) / 2) * Complex.cpow (100 / star y) ((k : ℂ) / 2) / star y)
+      ((((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) *
+        Complex.cpow (100 / star z) ((k : ℂ) / 2) / (star z) ^ 2) •
+          (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+  have hstar : HasFDerivAt (fun y : ℂ ↦ star y)
+      (Complex.conjCLE : ℂ →L[ℝ] ℂ) z := by
+    simpa [Complex.conjCLE_apply] using Complex.conjCLE.hasFDerivAt
+  have hstar0 : star z ≠ 0 := (map_ne_zero (starRingEnd ℂ)).mpr hz
+  have hbranch := hasFDerivAt_counterexamplePrincipalBranch k hz hslit
+  have hstarInv := (hasFDerivAt_inv' (𝕜 := ℝ) hstar0).comp z hstar
+  have h := ((hasFDerivAt_const (-((k : ℂ) / 2)) z).mul hbranch).mul hstarInv
+  apply h.congr_fderiv
+  ext v
+  simp [Complex.conjCLE_apply, div_eq_mul_inv]
+  field_simp
+  ring
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_counterexampleAlternateBranch (k : ℕ) {z : ℂ} (hz : z ≠ 0)
+    (hslit : -(100 / star z) ∈ Complex.slitPlane) :
+    HasFDerivAt (fun y : ℂ ↦
+      (Complex.I ^ k) * Complex.cpow (-(100 / star y)) ((k : ℂ) / 2))
+      ((-((k : ℂ) / 2) *
+        ((Complex.I ^ k) * Complex.cpow (-(100 / star z)) ((k : ℂ) / 2)) / star z) •
+          (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+  have hslit' : 100 / star (-z) ∈ Complex.slitPlane := by
+    rw [show 100 / star (-z) = -(100 / star z) by simp; ring]
+    exact hslit
+  have hbase := hasFDerivAt_counterexamplePrincipalBranch k (neg_ne_zero.mpr hz) hslit'
+  have hneg := hbase.comp z (hasFDerivAt_id z).neg
+  have hbase_eq (y : ℂ) : 100 / star (-y) = -(100 / star y) := by
+    simp
+    ring
+  have hfun : ((fun y : ℂ ↦ Complex.cpow (100 / star y) ((k : ℂ) / 2)) ∘ Neg.neg) =
+      fun y : ℂ ↦ Complex.cpow (-(100 / star y)) ((k : ℂ) / 2) := by
+    funext y
+    exact congrArg (fun u : ℂ ↦ Complex.cpow u ((k : ℂ) / 2)) (hbase_eq y)
+  have hneg' := hneg.congr_of_eventuallyEq
+    (Filter.Eventually.of_forall fun y ↦ (congrFun hfun y).symm)
+  have hraw := (hasFDerivAt_const (Complex.I ^ k) z).mul hneg'
+  have hmulfun :
+      ((fun _ : ℂ ↦ Complex.I ^ k) *
+        fun y : ℂ ↦ Complex.cpow (-(100 / star y)) ((k : ℂ) / 2)) =
+      fun y : ℂ ↦ (Complex.I ^ k) *
+        Complex.cpow (-(100 / star y)) ((k : ℂ) / 2) := by
+    funext y
+    rfl
+  rw [hmulfun] at hraw
+  apply hraw.congr_fderiv
+  ext v
+  simp [Complex.conjCLE_apply]
+  ring
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_counterexampleAlternateBranch_barDeriv (k : ℕ) {z : ℂ}
+    (hz : z ≠ 0) (hslit : -(100 / star z) ∈ Complex.slitPlane) :
+    HasFDerivAt (fun y : ℂ ↦ -((k : ℂ) / 2) *
+      ((Complex.I ^ k) * Complex.cpow (-(100 / star y)) ((k : ℂ) / 2)) / star y)
+      ((((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) *
+        ((Complex.I ^ k) * Complex.cpow (-(100 / star z)) ((k : ℂ) / 2)) /
+          (star z) ^ 2) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+  have hstar : HasFDerivAt (fun y : ℂ ↦ star y)
+      (Complex.conjCLE : ℂ →L[ℝ] ℂ) z := by
+    simpa [Complex.conjCLE_apply] using Complex.conjCLE.hasFDerivAt
+  have hstar0 : star z ≠ 0 := (map_ne_zero (starRingEnd ℂ)).mpr hz
+  have hbranch := hasFDerivAt_counterexampleAlternateBranch k hz hslit
+  have hstarInv := (hasFDerivAt_inv' (𝕜 := ℝ) hstar0).comp z hstar
+  have h := ((hasFDerivAt_const (-((k : ℂ) / 2)) z).mul hbranch).mul hstarInv
+  apply h.congr_fderiv
+  ext v
+  simp [Complex.conjCLE_apply, div_eq_mul_inv]
+  field_simp
+  ring
+
+@[category API, AMS 26]
+private theorem hasFDerivAt_radial_mul_seed_branch (W B : ℂ → ℂ) {z : ℂ} (hz : z ≠ 0)
+    (hW : HasFDerivAt W ((B z) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z) :
+    let G :=
+      (counterexampleRadialAmplitude ‖z‖ * counterexampleRadialLogDerivOne ‖z‖ : ℂ) *
+          z / ‖z‖ * counterexampleSeed (W z) +
+        2 * counterexampleRadialAmplitude ‖z‖ * seedWirtingerModel (W z) * B z
+    HasFDerivAt (fun y : ℂ ↦ counterexampleRadialAmplitude ‖y‖ * counterexampleSeed (W y))
+      (G.re • Complex.reCLM + G.im • Complex.imCLM) z := by
+  dsimp only
+  have hA := hasFDerivAt_counterexampleRadialAmplitude_norm hz
+  have hseed := (hasFDerivAt_counterexampleSeed (W z)).comp z hW
+  have hWre2 : (2 : ℂ) * ((W z).re : ℂ) = ((2 * (W z).re : ℝ) : ℂ) := by
+    norm_cast
+  have hWim2 : (2 : ℂ) * ((W z).im : ℂ) = ((2 * (W z).im : ℝ) : ℂ) := by
+    norm_cast
+  have hWim4 : (4 : ℂ) * ((W z).im : ℂ) = ((4 * (W z).im : ℝ) : ℂ) := by
+    norm_cast
+  apply (hA.mul hseed).congr_fderiv
+  ext v
+  rw [seedWirtingerModel_eq_gradient]
+  simp [seedGradient, Complex.conjCLE_apply, Complex.mul_re, Complex.mul_im]
+  rw [hWre2, hWim2, hWim4]
+  simp only [Complex.sin_ofReal_re, Complex.sin_ofReal_im,
+    Complex.cos_ofReal_re]
+  ring
+
+@[category API, AMS 26]
+private theorem exists_radial_seed_gradient_fderiv (W B : ℂ → ℂ) (C : ℂ) {z : ℂ}
+    (hz : z ≠ 0)
+    (hW : HasFDerivAt W ((B z) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z)
+    (hB : HasFDerivAt B (C • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z) :
+    let G := fun y : ℂ ↦
+      (counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+          y / ‖y‖ * counterexampleSeed (W y) +
+        2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y
+    ∃ G' : ℂ →L[ℝ] ℂ, HasFDerivAt G G' z ∧
+      G' 1 + Complex.I * G' Complex.I =
+        (counterexampleRadialAmplitude ‖z‖ : ℂ) *
+            star (seedTraceFreeHessianModel (W z)) * B z ^ 2 +
+          4 * counterexampleRadialAmplitude ‖z‖ * seedWirtingerModel (W z) * C +
+          4 * ((counterexampleRadialAmplitude ‖z‖ *
+              counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z / ‖z‖) *
+            seedWirtingerModel (W z) * B z +
+          ((counterexampleRadialAmplitude ‖z‖ *
+                (counterexampleRadialLogDerivOne ‖z‖ ^ 2 +
+                  counterexampleRadialLogDerivTwo ‖z‖) : ℝ) * z ^ 2 / ‖z‖ ^ 2 -
+              (counterexampleRadialAmplitude ‖z‖ *
+                counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z ^ 2 / ‖z‖ ^ 3) *
+            counterexampleSeed (W z) := by
+  dsimp only
+  rcases exists_counterexampleRadialGradient_fderiv hz with ⟨R, hR, hRbar⟩
+  rcases exists_seedWirtingerModel_fderiv (W z) with ⟨Q, hQ, hQbar⟩
+  have hAreal := hasFDerivAt_counterexampleRadialAmplitude_norm hz
+  have hA0 := Complex.ofRealCLM.hasFDerivAt.comp z hAreal
+  have hseedReal := (hasFDerivAt_counterexampleSeed (W z)).comp z hW
+  have hseed0 := Complex.ofRealCLM.hasFDerivAt.comp z hseedReal
+  have hq0 := hQ.comp z hW
+  let DA : ℂ →L[ℝ] ℂ :=
+    fderiv ℝ (fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) z
+  have hA : HasFDerivAt
+      (fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) DA z := by
+    exact (by simpa using hA0.differentiableAt : DifferentiableAt ℝ
+      (fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) z).hasFDerivAt
+  let Dseed : ℂ →L[ℝ] ℂ :=
+    fderiv ℝ (fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) z
+  have hseed : HasFDerivAt
+      (fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) Dseed z := by
+    exact (by simpa using hseed0.differentiableAt : DifferentiableAt ℝ
+      (fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) z).hasFDerivAt
+  let Dq : ℂ →L[ℝ] ℂ := fderiv ℝ (fun y : ℂ ↦ seedWirtingerModel (W y)) z
+  have hq : HasFDerivAt (fun y : ℂ ↦ seedWirtingerModel (W y)) Dq z := by
+    exact (by simpa using hq0.differentiableAt : DifferentiableAt ℝ
+      (fun y : ℂ ↦ seedWirtingerModel (W y)) z).hasFDerivAt
+  have hone0 := hR.mul hseed
+  have htwo0 := (hasFDerivAt_const (2 : ℂ) z).mul ((hA.mul hq).mul hB)
+  let Done : ℂ →L[ℝ] ℂ := fderiv ℝ (fun y : ℂ ↦
+    ((counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+      y / ‖y‖) * counterexampleSeed (W y)) z
+  have hone : HasFDerivAt (fun y : ℂ ↦
+      ((counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+        y / ‖y‖) * counterexampleSeed (W y)) Done z := by
+    exact (by simpa using hone0.differentiableAt : DifferentiableAt ℝ (fun y : ℂ ↦
+      ((counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+        y / ‖y‖) * counterexampleSeed (W y)) z).hasFDerivAt
+  let Dtwo : ℂ →L[ℝ] ℂ := fderiv ℝ (fun y : ℂ ↦
+    2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y) z
+  have htwo : HasFDerivAt (fun y : ℂ ↦
+      2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y)
+      Dtwo z := by
+    exact (by simpa [mul_assoc] using htwo0.differentiableAt : DifferentiableAt ℝ
+      (fun y : ℂ ↦
+        2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y) z).hasFDerivAt
+  have hG0 := hone.add htwo
+  let DG : ℂ →L[ℝ] ℂ := Done + Dtwo
+  have hG : HasFDerivAt (fun y : ℂ ↦
+      (counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+          y / ‖y‖ * counterexampleSeed (W y) +
+        2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y)
+      DG z := by
+    simpa only [DG, Pi.add_apply, mul_assoc] using hG0
+  have hAbar : DA 1 + Complex.I * DA Complex.I =
+      (counterexampleRadialAmplitude ‖z‖ *
+        counterexampleRadialLogDerivOne ‖z‖ : ℂ) * z / ‖z‖ := by
+    let DA0 : ℂ →L[ℝ] ℂ := Complex.ofRealCLM.comp
+      ((((counterexampleRadialAmplitude ‖z‖ * counterexampleRadialLogDerivOne ‖z‖) *
+            z.re / ‖z‖) • Complex.reCLM) +
+        (((counterexampleRadialAmplitude ‖z‖ * counterexampleRadialLogDerivOne ‖z‖) *
+            z.im / ‖z‖) • Complex.imCLM))
+    have hA0' : HasFDerivAt
+        (fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) DA0 z := by
+      simpa only [DA0, Function.comp_apply] using hA0
+    have hDA : DA = DA0 := hA.unique hA0'
+    rw [hDA]
+    simp [DA0, Complex.ofRealCLM_apply, Complex.reCLM_apply, Complex.imCLM_apply]
+    calc
+      _ = (counterexampleRadialAmplitude ‖z‖ *
+            counterexampleRadialLogDerivOne ‖z‖ : ℂ) *
+          ((z.re : ℂ) + (z.im : ℂ) * Complex.I) / ‖z‖ := by ring
+      _ = _ := by rw [Complex.re_add_im]
+  have hseedbar : Dseed 1 + Complex.I * Dseed Complex.I =
+      2 * seedWirtingerModel (W z) * B z := by
+    have hcombine (a b x : ℂ) :
+        a * (x.re : ℂ) + b * (x.im : ℂ) +
+            Complex.I * (a * (x.im : ℂ) + -(b * (x.re : ℂ))) =
+          2 * ((a - b * Complex.I) / 2) * x := by
+      apply Complex.ext <;>
+        simp [Complex.mul_re, Complex.mul_im] <;>
+        ring
+    let Dseed0 : ℂ →L[ℝ] ℂ := Complex.ofRealCLM.comp
+      ((seedGradient (W z)).comp
+        ((B z) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)))
+    have hseed0' : HasFDerivAt
+        (fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) Dseed0 z := by
+      simpa only [Dseed0, Function.comp_apply] using hseed0
+    have hDseed : Dseed = Dseed0 := hseed.unique hseed0'
+    rw [hDseed, seedWirtingerModel_eq_gradient]
+    simp [Dseed0, seedGradient, Complex.ofRealCLM_apply, Complex.conjCLE_apply,
+      Complex.mul_re, Complex.mul_im]
+    exact hcombine _ _ _
+  have hqbar : Dq 1 + Complex.I * Dq Complex.I =
+      B z * star (seedTraceFreeHessianModel (W z)) / 2 := by
+    let Dq0 : ℂ →L[ℝ] ℂ := Q.comp
+      ((B z) • (Complex.conjCLE : ℂ →L[ℝ] ℂ))
+    have hq0' : HasFDerivAt (fun y : ℂ ↦ seedWirtingerModel (W y)) Dq0 z := by
+      simpa only [Dq0, Function.comp_apply] using hq0
+    have hDqone : Dq0 1 = Q (B z) := by
+      simp [Dq0, Complex.conjCLE_apply]
+    have hDqI : Dq0 Complex.I = Q (-Complex.I * B z) := by
+      dsimp only [Dq0]
+      simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smul_apply, smul_eq_mul]
+      rw [show (Complex.conjCLE : ℂ →L[ℝ] ℂ) Complex.I = -Complex.I by
+        simp [Complex.conjCLE_apply]]
+      congr 1
+      ring
+    have hDq : Dq = Dq0 := hq.unique hq0'
+    rw [hDq]
+    rw [hDqone, hDqI]
+    exact hQbar (B z)
+  have hBbar : (C • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) 1 +
+      Complex.I * (C • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) Complex.I = 2 * C := by
+    simp [Complex.conjCLE_apply]
+    rw [show Complex.I * (C * Complex.I) = -C by
+      rw [show Complex.I * (C * Complex.I) = C * Complex.I ^ 2 by ring,
+        Complex.I_sq]
+      ring]
+    ring
+  have honebar : Done 1 + Complex.I * Done Complex.I =
+      ((counterexampleRadialAmplitude ‖z‖ *
+            (counterexampleRadialLogDerivOne ‖z‖ ^ 2 +
+              counterexampleRadialLogDerivTwo ‖z‖) : ℝ) * z ^ 2 / ‖z‖ ^ 2 -
+          (counterexampleRadialAmplitude ‖z‖ *
+            counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z ^ 2 / ‖z‖ ^ 3) *
+        counterexampleSeed (W z) +
+      2 * ((counterexampleRadialAmplitude ‖z‖ *
+          counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z / ‖z‖) *
+        seedWirtingerModel (W z) * B z := by
+    let Done0 : ℂ →L[ℝ] ℂ := fderiv ℝ
+      ((fun y : ℂ ↦
+        (counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+          y / ‖y‖) * fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) z
+    have hone0Raw : HasFDerivAt
+        ((fun y : ℂ ↦
+          (counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+            y / ‖y‖) * fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) Done0 z := by
+      exact hone0.differentiableAt.hasFDerivAt
+    have honeFun :
+        ((fun y : ℂ ↦
+          (counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+            y / ‖y‖) * fun y : ℂ ↦ (counterexampleSeed (W y) : ℂ)) =
+        fun y : ℂ ↦
+          ((counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+            y / ‖y‖) * counterexampleSeed (W y) := by
+      rfl
+    have hone0' : HasFDerivAt (fun y : ℂ ↦
+        ((counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+          y / ‖y‖) * counterexampleSeed (W y)) Done0 z := by
+      rw [← honeFun]
+      exact hone0Raw
+    have hDone : Done = Done0 := hone.unique hone0'
+    rw [hDone]
+    dsimp only [Done0]
+    rw [hone0.fderiv]
+    simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+      smul_eq_mul]
+    rw [show
+      ((counterexampleRadialAmplitude ‖z‖ * counterexampleRadialLogDerivOne ‖z‖ : ℂ) *
+          z / ‖z‖) * Dseed 1 + (counterexampleSeed (W z) : ℂ) * R 1 +
+          Complex.I *
+            (((counterexampleRadialAmplitude ‖z‖ *
+                counterexampleRadialLogDerivOne ‖z‖ : ℂ) * z / ‖z‖) *
+                Dseed Complex.I + (counterexampleSeed (W z) : ℂ) * R Complex.I) =
+        ((counterexampleRadialAmplitude ‖z‖ *
+            counterexampleRadialLogDerivOne ‖z‖ : ℂ) * z / ‖z‖) *
+            (Dseed 1 + Complex.I * Dseed Complex.I) +
+          (counterexampleSeed (W z) : ℂ) *
+            (R 1 + Complex.I * R Complex.I) by ring]
+    rw [hRbar, hseedbar]
+    simp only [Complex.ofReal_mul, Complex.ofReal_add, Complex.ofReal_pow]
+    ring
+  have htwobar : Dtwo 1 + Complex.I * Dtwo Complex.I =
+      (counterexampleRadialAmplitude ‖z‖ : ℂ) *
+          star (seedTraceFreeHessianModel (W z)) * B z ^ 2 +
+        4 * counterexampleRadialAmplitude ‖z‖ * seedWirtingerModel (W z) * C +
+        2 * ((counterexampleRadialAmplitude ‖z‖ *
+            counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z / ‖z‖) *
+          seedWirtingerModel (W z) * B z := by
+    let Dtwo0 : ℂ →L[ℝ] ℂ := fderiv ℝ
+      ((fun _ : ℂ ↦ (2 : ℂ)) *
+        (((fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) *
+          fun y : ℂ ↦ seedWirtingerModel (W y)) * B)) z
+    have htwo0Raw : HasFDerivAt
+        ((fun _ : ℂ ↦ (2 : ℂ)) *
+          (((fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) *
+            fun y : ℂ ↦ seedWirtingerModel (W y)) * B)) Dtwo0 z := by
+      exact htwo0.differentiableAt.hasFDerivAt
+    have htwoFun :
+        ((fun _ : ℂ ↦ (2 : ℂ)) *
+          (((fun y : ℂ ↦ (counterexampleRadialAmplitude ‖y‖ : ℂ)) *
+            fun y : ℂ ↦ seedWirtingerModel (W y)) * B)) =
+        fun y : ℂ ↦
+          2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y := by
+      funext y
+      simp only [Pi.mul_apply]
+      ring
+    have htwo0' : HasFDerivAt (fun y : ℂ ↦
+        2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y) Dtwo0 z := by
+      rw [← htwoFun]
+      exact htwo0Raw
+    have hDtwo : Dtwo = Dtwo0 := htwo.unique htwo0'
+    rw [hDtwo]
+    dsimp only [Dtwo0]
+    rw [htwo0.fderiv]
+    simp only [ContinuousLinearMap.add_apply, ContinuousLinearMap.smul_apply,
+      smul_eq_mul, Pi.mul_apply, ContinuousLinearMap.zero_apply, mul_zero, add_zero]
+    have hBbar' : C * (Complex.conjCLE : ℂ →L[ℝ] ℂ) 1 +
+        Complex.I * (C * (Complex.conjCLE : ℂ →L[ℝ] ℂ) Complex.I) = 2 * C := by
+      simpa only [ContinuousLinearMap.smul_apply, smul_eq_mul] using hBbar
+    rw [show
+      2 * ((counterexampleRadialAmplitude ‖z‖ : ℂ) * seedWirtingerModel (W z) *
+            (C * (Complex.conjCLE : ℂ →L[ℝ] ℂ) 1) +
+          B z * ((counterexampleRadialAmplitude ‖z‖ : ℂ) * Dq 1 +
+            seedWirtingerModel (W z) * DA 1)) +
+        Complex.I *
+          (2 * ((counterexampleRadialAmplitude ‖z‖ : ℂ) * seedWirtingerModel (W z) *
+              (C * (Complex.conjCLE : ℂ →L[ℝ] ℂ) Complex.I) +
+            B z * ((counterexampleRadialAmplitude ‖z‖ : ℂ) * Dq Complex.I +
+              seedWirtingerModel (W z) * DA Complex.I))) =
+        2 * ((counterexampleRadialAmplitude ‖z‖ : ℂ) * seedWirtingerModel (W z)) *
+            (C * (Complex.conjCLE : ℂ →L[ℝ] ℂ) 1 +
+              Complex.I * (C * (Complex.conjCLE : ℂ →L[ℝ] ℂ) Complex.I)) +
+          2 * B z *
+            ((counterexampleRadialAmplitude ‖z‖ : ℂ) *
+                (Dq 1 + Complex.I * Dq Complex.I) +
+              seedWirtingerModel (W z) * (DA 1 + Complex.I * DA Complex.I)) by ring,
+      hBbar', hqbar, hAbar]
+    simp only [Complex.ofReal_mul]
+    ring
+  have hDG : DG = Done + Dtwo := by
+    rfl
+  refine ⟨DG, hG, ?_⟩
+  rw [hDG]
+  simp only [ContinuousLinearMap.add_apply]
+  rw [show Done 1 + Dtwo 1 + Complex.I * (Done Complex.I + Dtwo Complex.I) =
+    (Done 1 + Complex.I * Done Complex.I) +
+      (Dtwo 1 + Complex.I * Dtwo Complex.I) by ring,
+    honebar, htwobar]
+  ring
+
+@[category API, AMS 26]
+private theorem traceFreeHessian_radial_mul_seed_branch (W B : ℂ → ℂ) (C : ℂ) (D : ℝ)
+    {z : ℂ} (hz : z ≠ 0)
+    (hW : ∀ᶠ y in 𝓝 z,
+      HasFDerivAt W ((B y) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) y)
+    (hB : HasFDerivAt B (C • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z) :
+    traceFreeHessian
+      (fun y : ℂ ↦ counterexampleRadialAmplitude ‖y‖ * counterexampleSeed (W y) + D) z =
+        (counterexampleRadialAmplitude ‖z‖ : ℂ) *
+            star (seedTraceFreeHessianModel (W z)) * B z ^ 2 +
+          4 * counterexampleRadialAmplitude ‖z‖ * seedWirtingerModel (W z) * C +
+          4 * ((counterexampleRadialAmplitude ‖z‖ *
+              counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z / ‖z‖) *
+            seedWirtingerModel (W z) * B z +
+          ((counterexampleRadialAmplitude ‖z‖ *
+                (counterexampleRadialLogDerivOne ‖z‖ ^ 2 +
+                  counterexampleRadialLogDerivTwo ‖z‖) : ℝ) * z ^ 2 / ‖z‖ ^ 2 -
+              (counterexampleRadialAmplitude ‖z‖ *
+                counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z ^ 2 / ‖z‖ ^ 3) *
+            counterexampleSeed (W z) := by
+  let G := fun y : ℂ ↦
+    (counterexampleRadialAmplitude ‖y‖ * counterexampleRadialLogDerivOne ‖y‖ : ℂ) *
+        y / ‖y‖ * counterexampleSeed (W y) +
+      2 * counterexampleRadialAmplitude ‖y‖ * seedWirtingerModel (W y) * B y
+  have hWz := hW.self_of_nhds
+  rcases exists_radial_seed_gradient_fderiv W B C hz hWz hB with ⟨G', hG, hGbar⟩
+  have hfirst : ∀ᶠ y in 𝓝 z, HasFDerivAt
+      (fun y : ℂ ↦ counterexampleRadialAmplitude ‖y‖ * counterexampleSeed (W y) + D)
+      ((G y).re • Complex.reCLM + (G y).im • Complex.imCLM) y := by
+    filter_upwards [hW, eventually_ne_nhds hz] with y hWy hy
+    simpa [G] using (hasFDerivAt_radial_mul_seed_branch W B hy hWy).add_const D
+  have hre := Complex.reCLM.hasFDerivAt.comp z hG
+  have him := Complex.imCLM.hasFDerivAt.comp z hG
+  have hgradient := (hre.smul_const Complex.reCLM).add (him.smul_const Complex.imCLM)
+  have hfirst' : fderiv ℝ
+      (fun y : ℂ ↦ counterexampleRadialAmplitude ‖y‖ * counterexampleSeed (W y) + D) =ᶠ[𝓝 z]
+      (fun y ↦ (G y).re • Complex.reCLM + (G y).im • Complex.imCLM) :=
+    hfirst.mono fun _ hy ↦ hy.fderiv
+  have hsymm : (G' Complex.I).re = (G' 1).im := by
+    have h := second_derivative_symmetric_of_eventually_of_real hfirst hgradient
+      (1 : ℂ) Complex.I
+    simpa using h.symm
+  rw [traceFreeHessian, (hgradient.congr_of_eventuallyEq hfirst').fderiv]
+  simp
+  have hcontract :
+      ((G' 1).re : ℂ) - ((G' Complex.I).im : ℂ) +
+          2 * ((G' 1).im : ℂ) * Complex.I = G' 1 + Complex.I * G' Complex.I := by
+    apply Complex.ext <;> simp [hsymm] <;> ring
+  rw [hcontract, hGbar]
+  push_cast
+  simp only [starRingEnd_apply]
+
+/-- The dominant part of the trace-free Hessian on the punctured plane. -/
+private noncomputable def counterexampleHessianLeading (k : ℕ) (z : ℂ) : ℂ :=
+  let r := ‖z‖
+  let w := Complex.cpow (100 / star z) ((k : ℂ) / 2)
+  (counterexampleRadialAmplitude r : ℂ) * star (seedTraceFreeHessianModel w) *
+    (-((k : ℂ) / 2) * w / star z) ^ 2
+
+/-- The lower-order part of the trace-free Hessian on a local analytic branch. -/
+private noncomputable def counterexampleHessianError (k : ℕ) (z : ℂ) : ℂ :=
+  let r := ‖z‖
+  let w := Complex.cpow (100 / star z) ((k : ℂ) / 2)
+  let wbar := -((k : ℂ) / 2) * w / star z
+  let wbarbar := ((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) * w / (star z) ^ 2
+  let A := counterexampleRadialAmplitude r
+  let L₁ := counterexampleRadialLogDerivOne r
+  let L₂ := counterexampleRadialLogDerivTwo r
+  let Abar : ℂ := (A * L₁ : ℝ) * z / (2 * r)
+  let Abarbar : ℂ :=
+    (A * (L₁ ^ 2 + L₂) : ℝ) * z ^ 2 / (4 * r ^ 2) -
+      (A * L₁ : ℝ) * z ^ 2 / (4 * r ^ 3)
+  4 * A * seedWirtingerModel w * wbarbar +
+    8 * Abar * seedWirtingerModel w * wbar +
+    4 * Abarbar * counterexampleSeed w
+
+@[category API, AMS 26]
+private theorem counterexampleRadialAmplitude_pos {r : ℝ} (hr : 0 < r) :
+    0 < counterexampleRadialAmplitude r := by
+  simp only [counterexampleRadialAmplitude]
+  positivity
+
+/-- A radial upper bound for the three lower-order Hessian terms. -/
+@[category API, AMS 26]
+private theorem counterexampleHessianError_raw_bound (k : ℕ) (hk : 0 < k) {z : ℂ}
+    (hz : z ≠ 0) (hz1 : ‖z‖ ≤ 1) :
+    ‖counterexampleHessianError k z‖ ≤
+      counterexampleRadialAmplitude ‖z‖ * (129 / 20) * ((k : ℝ) / 2) *
+          (((k : ℝ) / 2) + 1) *
+          ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖ / ‖z‖ ^ 2 +
+        counterexampleRadialAmplitude ‖z‖ * (903 / 20) * ((k : ℝ) / 2) *
+          ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖ *
+          ‖z‖ ^ (-(9 : ℝ) / 4) +
+        counterexampleRadialAmplitude ‖z‖ * (8349 / 80) *
+          ‖z‖ ^ (-(5 : ℝ) / 2) := by
+  let r := ‖z‖
+  let p := (k : ℝ) / 2
+  let w := Complex.cpow (100 / star z) ((k : ℂ) / 2)
+  let A := counterexampleRadialAmplitude r
+  let L₁ := counterexampleRadialLogDerivOne r
+  let L₂ := counterexampleRadialLogDerivTwo r
+  have hr : 0 < r := by simpa only [r] using norm_pos_iff.mpr hz
+  have hp : 0 < p := by
+    dsimp only [p]
+    positivity
+  have hA : 0 < A := by exact counterexampleRadialAmplitude_pos hr
+  have hL := counterexampleRadialLogDeriv_bounds hr (by simpa only [r] using hz1)
+  have hwbar : ‖-((k : ℂ) / 2) * w / star z‖ = p * ‖w‖ / r := by
+    have hpCast : ((k : ℂ) / 2) = ((p : ℝ) : ℂ) := by
+      dsimp only [p]
+      push_cast
+      ring
+    rw [hpCast]
+    simp only [norm_div, norm_mul, norm_neg, norm_star, Complex.norm_real,
+      Real.norm_eq_abs, abs_of_pos hp, show ‖z‖ = r by rfl]
+  have hwbarbar :
+      ‖((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) * w / (star z) ^ 2‖ =
+        p * (p + 1) * ‖w‖ / r ^ 2 := by
+    have hpCast : ((k : ℂ) / 2) = ((p : ℝ) : ℂ) := by
+      dsimp only [p]
+      push_cast
+      ring
+    rw [hpCast, show ((p : ℂ) + 1) = (((p + 1 : ℝ) : ℂ)) by push_cast; ring]
+    simp only [norm_div, norm_mul, norm_pow, norm_star, Complex.norm_real,
+      Real.norm_eq_abs, abs_of_pos hp, abs_of_pos (by positivity : 0 < p + 1),
+      show ‖z‖ = r by rfl]
+  let Abar : ℂ := (A * L₁ : ℝ) * z / (2 * r)
+  let Abarbar : ℂ :=
+    (A * (L₁ ^ 2 + L₂) : ℝ) * z ^ 2 / (4 * r ^ 2) -
+      (A * L₁ : ℝ) * z ^ 2 / (4 * r ^ 3)
+  have hAbar : ‖Abar‖ ≤ A * (7 / 2) * r ^ (-(5 : ℝ) / 4) := by
+    have hAbarNorm : ‖Abar‖ = A * |L₁| / 2 := by
+      dsimp only [Abar]
+      rw [norm_div, norm_mul, norm_mul, Complex.norm_real,
+        Real.norm_eq_abs, abs_mul, abs_of_pos hA,
+        show ‖z‖ = r by rfl]
+      simp only [Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr]
+      norm_num
+      field_simp [hr.ne']
+    rw [hAbarNorm]
+    calc
+      A * |L₁| / 2 ≤ A * (7 * r ^ (-(5 : ℝ) / 4)) / 2 := by
+        exact div_le_div_of_nonneg_right (mul_le_mul_of_nonneg_left hL.1 hA.le) (by norm_num)
+      _ = A * (7 / 2) * r ^ (-(5 : ℝ) / 4) := by ring
+  have hpowNineFive : r ^ (-(9 : ℝ) / 4) ≤ r ^ (-(5 : ℝ) / 2) :=
+    Real.rpow_le_rpow_of_exponent_ge hr (by simpa only [r] using hz1) (by norm_num)
+  have hpowSquare : (r ^ (-(5 : ℝ) / 4)) ^ 2 = r ^ (-(5 : ℝ) / 2) := by
+    rw [← Real.rpow_mul_natCast hr.le]
+    congr 1
+    ring
+  have hAbarbar : ‖Abarbar‖ ≤ A * (66 / 4) * r ^ (-(5 : ℝ) / 2) := by
+    calc
+      ‖Abarbar‖ ≤
+          ‖(A * (L₁ ^ 2 + L₂) : ℝ) * z ^ 2 / (4 * r ^ 2)‖ +
+            ‖(A * L₁ : ℝ) * z ^ 2 / (4 * r ^ 3)‖ := by
+        exact norm_sub_le _ _
+      _ = A / 4 * (|L₁ ^ 2 + L₂| + |L₁| / r) := by
+        rw [norm_div, norm_div, norm_mul, norm_mul, norm_mul, norm_mul,
+          Complex.norm_real, Complex.norm_real, norm_pow, norm_pow,
+          Real.norm_eq_abs, Real.norm_eq_abs, abs_mul, abs_mul,
+          abs_of_pos hA, show ‖z‖ = r by rfl]
+        simp only [Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr]
+        norm_num
+        field_simp [hr.ne']
+        rw [abs_of_pos hr]
+        ring
+      _ ≤ A / 4 *
+          ((7 * r ^ (-(5 : ℝ) / 4)) ^ 2 +
+            10 * r ^ (-(9 : ℝ) / 4) +
+            7 * r ^ (-(5 : ℝ) / 4) / r) := by
+        gcongr
+        · exact (abs_add_le _ _).trans <| add_le_add
+            (by simpa only [abs_pow] using pow_le_pow_left₀ (abs_nonneg L₁) hL.1 2)
+            hL.2
+        · exact hL.1
+      _ ≤ A * (66 / 4) * r ^ (-(5 : ℝ) / 2) := by
+        have hdiv : r ^ (-(5 : ℝ) / 4) / r = r ^ (-(9 : ℝ) / 4) := by
+          have h := Real.rpow_sub hr (-(5 : ℝ) / 4) 1
+          rw [Real.rpow_one] at h
+          rw [← h]
+          congr 1
+          ring
+        rw [mul_pow, hpowSquare]
+        have hsum : 7 ^ 2 * r ^ (-(5 : ℝ) / 2) +
+            10 * r ^ (-(9 : ℝ) / 4) + 7 * r ^ (-(9 : ℝ) / 4) ≤
+            66 * r ^ (-(5 : ℝ) / 2) := by
+          nlinarith only [hpowNineFive]
+        calc
+          A / 4 * (7 ^ 2 * r ^ (-(5 : ℝ) / 2) +
+              10 * r ^ (-(9 : ℝ) / 4) + 7 * r ^ (-(5 : ℝ) / 4) / r) =
+              A / 4 * (7 ^ 2 * r ^ (-(5 : ℝ) / 2) +
+                10 * r ^ (-(9 : ℝ) / 4) + 7 * (r ^ (-(5 : ℝ) / 4) / r)) := by
+            ring
+          _ = A / 4 * (7 ^ 2 * r ^ (-(5 : ℝ) / 2) +
+              10 * r ^ (-(9 : ℝ) / 4) + 7 * r ^ (-(9 : ℝ) / 4)) := by rw [hdiv]
+          _ ≤ A / 4 * (66 * r ^ (-(5 : ℝ) / 2)) :=
+            mul_le_mul_of_nonneg_left hsum (by positivity)
+          _ = _ := by ring
+  have htermOne :
+      ‖4 * A * seedWirtingerModel w *
+          (((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) * w / (star z) ^ 2)‖ ≤
+        A * (129 / 20) * p * (p + 1) * ‖w‖ / r ^ 2 := by
+    rw [norm_mul, norm_mul, norm_mul, hwbarbar]
+    norm_num [abs_of_pos hA]
+    calc
+      4 * A * ‖seedWirtingerModel w‖ * (p * (p + 1) * ‖w‖ / r ^ 2) ≤
+          4 * A * (129 / 80) * (p * (p + 1) * ‖w‖ / r ^ 2) := by
+        gcongr
+        exact norm_seedWirtingerModel_le w
+      _ = _ := by ring
+  have htermTwo :
+      ‖8 * Abar * seedWirtingerModel w * (-((k : ℂ) / 2) * w / star z)‖ ≤
+        A * (903 / 20) * p * ‖w‖ * r ^ (-(9 : ℝ) / 4) := by
+    rw [norm_mul, norm_mul, norm_mul, hwbar]
+    norm_num
+    calc
+      8 * ‖Abar‖ * ‖seedWirtingerModel w‖ * (p * ‖w‖ / r) ≤
+          8 * (A * (7 / 2) * r ^ (-(5 : ℝ) / 4)) * (129 / 80) *
+            (p * ‖w‖ / r) := by gcongr; exact norm_seedWirtingerModel_le w
+      _ = A * (903 / 20) * p * ‖w‖ * r ^ (-(9 / 4 : ℝ)) := by
+        have hdiv : r ^ (-(5 : ℝ) / 4) / r = r ^ (-(9 : ℝ) / 4) := by
+          have h := Real.rpow_sub hr (-(5 : ℝ) / 4) 1
+          rw [Real.rpow_one] at h
+          rw [← h]
+          congr 1
+          ring
+        have hExp : r ^ (-(9 : ℝ) / 4) = r ^ (-(9 / 4 : ℝ)) := by
+          congr 1
+          ring
+        have hdiv' : r ^ (-(5 : ℝ) / 4) / r = r ^ (-(9 / 4 : ℝ)) :=
+          hdiv.trans hExp
+        calc
+          8 * (A * (7 / 2) * r ^ (-(5 : ℝ) / 4)) * (129 / 80) *
+              (p * ‖w‖ / r) =
+              A * (903 / 20) * p * ‖w‖ *
+                (r ^ (-(5 : ℝ) / 4) / r) := by ring
+          _ = A * (903 / 20) * p * ‖w‖ * r ^ (-(9 / 4 : ℝ)) :=
+            congrArg (fun x : ℝ ↦ A * (903 / 20) * p * ‖w‖ * x) hdiv'
+  have htermThree : ‖4 * Abarbar * counterexampleSeed w‖ ≤
+      A * (8349 / 80) * r ^ (-(5 : ℝ) / 2) := by
+    rw [norm_mul, norm_mul, Complex.norm_real, Real.norm_eq_abs]
+    norm_num
+    calc
+      4 * ‖Abarbar‖ * |counterexampleSeed w| ≤
+          4 * (A * (66 / 4) * r ^ (-(5 : ℝ) / 2)) * (253 / 160) := by
+        gcongr
+        exact counterexampleSeed_abs_le w
+      _ = _ := by ring
+  simp only [counterexampleHessianError]
+  dsimp only [r, p, w, A, L₁, L₂, Abar, Abarbar] at *
+  calc
+    ‖4 * counterexampleRadialAmplitude ‖z‖ *
+          seedWirtingerModel (Complex.cpow (100 / star z) ((k : ℂ) / 2)) *
+          (((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) *
+            Complex.cpow (100 / star z) ((k : ℂ) / 2) / (star z) ^ 2) +
+        8 * ((counterexampleRadialAmplitude ‖z‖ *
+              counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z / (2 * ‖z‖)) *
+          seedWirtingerModel (Complex.cpow (100 / star z) ((k : ℂ) / 2)) *
+          (-((k : ℂ) / 2) * Complex.cpow (100 / star z) ((k : ℂ) / 2) / star z) +
+        4 * ((counterexampleRadialAmplitude ‖z‖ *
+              (counterexampleRadialLogDerivOne ‖z‖ ^ 2 +
+                counterexampleRadialLogDerivTwo ‖z‖) : ℝ) * z ^ 2 /
+              (4 * ‖z‖ ^ 2) -
+            (counterexampleRadialAmplitude ‖z‖ *
+              counterexampleRadialLogDerivOne ‖z‖ : ℝ) * z ^ 2 /
+              (4 * ‖z‖ ^ 3)) *
+          counterexampleSeed (Complex.cpow (100 / star z) ((k : ℂ) / 2))‖ ≤
+        _ := (norm_add_le _ _).trans (add_le_add (norm_add_le _ _) le_rfl)
+    _ ≤ _ := add_le_add (add_le_add htermOne htermTwo) htermThree
+
+@[category API, AMS 26]
+private theorem counterexampleBranch_norm (k : ℕ) (z : ℂ) :
+    ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖ =
+      (100 / ‖z‖) ^ ((k : ℝ) / 2) := by
+  rw [Complex.cpow_eq_pow,
+    show ((k : ℂ) / 2) = (((k : ℝ) / 2 : ℝ) : ℂ) by push_cast; ring,
+    Complex.norm_cpow_real, norm_div, norm_star]
+  norm_num
+
+@[category API, AMS 26]
+private theorem counterexampleHessianLeading_lower_bound (k : ℕ) (hk : 0 < k) {z : ℂ}
+    (hz : z ≠ 0) :
+    counterexampleRadialAmplitude ‖z‖ * (7 / 50) *
+        (((k : ℝ) / 2) ^ 2 *
+          ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖ ^ 2 / ‖z‖ ^ 2) ≤
+      ‖counterexampleHessianLeading k z‖ := by
+  have hk0 : (0 : ℝ) ≤ k := by positivity
+  have hA := counterexampleRadialAmplitude_pos (norm_pos_iff.mpr hz)
+  have hsquare :
+      ((k : ℝ) / 2) ^ 2 *
+          ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖ ^ 2 / ‖z‖ ^ 2 =
+        (((k : ℝ) / 2) *
+          ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖ / ‖z‖) ^ 2 := by
+    ring
+  rw [hsquare]
+  simp only [counterexampleHessianLeading, norm_mul, norm_star, norm_pow, norm_neg,
+    norm_div, Complex.norm_natCast, Complex.norm_real, Real.norm_eq_abs]
+  norm_num [abs_of_nonneg hk0]
+  rw [abs_of_pos hA]
+  gcongr
+  exact seven_div_fifty_le_norm_seedTraceFreeHessianModel _
+
+@[category API, AMS 26]
+private theorem counterexampleHessianLeading_ne_zero (k : ℕ) (hk : 0 < k) {z : ℂ}
+    (hz : z ≠ 0) : counterexampleHessianLeading k z ≠ 0 := by
+  rw [← norm_pos_iff]
+  have hW : Complex.cpow (100 / star z) ((k : ℂ) / 2) ≠ 0 :=
+    Complex.cpow_ne_zero_iff.mpr <| Or.inl <|
+      div_ne_zero (by norm_num) ((map_ne_zero (starRingEnd ℂ)).mpr hz)
+  have hlower := counterexampleHessianLeading_lower_bound k hk hz
+  refine lt_of_lt_of_le ?_ hlower
+  have hk' : (0 : ℝ) < k := by exact_mod_cast hk
+  have hA := counterexampleRadialAmplitude_pos (norm_pos_iff.mpr hz)
+  positivity
+
+/-- The three error terms are bounded by the leading term times a sum of positive powers of
+the radius. -/
+@[category API, AMS 26]
+private theorem counterexampleHessianError_le_leading_mul_ratio (k : ℕ) (hk : 0 < k)
+    {z : ℂ} (hz : z ≠ 0) (hz_one : ‖z‖ ≤ 1) :
+    ‖counterexampleHessianError k z‖ ≤ ‖counterexampleHessianLeading k z‖ *
+      (140 * ‖z‖ ^ ((k : ℝ) / 2) +
+        645 * ‖z‖ ^ ((k : ℝ) / 2 - 1 / 4) +
+        3000 * ‖z‖ ^ ((k : ℝ) - 1 / 2)) := by
+  let r := ‖z‖
+  let p := (k : ℝ) / 2
+  let W := ‖Complex.cpow (100 / star z) ((k : ℂ) / 2)‖
+  let A := counterexampleRadialAmplitude r
+  let D := A * (7 / 50) * (p ^ 2 * W ^ 2 / r ^ 2)
+  have hr : 0 < r := by simpa only [r] using norm_pos_iff.mpr hz
+  have hkR : (1 : ℝ) ≤ k := by exact_mod_cast hk
+  have hp : (1 : ℝ) / 2 ≤ p := by
+    dsimp only [p]
+    linarith
+  have hp0 : 0 < p := lt_of_lt_of_le (by norm_num) hp
+  have hA : 0 < A := counterexampleRadialAmplitude_pos hr
+  have hW : 0 < W := by
+    dsimp only [W]
+    rw [norm_pos_iff]
+    exact Complex.cpow_ne_zero_iff.mpr <| Or.inl <|
+      div_ne_zero (by norm_num) ((map_ne_zero (starRingEnd ℂ)).mpr hz)
+  have hscale : 1 ≤ r ^ p * W := by
+    calc
+      1 ≤ (100 : ℝ) ^ p := Real.one_le_rpow (by norm_num) hp0.le
+      _ = r ^ p * (100 / r) ^ p := by
+        rw [Real.div_rpow (by norm_num) hr.le]
+        field_simp [(Real.rpow_pos_of_pos hr p).ne']
+      _ = r ^ p * W := by
+        dsimp only [W, r, p]
+        rw [counterexampleBranch_norm]
+  have hraw : ‖counterexampleHessianError k z‖ ≤
+      A * (129 / 20) * p * (p + 1) * W / r ^ 2 +
+        A * (903 / 20) * p * W * r ^ (-(9 : ℝ) / 4) +
+        A * (8349 / 80) * r ^ (-(5 : ℝ) / 2) := by
+    simpa only [A, W, p, r] using counterexampleHessianError_raw_bound k hk hz hz_one
+  have hcoeffOne : (129 / 20) * p * (p + 1) ≤ (98 / 5) * p ^ 2 := by
+    nlinarith only [hp]
+  have hcoeffTwo : (903 / 20) * p ≤ (903 / 10) * p ^ 2 := by
+    nlinarith only [hp]
+  have hcoeffThree : (8349 / 80) ≤ 420 * p ^ 2 := by
+    nlinarith only [hp, sq_nonneg (p - 1 / 2)]
+  have hpowTwo : r ^ (p - 1 / 4) / r ^ 2 =
+      r ^ p * r ^ (-(9 : ℝ) / 4) := by
+    calc
+      r ^ (p - 1 / 4) / r ^ 2 = r ^ (p - 1 / 4) / r ^ (2 : ℝ) :=
+        congrArg (fun x : ℝ ↦ r ^ (p - 1 / 4) / x) (Real.rpow_natCast r 2).symm
+      _ = r ^ ((p - 1 / 4) - 2) :=
+        (Real.rpow_sub hr _ _).symm
+      _ = r ^ (p + (-(9 : ℝ) / 4)) := by congr 1; ring
+      _ = r ^ p * r ^ (-(9 : ℝ) / 4) := Real.rpow_add hr _ _
+  have hpowThree : r ^ ((k : ℝ) - 1 / 2) / r ^ 2 =
+      (r ^ p) ^ 2 * r ^ (-(5 : ℝ) / 2) := by
+    calc
+      r ^ ((k : ℝ) - 1 / 2) / r ^ 2 =
+          r ^ ((k : ℝ) - 1 / 2) / r ^ (2 : ℝ) :=
+        congrArg (fun x : ℝ ↦ r ^ ((k : ℝ) - 1 / 2) / x)
+          (Real.rpow_natCast r 2).symm
+      _ = r ^ (((k : ℝ) - 1 / 2) - 2) := (Real.rpow_sub hr _ _).symm
+      _ = r ^ (p + p + (-(5 : ℝ) / 2)) := by
+        congr 1
+        dsimp only [p]
+        ring
+      _ = (r ^ p) ^ 2 * r ^ (-(5 : ℝ) / 2) := by
+        rw [Real.rpow_add hr, Real.rpow_add hr]
+        ring
+  have htermOne : A * (129 / 20) * p * (p + 1) * W / r ^ 2 ≤
+      D * (140 * r ^ p) := by
+    have hbase : 0 ≤ A * (98 / 5) * p ^ 2 * W / r ^ 2 := by positivity
+    calc
+      A * (129 / 20) * p * (p + 1) * W / r ^ 2 ≤
+          A * (98 / 5) * p ^ 2 * W / r ^ 2 := by
+        calc
+          _ = (A * W / r ^ 2) * ((129 / 20) * p * (p + 1)) := by ring
+          _ ≤ (A * W / r ^ 2) * ((98 / 5) * p ^ 2) :=
+            mul_le_mul_of_nonneg_left hcoeffOne (by positivity)
+          _ = _ := by ring
+      _ ≤ (A * (98 / 5) * p ^ 2 * W / r ^ 2) * (r ^ p * W) :=
+        le_mul_of_one_le_right hbase hscale
+      _ = D * (140 * r ^ p) := by
+        dsimp only [D]
+        ring
+  have htargetTwo : D * (645 * r ^ (p - 1 / 4)) =
+      (A * (903 / 10) * p ^ 2 * W * r ^ (-(9 : ℝ) / 4)) * (r ^ p * W) := by
+    dsimp only [D]
+    calc
+      (A * (7 / 50) * (p ^ 2 * W ^ 2 / r ^ 2)) *
+            (645 * r ^ (p - 1 / 4)) =
+          A * (903 / 10) * p ^ 2 * W ^ 2 *
+            (r ^ (p - 1 / 4) / r ^ 2) := by ring
+      _ = _ := by rw [hpowTwo]; ring
+  have htermTwo : A * (903 / 20) * p * W * r ^ (-(9 : ℝ) / 4) ≤
+      D * (645 * r ^ (p - 1 / 4)) := by
+    have hbase : 0 ≤ A * (903 / 10) * p ^ 2 * W * r ^ (-(9 : ℝ) / 4) := by
+      positivity
+    calc
+      A * (903 / 20) * p * W * r ^ (-(9 : ℝ) / 4) ≤
+          A * (903 / 10) * p ^ 2 * W * r ^ (-(9 : ℝ) / 4) := by
+        calc
+          _ = (A * W * r ^ (-(9 : ℝ) / 4)) * ((903 / 20) * p) := by ring
+          _ ≤ (A * W * r ^ (-(9 : ℝ) / 4)) * ((903 / 10) * p ^ 2) :=
+            mul_le_mul_of_nonneg_left hcoeffTwo (by positivity)
+          _ = _ := by ring
+      _ ≤ (A * (903 / 10) * p ^ 2 * W * r ^ (-(9 : ℝ) / 4)) *
+          (r ^ p * W) := le_mul_of_one_le_right hbase hscale
+      _ = D * (645 * r ^ (p - 1 / 4)) := htargetTwo.symm
+  have hscaleSquare : 1 ≤ (r ^ p * W) ^ 2 := by nlinarith only [hscale]
+  have htargetThree : D * (3000 * r ^ ((k : ℝ) - 1 / 2)) =
+      (A * 420 * p ^ 2 * r ^ (-(5 : ℝ) / 2)) * (r ^ p * W) ^ 2 := by
+    dsimp only [D]
+    calc
+      (A * (7 / 50) * (p ^ 2 * W ^ 2 / r ^ 2)) *
+            (3000 * r ^ ((k : ℝ) - 1 / 2)) =
+          A * 420 * p ^ 2 * W ^ 2 *
+            (r ^ ((k : ℝ) - 1 / 2) / r ^ 2) := by ring
+      _ = _ := by rw [hpowThree]; ring
+  have htermThree : A * (8349 / 80) * r ^ (-(5 : ℝ) / 2) ≤
+      D * (3000 * r ^ ((k : ℝ) - 1 / 2)) := by
+    have hbase : 0 ≤ A * 420 * p ^ 2 * r ^ (-(5 : ℝ) / 2) := by positivity
+    calc
+      A * (8349 / 80) * r ^ (-(5 : ℝ) / 2) ≤
+          A * 420 * p ^ 2 * r ^ (-(5 : ℝ) / 2) := by
+        calc
+          _ = (A * r ^ (-(5 : ℝ) / 2)) * (8349 / 80) := by ring
+          _ ≤ (A * r ^ (-(5 : ℝ) / 2)) * (420 * p ^ 2) :=
+            mul_le_mul_of_nonneg_left hcoeffThree (by positivity)
+          _ = _ := by ring
+      _ ≤ (A * 420 * p ^ 2 * r ^ (-(5 : ℝ) / 2)) * (r ^ p * W) ^ 2 :=
+        le_mul_of_one_le_right hbase hscaleSquare
+      _ = D * (3000 * r ^ ((k : ℝ) - 1 / 2)) := htargetThree.symm
+  have hratioNonneg : 0 ≤
+      140 * r ^ p + 645 * r ^ (p - 1 / 4) +
+        3000 * r ^ ((k : ℝ) - 1 / 2) := by positivity
+  have hlower : D ≤ ‖counterexampleHessianLeading k z‖ := by
+    simpa only [D, A, W, p, r] using counterexampleHessianLeading_lower_bound k hk hz
+  calc
+    ‖counterexampleHessianError k z‖ ≤
+        A * (129 / 20) * p * (p + 1) * W / r ^ 2 +
+          A * (903 / 20) * p * W * r ^ (-(9 : ℝ) / 4) +
+          A * (8349 / 80) * r ^ (-(5 : ℝ) / 2) := hraw
+    _ ≤ D * (140 * r ^ p) + D * (645 * r ^ (p - 1 / 4)) +
+        D * (3000 * r ^ ((k : ℝ) - 1 / 2)) :=
+      add_le_add (add_le_add htermOne htermTwo) htermThree
+    _ = D * (140 * r ^ p + 645 * r ^ (p - 1 / 4) +
+        3000 * r ^ ((k : ℝ) - 1 / 2)) := by ring
+    _ ≤ ‖counterexampleHessianLeading k z‖ *
+        (140 * r ^ p + 645 * r ^ (p - 1 / 4) +
+          3000 * r ^ ((k : ℝ) - 1 / 2)) :=
+      mul_le_mul_of_nonneg_right hlower hratioNonneg
+    _ = ‖counterexampleHessianLeading k z‖ *
+        (140 * ‖z‖ ^ ((k : ℝ) / 2) +
+          645 * ‖z‖ ^ ((k : ℝ) / 2 - 1 / 4) +
+          3000 * ‖z‖ ^ ((k : ℝ) - 1 / 2)) := by rfl
+
+/-- The Hessian error is eventually strictly smaller than the leading term. -/
+@[category API, AMS 26]
+private theorem counterexampleHessianError_lt_leading_eventually (k : ℕ) (hk : 0 < k) :
+    ∀ᶠ z in 𝓝[≠] (0 : ℂ),
+      ‖counterexampleHessianError k z‖ < ‖counterexampleHessianLeading k z‖ := by
+  rcases counterexample_error_powers_tendsto_zero k hk with
+    ⟨hhalf, hquarter, hminus⟩
+  have hratio : Tendsto
+      (fun z : ℂ ↦ 140 * ‖z‖ ^ ((k : ℝ) / 2) +
+        645 * ‖z‖ ^ ((k : ℝ) / 2 - 1 / 4) +
+        3000 * ‖z‖ ^ ((k : ℝ) - 1 / 2))
+      (𝓝[≠] 0) (𝓝 0) := by
+    simpa only [mul_zero, add_zero] using
+      (((hhalf.const_mul (140 : ℝ)).add (hquarter.const_mul (645 : ℝ))).add
+        (hminus.const_mul (3000 : ℝ)))
+  have hnormAt : ContinuousAt (fun z : ℂ ↦ ‖z‖) 0 := continuous_norm.continuousAt
+  have hnorm : Tendsto (fun z : ℂ ↦ ‖z‖) (𝓝[≠] 0) (𝓝 0) := by
+    simpa using hnormAt.tendsto.mono_left
+      (show 𝓝[≠] (0 : ℂ) ≤ 𝓝 0 from inf_le_left)
+  filter_upwards [hratio.eventually_lt_const zero_lt_one,
+    hnorm.eventually_lt_const zero_lt_one, self_mem_nhdsWithin] with z hR hz_one hz
+  have hz' : z ≠ 0 := by simpa using hz
+  have hlead : 0 < ‖counterexampleHessianLeading k z‖ :=
+    norm_pos_iff.mpr (counterexampleHessianLeading_ne_zero k hk hz')
+  calc
+    ‖counterexampleHessianError k z‖ ≤
+        ‖counterexampleHessianLeading k z‖ *
+          (140 * ‖z‖ ^ ((k : ℝ) / 2) +
+            645 * ‖z‖ ^ ((k : ℝ) / 2 - 1 / 4) +
+            3000 * ‖z‖ ^ ((k : ℝ) - 1 / 2)) :=
+      counterexampleHessianError_le_leading_mul_ratio k hk hz' hz_one.le
+    _ < ‖counterexampleHessianLeading k z‖ * 1 := mul_lt_mul_of_pos_left hR hlead
+    _ = ‖counterexampleHessianLeading k z‖ := mul_one _
+
+/-- On either analytic square-root branch, the trace-free Hessian is the displayed dominant
+term plus the three lower-order product-and-chain-rule terms. -/
+@[category API, AMS 26]
+private theorem counterexample_traceFreeHessian_decomposition (k : ℕ) {z : ℂ} (hz : z ≠ 0) :
+    traceFreeHessian (counterexample k) z =
+      counterexampleHessianLeading k z + counterexampleHessianError k z := by
+  let U : ℂ → ℂ := fun y ↦ 100 / star y
+  let W : ℂ → ℂ := fun y ↦ Complex.cpow (U y) ((k : ℂ) / 2)
+  let B : ℂ → ℂ := fun y ↦ -((k : ℂ) / 2) * W y / star y
+  let C : ℂ := ((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) * W z / (star z) ^ 2
+  have hU0 : U z ≠ 0 :=
+    div_ne_zero (by norm_num) ((map_ne_zero (starRingEnd ℂ)).mpr hz)
+  rcases Complex.mem_slitPlane_or_neg_mem_slitPlane hU0 with hslit | hslit
+  · have hUcont : ContinuousAt U z := by
+      dsimp [U]
+      fun_prop (disch := aesop)
+    have hW : ∀ᶠ y in 𝓝 z,
+        HasFDerivAt W ((B y) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) y := by
+      filter_upwards [hUcont (Complex.isOpen_slitPlane.mem_nhds hslit),
+        eventually_ne_nhds hz] with y hyU hy
+      simpa [U, W, B] using hasFDerivAt_counterexamplePrincipalBranch k hy hyU
+    have hB : HasFDerivAt B (C • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+      simpa [U, W, B, C] using
+        hasFDerivAt_counterexamplePrincipalBranch_barDeriv k hz hslit
+    have htrace := traceFreeHessian_radial_mul_seed_branch W B C (10 ^ 10) hz hW hB
+    have hcounterexample : counterexample k = fun y : ℂ ↦
+        counterexampleRadialAmplitude ‖y‖ * counterexampleSeed (W y) + 10 ^ 10 := by
+      funext y
+      simp [counterexample, counterexampleRadialAmplitude, U, W]
+      ring
+    rw [hcounterexample, htrace]
+    simp only [counterexampleHessianLeading, counterexampleHessianError]
+    dsimp only [U, W, B, C]
+    field_simp [norm_ne_zero_iff.mpr hz]
+    ring
+  · let W' : ℂ → ℂ := fun y ↦
+      (Complex.I ^ k) * Complex.cpow (-U y) ((k : ℂ) / 2)
+    let B' : ℂ → ℂ := fun y ↦ -((k : ℂ) / 2) * W' y / star y
+    let C' : ℂ := ((k : ℂ) / 2) * ((k : ℂ) / 2 + 1) * W' z / (star z) ^ 2
+    have hUcont : ContinuousAt (fun y ↦ -U y) z := by
+      dsimp [U]
+      fun_prop (disch := aesop)
+    have hW' : ∀ᶠ y in 𝓝 z,
+        HasFDerivAt W' ((B' y) • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) y := by
+      filter_upwards [hUcont (Complex.isOpen_slitPlane.mem_nhds hslit),
+        eventually_ne_nhds hz] with y hyU hy
+      simpa [U, W', B'] using hasFDerivAt_counterexampleAlternateBranch k hy hyU
+    have hB' : HasFDerivAt B' (C' • (Complex.conjCLE : ℂ →L[ℝ] ℂ)) z := by
+      simpa [U, W', B', C'] using
+        hasFDerivAt_counterexampleAlternateBranch_barDeriv k hz hslit
+    have htrace := traceFreeHessian_radial_mul_seed_branch W' B' C' (10 ^ 10) hz hW' hB'
+    have hcounterexample : counterexample k = fun y : ℂ ↦
+        counterexampleRadialAmplitude ‖y‖ * counterexampleSeed (W' y) + 10 ^ 10 := by
+      funext y
+      simp only [counterexample]
+      have hseed : counterexampleSeed (Complex.cpow (U y) ((k : ℂ) / 2)) =
+          counterexampleSeed
+            ((Complex.I ^ k) * Complex.cpow (-U y) ((k : ℂ) / 2)) := by
+        simpa only [← Complex.cpow_eq_pow] using counterexampleSeed_cpow_eq_alt k (U y)
+      rw [hseed]
+      simp [counterexampleRadialAmplitude, U, W']
+      ring
+    rw [hcounterexample]
+    have hrelation := cpow_half_nat_eq_or_eq_neg_alt k (U z)
+    rcases hrelation with hrelation | hrelation
+    · have hWvalue : W z = W' z := by simpa [W, W', U] using hrelation
+      rw [htrace]
+      dsimp only [B', C']
+      rw [← hWvalue]
+      simp only [counterexampleHessianLeading, counterexampleHessianError]
+      dsimp only [U, W, B, C]
+      field_simp [norm_ne_zero_iff.mpr hz]
+      ring
+    · have hWvalue : W' z = -W z := by
+        have hneg := congrArg Neg.neg hrelation
+        simpa [W, W', U] using hneg.symm
+      rw [htrace]
+      dsimp only [B', C']
+      rw [hWvalue]
+      simp only [seedTraceFreeHessianModel_neg, seedWirtingerModel_neg,
+        counterexampleSeed_neg]
+      simp only [counterexampleHessianLeading, counterexampleHessianError]
+      dsimp only [U, W, B, C]
+      field_simp [norm_ne_zero_iff.mpr hz]
+      ring
+
+/-- The trace-free Hessian of a smooth member of the family is continuous. -/
+@[category API, AMS 26]
+private theorem continuous_traceFreeHessian_counterexample (k : ℕ) (hk : 0 < k) :
+    Continuous (traceFreeHessian (counterexample k)) := by
+  have hfirst : ContDiff ℝ ∞ (fderiv ℝ (counterexample k)) :=
+    (contDiff_infty_iff_fderiv.mp (counterexample_contDiff k hk)).2
+  have hsecond : Continuous
+      (fderiv ℝ (fun z ↦ fderiv ℝ (counterexample k) z)) :=
+    hfirst.continuous_fderiv (by simp)
+  unfold traceFreeHessian
+  fun_prop
+
+/-- The principal-branch leading term on a circle admits a continuous representative and an
+argument lift. The representative uses the continuous half-power branch
+`(100/r)^(k/2) exp(i(k/2)t)`, including when `k` is odd. -/
+@[category API, AMS 26]
+private theorem exists_continuous_counterexampleHessianLeading_circle
+    (k : ℕ) (hk : 0 < k) {r : ℝ} (hr : 0 < r) :
+    ∃ L : ℝ → ℂ, Continuous L ∧
+      (∀ t, L t = counterexampleHessianLeading k
+        ((r : ℂ) * Complex.exp ((t : ℂ) * Complex.I))) ∧
+      L (2 * Real.pi) = L 0 ∧
+      ∃ θ : ℝ → ℝ, Continuous θ ∧
+        (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) = L t / ‖L t‖) ∧
+        θ (2 * Real.pi) - θ 0 = 2 * Real.pi * ((2 + k : ℕ) : ℤ) := by
+  let p : ℝ := (k : ℝ) / 2
+  let a : ℝ := (100 / r) ^ p
+  let zcircle : ℝ → ℂ := fun t ↦
+    (r : ℂ) * Complex.exp ((t : ℂ) * Complex.I)
+  let w : ℝ → ℂ := fun t ↦
+    (a : ℂ) * Complex.exp (((p * t : ℝ) : ℂ) * Complex.I)
+  let S : ℝ := counterexampleRadialAmplitude r * p ^ 2 * a ^ 2 / r ^ 2
+  let L : ℝ → ℂ := fun t ↦
+    (S : ℂ) *
+      Complex.exp (((((2 + k : ℕ) : ℝ) * t : ℝ) : ℂ) * Complex.I) *
+      star (seedTraceFreeHessianModel (w t))
+  have hp : 0 < p := by
+    dsimp only [p]
+    positivity
+  have ha : 0 < a := by
+    dsimp only [a]
+    exact Real.rpow_pos_of_pos (by positivity) _
+  have hS : 0 < S := by
+    dsimp only [S]
+    have hA := counterexampleRadialAmplitude_pos hr
+    positivity
+  have hzNorm (t : ℝ) : ‖zcircle t‖ = r := by
+    dsimp only [zcircle]
+    rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr,
+      Complex.norm_exp]
+    simp [Complex.mul_re]
+  have hzNe (t : ℝ) : zcircle t ≠ 0 := by
+    rw [← norm_pos_iff, hzNorm]
+    exact hr
+  have hstar (t : ℝ) : star (zcircle t) =
+      (r : ℂ) * Complex.exp (-((t : ℂ) * Complex.I)) := by
+    change (starRingEnd ℂ) ((r : ℂ) * Complex.exp ((t : ℂ) * Complex.I)) = _
+    rw [map_mul, ← Complex.exp_conj]
+    simp
+  have hU (t : ℝ) : 100 / star (zcircle t) =
+      ((100 / r : ℝ) : ℂ) * Complex.exp ((t : ℂ) * Complex.I) := by
+    rw [hstar, div_eq_mul_inv, mul_inv, Complex.exp_neg, inv_inv]
+    push_cast
+    field_simp [hr.ne']
+  have haSq : a ^ 2 = (100 / r) ^ k := by
+    dsimp only [a]
+    rw [← Real.rpow_mul_natCast (by positivity : 0 ≤ 100 / r)]
+    have hpTwo : p * (2 : ℕ) = (k : ℝ) := by
+      dsimp only [p]
+      push_cast
+      ring
+    rw [hpTwo, Real.rpow_natCast]
+  have hpCast : ((k : ℂ) / 2) = ((p : ℝ) : ℂ) := by
+    dsimp only [p]
+    push_cast
+    ring
+  have hwsq (t : ℝ) : w t ^ 2 =
+      Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2) ^ 2 := by
+    rw [counterexamplePrincipalBranch_sq, hU, mul_pow]
+    rw [mul_pow]
+    have haSqC : (a : ℂ) ^ 2 = (((100 / r) ^ k : ℝ) : ℂ) := by
+      exact_mod_cast haSq
+    have hbasePowC : ((100 / r : ℝ) : ℂ) ^ k =
+        (((100 / r) ^ k : ℝ) : ℂ) := by norm_cast
+    rw [haSqC, hbasePowC, ← Complex.exp_nat_mul, ← Complex.exp_nat_mul]
+    congr 1
+    dsimp only [p]
+    push_cast
+    ring
+  have hmodel (t : ℝ) : seedTraceFreeHessianModel (w t) =
+      seedTraceFreeHessianModel
+        (Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2)) := by
+    have hbranches : w t = Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2) ∨
+        w t = -Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2) := by
+      apply eq_or_eq_neg_of_sq_eq_sq
+      exact hwsq t
+    rcases hbranches with hbranch | hbranch
+    · rw [hbranch]
+    · rw [hbranch, seedTraceFreeHessianModel_neg]
+  have hphaseFactor (t : ℝ) :
+      Complex.exp (((p * t : ℝ) : ℂ) * Complex.I) ^ 2 /
+          Complex.exp (-((t : ℂ) * Complex.I)) ^ 2 =
+        Complex.exp (((((2 + k : ℕ) : ℝ) * t : ℝ) : ℂ) * Complex.I) := by
+    rw [← Complex.exp_nat_mul, ← Complex.exp_nat_mul, div_eq_mul_inv,
+      ← Complex.exp_neg, ← Complex.exp_add]
+    congr 1
+    dsimp only [p]
+    push_cast
+    ring
+  have hfactor (t : ℝ) :
+      (-((k : ℂ) / 2) *
+          Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2) /
+          star (zcircle t)) ^ 2 =
+        ((p ^ 2 * a ^ 2 / r ^ 2 : ℝ) : ℂ) *
+          Complex.exp (((((2 + k : ℕ) : ℝ) * t : ℝ) : ℂ) * Complex.I) := by
+    calc
+      _ = (((k : ℂ) / 2) ^ 2 *
+            Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2) ^ 2) /
+          star (zcircle t) ^ 2 := by ring
+      _ = ((p : ℂ) ^ 2 *
+            Complex.cpow (100 / star (zcircle t)) ((k : ℂ) / 2) ^ 2) /
+          star (zcircle t) ^ 2 := by rw [hpCast]
+      _ = ((p : ℂ) ^ 2 * w t ^ 2) / star (zcircle t) ^ 2 := by rw [hwsq]
+      _ = ((p ^ 2 * a ^ 2 / r ^ 2 : ℝ) : ℂ) *
+          (Complex.exp (((p * t : ℝ) : ℂ) * Complex.I) ^ 2 /
+            Complex.exp (-((t : ℂ) * Complex.I)) ^ 2) := by
+        dsimp only [w]
+        rw [hstar, mul_pow, mul_pow]
+        push_cast
+        field_simp [hr.ne']
+      _ = _ := by rw [hphaseFactor]
+  have hLeq (t : ℝ) : L t = counterexampleHessianLeading k (zcircle t) := by
+    simp only [counterexampleHessianLeading]
+    rw [hzNorm, ← hmodel, hfactor]
+    dsimp only [L, S]
+    push_cast
+    ring
+  have hLcont : Continuous L := by
+    have hmodelCont : Continuous seedTraceFreeHessianModel := by
+      unfold seedTraceFreeHessianModel
+      fun_prop
+    have hwcont : Continuous w := by
+      dsimp only [w]
+      fun_prop
+    have hphaseCont : Continuous (fun t : ℝ ↦
+        Complex.exp (((((2 + k : ℕ) : ℝ) * t : ℝ) : ℂ) * Complex.I)) := by
+      fun_prop
+    exact (continuous_const.mul hphaseCont).mul
+      (continuous_star.comp (hmodelCont.comp hwcont))
+  have hLnorm (t : ℝ) : ‖L t‖ = S * ‖seedTraceFreeHessianModel (w t)‖ := by
+    dsimp only [L]
+    rw [norm_mul, norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hS,
+      Complex.norm_exp, norm_star]
+    simp [Complex.mul_re]
+  have hzperiod : zcircle (2 * Real.pi) = zcircle 0 := by
+    dsimp only [zcircle]
+    rw [show ((2 * Real.pi : ℝ) : ℂ) * Complex.I =
+      2 * (Real.pi : ℂ) * Complex.I by push_cast; ring,
+      Complex.exp_two_pi_mul_I]
+    simp
+  have hLperiod : L (2 * Real.pi) = L 0 := by
+    rw [hLeq, hLeq, hzperiod]
+  rcases exists_seed_leading_argument k a 0 with ⟨θ, hθcont, hθphase, hθchange⟩
+  refine ⟨L, hLcont, fun t ↦ by simpa only [zcircle] using hLeq t,
+    hLperiod, θ, hθcont, ?_, hθchange⟩
+  intro t
+  have hphase : Complex.exp ((θ t : ℂ) * Complex.I) =
+      Complex.exp (((((2 + k : ℕ) : ℝ) * t : ℝ) : ℂ) * Complex.I) *
+        star (seedTraceFreeHessianModel (w t)) /
+          ‖seedTraceFreeHessianModel (w t)‖ := by
+    simpa [w, p] using hθphase t
+  rw [hphase, hLnorm]
+  dsimp only [L]
+  push_cast
+  field_simp [hS.ne']
+
+/-- Flatness at the origin makes the trace-free Hessian vanish there. -/
+@[category research solved, AMS 26 53]
+theorem counterexample_traceFreeHessian_zero (k : ℕ) (hk : 0 < k) :
+    traceFreeHessian (counterexample k) 0 = 0 := by
+  exact traceFreeHessian_eq_zero_of_second_fderiv_eq_zero _ _
+    (counterexample_fderiv_fderiv_zero k hk)
+
+/-- The leading oscillatory Hessian term dominates on a punctured neighbourhood of the origin. -/
+@[category research solved, AMS 26 53 57]
+theorem counterexample_traceFreeHessian_isolated (k : ℕ) (hk : 0 < k) :
+    ∃ ε > 0, ∀ w, w ≠ 0 → dist w 0 < ε →
+      traceFreeHessian (counterexample k) w ≠ 0 := by
+  have hdom := counterexampleHessianError_lt_leading_eventually k hk
+  have hnonzero : ∀ᶠ z in 𝓝[≠] (0 : ℂ),
+      traceFreeHessian (counterexample k) z ≠ 0 := by
+    filter_upwards [hdom, self_mem_nhdsWithin] with z hsmall hz
+    have hz' : z ≠ 0 := by simpa using hz
+    rw [counterexample_traceFreeHessian_decomposition k hz']
+    intro hzero
+    have heq : counterexampleHessianLeading k z = -counterexampleHessianError k z :=
+      eq_neg_of_add_eq_zero_left hzero
+    have hnormeq : ‖counterexampleHessianLeading k z‖ =
+        ‖counterexampleHessianError k z‖ := by rw [heq, norm_neg]
+    exact (ne_of_gt hsmall) hnormeq
+  rw [eventually_nhdsWithin_iff] at hnonzero
+  rcases Metric.eventually_nhds_iff.mp hnonzero with ⟨ε, hε, hεprop⟩
+  refine ⟨ε, hε, fun w hw hdist ↦ ?_⟩
+  exact hεprop hdist (by simpa using hw)
+
+/-- On an arbitrarily small positively oriented circle, the trace-free Hessian has an argument
+lift whose total change is `2π(2+k)`. -/
+@[category research solved, AMS 26 53 57]
+theorem counterexample_traceFreeHessian_argument (k : ℕ) (hk : 0 < k)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∃ r, 0 < r ∧ r < ε ∧ ∃ θ : ℝ → ℝ, Continuous θ ∧
+      (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
+        traceFreeHessian (counterexample k) (r * Complex.exp ((t : ℂ) * Complex.I)) /
+          ‖traceFreeHessian (counterexample k)
+            (r * Complex.exp ((t : ℂ) * Complex.I))‖) ∧
+      θ (2 * Real.pi) - θ 0 = 2 * Real.pi * ((2 + k : ℕ) : ℤ) := by
+  have hdom := counterexampleHessianError_lt_leading_eventually k hk
+  rw [eventually_nhdsWithin_iff] at hdom
+  rcases Metric.eventually_nhds_iff.mp hdom with ⟨δ, hδ, hδprop⟩
+  let r := min (ε / 2) (δ / 2)
+  have hr : 0 < r := by
+    dsimp only [r]
+    exact lt_min (half_pos hε) (half_pos hδ)
+  have hrε : r < ε := lt_of_le_of_lt (min_le_left _ _) (half_lt_self hε)
+  have hrδ : r < δ := lt_of_le_of_lt (min_le_right _ _) (half_lt_self hδ)
+  let circle : ℝ → ℂ := fun t ↦
+    (r : ℂ) * Complex.exp ((t : ℂ) * Complex.I)
+  have hcircleNorm (t : ℝ) : ‖circle t‖ = r := by
+    dsimp only [circle]
+    rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr,
+      Complex.norm_exp]
+    simp [Complex.mul_re]
+  have hcircleNe (t : ℝ) : circle t ≠ 0 := by
+    rw [← norm_pos_iff, hcircleNorm]
+    exact hr
+  have hcircleDist (t : ℝ) : dist (circle t) 0 = r := by
+    rw [dist_zero_right, hcircleNorm]
+  have hcirclePeriod : circle (2 * Real.pi) = circle 0 := by
+    dsimp only [circle]
+    rw [show ((2 * Real.pi : ℝ) : ℂ) * Complex.I =
+      2 * (Real.pi : ℂ) * Complex.I by push_cast; ring,
+      Complex.exp_two_pi_mul_I]
+    simp
+  rcases exists_continuous_counterexampleHessianLeading_circle k hk hr with
+    ⟨L, hLcont, hLeq, hLperiod, θ0, hθ0cont, hθ0phase, hθ0change⟩
+  let q : ℝ → ℂ := fun t ↦ traceFreeHessian (counterexample k) (circle t)
+  let error : ℝ → ℂ := fun t ↦ q t - L t
+  have hcircleCont : Continuous circle := by
+    dsimp only [circle]
+    fun_prop
+  have hqcont : Continuous q :=
+    (continuous_traceFreeHessian_counterexample k hk).comp hcircleCont
+  have herrorcont : Continuous error := hqcont.sub hLcont
+  have herrorEq (t : ℝ) : error t = counterexampleHessianError k (circle t) := by
+    dsimp only [error, q]
+    rw [counterexample_traceFreeHessian_decomposition k (hcircleNe t), ← hLeq]
+    ring
+  have hsmall (t : ℝ) : ‖error t‖ < ‖L t‖ := by
+    rw [herrorEq, hLeq]
+    exact hδprop (by simpa only [hcircleDist] using hrδ) (by simpa using hcircleNe t)
+  have hqperiod : q (2 * Real.pi) = q 0 := by
+    dsimp only [q]
+    rw [hcirclePeriod]
+  have herrorperiod : error (2 * Real.pi) = error 0 := by
+    dsimp only [error]
+    rw [hqperiod, hLperiod]
+  have hC : Circle.exp (2 * Real.pi * ((2 + k : ℕ) : ℤ)) = 1 :=
+    Circle.exp_two_pi_mul_int ((2 + k : ℕ) : ℤ)
+  rcases exists_argument_of_norm_error_lt L error (2 * Real.pi)
+      (2 * Real.pi * ((2 + k : ℕ) : ℤ)) hLcont herrorcont hsmall hLperiod
+      herrorperiod θ0 hθ0cont hθ0phase hθ0change hC with
+    ⟨θ, hθcont, hθphase, hθchange⟩
+  refine ⟨r, hr, hrε, θ, hθcont, ?_, hθchange⟩
+  intro t
+  have hsum : L t + error t = q t := by
+    dsimp only [error]
+    ring
+  have hphase := hθphase t
+  rw [hsum] at hphase
+  simpa only [q, circle] using hphase
+
+/-- For positive `k`, the origin is an isolated umbilic of principal-line index `1 + k / 2`.
+
+`HasIsolatedZeroIndex` stores twice the principal-line index, hence the integer `2 + k` here. -/
+@[category research solved, AMS 26 53 57]
+theorem counterexample_hasIsolatedZeroIndex (k : ℕ) (hk : 0 < k) :
+    HasIsolatedZeroIndex (traceFreeHessian (counterexample k)) 0 (2 + k) := by
+  rcases counterexample_traceFreeHessian_isolated k hk with ⟨ε, hε, hisolated⟩
+  refine ⟨ε, hε, counterexample_traceFreeHessian_zero k hk, hisolated, ?_⟩
+  simpa using counterexample_traceFreeHessian_argument k hk ε hε
+
+/-- Every positive member with `k > 0` violates the index bound in the smooth Loewner
+conjecture. -/
+@[category research solved, AMS 53 57]
+theorem counterexample_not_loewner_bound (k : ℕ) (hk : 0 < k) :
+    ¬ ((2 + k : ℕ) : ℤ) ≤ 2 := by
+  omega
+
+end CaratheodoryLoewnerCounterexample

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Index.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Index.lean
@@ -35,10 +35,19 @@ namespace CaratheodoryLoewnerCounterexample
 open LoewnerConjecture
 
 @[category API, AMS 26]
+private theorem traceFreeHessian_eq_second_fderiv (f : ℂ → ℝ) (z : ℂ) :
+    traceFreeHessian f z =
+      let H := fderiv ℝ (fun w ↦ fderiv ℝ f w) z
+      (H 1 1 - H Complex.I Complex.I : ℝ) +
+        (2 * H 1 Complex.I : ℝ) * Complex.I := by
+  simp [traceFreeHessian, iteratedFDeriv_two_apply]
+
+@[category API, AMS 26]
 private theorem traceFreeHessian_eq_zero_of_second_fderiv_eq_zero (f : ℂ → ℝ) (z : ℂ)
     (h : fderiv ℝ (fun w ↦ fderiv ℝ f w) z = 0) :
     traceFreeHessian f z = 0 := by
-  simp [traceFreeHessian, h]
+  rw [traceFreeHessian_eq_second_fderiv, h]
+  simp
 
 /-- The explicit trace-free Hessian of the seed. Keeping this local avoids adding another
 public synonym for a one-line expression. -/
@@ -228,9 +237,7 @@ repository's Fréchet-derivative encoding. -/
 @[category API, AMS 26]
 private theorem traceFreeHessian_counterexampleSeed (z : ℂ) :
     traceFreeHessian counterexampleSeed z = seedTraceFreeHessianModel z := by
-  rw [traceFreeHessian]
-  change (let H := fderiv ℝ (fun w ↦ fderiv ℝ counterexampleSeed w) z
-    (H 1 1 - H Complex.I Complex.I : ℝ) + (2 * H 1 Complex.I : ℝ) * Complex.I) = _
+  rw [traceFreeHessian_eq_second_fderiv]
   rw [show (fun w ↦ fderiv ℝ counterexampleSeed w) = seedGradient by
     funext w
     exact (hasFDerivAt_counterexampleSeed w).fderiv]
@@ -1562,7 +1569,8 @@ private theorem traceFreeHessian_radial_mul_seed_branch (W B : ℂ → ℂ) (C :
     have h := second_derivative_symmetric_of_eventually_of_real hfirst hgradient
       (1 : ℂ) Complex.I
     simpa using h.symm
-  rw [traceFreeHessian, (hgradient.congr_of_eventuallyEq hfirst').fderiv]
+  rw [traceFreeHessian_eq_second_fderiv,
+    (hgradient.congr_of_eventuallyEq hfirst').fderiv]
   simp
   have hcontract :
       ((G' 1).re : ℂ) - ((G' Complex.I).im : ℂ) +
@@ -2117,11 +2125,10 @@ private theorem counterexample_traceFreeHessian_decomposition (k : ℕ) {z : ℂ
 @[category API, AMS 26]
 private theorem continuous_traceFreeHessian_counterexample (k : ℕ) (hk : 0 < k) :
     Continuous (traceFreeHessian (counterexample k)) := by
-  have hfirst : ContDiff ℝ ∞ (fderiv ℝ (counterexample k)) :=
-    (contDiff_infty_iff_fderiv.mp (counterexample_contDiff k hk)).2
   have hsecond : Continuous
-      (fderiv ℝ (fun z ↦ fderiv ℝ (counterexample k) z)) :=
-    hfirst.continuous_fderiv (by simp)
+      (iteratedFDeriv ℝ 2 (counterexample k)) :=
+    ContDiff.continuous_iteratedFDeriv (n := (⊤ : ℕ∞))
+      (WithTop.coe_le_coe.2 le_top) (counterexample_contDiff k hk)
   unfold traceFreeHessian
   fun_prop
 
@@ -2401,8 +2408,10 @@ theorem counterexample_traceFreeHessian_argument (k : ℕ) (hk : 0 < k)
 theorem counterexample_hasIsolatedZeroIndex (k : ℕ) (hk : 0 < k) :
     HasIsolatedZeroIndex (traceFreeHessian (counterexample k)) 0 (2 + k) := by
   rcases counterexample_traceFreeHessian_isolated k hk with ⟨ε, hε, hisolated⟩
-  refine ⟨ε, hε, counterexample_traceFreeHessian_zero k hk, hisolated, ?_⟩
-  simpa using counterexample_traceFreeHessian_argument k hk ε hε
+  refine ⟨ε, hε, (continuous_traceFreeHessian_counterexample k hk).continuousOn,
+    counterexample_traceFreeHessian_zero k hk, hisolated, ?_⟩
+  simpa [NormedSpace.normalize, div_eq_mul_inv, mul_comm] using
+    counterexample_traceFreeHessian_argument k hk ε hε
 
 /-- Every positive member with `k > 0` violates the index bound in the smooth Loewner
 conjecture. -/

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Smooth.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Smooth.lean
@@ -16,8 +16,6 @@ limitations under the License.
 
 import FormalConjecturesUtil
 import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Defs
-import FormalConjecturesForMathlib.Analysis.SpecialFunctions.FlatRpowExp
-import Mathlib.Analysis.Distribution.TemperateGrowth
 
 /-!
 # Smoothness of the announced Carathéodory–Loewner counterexamples

--- a/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Smooth.lean
+++ b/FormalConjectures/Other/CaratheodoryLoewnerCounterexample/Smooth.lean
@@ -1,0 +1,711 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+import FormalConjectures.Other.CaratheodoryLoewnerCounterexample.Defs
+import FormalConjecturesForMathlib.Analysis.SpecialFunctions.FlatRpowExp
+import Mathlib.Analysis.Distribution.TemperateGrowth
+
+/-!
+# Smoothness of the announced Carathéodory–Loewner counterexamples
+
+The proof is split between the punctured plane, where branch independence is the main issue, and
+the origin, where the flat exponential dominates every derivative.
+
+*Reference:*
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
+-/
+
+open Filter Topology
+open scoped ContDiff
+
+namespace CaratheodoryLoewnerCounterexample
+
+noncomputable section
+
+/-- The trigonometric seed is smooth as a real-valued function of the complex variable. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_contDiff : ContDiff ℝ ∞ counterexampleSeed := by
+  unfold counterexampleSeed
+  have hre : ContDiff ℝ ∞ (fun z : ℂ ↦ z.re) := by
+    simpa [Complex.reCLM_apply] using Complex.reCLM.contDiff
+  have him : ContDiff ℝ ∞ (fun z : ℂ ↦ z.im) := by
+    simpa [Complex.imCLM_apply] using Complex.imCLM.contDiff
+  fun_prop
+
+@[fun_prop, category API, AMS 26]
+private theorem sin_hasTemperateGrowth : Function.HasTemperateGrowth Real.sin := by
+  refine ⟨Real.contDiff_sin, fun n ↦ ⟨0, 1, fun x ↦ ?_⟩⟩
+  simpa only [norm_iteratedFDeriv_eq_norm_iteratedDeriv, Real.norm_eq_abs, pow_zero, mul_one]
+    using Real.abs_iteratedDeriv_sin_le_one n x
+
+@[fun_prop, category API, AMS 26]
+private theorem cos_hasTemperateGrowth : Function.HasTemperateGrowth Real.cos := by
+  refine ⟨Real.contDiff_cos, fun n ↦ ⟨0, 1, fun x ↦ ?_⟩⟩
+  simpa only [norm_iteratedFDeriv_eq_norm_iteratedDeriv, Real.norm_eq_abs, pow_zero, mul_one]
+    using Real.abs_iteratedDeriv_cos_le_one n x
+
+@[category API, AMS 26]
+private theorem counterexampleSeed_hasTemperateGrowth :
+    Function.HasTemperateGrowth counterexampleSeed := by
+  unfold counterexampleSeed
+  have hre : Function.HasTemperateGrowth (fun z : ℂ ↦ z.re) := by
+    simpa [Complex.reCLM_apply] using Complex.reCLM.hasTemperateGrowth
+  have him : Function.HasTemperateGrowth (fun z : ℂ ↦ z.im) := by
+    simpa [Complex.imCLM_apply] using Complex.imCLM.hasTemperateGrowth
+  simp only [div_eq_mul_inv]
+  fun_prop
+
+private def cpowFalling : ℂ → ℕ → ℂ
+  | _, 0 => 1
+  | c, n + 1 => c * cpowFalling (c - 1) n
+
+@[category API, AMS 26]
+private theorem iteratedDeriv_cpow_const (c : ℂ) (n : ℕ) {z : ℂ}
+    (hz : z ∈ Complex.slitPlane) :
+    iteratedDeriv n (fun w : ℂ ↦ w ^ c) z = cpowFalling c n * z ^ (c - n) := by
+  induction n generalizing c with
+  | zero => simp [cpowFalling]
+  | succ n ih =>
+      rw [iteratedDeriv_succ']
+      have hderiv : deriv (fun w : ℂ ↦ w ^ c) =ᶠ[𝓝 z] fun w ↦ c * w ^ (c - 1) := by
+        filter_upwards [Complex.isOpen_slitPlane.mem_nhds hz] with w hw
+        simpa using ((hasDerivAt_id w).cpow_const hw).deriv
+      rw [hderiv.iteratedDeriv_eq n]
+      have hsmooth : ContDiffAt ℂ n (fun w : ℂ ↦ w ^ (c - 1)) z :=
+        (analyticAt_id.cpow analyticAt_const hz).contDiffAt.of_le (mod_cast le_top)
+      rw [iteratedDeriv_const_mul hsmooth c, ih (c - 1)]
+      have hexp : c - 1 - (n : ℂ) = c - ((n + 1 : ℕ) : ℂ) := by
+        norm_num [Nat.cast_add]
+        ring
+      change c * (cpowFalling (c - 1) n * z ^ (c - 1 - (n : ℂ))) =
+        (c * cpowFalling (c - 1) n) * z ^ (c - ((n + 1 : ℕ) : ℂ))
+      rw [mul_assoc, hexp]
+
+@[category API, AMS 26]
+private theorem norm_iteratedFDeriv_cpow_const (c : ℝ) (n : ℕ) {z : ℂ}
+    (hz : z ∈ Complex.slitPlane) :
+    ‖iteratedFDeriv ℝ n (fun w : ℂ ↦ w ^ (c : ℂ)) z‖ =
+      ‖cpowFalling (c : ℂ) n‖ * ‖z‖ ^ (c - n) := by
+  have hsmooth : ContDiffAt ℂ n (fun w : ℂ ↦ w ^ (c : ℂ)) z :=
+    (analyticAt_id.cpow analyticAt_const hz).contDiffAt.of_le (mod_cast le_top)
+  rw [← hsmooth.restrictScalars_iteratedFDeriv (𝕜 := ℝ), Function.comp_apply,
+    ContinuousMultilinearMap.norm_restrictScalars,
+    norm_iteratedFDeriv_eq_norm_iteratedDeriv, iteratedDeriv_cpow_const (c : ℂ) n hz,
+    norm_mul]
+  congr 1
+  convert Complex.norm_cpow_real z (c - n) using 1
+  push_cast
+  ring
+
+@[category API, AMS 26]
+private theorem cpow_pos_mul (r : ℝ) (hr : 0 < r) {z c : ℂ} (hz : z ≠ 0) :
+    ((r : ℂ) * z) ^ c = (r : ℂ) ^ c * z ^ c := by
+  rw [Complex.cpow_def_of_ne_zero (mul_ne_zero (Complex.ofReal_ne_zero.mpr hr.ne') hz),
+    Complex.cpow_def_of_ne_zero (Complex.ofReal_ne_zero.mpr hr.ne'),
+    Complex.cpow_def_of_ne_zero hz, Complex.log_ofReal_mul hr hz, add_mul, Complex.exp_add,
+    Complex.ofReal_log hr.le]
+
+@[category API, AMS 26]
+private theorem div_cpow_eq (k : ℕ) {z : ℂ} (hz : z ∈ Complex.slitPlane) :
+    (100 / z) ^ ((k : ℂ) / 2) =
+      (100 : ℂ) ^ ((k : ℂ) / 2) * z ^ (-((k : ℂ) / 2)) := by
+  rw [div_eq_mul_inv]
+  change (((100 : ℝ) : ℂ) * z⁻¹) ^ ((k : ℂ) / 2) =
+    ((100 : ℂ) ^ ((k : ℂ) / 2)) * z ^ (-((k : ℂ) / 2))
+  rw [cpow_pos_mul 100 (by norm_num)
+      (inv_ne_zero (Complex.slitPlane_ne_zero hz)),
+    Complex.inv_cpow z _ (Complex.slitPlane_arg_ne_pi hz), Complex.cpow_neg]
+  norm_num
+
+private def negConjLIE : ℂ ≃ₗᵢ[ℝ] ℂ :=
+  Complex.conjLIE.trans (LinearIsometryEquiv.neg ℝ)
+
+@[simp, category API, AMS 26]
+private theorem negConjLIE_apply (z : ℂ) : negConjLIE z = -star z := by
+  rfl
+
+private def branchPhase (k : ℕ) (a : ℂ) (z : ℂ) : ℂ :=
+  a * (100 : ℂ) ^ ((k : ℂ) / 2) * z ^ (-((k : ℂ) / 2))
+
+@[category API, AMS 26]
+private theorem norm_iteratedFDeriv_branchPhase (k n : ℕ) (a : ℂ) {z : ℂ}
+    (hz : z ∈ Complex.slitPlane) :
+    ‖iteratedFDeriv ℝ n (branchPhase k a) z‖ =
+      ‖a * (100 : ℂ) ^ ((k : ℂ) / 2)‖ *
+        ‖cpowFalling (-((k : ℂ) / 2)) n‖ * ‖z‖ ^ (-(k : ℝ) / 2 - n) := by
+  have hsmooth : ContDiffAt ℝ n (fun w : ℂ ↦ w ^ (-((k : ℂ) / 2))) z :=
+    ((analyticAt_id.cpow analyticAt_const hz).restrictScalars.contDiffAt).of_le
+      (mod_cast le_top)
+  have hc : -((k : ℂ) / 2) = ((-(k : ℝ) / 2 : ℝ) : ℂ) := by
+    push_cast
+    ring
+  rw [show branchPhase k a = fun w ↦
+      (a * (100 : ℂ) ^ ((k : ℂ) / 2)) • w ^ (-((k : ℂ) / 2)) by
+        funext w; simp [branchPhase],
+    iteratedFDeriv_const_smul_apply' hsmooth, norm_smul, hc,
+    norm_iteratedFDeriv_cpow_const (-(k : ℝ) / 2) n hz]
+  push_cast
+  ring
+
+@[category API, AMS 26]
+private theorem norm_iteratedFDeriv_branchPhase_comp_conj (k n : ℕ) (a : ℂ) (z : ℂ) :
+    ‖iteratedFDeriv ℝ n (branchPhase k a ∘ Complex.conjLIE) z‖ =
+      ‖iteratedFDeriv ℝ n (branchPhase k a) (star z)‖ := by
+  simpa [Complex.conjLIE_apply] using
+    Complex.conjLIE.norm_iteratedFDeriv_comp_right (branchPhase k a) z n
+
+@[category API, AMS 26]
+private theorem norm_iteratedFDeriv_branchPhase_comp_negConj (k n : ℕ) (a : ℂ) (z : ℂ) :
+    ‖iteratedFDeriv ℝ n (branchPhase k a ∘ negConjLIE) z‖ =
+      ‖iteratedFDeriv ℝ n (branchPhase k a) (-star z)‖ := by
+  simpa using negConjLIE.norm_iteratedFDeriv_comp_right (branchPhase k a) z n
+
+@[category API, AMS 26]
+private theorem branchOscillatory_iteratedFDeriv_polynomial_bound (k n : ℕ) (a : ℂ)
+    (ha : ‖a‖ = 1) (e : ℂ ≃ₗᵢ[ℝ] ℂ) :
+    ∃ (N : ℕ) (C : ℝ), 0 ≤ C ∧ ∀ z : ℂ, e z ∈ Complex.slitPlane → ‖z‖ ≤ 1 →
+      ‖iteratedFDeriv ℝ n (counterexampleSeed ∘ branchPhase k a ∘ e) z‖ ≤
+        C * ‖z‖ ^ (-(N : ℝ)) := by
+  obtain ⟨d, C, hC, hseed⟩ :=
+    counterexampleSeed_hasTemperateGrowth.norm_iteratedFDeriv_le_uniform n
+  let P := k + n
+  let B := 1 + ‖(100 : ℂ) ^ ((k : ℂ) / 2)‖ *
+    ∑ i ∈ Finset.range (n + 1), ‖cpowFalling (-((k : ℂ) / 2)) i‖
+  refine ⟨P * (d + n), Nat.factorial n * C * (1 + B) ^ d * B ^ n,
+    by positivity, ?_⟩
+  intro z hz hz_one
+  have hz0 : z ≠ 0 := fun h ↦ Complex.slitPlane_ne_zero hz (by simp [h])
+  have hr : 0 < ‖z‖ := norm_pos_iff.mpr hz0
+  have hB : 1 ≤ B := by
+    simp only [B, le_add_iff_nonneg_right]
+    positivity
+  let R : ℝ := ‖z‖ ^ (-(P : ℝ))
+  have hR : 1 ≤ R := by
+    exact Real.one_le_rpow_of_pos_of_le_one_of_nonpos hr hz_one
+      (neg_nonpos.mpr (Nat.cast_nonneg P))
+  let Q := B * R
+  have hQ : 1 ≤ Q := one_le_mul_of_one_le_of_one_le hB hR
+  have hphase (i : ℕ) (hi : i ≤ n) :
+      ‖iteratedFDeriv ℝ i (branchPhase k a ∘ e) z‖ ≤ Q := by
+    rw [e.norm_iteratedFDeriv_comp_right]
+    rw [norm_iteratedFDeriv_branchPhase k i a hz]
+    rw [LinearIsometryEquiv.norm_map]
+    have hcoeff : ‖a * (100 : ℂ) ^ ((k : ℂ) / 2)‖ *
+        ‖cpowFalling (-((k : ℂ) / 2)) i‖ ≤ B := by
+      rw [norm_mul, ha, one_mul]
+      have hi_mem : i ∈ Finset.range (n + 1) := Finset.mem_range.mpr (Nat.lt_succ_of_le hi)
+      have hsum : ‖cpowFalling (-((k : ℂ) / 2)) i‖ ≤
+          ∑ j ∈ Finset.range (n + 1), ‖cpowFalling (-((k : ℂ) / 2)) j‖ :=
+        Finset.single_le_sum (f := fun j ↦ ‖cpowFalling (-((k : ℂ) / 2)) j‖)
+          (fun _ _ ↦ norm_nonneg _) hi_mem
+      dsimp only [B]
+      nlinarith [mul_le_mul_of_nonneg_left hsum (norm_nonneg ((100 : ℂ) ^ ((k : ℂ) / 2)))]
+    have hexp : ‖z‖ ^ (-(k : ℝ) / 2 - i) ≤ R := by
+      apply Real.rpow_le_rpow_of_exponent_ge hr hz_one
+      dsimp only [R, P]
+      have hiR : (i : ℝ) ≤ n := by exact_mod_cast hi
+      have hkR : 0 ≤ (k : ℝ) := Nat.cast_nonneg k
+      push_cast
+      linarith
+    dsimp only [Q]
+    exact mul_le_mul hcoeff hexp (Real.rpow_nonneg (norm_nonneg z) _) (by positivity)
+  let s := e ⁻¹' Complex.slitPlane
+  have hs : IsOpen s := Complex.isOpen_slitPlane.preimage e.continuous
+  have hzs : z ∈ s := hz
+  have hinner : ContDiffOn ℝ ∞ (branchPhase k a ∘ e) s := by
+    intro x hx
+    apply ContDiffAt.contDiffWithinAt
+    apply ContDiffAt.comp x ?_ e.contDiff.contDiffAt
+    unfold branchPhase
+    exact (contDiffAt_const.mul
+      ((analyticAt_id.cpow analyticAt_const hx).restrictScalars.contDiffAt))
+  have houter (i : ℕ) (hi : i ≤ n) :
+      ‖iteratedFDerivWithin ℝ i counterexampleSeed Set.univ
+          ((branchPhase k a ∘ e) z)‖ ≤ C * (1 + Q) ^ d := by
+    rw [iteratedFDerivWithin_univ]
+    refine (hseed i hi _).trans ?_
+    gcongr
+    simpa only [norm_iteratedFDeriv_zero] using hphase 0 (zero_le n)
+  have hinner_bound (i : ℕ) (hi : 1 ≤ i) (hin : i ≤ n) :
+      ‖iteratedFDerivWithin ℝ i (branchPhase k a ∘ e) s z‖ ≤ Q ^ i := by
+    rw [iteratedFDerivWithin_of_isOpen i hs hzs]
+    exact (hphase i hin).trans (le_self_pow₀ hQ (Nat.ne_of_gt hi))
+  have hcomp := norm_iteratedFDerivWithin_comp_le
+    counterexampleSeed_contDiff.contDiffOn hinner (mod_cast le_top)
+    uniqueDiffOn_univ hs.uniqueDiffOn (fun _ _ ↦ Set.mem_univ _) hzs houter hinner_bound
+  rw [iteratedFDerivWithin_of_isOpen n hs hzs] at hcomp
+  have h_one_add : 1 + Q ≤ (1 + B) * R := by
+    dsimp only [Q]
+    nlinarith [mul_nonneg (sub_nonneg.mpr hB) (sub_nonneg.mpr hR)]
+  have hRpow : R ^ (d + n) = ‖z‖ ^ (-((P * (d + n) : ℕ) : ℝ)) := by
+    dsimp only [R]
+    rw [← Real.rpow_natCast, ← Real.rpow_mul (norm_nonneg z)]
+    congr 1
+    push_cast
+    ring
+  calc
+    ‖iteratedFDeriv ℝ n (counterexampleSeed ∘ branchPhase k a ∘ e) z‖
+        ≤ Nat.factorial n * (C * (1 + Q) ^ d) * Q ^ n := hcomp
+    _ ≤ Nat.factorial n * (C * ((1 + B) * R) ^ d) * (B * R) ^ n := by
+      gcongr
+    _ = (Nat.factorial n * C * (1 + B) ^ d * B ^ n) * (R ^ d * R ^ n) := by
+      rw [mul_pow, mul_pow]
+      ring
+    _ = (Nat.factorial n * C * (1 + B) ^ d * B ^ n) * R ^ (d + n) := by
+      rw [pow_add]
+    _ = (Nat.factorial n * C * (1 + B) ^ d * B ^ n) *
+        ‖z‖ ^ (-((P * (d + n) : ℕ) : ℝ)) := by rw [hRpow]
+
+private def oscillatoryFactor (k : ℕ) (z : ℂ) : ℝ :=
+  counterexampleSeed (Complex.cpow (100 / star z) ((k : ℂ) / 2))
+
+@[category API, AMS 26]
+private theorem oscillatoryFactor_eq_plus (k : ℕ) {z : ℂ}
+    (hz : star z ∈ Complex.slitPlane) :
+    oscillatoryFactor k z = counterexampleSeed ((branchPhase k 1 ∘ Complex.conjLIE) z) := by
+  simpa [oscillatoryFactor, Function.comp_apply, Complex.conjLIE_apply, branchPhase] using
+    congrArg counterexampleSeed (div_cpow_eq k hz)
+
+private def radialArgument (z : ℂ) : ℝ :=
+  Complex.normSq z * Real.exp (8 * Complex.normSq z)
+
+private def radialFlat (z : ℂ) : ℝ :=
+  Real.flatRpowExp (1 / 8 : ℝ) 1 (radialArgument z)
+
+@[category API, AMS 26]
+private theorem normSq_contDiff : ContDiff ℝ ∞ Complex.normSq := by
+  have hre : ContDiff ℝ ∞ (fun z : ℂ ↦ z.re) := by
+    simpa [Complex.reCLM_apply] using Complex.reCLM.contDiff
+  have him : ContDiff ℝ ∞ (fun z : ℂ ↦ z.im) := by
+    simpa [Complex.imCLM_apply] using Complex.imCLM.contDiff
+  simpa only [Complex.normSq_apply] using hre.mul hre |>.add (him.mul him)
+
+@[category API, AMS 26]
+private theorem radialArgument_contDiff : ContDiff ℝ ∞ radialArgument := by
+  unfold radialArgument
+  exact normSq_contDiff.mul <| Real.contDiff_exp.comp <| contDiff_const.mul normSq_contDiff
+
+@[category API, AMS 26]
+private theorem radialArgument_zero : radialArgument 0 = 0 := by
+  simp [radialArgument]
+
+@[category API, AMS 26]
+private theorem radialFlat_contDiff : ContDiff ℝ ∞ radialFlat := by
+  unfold radialFlat
+  exact (Real.flatRpowExp.contDiff (by norm_num) (by norm_num)).comp radialArgument_contDiff
+
+@[category API, AMS 26]
+private theorem radialFlat_iteratedFDeriv_zero (n : ℕ) :
+    iteratedFDeriv ℝ n radialFlat 0 = 0 := by
+  unfold radialFlat
+  exact ContDiff.iteratedFDeriv_comp_zero_of_outer
+    (Real.flatRpowExp.contDiff (by norm_num) (by norm_num)) radialArgument_contDiff
+    radialArgument_zero (Real.flatRpowExp.iteratedFDeriv_zero (by norm_num) (by norm_num)) n
+
+private def radialAmplitude (z : ℂ) : ℝ :=
+  radialFlat z * (Complex.normSq z / (1 + Complex.normSq z))
+
+@[category API, AMS 26]
+private theorem radialAmplitude_contDiff : ContDiff ℝ ∞ radialAmplitude := by
+  unfold radialAmplitude
+  apply radialFlat_contDiff.mul
+  exact normSq_contDiff.div (contDiff_const.add normSq_contDiff) fun z ↦
+    ne_of_gt (by have := Complex.normSq_nonneg z; linarith)
+
+@[category API, AMS 26]
+private theorem radialAmplitude_iteratedFDeriv_zero (n : ℕ) :
+    iteratedFDeriv ℝ n radialAmplitude 0 = 0 := by
+  unfold radialAmplitude
+  apply ContDiff.iteratedFDeriv_mul_zero_of_left radialFlat_contDiff
+  · exact normSq_contDiff.div (contDiff_const.add normSq_contDiff) fun z ↦
+      ne_of_gt (by have := Complex.normSq_nonneg z; linarith)
+  · exact radialFlat_iteratedFDeriv_zero
+
+@[category API, AMS 26]
+private theorem radialAmplitude_isLittleO_norm_pow (m n : ℕ) :
+    iteratedFDeriv ℝ m radialAmplitude =o[𝓝 0] fun z : ℂ ↦ ‖z‖ ^ n :=
+  ContDiff.isLittleO_norm_pow_of_iteratedFDeriv_zero radialAmplitude_contDiff
+    radialAmplitude_iteratedFDeriv_zero m n
+
+@[category API, AMS 26]
+private theorem radialFlat_eq (z : ℂ) (hz : z ≠ 0) :
+    radialFlat z =
+      Real.exp (-‖z‖ ^ (-(1 : ℝ) / 4) * Real.exp (-‖z‖ ^ 2)) := by
+  have hr : 0 < ‖z‖ := norm_pos_iff.mpr hz
+  have hx : 0 < Complex.normSq z := Complex.normSq_pos.mpr hz
+  rw [radialFlat, radialArgument,
+    Real.flatRpowExp.of_pos _ _ (mul_pos hx (Real.exp_pos _))]
+  have hpow : Complex.normSq z ^ (-(1 / 8 : ℝ)) = ‖z‖ ^ (-(1 : ℝ) / 4) := by
+    rw [Complex.normSq_eq_norm_sq, ← Real.rpow_natCast, ← Real.rpow_mul (norm_nonneg z)]
+    congr 1
+    ring
+  have hexp : Real.exp (8 * Complex.normSq z) ^ (-(1 / 8 : ℝ)) =
+      Real.exp (-‖z‖ ^ 2) := by
+    rw [Real.rpow_def_of_pos (Real.exp_pos _), Real.log_exp,
+      Complex.normSq_eq_norm_sq]
+    congr 1
+    ring
+  rw [Real.mul_rpow hx.le (Real.exp_pos _).le, hpow, hexp]
+  congr 1
+  ring
+
+@[category API, AMS 26]
+private theorem counterexample_eq_radialAmplitude (k : ℕ) (z : ℂ) (hz : z ≠ 0) :
+    counterexample k z = radialAmplitude z * oscillatoryFactor k z + 10 ^ 10 := by
+  have hexp :
+      Real.exp (-(Real.rpow ‖z‖ (-(1 : ℝ) / 4) * Real.exp (-‖z‖ ^ 2))) =
+        Real.exp (-(Real.exp (-‖z‖ ^ 2) * ‖z‖ ^ (-(1 : ℝ) / 4))) := by
+    congr 1
+    change -(‖z‖ ^ (-(1 : ℝ) / 4) * Real.exp (-‖z‖ ^ 2)) =
+      -(Real.exp (-‖z‖ ^ 2) * ‖z‖ ^ (-(1 : ℝ) / 4))
+    ring
+  rw [counterexample, radialAmplitude, oscillatoryFactor, radialFlat_eq z hz,
+    Complex.normSq_eq_norm_sq]
+  ring_nf
+  all_goals rw [hexp]
+  all_goals ring
+
+@[category API, AMS 26]
+private lemma cpow_half_nat_sq (z : ℂ) (k : ℕ) :
+    (z ^ ((k : ℂ) / 2)) ^ 2 = z ^ k := by
+  rw [← Complex.cpow_mul_nat, ← Complex.cpow_natCast]
+  congr 1
+  push_cast
+  ring
+
+@[category API, AMS 26]
+private lemma alt_cpow_half_nat_sq (z : ℂ) (k : ℕ) :
+    ((Complex.I ^ k) * ((-z) ^ ((k : ℂ) / 2))) ^ 2 = z ^ k := by
+  rw [mul_pow, cpow_half_nat_sq, ← pow_mul]
+  conv_lhs => lhs; rw [show k * 2 = 2 * k by omega]
+  rw [pow_mul, Complex.I_sq]
+  rw [neg_pow z k]
+  have hsign : (-1 : ℂ) ^ k * (-1 : ℂ) ^ k = 1 := by
+    rw [← mul_pow]
+    simp
+  rw [← mul_assoc, hsign, one_mul]
+
+@[category API, AMS 26]
+private lemma counterexampleSeed_eq_of_sq_eq_sq {z w : ℂ} (h : z ^ 2 = w ^ 2) :
+    counterexampleSeed z = counterexampleSeed w := by
+  rcases eq_or_eq_neg_of_sq_eq_sq z w h with h | h
+  · rw [h]
+  · rw [h, counterexampleSeed_neg]
+
+/-- The seed identifies the principal half-integral power with the smooth alternate branch based
+at `-z`. This pointwise identity is useful for differentiating at points on the branch cut. -/
+@[category API, AMS 26]
+theorem counterexampleSeed_cpow_eq_alt (k : ℕ) (z : ℂ) :
+    counterexampleSeed (z ^ ((k : ℂ) / 2)) =
+      counterexampleSeed ((Complex.I ^ k) * ((-z) ^ ((k : ℂ) / 2))) :=
+  counterexampleSeed_eq_of_sq_eq_sq <|
+    (cpow_half_nat_sq z k).trans (alt_cpow_half_nat_sq z k).symm
+
+@[category API, AMS 26]
+private theorem oscillatoryFactor_eq_minus (k : ℕ) {z : ℂ}
+    (hz : -star z ∈ Complex.slitPlane) :
+    oscillatoryFactor k z = counterexampleSeed ((branchPhase k (Complex.I ^ k) ∘ negConjLIE) z) := by
+  have hneg : -(100 / star z) = 100 / (-star z) := by ring
+  calc
+    oscillatoryFactor k z =
+        counterexampleSeed ((Complex.I ^ k) * ((-(100 / star z)) ^ ((k : ℂ) / 2))) := by
+      simpa [oscillatoryFactor] using counterexampleSeed_cpow_eq_alt k (100 / star z)
+    _ = counterexampleSeed
+        ((Complex.I ^ k) * ((100 / (-star z)) ^ ((k : ℂ) / 2))) := by rw [hneg]
+    _ = counterexampleSeed ((branchPhase k (Complex.I ^ k) ∘ negConjLIE) z) := by
+      rw [div_cpow_eq k hz]
+      simp only [Function.comp_apply, negConjLIE_apply, branchPhase]
+      ring_nf
+
+@[category API, AMS 26]
+private theorem oscillatoryFactor_iteratedFDeriv_polynomial_bound (k n : ℕ) :
+    ∃ (N : ℕ) (C : ℝ), 0 ≤ C ∧ ∀ z : ℂ, z ≠ 0 → ‖z‖ ≤ 1 →
+      ‖iteratedFDeriv ℝ n (oscillatoryFactor k) z‖ ≤ C * ‖z‖ ^ (-(N : ℝ)) := by
+  obtain ⟨Np, Cp, hCp, hp⟩ :=
+    branchOscillatory_iteratedFDeriv_polynomial_bound k n 1 (by simp) Complex.conjLIE
+  obtain ⟨Nm, Cm, hCm, hm⟩ :=
+    branchOscillatory_iteratedFDeriv_polynomial_bound k n (Complex.I ^ k)
+      (by simp) negConjLIE
+  refine ⟨Np + Nm, Cp + Cm, add_nonneg hCp hCm, ?_⟩
+  intro z hz hz_one
+  have hr : 0 < ‖z‖ := norm_pos_iff.mpr hz
+  have hpowp : ‖z‖ ^ (-(Np : ℝ)) ≤ ‖z‖ ^ (-((Np + Nm : ℕ) : ℝ)) := by
+    apply Real.rpow_le_rpow_of_exponent_ge hr hz_one
+    push_cast
+    linarith
+  have hpowm : ‖z‖ ^ (-(Nm : ℝ)) ≤ ‖z‖ ^ (-((Np + Nm : ℕ) : ℝ)) := by
+    apply Real.rpow_le_rpow_of_exponent_ge hr hz_one
+    push_cast
+    linarith
+  rcases Complex.mem_slitPlane_or_neg_mem_slitPlane (star_ne_zero.mpr hz) with hslit | hslit
+  · have heq : oscillatoryFactor k =ᶠ[𝓝 z]
+        counterexampleSeed ∘ branchPhase k 1 ∘ Complex.conjLIE := by
+      filter_upwards [Complex.isOpen_slitPlane.preimage Complex.continuous_conj |>.mem_nhds hslit]
+        with w hw
+      exact oscillatoryFactor_eq_plus k hw
+    rw [(heq.iteratedFDeriv ℝ n).eq_of_nhds]
+    calc
+      _ ≤ Cp * ‖z‖ ^ (-(Np : ℝ)) := hp z hslit hz_one
+      _ ≤ (Cp + Cm) * ‖z‖ ^ (-((Np + Nm : ℕ) : ℝ)) := by
+        exact (mul_le_mul_of_nonneg_left hpowp hCp).trans <|
+          mul_le_mul_of_nonneg_right (le_add_of_nonneg_right hCm)
+            (Real.rpow_nonneg (norm_nonneg z) _)
+  · have heq : oscillatoryFactor k =ᶠ[𝓝 z]
+        counterexampleSeed ∘ branchPhase k (Complex.I ^ k) ∘ negConjLIE := by
+      filter_upwards [Complex.isOpen_slitPlane.preimage negConjLIE.continuous |>.mem_nhds hslit]
+        with w hw
+      exact oscillatoryFactor_eq_minus k hw
+    rw [(heq.iteratedFDeriv ℝ n).eq_of_nhds]
+    calc
+      _ ≤ Cm * ‖z‖ ^ (-(Nm : ℝ)) := hm z hslit hz_one
+      _ ≤ (Cp + Cm) * ‖z‖ ^ (-((Np + Nm : ℕ) : ℝ)) := by
+        exact (mul_le_mul_of_nonneg_left hpowm hCm).trans <|
+          mul_le_mul_of_nonneg_right (le_add_of_nonneg_left hCp)
+            (Real.rpow_nonneg (norm_nonneg z) _)
+
+@[category API, AMS 26]
+private theorem counterexampleSeed_cpow_contDiffAt (k : ℕ) {z : ℂ} (hz : z ≠ 0) :
+    ContDiffAt ℝ ∞ (fun w : ℂ ↦ counterexampleSeed (w ^ ((k : ℂ) / 2))) z := by
+  rcases Complex.mem_slitPlane_or_neg_mem_slitPlane hz with hz | hz
+  · exact counterexampleSeed_contDiff.contDiffAt.comp z
+      ((analyticAt_id.cpow analyticAt_const hz).restrictScalars.contDiffAt)
+  · have hq : ContDiffAt ℝ ∞
+        (fun w : ℂ ↦ (Complex.I ^ k) * ((-w) ^ ((k : ℂ) / 2))) z :=
+      ((analyticAt_const.mul
+        (analyticAt_id.neg.cpow analyticAt_const hz)).restrictScalars.contDiffAt)
+    apply (counterexampleSeed_contDiff.contDiffAt.comp z hq).congr_of_eventuallyEq
+    filter_upwards
+    intro w
+    exact counterexampleSeed_cpow_eq_alt k w
+
+@[category API, AMS 26]
+private theorem oscillatoryFactor_contDiffAt (k : ℕ) {z : ℂ} (hz : z ≠ 0) :
+    ContDiffAt ℝ ∞ (oscillatoryFactor k) z := by
+  have hstar : ContDiffAt ℝ ∞ (fun w : ℂ ↦ star w) z := by
+    simpa [Complex.conjLIE_apply] using Complex.conjLIE.contDiff.contDiffAt
+  have hstar_ne : star z ≠ 0 := star_ne_zero.mpr hz
+  have hinv : ContDiffAt ℝ ∞ (fun w : ℂ ↦ 100 / star w) z := by
+    simpa [div_eq_mul_inv] using contDiffAt_const.mul (hstar.inv hstar_ne)
+  simpa [oscillatoryFactor, Function.comp_def] using
+    (counterexampleSeed_cpow_contDiffAt k (div_ne_zero (by norm_num) hstar_ne)).comp z hinv
+
+@[category API, AMS 26]
+private theorem radialAmplitude_mul_oscillatory_flatness (k : ℕ) :
+    ContDiffAt ℝ ∞ (fun z ↦ radialAmplitude z * oscillatoryFactor k z) 0 ∧
+      ∀ m, iteratedFDeriv ℝ m (fun z ↦ radialAmplitude z * oscillatoryFactor k z) =o[𝓝[≠] 0]
+        (id : ℂ → ℂ) := by
+  let s : Set ℂ := {0}ᶜ
+  have hs : IsOpen s := isClosed_singleton.isOpen_compl
+  have hosc : ContDiffOn ℝ ∞ (oscillatoryFactor k) s := by
+    intro z hz
+    exact (oscillatoryFactor_contDiffAt k (by simpa [s] using hz)).contDiffWithinAt
+  have hflat : ∀ m, iteratedFDeriv ℝ m
+      (fun z ↦ radialAmplitude z * oscillatoryFactor k z) =o[𝓝[≠] 0]
+        (id : ℂ → ℂ) := by
+    intro m
+    have hsum : (fun z : ℂ ↦ ∑ i ∈ Finset.range (m + 1),
+        (m.choose i : ℝ) * ‖iteratedFDeriv ℝ i radialAmplitude z‖ *
+          ‖iteratedFDeriv ℝ (m - i) (oscillatoryFactor k) z‖) =o[𝓝[≠] 0]
+        fun z ↦ ‖z‖ := by
+      apply Asymptotics.IsLittleO.sum
+      intro i hi
+      obtain ⟨N, C, hC, hpoly⟩ :=
+        oscillatoryFactor_iteratedFDeriv_polynomial_bound k (m - i)
+      have hoscO : (iteratedFDeriv ℝ (m - i) (oscillatoryFactor k)) =O[𝓝[≠] 0]
+          fun z : ℂ ↦ ‖z‖ ^ (-(N : ℝ)) := by
+        rw [Asymptotics.isBigO_iff]
+        refine ⟨C, ?_⟩
+        have hball : ∀ᶠ z in 𝓝[≠] (0 : ℂ), z ∈ Metric.ball 0 1 :=
+          Filter.Eventually.filter_mono inf_le_left (Metric.ball_mem_nhds 0 one_pos)
+        filter_upwards [self_mem_nhdsWithin, hball] with z hz hball
+        simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
+        have hz_one : ‖z‖ ≤ 1 := by
+          rw [Metric.mem_ball, dist_zero_right] at hball
+          exact hball.le
+        rw [Real.norm_of_nonneg (Real.rpow_nonneg (norm_nonneg z) _)]
+        exact hpoly z hz hz_one
+      have hamp := (radialAmplitude_isLittleO_norm_pow i (N + 1)).mono
+        (show 𝓝[≠] (0 : ℂ) ≤ 𝓝 0 from inf_le_left)
+      have hprod : (fun z : ℂ ↦
+          ‖iteratedFDeriv ℝ i radialAmplitude z‖ *
+            ‖iteratedFDeriv ℝ (m - i) (oscillatoryFactor k) z‖) =o[𝓝[≠] 0]
+          fun z ↦ ‖z‖ ^ (N + 1) * ‖z‖ ^ (-(N : ℝ)) :=
+        hamp.norm_left.mul_isBigO hoscO.norm_left
+      have htarget : (fun z : ℂ ↦ ‖z‖ ^ (N + 1) * ‖z‖ ^ (-(N : ℝ))) =ᶠ[𝓝[≠] 0]
+          fun z ↦ ‖z‖ := by
+        filter_upwards [self_mem_nhdsWithin] with z hz
+        simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
+        have hr : 0 < ‖z‖ := norm_pos_iff.mpr hz
+        rw [← Real.rpow_natCast, ← Real.rpow_add hr]
+        have hN : ((N + 1 : ℕ) : ℝ) + -(N : ℝ) = 1 := by
+          push_cast
+          ring
+        rw [hN, Real.rpow_one]
+      simpa only [mul_assoc] using
+        (hprod.congr' EventuallyEq.rfl htarget).const_mul_left (m.choose i : ℝ)
+    rw [Asymptotics.isLittleO_iff] at hsum ⊢
+    intro c hc
+    filter_upwards [hsum hc, self_mem_nhdsWithin] with z hbound hz
+    simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hz
+    have hmul := norm_iteratedFDerivWithin_mul_le
+      radialAmplitude_contDiff.contDiffOn hosc hs.uniqueDiffOn (show z ∈ s by simpa [s] using hz)
+      (mod_cast le_top : m ≤ (∞ : WithTop ℕ∞))
+    rw [iteratedFDerivWithin_of_isOpen m hs (show z ∈ s by simpa [s] using hz)] at hmul
+    simp_rw [iteratedFDerivWithin_of_isOpen _ hs (show z ∈ s by simpa [s] using hz)] at hmul
+    have hsum_nonneg : 0 ≤ ∑ i ∈ Finset.range (m + 1),
+        (m.choose i : ℝ) * ‖iteratedFDeriv ℝ i radialAmplitude z‖ *
+          ‖iteratedFDeriv ℝ (m - i) (oscillatoryFactor k) z‖ := by
+      apply Finset.sum_nonneg
+      intro i hi
+      exact mul_nonneg
+        (mul_nonneg (Nat.cast_nonneg _) (norm_nonneg _)) (norm_nonneg _)
+    rw [Real.norm_of_nonneg hsum_nonneg] at hbound
+    exact hmul.trans (by simpa using hbound)
+  refine ⟨?_, hflat⟩
+  apply ContDiff.at_zero_of_iteratedFDeriv_isLittleO
+  · intro z hz
+    exact radialAmplitude_contDiff.contDiffAt.mul (oscillatoryFactor_contDiffAt k hz)
+  · simp [radialAmplitude, radialFlat, radialArgument]
+  · exact hflat
+
+@[category API, AMS 26]
+private theorem radialAmplitude_mul_oscillatory_iteratedFDeriv_isLittleO (k m : ℕ) :
+    iteratedFDeriv ℝ m (fun z ↦ radialAmplitude z * oscillatoryFactor k z) =o[𝓝[≠] 0]
+      (id : ℂ → ℂ) :=
+  (radialAmplitude_mul_oscillatory_flatness k).2 m
+
+@[category API, AMS 26]
+private theorem radialAmplitude_mul_oscillatory_contDiffAt_zero (k : ℕ) :
+    ContDiffAt ℝ ∞ (fun z ↦ radialAmplitude z * oscillatoryFactor k z) 0 :=
+  (radialAmplitude_mul_oscillatory_flatness k).1
+
+@[category API, AMS 26]
+private theorem radialAmplitude_mul_oscillatory_iteratedFDeriv_zero (k m : ℕ) :
+    iteratedFDeriv ℝ m (fun z ↦ radialAmplitude z * oscillatoryFactor k z) 0 = 0 := by
+  have hcontinuous := (radialAmplitude_mul_oscillatory_contDiffAt_zero k)
+    |>.continuousAt_iteratedFDeriv (mod_cast le_top : m ≤ (∞ : WithTop ℕ∞))
+  have hcontinuous' : Tendsto
+      (iteratedFDeriv ℝ m (fun z ↦ radialAmplitude z * oscillatoryFactor k z))
+      (𝓝[≠] 0) (𝓝 (iteratedFDeriv ℝ m
+        (fun z ↦ radialAmplitude z * oscillatoryFactor k z) 0)) :=
+    hcontinuous.mono_left (show 𝓝[≠] (0 : ℂ) ≤ 𝓝 0 from inf_le_left)
+  have hzero := (radialAmplitude_mul_oscillatory_iteratedFDeriv_isLittleO k m).trans_tendsto
+    (tendsto_id.mono_left inf_le_left)
+  exact tendsto_nhds_unique' (NormedField.nhdsNE_neBot (0 : ℂ)) hcontinuous' hzero
+
+/-- Away from the origin the principal-power formula is smooth. For odd `k`, evenness of the seed
+removes the sign jump of the chosen square-root branch. -/
+@[category research solved, AMS 26 53]
+theorem counterexample_contDiffAt_of_ne_zero (k : ℕ) {z : ℂ} (hz : z ≠ 0) :
+    ContDiffAt ℝ ∞ (counterexample k) z := by
+  have hstar : ContDiffAt ℝ ∞ (fun w : ℂ ↦ star w) z := by
+    simpa [Complex.conjLIE_apply] using Complex.conjLIE.contDiff.contDiffAt
+  have hstar_ne : star z ≠ 0 := star_ne_zero.mpr hz
+  have hinv : ContDiffAt ℝ ∞ (fun w : ℂ ↦ 100 / star w) z := by
+    simpa [div_eq_mul_inv] using contDiffAt_const.mul (hstar.inv hstar_ne)
+  have hseed : ContDiffAt ℝ ∞
+      (fun w : ℂ ↦ counterexampleSeed ((100 / star w) ^ ((k : ℂ) / 2))) z :=
+    by
+      simpa [Function.comp_def] using
+        (counterexampleSeed_cpow_contDiffAt k (div_ne_zero (by norm_num) hstar_ne)).comp z hinv
+  apply (radialAmplitude_contDiff.contDiffAt.mul hseed).add contDiffAt_const
+    |>.congr_of_eventuallyEq
+  filter_upwards [eventually_ne_nhds hz] with w hw
+  exact counterexample_eq_radialAmplitude k w hw
+
+@[category API, AMS 26 53]
+private theorem counterexample_contDiffAt_zero_all (k : ℕ) :
+    ContDiffAt ℝ ∞ (counterexample k) 0 := by
+  have hconstant : ContDiffAt ℝ ∞ (fun _ : ℂ ↦ (10 : ℝ) ^ 10) 0 := contDiffAt_const
+  apply (radialAmplitude_mul_oscillatory_contDiffAt_zero k).add hconstant
+    |>.congr_of_eventuallyEq
+  filter_upwards
+  intro z
+  by_cases hz : z = 0
+  · subst z
+    simp [counterexample_zero, radialAmplitude, radialFlat, radialArgument]
+  · exact counterexample_eq_radialAmplitude k z hz
+
+/-- At the origin the nonconstant part of `counterexample k` is flat: exponential decay dominates
+the algebraic growth of every derivative of the oscillatory factor. -/
+@[category research solved, AMS 26 53]
+theorem counterexample_contDiffAt_zero (k : ℕ) (hk : 0 < k) :
+    ContDiffAt ℝ ∞ (counterexample k) 0 := by
+  cases k with
+  | zero => omega
+  | succ k => exact counterexample_contDiffAt_zero_all (k + 1)
+
+/-- The first Fréchet derivative of the counterexample vanishes at the origin. -/
+@[category API, AMS 26 53]
+theorem counterexample_fderiv_zero (k : ℕ) (hk : 0 < k) :
+    fderiv ℝ (counterexample k) 0 = 0 := by
+  cases k with
+  | zero => omega
+  | succ k =>
+    have hfun : counterexample (Nat.succ k) = fun z ↦
+        radialAmplitude z * oscillatoryFactor (Nat.succ k) z + (10 : ℝ) ^ 10 := by
+      funext z
+      by_cases hz : z = 0
+      · subst z
+        simp [counterexample_zero, radialAmplitude, radialFlat, radialArgument]
+      · exact counterexample_eq_radialAmplitude (Nat.succ k) z hz
+    rw [hfun]
+    simp only [fderiv_add_const]
+    ext v
+    have hzero := radialAmplitude_mul_oscillatory_iteratedFDeriv_zero (Nat.succ k) 1
+    have happ := congrArg (fun L : ℂ [×1]→L[ℝ] ℝ ↦ L ![v]) hzero
+    simpa only [iteratedFDeriv_one_apply, ContinuousMultilinearMap.zero_apply] using happ
+
+@[category API, AMS 26 53]
+private theorem counterexample_fderiv_fderiv_zero_all (k : ℕ) :
+    fderiv ℝ (fun w ↦ fderiv ℝ (counterexample k) w) 0 = 0 := by
+  have hfun : counterexample k = fun z ↦
+      radialAmplitude z * oscillatoryFactor k z + (10 : ℝ) ^ 10 := by
+    funext z
+    by_cases hz : z = 0
+    · subst z
+      simp [counterexample_zero, radialAmplitude, radialFlat, radialArgument]
+    · exact counterexample_eq_radialAmplitude k z hz
+  rw [hfun]
+  simp only [fderiv_add_const]
+  ext v w
+  have hzero := radialAmplitude_mul_oscillatory_iteratedFDeriv_zero k 2
+  have happ := congrArg (fun L : ℂ [×2]→L[ℝ] ℝ ↦ L ![v, w]) hzero
+  simpa only [iteratedFDeriv_two_apply, ContinuousMultilinearMap.zero_apply] using happ
+
+/-- The second Fréchet derivative of the counterexample vanishes at the origin. This is the
+flatness consequence used in the index computation. -/
+@[category API, AMS 26 53]
+theorem counterexample_fderiv_fderiv_zero (k : ℕ) (hk : 0 < k) :
+    fderiv ℝ (fun w ↦ fderiv ℝ (counterexample k) w) 0 = 0 := by
+  cases k with
+  | zero => omega
+  | succ k => exact counterexample_fderiv_fderiv_zero_all (k + 1)
+
+/-- Each positive member of the announced family is smooth on the whole complex plane, including
+at the origin. The flat exponential factor is essential at the origin. -/
+@[category research solved, AMS 26 53]
+theorem counterexample_contDiff (k : ℕ) (hk : 0 < k) : ContDiff ℝ ∞ (counterexample k) := by
+  rw [contDiff_iff_contDiffAt]
+  intro z
+  by_cases hz : z = 0
+  · simpa [hz] using counterexample_contDiffAt_zero k hk
+  · exact counterexample_contDiffAt_of_ne_zero k hz
+
+end
+
+end CaratheodoryLoewnerCounterexample

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -1,0 +1,87 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Loewner's conjecture
+
+Loewner's conjecture says that an isolated umbilic point of a sufficiently smooth surface has
+principal-line index at most one. We state the conjecture for smooth functions and the classical
+positive result for real-analytic functions.
+
+*References:*
+- [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problem
+  8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
+- [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
+  umbilic points*](https://doi.org/10.1007/BF02392036)
+-/
+
+open Metric
+open scoped ContDiff
+
+namespace LoewnerConjecture
+
+/-- The trace-free part of the Hessian of `f : ℂ → ℝ`, encoded as a complex number.
+
+Its zeros are precisely the points where the two eigendirections of the Hessian are not
+distinct. The argument of this complex number is twice the angle of a principal line. -/
+noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
+  let H := fderiv ℝ (fun w ↦ fderiv ℝ f w) z
+  (H 1 1 - H Complex.I Complex.I : ℝ) + (2 * H 1 Complex.I : ℝ) * Complex.I
+
+/-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
+
+The lift `θ` records the argument of `q` on a sufficiently small positively oriented circle.
+For a trace-free Hessian, the corresponding principal-line index is `m / 2`. -/
+def HasIsolatedZeroIndex (q : ℂ → ℂ) (z : ℂ) (m : ℤ) : Prop :=
+  ∃ ε > 0,
+    q z = 0 ∧
+      (∀ w, w ≠ z → dist w z < ε → q w ≠ 0) ∧
+      ∃ r, 0 < r ∧ r < ε ∧ ∃ θ : ℝ → ℝ, Continuous θ ∧
+        (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
+          q (z + r * Complex.exp ((t : ℂ) * Complex.I)) /
+            ‖q (z + r * Complex.exp ((t : ℂ) * Complex.I))‖) ∧
+        θ (2 * Real.pi) - θ 0 = 2 * Real.pi * m
+
+/-- Loewner's conjecture for functions of class `C^k` near an isolated umbilic. The integer `m`
+is twice the principal-line index, so the bound `m ≤ 2` says that this index is at most one. -/
+def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
+  ∀ (f : ℂ → ℝ) (z : ℂ) (m : ℤ), ContDiffAt ℝ k f z →
+    HasIsolatedZeroIndex (traceFreeHessian f) z m → m ≤ 2
+
+/-- The smooth Loewner conjecture. -/
+abbrev SmoothLoewnerConjecture := LoewnerConjectureOfClass ∞
+
+/-- The real-analytic Loewner conjecture. -/
+abbrev AnalyticLoewnerConjecture := LoewnerConjectureOfClass ω
+
+/-- **The smooth Loewner conjecture.**
+
+The principal-line index at an isolated umbilic of a smooth Hessian is at most one. -/
+@[category research open, AMS 53 57]
+theorem loewner_conjecture : answer(sorry) ↔ SmoothLoewnerConjecture := by
+  sorry
+
+/-- **The real-analytic Loewner conjecture.**
+
+The principal-line index at an isolated umbilic of a real-analytic Hessian is at most one.
+This is the classical result attributed to Hamburger and subsequently treated by Titus. -/
+@[category research solved, AMS 53 57]
+theorem loewner_conjecture_analytic : AnalyticLoewnerConjecture := by
+  sorry
+
+end LoewnerConjecture

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -21,13 +21,16 @@ import FormalConjecturesUtil
 # Loewner's conjecture
 
 Loewner's conjecture says that an isolated umbilic point of a sufficiently smooth surface has
-principal-line index at most one. We record the smooth conjecture and real-analytic theorem.
+principal-line index at most one. We state the now-disproved smooth version for functions and the
+classical positive result for real-analytic functions. Levent Alpöge announced the smooth
+counterexample on 19 August 2026.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problem
   8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
 - [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
   umbilic points*](https://doi.org/10.1007/BF02392036)
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
 -/
 
 open Metric
@@ -64,9 +67,11 @@ def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
 
 /-- **The smooth Loewner conjecture.**
 
-The principal-line index at an isolated umbilic of a smooth Hessian is at most one. -/
-@[category research open, AMS 53 57]
-theorem loewner_conjecture : answer(sorry) ↔ LoewnerConjectureOfClass ∞ := by
+The principal-line index at an isolated umbilic of a smooth Hessian was conjectured to be at most
+one. Alpöge's smooth family gives isolated umbilics of larger index, so the answer is false. -/
+@[category research solved, AMS 53 57,
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/c0591a2d3c3c8fca852865c8ceecfe4dfb083d10/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L53"]
+theorem loewner_conjecture : answer(False) ↔ LoewnerConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Loewner conjecture.**

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -70,7 +70,7 @@ def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
 The principal-line index at an isolated umbilic of a smooth Hessian was conjectured to be at most
 one. Alpöge's smooth family gives isolated umbilics of larger index, so the answer is false. -/
 @[category research solved, AMS 53 57,
-  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/150d2159bd37294ac7ad45c4ae7f199fb7dcd871/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L53"]
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/a4677e237082ea8740b8a47d8f5f0086628b11d4/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L53"]
 theorem loewner_conjecture : answer(False) ↔ LoewnerConjectureOfClass ∞ := by
   sorry
 

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -63,17 +63,11 @@ def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
   ∀ (f : ℂ → ℝ) (z : ℂ) (m : ℤ), ContDiffAt ℝ k f z →
     HasIsolatedZeroIndex (traceFreeHessian f) z m → m ≤ 2
 
-/-- The smooth Loewner conjecture. -/
-abbrev SmoothLoewnerConjecture := LoewnerConjectureOfClass ∞
-
-/-- The real-analytic Loewner conjecture. -/
-abbrev AnalyticLoewnerConjecture := LoewnerConjectureOfClass ω
-
 /-- **The smooth Loewner conjecture.**
 
 The principal-line index at an isolated umbilic of a smooth Hessian is at most one. -/
 @[category research open, AMS 53 57]
-theorem loewner_conjecture : answer(sorry) ↔ SmoothLoewnerConjecture := by
+theorem loewner_conjecture : answer(sorry) ↔ LoewnerConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Loewner conjecture.**
@@ -81,7 +75,7 @@ theorem loewner_conjecture : answer(sorry) ↔ SmoothLoewnerConjecture := by
 The principal-line index at an isolated umbilic of a real-analytic Hessian is at most one.
 This is the classical result attributed to Hamburger and subsequently treated by Titus. -/
 @[category research solved, AMS 53 57]
-theorem loewner_conjecture_analytic : AnalyticLoewnerConjecture := by
+theorem loewner_conjecture_analytic : LoewnerConjectureOfClass ω := by
   sorry
 
 end LoewnerConjecture

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -21,8 +21,7 @@ import FormalConjecturesUtil
 # Loewner's conjecture
 
 Loewner's conjecture says that an isolated umbilic point of a sufficiently smooth surface has
-principal-line index at most one. We state the conjecture for smooth functions and the classical
-positive result for real-analytic functions.
+principal-line index at most one. We record the smooth conjecture and real-analytic theorem.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problem
@@ -36,10 +35,8 @@ open scoped ContDiff
 
 namespace LoewnerConjecture
 
-/-- The trace-free part of the Hessian of `f : ℂ → ℝ`, encoded as a complex number.
-
-Its zeros are precisely the points where the two eigendirections of the Hessian are not
-distinct. The argument of this complex number is twice the angle of a principal line. -/
+/-- The trace-free Hessian of `f : ℂ → ℝ`, encoded so its argument is twice the principal-line
+angle. Its zeros are exactly the points where the Hessian has a repeated eigenvalue. -/
 noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
   let H := iteratedFDeriv ℝ 2 f z
   (H ![1, 1] - H ![Complex.I, Complex.I] : ℝ) +
@@ -47,9 +44,8 @@ noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
 
 /-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
 
-The function `q` is continuous on the ball witnessing isolation, so its winding number is
-independent of the sufficiently small positively oriented circle used below. The lift `θ` records
-the argument of `q` on one such circle. For a trace-free Hessian, the corresponding principal-line
+Continuity on the witness ball makes the winding number independent of the sufficiently small
+circle; `θ` is an argument lift on one such circle. For a trace-free Hessian, the principal-line
 index is `m / 2`. -/
 def HasIsolatedZeroIndex (q : ℂ → ℂ) (z : ℂ) (m : ℤ) : Prop :=
   ∃ ε > 0,

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
-import Mathlib.Analysis.Normed.Module.Normalize
 import FormalConjecturesUtil
 
 /-!

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -20,14 +20,16 @@ import FormalConjecturesUtil
 # Loewner's conjecture
 
 Loewner's conjecture says that an isolated umbilic point of a sufficiently smooth surface has
-principal-line index at most one. We state the conjecture for smooth functions and the classical
-positive result for real-analytic functions.
+principal-line index at most one. We state the now-disproved smooth version for functions and the
+classical positive result for real-analytic functions. Levent Alpöge announced the smooth
+counterexample on 19 August 2026.
 
 *References:*
 - [M. Ghomi, *Open Problems in Geometry of Curves and Surfaces*, Problem
   8.2](https://ghomi.math.gatech.edu/Papers/op.pdf)
 - [C. J. Titus, *A proof of a conjecture of Loewner and of the conjecture of Carathéodory on
   umbilic points*](https://doi.org/10.1007/BF02392036)
+- [L. Alpöge, X post 2089971359921156203](https://x.com/__alpoge__/status/2089971359921156203)
 -/
 
 open Metric
@@ -65,9 +67,11 @@ def LoewnerConjectureOfClass (k : WithTop ℕ∞) : Prop :=
 
 /-- **The smooth Loewner conjecture.**
 
-The principal-line index at an isolated umbilic of a smooth Hessian is at most one. -/
-@[category research open, AMS 53 57]
-theorem loewner_conjecture : answer(sorry) ↔ LoewnerConjectureOfClass ∞ := by
+The principal-line index at an isolated umbilic of a smooth Hessian was conjectured to be at most
+one. Alpöge's smooth family gives isolated umbilics of larger index, so the answer is false. -/
+@[category research solved, AMS 53 57,
+  formal_proof using formal_conjectures at "https://github.com/google-deepmind/formal-conjectures/blob/150d2159bd37294ac7ad45c4ae7f199fb7dcd871/FormalConjectures/Other/CaratheodoryLoewnerCounterexample.lean#L53"]
+theorem loewner_conjecture : answer(False) ↔ LoewnerConjectureOfClass ∞ := by
   sorry
 
 /-- **The real-analytic Loewner conjecture.**

--- a/FormalConjectures/Other/LoewnerConjecture.lean
+++ b/FormalConjectures/Other/LoewnerConjecture.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
+import Mathlib.Analysis.Normed.Module.Normalize
 import FormalConjecturesUtil
 
 /-!
@@ -40,21 +41,23 @@ namespace LoewnerConjecture
 Its zeros are precisely the points where the two eigendirections of the Hessian are not
 distinct. The argument of this complex number is twice the angle of a principal line. -/
 noncomputable def traceFreeHessian (f : ℂ → ℝ) (z : ℂ) : ℂ :=
-  let H := fderiv ℝ (fun w ↦ fderiv ℝ f w) z
-  (H 1 1 - H Complex.I Complex.I : ℝ) + (2 * H 1 Complex.I : ℝ) * Complex.I
+  let H := iteratedFDeriv ℝ 2 f z
+  (H ![1, 1] - H ![Complex.I, Complex.I] : ℝ) +
+    (2 * H ![1, Complex.I] : ℝ) * Complex.I
 
 /-- A complex-valued function `q` has an isolated zero at `z` with winding number `m`.
 
-The lift `θ` records the argument of `q` on a sufficiently small positively oriented circle.
-For a trace-free Hessian, the corresponding principal-line index is `m / 2`. -/
+The function `q` is continuous on the ball witnessing isolation, so its winding number is
+independent of the sufficiently small positively oriented circle used below. The lift `θ` records
+the argument of `q` on one such circle. For a trace-free Hessian, the corresponding principal-line
+index is `m / 2`. -/
 def HasIsolatedZeroIndex (q : ℂ → ℂ) (z : ℂ) (m : ℤ) : Prop :=
   ∃ ε > 0,
-    q z = 0 ∧
+    ContinuousOn q (ball z ε) ∧ q z = 0 ∧
       (∀ w, w ≠ z → dist w z < ε → q w ≠ 0) ∧
       ∃ r, 0 < r ∧ r < ε ∧ ∃ θ : ℝ → ℝ, Continuous θ ∧
         (∀ t, Complex.exp ((θ t : ℂ) * Complex.I) =
-          q (z + r * Complex.exp ((t : ℂ) * Complex.I)) /
-            ‖q (z + r * Complex.exp ((t : ℂ) * Complex.I))‖) ∧
+          NormedSpace.normalize (q (z + r * Complex.exp ((t : ℂ) * Complex.I)))) ∧
         θ (2 * Real.pi) - θ 0 = 2 * Real.pi * m
 
 /-- Loewner's conjecture for functions of class `C^k` near an isolated umbilic. The integer `m`

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -123,6 +123,7 @@ public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+public import FormalConjecturesForMathlib.Geometry.SphereImmersionRegularity
 public import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -122,6 +122,7 @@ public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+public import FormalConjecturesForMathlib.Geometry.SphereImmersionRegularity
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -122,6 +122,7 @@ public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
 public import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -35,6 +35,7 @@ public import FormalConjecturesForMathlib.Analysis.HasGaps
 public import FormalConjecturesForMathlib.Analysis.Matrix.Spectrum
 public import FormalConjecturesForMathlib.Analysis.Real.Cardinality
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.AdditiveCharacter
+public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.FlatRpowExp
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Log.Basic
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.NthRoot
 public import FormalConjecturesForMathlib.Combinatorics.AP.Basic
@@ -120,6 +121,7 @@ public import FormalConjecturesForMathlib.Data.ZMod.PerfectDifferenceSet
 public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.Metric
+public import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -120,6 +120,7 @@ public import FormalConjecturesForMathlib.Data.ZMod.Fp
 public import FormalConjecturesForMathlib.Data.ZMod.PerfectDifferenceSet
 public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
+public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
 public import FormalConjecturesForMathlib.Geometry.«2d»

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -121,6 +121,7 @@ public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -35,6 +35,7 @@ public import FormalConjecturesForMathlib.Analysis.HasGaps
 public import FormalConjecturesForMathlib.Analysis.Matrix.Spectrum
 public import FormalConjecturesForMathlib.Analysis.Real.Cardinality
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.AdditiveCharacter
+public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.FlatRpowExp
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Log.Basic
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.NthRoot
 public import FormalConjecturesForMathlib.Combinatorics.AP.Basic
@@ -123,6 +124,7 @@ public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.SphereImmersion
 public import FormalConjecturesForMathlib.Geometry.SphereImmersionRegularity
+public import FormalConjecturesForMathlib.Geometry.SupportFunctionSphere
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -119,6 +119,7 @@ public import FormalConjecturesForMathlib.Data.ZMod.Fp
 public import FormalConjecturesForMathlib.Data.ZMod.PerfectDifferenceSet
 public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
+public import FormalConjecturesForMathlib.Geometry.EuclideanHypersurface
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»

--- a/FormalConjecturesForMathlib/Analysis/SpecialFunctions/FlatRpowExp.lean
+++ b/FormalConjecturesForMathlib/Analysis/SpecialFunctions/FlatRpowExp.lean
@@ -1,0 +1,343 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
+public import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
+public import Mathlib.Analysis.SpecialFunctions.SmoothTransition
+public import Mathlib.Analysis.Calculus.MeanValue
+public import Mathlib.Analysis.Calculus.ContDiff.Bounds
+
+@[expose] public section
+
+noncomputable section
+
+open Filter Function Topology
+
+namespace ContDiff
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- A smooth function on the punctured space whose every iterated derivative is little-oh of the
+distance to the origin extends smoothly across the origin, with zero Taylor series there. -/
+theorem at_zero_of_iteratedFDeriv_isLittleO {f : E → F}
+    (hf : ∀ x ≠ 0, ContDiffAt 𝕜 ∞ f x) (hzero : f 0 = 0)
+    (hflat : ∀ m : ℕ, (iteratedFDeriv 𝕜 m f) =o[𝓝[≠] 0] (id : E → E)) :
+    ContDiffAt 𝕜 ∞ f 0 := by
+  classical
+  let p : E → FormalMultilinearSeries 𝕜 E F := fun x m ↦
+    if x = 0 then 0 else iteratedFDeriv 𝕜 m f x
+  have hp_flat (m : ℕ) : (fun x ↦ p x m) =o[𝓝 0] (id : E → E) := by
+    have heq : iteratedFDeriv 𝕜 m f =ᶠ[𝓝[≠] 0] fun x ↦ p x m := by
+      filter_upwards [self_mem_nhdsWithin] with x hx
+      simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hx
+      simp [p, hx]
+    rw [← nhdsNE_sup_pure (0 : E)]
+    refine ((hflat m).congr' heq EventuallyEq.rfl).sup <|
+      Asymptotics.isLittleO_iff.2 fun c hc ↦ ?_
+    rw [eventually_pure]
+    simp [p]
+  have hp_deriv (m : ℕ) (x : E) :
+      HasFDerivAt (p · m) (p x m.succ).curryLeft x := by
+    by_cases hx : x = 0
+    · subst x
+      rw [hasFDerivAt_iff_isLittleO_nhds_zero]
+      have hfun : (fun h : E ↦ p h m - p 0 m - (p 0 m.succ).curryLeft h) =
+          fun h ↦ p h m := by
+        funext h
+        have hp0 (i : ℕ) : p 0 i = 0 := by simp [p]
+        rw [hp0 m, hp0 m.succ]
+        have hz : (0 : ContinuousMultilinearMap 𝕜 (fun _ : Fin (m + 1) ↦ E) F).curryLeft h =
+            0 := by
+          ext v
+          rfl
+        rw [hz, sub_zero, sub_zero]
+      simp only [zero_add]
+      rw [hfun]
+      exact hp_flat m
+    · have heq (i : ℕ) : (fun y ↦ p y i) =ᶠ[𝓝 x] iteratedFDeriv 𝕜 i f := by
+        filter_upwards [eventually_ne_nhds hx] with y hy
+        simp [p, hy]
+      have hd := ((hf x hx).differentiableAt_iteratedFDeriv (m := m)
+        (ENat.natCast_lt_of_coe_top_le_withTop le_rfl m)).hasFDerivAt
+      rw [fderiv_iteratedFDeriv, Function.comp_apply] at hd
+      refine (hd.congr_of_eventuallyEq (heq m)).congr_fderiv ?_
+      simp only [p, hx, if_false, Nat.succ_eq_add_one]
+      rfl
+  have hp : HasFTaylorSeriesUpToOn ∞ f p Set.univ := by
+    rw [hasFTaylorSeriesUpToOn_top_iff' le_rfl]
+    constructor
+    · intro x _
+      by_cases hx : x = 0
+      · subst x
+        simp [p, hzero]
+      · simp [p, hx]
+    · intro m x _
+      simpa only [hasFDerivWithinAt_univ] using hp_deriv m x
+  exact hp.contDiffOn.contDiffAt univ_mem
+
+/-- A smooth function with zero Taylor series at the origin is little-oh of every power of the
+distance to the origin. -/
+theorem isLittleO_norm_pow_of_iteratedFDeriv_zero [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {f : E → F} (hf : ContDiff ℝ ∞ f)
+    (hzero : ∀ m : ℕ, iteratedFDeriv ℝ m f 0 = 0) (m n : ℕ) :
+    iteratedFDeriv ℝ m f =o[𝓝 0] fun x ↦ ‖x‖ ^ n := by
+  induction n generalizing m with
+  | zero =>
+      rw [show (fun x : E ↦ ‖x‖ ^ 0) = fun _ ↦ (1 : ℝ) by simp]
+      rw [Asymptotics.isLittleO_one_iff]
+      rw [← hzero m]
+      exact hf.continuous_iteratedFDeriv (m := m)
+        (ENat.natCast_le_of_coe_top_le_withTop le_rfl m) |>.continuousAt
+  | succ n ih =>
+      have hdiff : Differentiable ℝ (iteratedFDeriv ℝ m f) :=
+        hf.differentiable_iteratedFDeriv
+          (ENat.natCast_lt_of_coe_top_le_withTop le_rfl m)
+      have hderiv : fderiv ℝ (iteratedFDeriv ℝ m f) =o[𝓝 0] fun x ↦ ‖x‖ ^ n := by
+        rw [Asymptotics.isLittleO_iff] at ⊢
+        intro c hc
+        filter_upwards [(ih (m + 1)).bound hc] with x hx
+        rw [norm_fderiv_iteratedFDeriv]
+        exact hx
+      have h := (convex_univ : Convex ℝ (Set.univ : Set E)).isLittleO_pow_succ
+        (Set.mem_univ 0) (fun x _ ↦ hdiff.differentiableAt.hasFDerivAt.hasFDerivWithinAt)
+        (by simpa using hderiv)
+      simpa [hzero m] using h
+
+/-- Composing on the right preserves a zero Taylor series at the origin, provided the inner
+function fixes the origin. -/
+theorem iteratedFDeriv_comp_zero_of_outer [NormedSpace ℝ E] [NormedSpace ℝ F]
+    {G : Type*} [NormedAddCommGroup G] [NormedSpace ℝ G] {g : F → G} {f : E → F}
+    (hg : ContDiff ℝ ∞ g) (hf : ContDiff ℝ ∞ f) (hf0 : f 0 = 0)
+    (hzero : ∀ m : ℕ, iteratedFDeriv ℝ m g 0 = 0) (n : ℕ) :
+    iteratedFDeriv ℝ n (g ∘ f) 0 = 0 := by
+  let D := 1 + ∑ i ∈ Finset.range (n + 1), ‖iteratedFDeriv ℝ i f 0‖
+  rw [← norm_eq_zero]
+  apply le_antisymm
+  · refine (norm_iteratedFDeriv_comp_le hg hf (mod_cast le_top) 0
+      (C := 0) (D := D) ?_ ?_).trans ?_
+    · intro i hi
+      rw [hf0, hzero i]
+      simp only [norm_zero]
+      exact le_rfl
+    · intro i hi hin
+      have hD_one : 1 ≤ D := by
+        simp only [D, le_add_iff_nonneg_right]
+        exact Finset.sum_nonneg fun _ _ ↦ norm_nonneg _
+      calc
+        ‖iteratedFDeriv ℝ i f 0‖ ≤ D := by
+          simp only [D]
+          exact le_add_of_nonneg_of_le zero_le_one <|
+            Finset.single_le_sum (f := fun j ↦ ‖iteratedFDeriv ℝ j f 0‖)
+              (fun j _ ↦ norm_nonneg _)
+              (Finset.mem_range.mpr (Nat.lt_succ_of_le hin))
+        _ ≤ D ^ i := le_self_pow₀ hD_one (Nat.ne_of_gt hi)
+    · simp
+  · exact norm_nonneg _
+
+/-- Multiplying a smooth scalar-valued function with zero Taylor series by another smooth
+function preserves its zero Taylor series. -/
+theorem iteratedFDeriv_mul_zero_of_left [NormedSpace ℝ E] {f g : E → ℝ}
+    (hf : ContDiff ℝ ∞ f) (hg : ContDiff ℝ ∞ g)
+    (hzero : ∀ m : ℕ, iteratedFDeriv ℝ m f 0 = 0) (n : ℕ) :
+    iteratedFDeriv ℝ n (fun x ↦ f x * g x) 0 = 0 := by
+  rw [← norm_eq_zero]
+  apply le_antisymm
+  · refine (norm_iteratedFDeriv_mul_le hf hg 0 (mod_cast le_top) (n := n)).trans ?_
+    apply le_of_eq
+    apply Finset.sum_eq_zero
+    intro i hi
+    rw [hzero i]
+    simp
+  · exact norm_nonneg _
+
+end ContDiff
+
+namespace Real
+
+/-- The extension by zero of `x ↦ exp (-c * x ^ (-a))` from the positive half-line. -/
+def flatRpowExp (a c x : ℝ) : ℝ :=
+  if x ≤ 0 then 0 else exp (-c * x ^ (-a))
+
+namespace flatRpowExp
+
+theorem zero_of_nonpos (a c : ℝ) {x : ℝ} (hx : x ≤ 0) : flatRpowExp a c x = 0 := by
+  simp [flatRpowExp, hx]
+
+@[simp]
+theorem zero (a c : ℝ) : flatRpowExp a c 0 = 0 := zero_of_nonpos a c le_rfl
+
+theorem of_pos (a c : ℝ) {x : ℝ} (hx : 0 < x) :
+    flatRpowExp a c x = exp (-c * x ^ (-a)) := by
+  simp [flatRpowExp, hx.not_ge]
+
+/-- Exponential decay at zero dominates every real power. -/
+theorem tendsto_rpow_mul_zero {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (s : ℝ) :
+    Tendsto (fun x : ℝ ↦ x ^ s * flatRpowExp a c x) (𝓝[>] 0) (𝓝 0) := by
+  have ht : Tendsto (fun x : ℝ ↦ x ^ (-a)) (𝓝[>] 0) atTop :=
+    tendsto_rpow_neg_nhdsGT_zero (neg_neg_of_pos ha)
+  refine ((tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero (-s / a) c hc).comp ht).congr' ?_
+  filter_upwards [self_mem_nhdsWithin] with x hx
+  change (x ^ (-a)) ^ (-s / a) * exp (-c * x ^ (-a)) =
+    x ^ s * flatRpowExp a c x
+  rw [of_pos a c hx, ← Real.rpow_mul hx.le]
+  congr 2
+  field_simp [ha.ne']
+
+/-- A single generalized Laurent monomial times `flatRpowExp`. -/
+private def term (a c ν d x : ℝ) : ℝ := d * x ^ ν * flatRpowExp a c x
+
+private theorem term_tendsto_zero {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (ν d : ℝ) :
+    Tendsto (term a c ν d) (𝓝 0) (𝓝 0) := by
+  have hinner : Tendsto (fun x : ℝ ↦ x ^ ν * flatRpowExp a c x) (𝓝 0) (𝓝 0) := by
+    simp only [flatRpowExp, mul_ite, mul_zero]
+    refine tendsto_const_nhds.if ?_
+    simp only [not_le]
+    refine (tendsto_rpow_mul_zero ha hc ν).congr' ?_
+    filter_upwards [self_mem_nhdsWithin] with x hx
+    rw [of_pos a c hx]
+  change Tendsto (fun x : ℝ ↦ d * x ^ ν * flatRpowExp a c x) (𝓝 0) (𝓝 0)
+  simpa only [mul_assoc, mul_zero] using
+    (tendsto_const_nhds.mul hinner :
+      Tendsto (fun x : ℝ ↦ d * (x ^ ν * flatRpowExp a c x)) (𝓝 0) (𝓝 (d * 0)))
+
+private theorem term_hasDerivAt {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (ν d x : ℝ) :
+    HasDerivAt (term a c ν d)
+      (term a c (ν - 1) (d * ν) x + term a c (ν - a - 1) (d * c * a) x) x := by
+  rcases lt_trichotomy x 0 with hx | rfl | hx
+  · have heq : term a c ν d =ᶠ[𝓝 x] fun _ ↦ 0 := by
+      filter_upwards [gt_mem_nhds hx] with y hy
+      simp [term, zero_of_nonpos a c hy.le]
+    simpa [term, zero_of_nonpos a c hx.le] using
+      (hasDerivAt_const x 0).congr_of_eventuallyEq heq
+  · simp only [term, zero a c, mul_zero, add_zero]
+    rw [hasDerivAt_iff_tendsto_slope]
+    refine ((term_tendsto_zero ha hc (ν - 1) d).mono_left inf_le_left).congr' ?_
+    filter_upwards [self_mem_nhdsWithin] with y hy
+    simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hy
+    by_cases hypos : 0 < y
+    · simp [slope_def_field, term, zero a c, of_pos a c hypos, div_eq_mul_inv]
+      rw [Real.rpow_sub_one hypos.ne']
+      ring
+    · have hynonpos : y ≤ 0 := le_of_not_gt hypos
+      simp [slope_def_field, term, zero a c, zero_of_nonpos a c hynonpos]
+  · have hpow : HasDerivAt (fun y : ℝ ↦ y ^ ν) (ν * x ^ (ν - 1)) x :=
+      Real.hasDerivAt_rpow_const (Or.inl hx.ne')
+    have hpow' : HasDerivAt (fun y : ℝ ↦ y ^ (-a))
+        ((-a) * x ^ (-a - 1)) x := Real.hasDerivAt_rpow_const (Or.inl hx.ne')
+    have hinner : HasDerivAt (fun y : ℝ ↦ -c * y ^ (-a))
+        (c * a * x ^ (-a - 1)) x := by
+      convert (hasDerivAt_const x (-c)).mul hpow' using 1
+      all_goals ring
+    have hexp : HasDerivAt (fun y : ℝ ↦ exp (-c * y ^ (-a)))
+        (exp (-c * x ^ (-a)) * (c * a * x ^ (-a - 1))) x := hinner.exp
+    have heq : term a c ν d =ᶠ[𝓝 x]
+        ((fun _ : ℝ ↦ d) * (fun y ↦ y ^ ν)) * fun y ↦ exp (-c * y ^ (-a)) := by
+      filter_upwards [lt_mem_nhds hx] with y hy
+      simp [term, of_pos a c hy]
+    have hderiv := (((hasDerivAt_const x d).mul hpow).mul hexp).congr_of_eventuallyEq heq
+    have hrpow : x ^ (ν - a - 1) = x ^ ν * x ^ (-a - 1) := by
+      rw [← Real.rpow_add hx]
+      congr 1
+      ring
+    convert hderiv using 1
+    simp [term, of_pos a c hx]
+    rw [hrpow]
+    ring
+
+/-- A finite sum of generalized Laurent monomials times `flatRpowExp`. -/
+private def sum (a c : ℝ) (p : Multiset (ℝ × ℝ)) (x : ℝ) : ℝ :=
+  (p.map fun q ↦ term a c q.1 q.2 x).sum
+
+private theorem sum_hasDerivAt {a c : ℝ} (ha : 0 < a) (hc : 0 < c)
+    (p : Multiset (ℝ × ℝ)) : ∃ q : Multiset (ℝ × ℝ),
+      ∀ x, HasDerivAt (sum a c p) (sum a c q x) x := by
+  induction p using Multiset.induction_on with
+  | empty =>
+      exact ⟨0, fun x ↦ by simpa [sum] using hasDerivAt_const x 0⟩
+  | @cons head tail ih =>
+      rcases ih with ⟨q, hq⟩
+      refine ⟨(head.1 - 1, head.2 * head.1) ::ₘ
+        (head.1 - a - 1, head.2 * c * a) ::ₘ q, fun x ↦ ?_⟩
+      have h := (term_hasDerivAt ha hc head.1 head.2 x).add (hq x)
+      convert h using 1
+      · ext y
+        simp [sum]
+      · simp [sum, add_assoc]
+
+private theorem sum_contDiff {a c : ℝ} (ha : 0 < a) (hc : 0 < c)
+    (p : Multiset (ℝ × ℝ)) {n : ℕ∞} : ContDiff ℝ n (sum a c p) := by
+  apply contDiff_all_iff_nat.2 (fun m ↦ ?_) n
+  induction m generalizing p with
+  | zero =>
+      exact contDiff_zero.2 <| continuous_iff_continuousAt.2 fun x ↦
+        ((sum_hasDerivAt ha hc p).choose_spec x).continuousAt
+  | succ m ih =>
+      obtain ⟨q, hq⟩ := sum_hasDerivAt ha hc p
+      rw [show ((m + 1 : ℕ) : WithTop ℕ∞) = m + 1 from rfl]
+      refine contDiff_succ_iff_deriv.2 ⟨fun x ↦ (hq x).differentiableAt, by simp, ?_⟩
+      convert ih q using 2
+      funext x
+      exact (hq x).deriv
+
+private theorem sum_iteratedDeriv_zero {a c : ℝ} (ha : 0 < a) (hc : 0 < c)
+    (p : Multiset (ℝ × ℝ)) (n : ℕ) : iteratedDeriv n (sum a c p) 0 = 0 := by
+  induction n generalizing p with
+  | zero => simp [sum, term]
+  | succ n ih =>
+      obtain ⟨q, hq⟩ := sum_hasDerivAt ha hc p
+      rw [iteratedDeriv_succ']
+      have hderiv : deriv (sum a c p) = sum a c q := funext fun x ↦ (hq x).deriv
+      rw [hderiv]
+      exact ih q
+
+/-- Multiplying `flatRpowExp a c` by an arbitrary real power preserves smoothness. -/
+@[fun_prop]
+theorem rpow_mul_contDiff {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (s : ℝ) {n : ℕ∞} :
+    ContDiff ℝ n (fun x ↦ x ^ s * flatRpowExp a c x) := by
+  convert sum_contDiff (n := n) ha hc ({(s, 1)} : Multiset (ℝ × ℝ)) using 1
+  funext x
+  simp [sum, term]
+
+/-- Every iterated derivative of `x ^ s * flatRpowExp a c x` vanishes at the origin. -/
+theorem rpow_mul_iteratedFDeriv_zero {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (s : ℝ)
+    (n : ℕ) : iteratedFDeriv ℝ n (fun x ↦ x ^ s * flatRpowExp a c x) 0 = 0 := by
+  have hfun : (fun x ↦ x ^ s * flatRpowExp a c x) =
+      sum a c ({(s, 1)} : Multiset (ℝ × ℝ)) := by
+    funext x
+    simp [sum, term]
+  rw [hfun, ← norm_eq_zero, norm_iteratedFDeriv_eq_norm_iteratedDeriv,
+    sum_iteratedDeriv_zero ha hc]
+  simp
+
+/-- Every iterated derivative of `flatRpowExp a c` vanishes at the origin. -/
+theorem iteratedFDeriv_zero {a c : ℝ} (ha : 0 < a) (hc : 0 < c) (n : ℕ) :
+    iteratedFDeriv ℝ n (flatRpowExp a c) 0 = 0 := by
+  simpa using rpow_mul_iteratedFDeriv_zero ha hc 0 n
+
+/-- `flatRpowExp a c` is smooth when both parameters are positive. -/
+@[fun_prop]
+theorem contDiff {a c : ℝ} (ha : 0 < a) (hc : 0 < c) {n : ℕ∞} :
+    ContDiff ℝ n (flatRpowExp a c) := by
+  convert sum_contDiff (n := n) ha hc ({(0, 1)} : Multiset (ℝ × ℝ)) using 1
+  funext x
+  simp [sum, term]
+
+end flatRpowExp
+
+end Real

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -42,10 +42,6 @@ Presumably this can be avoided by assuming `[NeZero n]`. -/
 noncomputable instance Module.orientedEuclideanSpaceFinThree : Module.Oriented ℝ ℝ³ (Fin 3) :=
   ⟨Basis.orientation <| PiLp.basisFun ..⟩
 
-/-- Three dimensional euclidean space is three-dimensional. -/
-instance fact_finrank_euclideanSpace_fin_three : Fact (Module.finrank ℝ ℝ³ = 3) :=
-  ⟨finrank_euclideanSpace_fin⟩
-
 namespace EuclideanHypersurface
 
 /-- The usual cross product on three-dimensional Euclidean space, as a bundled continuous

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -24,8 +24,8 @@ public import Mathlib.Topology.Algebra.Module.FiniteDimension
 # Three-dimensional Euclidean geometry
 
 This file supplies the preferred orientation on `ℝ³` and transports the usual cross product on
-coordinate triples to a bundled bilinear map on Euclidean space. It also records the standard
-algebraic and metric identities for this cross product.
+coordinate triples to a bundled continuous bilinear map on Euclidean space. It also records the
+standard algebraic and metric identities for this cross product.
 -/
 
 @[expose] public section
@@ -73,8 +73,7 @@ theorem euclideanCross_anticomm (a b : ℝ³) :
 /-- A vector has zero cross product with itself. -/
 @[simp]
 theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
-  simpa only [euclideanCross_apply, map_zero] using
-    congrArg (WithLp.toLp 2) (cross_self (WithLp.ofLp a))
+  simp [euclideanCross_apply]
 
 /-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
 @[simp]

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -18,6 +18,7 @@ module
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
 # Three-dimensional Euclidean geometry
@@ -48,10 +49,13 @@ instance fact_finrank_euclideanSpace_fin_three : Fact (Module.finrank ℝ ℝ³ 
 
 namespace EuclideanHypersurface
 
-/-- The usual cross product on three-dimensional Euclidean space, as a bundled bilinear map. -/
-noncomputable def euclideanCross : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+/-- The usual cross product on three-dimensional Euclidean space, as a bundled continuous
+bilinear map. -/
+noncomputable def euclideanCross : ℝ³ →L[ℝ] ℝ³ →L[ℝ] ℝ³ :=
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
-  ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
+  let f : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+    ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
+  LinearMap.toContinuousLinearMap (LinearMap.toContinuousLinearMap.toLinearMap.comp f)
 
 /-- The bundled Euclidean cross product agrees with the coordinate cross product. -/
 theorem euclideanCross_apply (a b : ℝ³) :

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -22,9 +22,7 @@ public import Mathlib.LinearAlgebra.Orientation
 /-!
 # Three-dimensional Euclidean geometry
 
-This file supplies the preferred orientation on `ℝ³` and transports the usual cross product on
-coordinate triples to a bundled continuous bilinear map on Euclidean space. It also records the
-standard algebraic and metric identities for this cross product.
+This file defines the preferred orientation and bundled continuous cross product on `ℝ³`.
 -/
 
 @[expose] public section
@@ -44,8 +42,7 @@ noncomputable instance Module.orientedEuclideanSpaceFinThree : Module.Oriented �
 
 namespace EuclideanHypersurface
 
-/-- The usual cross product on three-dimensional Euclidean space, as a bundled continuous
-bilinear map. -/
+/-- The cross product on `ℝ³`, bundled as a continuous bilinear map. -/
 noncomputable def euclideanCross : ℝ³ →L[ℝ] ℝ³ →L[ℝ] ℝ³ :=
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
   let f : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
@@ -71,13 +68,13 @@ theorem euclideanCross_anticomm (a b : ℝ³) :
 theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
   simp [euclideanCross_apply]
 
-/-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
+/-- The cross product is orthogonal to its left input. -/
 @[simp]
 theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
   simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,
     dot_self_cross]
 
-/-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
+/-- The cross product is orthogonal to its right input. -/
 @[simp]
 theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
   simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -16,13 +16,25 @@ limitations under the License.
 module
 
 public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
+
+public meta import FormalConjecturesUtil.Attributes.Basic
+
+/-!
+# Three-dimensional Euclidean geometry
+
+This file supplies the preferred orientation on `ℝ³` and transports the usual cross product on
+coordinate triples to a bundled bilinear map on Euclidean space. It also records the standard
+algebraic and metric identities for this cross product.
+-/
 
 @[expose] public section
 
 scoped[EuclideanGeometry] notation "ℝ³" => EuclideanSpace ℝ (Fin 3)
 
 open scoped EuclideanGeometry
+open Matrix
 
 /-- The standard basis gives us a preferred orientation in `ℝ³`.
 
@@ -35,3 +47,100 @@ noncomputable instance Module.orientedEuclideanSpaceFinThree : Module.Oriented �
 /-- Three dimensional euclidean space is three-dimensional. -/
 instance fact_finrank_euclideanSpace_fin_three : Fact (Module.finrank ℝ ℝ³ = 3) :=
   ⟨finrank_euclideanSpace_fin⟩
+
+namespace EuclideanHypersurface
+
+/-- The usual cross product on three-dimensional Euclidean space, as a bundled bilinear map. -/
+noncomputable def euclideanCross : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
+  let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
+  ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
+
+/-- The bundled Euclidean cross product agrees with the coordinate cross product. -/
+@[category API, AMS 53]
+theorem euclideanCross_apply (a b : ℝ³) :
+    euclideanCross a b =
+      WithLp.toLp 2 (crossProduct (WithLp.ofLp a) (WithLp.ofLp b)) :=
+  rfl
+
+/-- Swapping the arguments of the cross product negates it. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_anticomm (a b : ℝ³) :
+    -euclideanCross a b = euclideanCross b a := by
+  simpa only [euclideanCross_apply, map_neg] using
+    congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
+
+/-- A vector has zero cross product with itself. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
+  simpa only [euclideanCross_apply, map_zero] using
+    congrArg (WithLp.toLp 2) (cross_self (WithLp.ofLp a))
+
+/-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
+  rw [euclideanCross_apply]
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_self_cross]
+
+/-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
+@[simp, category API, AMS 53]
+theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
+  rw [euclideanCross_apply]
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_cross_self]
+
+/-- The inner product of two cross products is the corresponding Gram-determinant expression. -/
+@[category API, AMS 53]
+theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
+    inner ℝ (euclideanCross a b) (euclideanCross c d) =
+      inner ℝ a c * inner ℝ b d - inner ℝ a d * inner ℝ b c := by
+  simp only [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
+    cross_dot_cross]
+  rw [dotProduct_comm (WithLp.ofLp d) (WithLp.ofLp a)]
+  ring
+
+/-- The right-nested vector triple-product identity. -/
+@[category API, AMS 53]
+theorem euclideanCross_cross (u v w : ℝ³) :
+    euclideanCross u (euclideanCross v w) =
+      inner ℝ u w • v - inner ℝ u v • w := by
+  change WithLp.toLp 2
+    (crossProduct (WithLp.ofLp u) (crossProduct (WithLp.ofLp v) (WithLp.ofLp w))) = _
+  rw [cross_cross_eq_smul_sub_smul']
+  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial]
+  rw [dotProduct_comm (WithLp.ofLp w) (WithLp.ofLp u),
+    dotProduct_comm (WithLp.ofLp v) (WithLp.ofLp u)]
+  rfl
+
+/-- A cross product is nonzero exactly when its two inputs are linearly independent. -/
+@[category API, AMS 53]
+theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
+    euclideanCross a b ≠ 0 ↔ LinearIndependent ℝ ![a, b] := by
+  let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
+  have hne : euclideanCross a b ≠ 0 ↔ crossProduct (e a) (e b) ≠ 0 := by
+    rw [euclideanCross]
+    exact e.symm.injective.ne_iff
+  rw [hne, crossProduct_ne_zero_iff_linearIndependent]
+  have hLI := e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
+    (v := ![a, b])
+  have hf : e.toLinearMap ∘ ![a, b] = ![e a, e b] := by
+    funext i
+    fin_cases i <;> simp
+  rwa [hf] at hLI
+
+/-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
+@[category API, AMS 53]
+theorem euclideanCross_eq_inner_smul_of_orthogonal
+    (p x y : ℝ³) (hp : ‖p‖ = 1) (hx : inner ℝ p x = 0) (hy : inner ℝ p y = 0) :
+    euclideanCross x y = inner ℝ (euclideanCross x y) p • p := by
+  let c := euclideanCross x y
+  have hpc : euclideanCross p c = 0 := by
+    dsimp only [c]
+    rw [euclideanCross_cross, hy, hx]
+    simp
+  have hpp : inner ℝ p p = 1 := by
+    simp [hp]
+  have hsecond := euclideanCross_cross p p c
+  rw [hpc, map_zero, hpp, one_smul] at hsecond
+  have hc := (sub_eq_zero.mp hsecond.symm).symm
+  simpa only [c, real_inner_comm] using hc
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -18,7 +18,6 @@ module
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
-public import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
 # Three-dimensional Euclidean geometry
@@ -93,8 +92,7 @@ theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
       inner ℝ a c * inner ℝ b d - inner ℝ a d * inner ℝ b c := by
   simp only [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct, star_trivial,
     cross_dot_cross]
-  rw [dotProduct_comm (WithLp.ofLp d) (WithLp.ofLp a)]
-  ring
+  rw [mul_comm (WithLp.ofLp c ⬝ᵥ WithLp.ofLp b)]
 
 /-- The right-nested vector triple-product identity. -/
 theorem euclideanCross_cross (u v w : ℝ³) :
@@ -130,13 +128,12 @@ theorem euclideanCross_eq_inner_smul_of_orthogonal
   let c := euclideanCross x y
   have hpc : euclideanCross p c = 0 := by
     dsimp only [c]
-    rw [euclideanCross_cross, hy, hx]
-    simp
+    simp only [euclideanCross_cross, hy, hx, zero_smul, sub_zero]
   have hpp : inner ℝ p p = 1 := by
     simp [hp]
   have hsecond := euclideanCross_cross p p c
   rw [hpc, map_zero, hpp, one_smul] at hsecond
-  have hc := (sub_eq_zero.mp hsecond.symm).symm
+  have hc : c = inner ℝ p c • p := (sub_eq_zero.mp hsecond.symm).symm
   simpa only [c, real_inner_comm] using hc
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -66,8 +66,9 @@ theorem euclideanCross_apply (a b : ℝ³) :
 @[simp]
 theorem euclideanCross_anticomm (a b : ℝ³) :
     -euclideanCross a b = euclideanCross b a := by
-  simpa only [euclideanCross_apply, map_neg] using
-    congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
+  rw [euclideanCross_apply, euclideanCross_apply]
+  change WithLp.toLp 2 (-crossProduct (WithLp.ofLp a) (WithLp.ofLp b)) = _
+  exact congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
 
 /-- A vector has zero cross product with itself. -/
 @[simp]
@@ -77,14 +78,14 @@ theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
 /-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
 @[simp]
 theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
-  rw [euclideanCross_apply]
-  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_self_cross]
+  simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,
+    dot_self_cross]
 
 /-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
 @[simp]
 theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
-  rw [euclideanCross_apply]
-  simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_cross_self]
+  simp [euclideanCross_apply, EuclideanSpace.inner_eq_star_dotProduct,
+    dot_cross_self]
 
 /-- The inner product of two cross products is the corresponding Gram-determinant expression. -/
 theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
@@ -114,12 +115,11 @@ theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
     rw [euclideanCross]
     exact e.symm.injective.ne_iff
   rw [hne, crossProduct_ne_zero_iff_linearIndependent]
-  have hLI := e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
-    (v := ![a, b])
   have hf : e.toLinearMap ∘ ![a, b] = ![e a, e b] := by
     funext i
     fin_cases i <;> simp
-  rwa [hf] at hLI
+  exact hf ▸ e.toLinearMap.linearIndependent_iff_of_injOn e.injective.injOn
+    (v := ![a, b])
 
 /-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
 theorem euclideanCross_eq_inner_smul_of_orthogonal
@@ -128,12 +128,9 @@ theorem euclideanCross_eq_inner_smul_of_orthogonal
   let c := euclideanCross x y
   have hpc : euclideanCross p c = 0 := by
     dsimp only [c]
-    simp only [euclideanCross_cross, hy, hx, zero_smul, sub_zero]
-  have hpp : inner ℝ p p = 1 := by
-    simp [hp]
+    simp [euclideanCross_cross, hy, hx]
   have hsecond := euclideanCross_cross p p c
-  rw [hpc, map_zero, hpp, one_smul] at hsecond
-  have hc : c = inner ℝ p c • p := (sub_eq_zero.mp hsecond.symm).symm
-  simpa only [c, real_inner_comm] using hc
+  rw [hpc, map_zero, show inner ℝ p p = 1 by simp [hp], one_smul] at hsecond
+  simpa [c, real_inner_comm] using (sub_eq_zero.mp hsecond.symm).symm
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/3d.lean
+++ b/FormalConjecturesForMathlib/Geometry/3d.lean
@@ -19,8 +19,6 @@ public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.LinearAlgebra.CrossProduct
 public import Mathlib.LinearAlgebra.Orientation
 
-public meta import FormalConjecturesUtil.Attributes.Basic
-
 /-!
 # Three-dimensional Euclidean geometry
 
@@ -56,39 +54,37 @@ noncomputable def euclideanCross : ℝ³ →ₗ[ℝ] ℝ³ →ₗ[ℝ] ℝ³ :=
   ((crossProduct.comp e.toLinearMap).compl₂ e.toLinearMap).compr₂ e.symm.toLinearMap
 
 /-- The bundled Euclidean cross product agrees with the coordinate cross product. -/
-@[category API, AMS 53]
 theorem euclideanCross_apply (a b : ℝ³) :
     euclideanCross a b =
       WithLp.toLp 2 (crossProduct (WithLp.ofLp a) (WithLp.ofLp b)) :=
   rfl
 
 /-- Swapping the arguments of the cross product negates it. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_anticomm (a b : ℝ³) :
     -euclideanCross a b = euclideanCross b a := by
   simpa only [euclideanCross_apply, map_neg] using
     congrArg (WithLp.toLp 2) (cross_anticomm (WithLp.ofLp a) (WithLp.ofLp b))
 
 /-- A vector has zero cross product with itself. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_self (a : ℝ³) : euclideanCross a a = 0 := by
   simpa only [euclideanCross_apply, map_zero] using
     congrArg (WithLp.toLp 2) (cross_self (WithLp.ofLp a))
 
 /-- The cross product is orthogonal to its left input, with the inner-product arguments swapped. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_inner_left (a b : ℝ³) : inner ℝ (euclideanCross a b) a = 0 := by
   rw [euclideanCross_apply]
   simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_self_cross]
 
 /-- The cross product is orthogonal to its right input, with the inner-product arguments swapped. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem euclideanCross_inner_right (a b : ℝ³) : inner ℝ (euclideanCross a b) b = 0 := by
   rw [euclideanCross_apply]
   simp only [EuclideanSpace.inner_eq_star_dotProduct, star_trivial, dot_cross_self]
 
 /-- The inner product of two cross products is the corresponding Gram-determinant expression. -/
-@[category API, AMS 53]
 theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
     inner ℝ (euclideanCross a b) (euclideanCross c d) =
       inner ℝ a c * inner ℝ b d - inner ℝ a d * inner ℝ b c := by
@@ -98,7 +94,6 @@ theorem inner_euclideanCross_euclideanCross (a b c d : ℝ³) :
   ring
 
 /-- The right-nested vector triple-product identity. -/
-@[category API, AMS 53]
 theorem euclideanCross_cross (u v w : ℝ³) :
     euclideanCross u (euclideanCross v w) =
       inner ℝ u w • v - inner ℝ u v • w := by
@@ -111,7 +106,6 @@ theorem euclideanCross_cross (u v w : ℝ³) :
   rfl
 
 /-- A cross product is nonzero exactly when its two inputs are linearly independent. -/
-@[category API, AMS 53]
 theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
     euclideanCross a b ≠ 0 ↔ LinearIndependent ℝ ![a, b] := by
   let e := WithLp.linearEquiv 2 ℝ (Fin 3 → ℝ)
@@ -127,7 +121,6 @@ theorem euclideanCross_ne_zero_iff_linearIndependent (a b : ℝ³) :
   rwa [hf] at hLI
 
 /-- The cross product of two vectors orthogonal to a unit vector is parallel to that vector. -/
-@[category API, AMS 53]
 theorem euclideanCross_eq_inner_smul_of_orthogonal
     (p x y : ℝ³) (hp : ‖p‖ = 1) (hx : inner ℝ p x = 0) (hy : inner ℝ p y = 0) :
     euclideanCross x y = inner ℝ (euclideanCross x y) p • p := by

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -19,8 +19,6 @@ module
 public import Mathlib.Analysis.InnerProductSpace.LinearMap
 public import Mathlib.LinearAlgebra.BilinearForm.Hom
 
-@[expose] public section
-
 /-!
 # Extrinsic fundamental forms in Euclidean space
 
@@ -28,6 +26,8 @@ This small API packages the first and second fundamental forms determined by the
 an immersion and a chosen normal field. The sign in the second form is the convention
 `II(v, w) = -⟪dn(v), dF(w)⟫`; consequently `dn = c • dF` corresponds to `II = (-c) • I`.
 -/
+
+@[expose] public section
 
 open scoped RealInnerProductSpace
 
@@ -51,13 +51,13 @@ def IsUmbilic (dF dn : V →L[ℝ] E) : Prop :=
 
 @[simp]
 theorem firstFundamentalFormAt_apply (dF : V →L[ℝ] E) (v w : V) :
-    firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) := by
-  simp [firstFundamentalFormAt]
+    firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) :=
+  rfl
 
 @[simp]
 theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
-    secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) := by
-  simp [secondFundamentalFormAt]
+    secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) :=
+  rfl
 
 /-- A scalar normal differential makes a point umbilic.
 
@@ -68,8 +68,7 @@ theorem isUmbilic_of_normal_deriv_eq_smul
   refine ⟨-c, ?_⟩
   ext v w
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
-  rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left]
-  ring
+  rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left, neg_mul]
 
 /-- Under a tangency hypothesis, umbilicity is equivalent to the normal differential being a
 scalar multiple of the immersion differential. The range hypothesis is exactly what rules out an
@@ -85,16 +84,12 @@ theorem isUmbilic_iff_normal_deriv_eq_smul
     have horth (w : V) : inner ℝ (dn v + κ • dF v) (dF w) = 0 := by
       have h := congrArg (fun B : LinearMap.BilinForm ℝ V ↦ B v w) hκ
       change -inner ℝ (dn v) (dF w) = κ * inner ℝ (dF v) (dF w) at h
-      rw [inner_add_left, real_inner_smul_left]
-      linarith [h]
+      rw [inner_add_left, real_inner_smul_left, ← h, add_neg_cancel]
     have hrange : dn v + κ • dF v = dF (u + κ • v) := by
       change dF u = dn v at hu
       rw [map_add, map_smul, ← hu]
-    have := horth (u + κ • v)
-    rw [← hrange, real_inner_self_eq_norm_sq] at this
-    have hzero : dn v + κ • dF v = 0 := by
-      apply norm_eq_zero.mp
-      nlinarith [norm_nonneg (dn v + κ • dF v)]
+    have hzero := horth (u + κ • v)
+    rw [← hrange, real_inner_self_eq_norm_sq, sq_eq_zero_iff, norm_eq_zero] at hzero
     simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
       eq_neg_of_add_eq_zero_left hzero
   · rintro ⟨c, hc⟩

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -90,9 +90,8 @@ theorem isUmbilic_iff_normal_deriv_eq_smul
       rw [map_add, map_smul, ← hu]
     have hzero := horth (u + κ • v)
     rw [← hrange, real_inner_self_eq_norm_sq, sq_eq_zero_iff, norm_eq_zero] at hzero
-    simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
+    simpa [ContinuousLinearMap.smul_apply] using
       eq_neg_of_add_eq_zero_left hzero
-  · rintro ⟨c, hc⟩
-    exact isUmbilic_of_normal_deriv_eq_smul dF dn c hc
+  · exact fun ⟨c, hc⟩ ↦ isUmbilic_of_normal_deriv_eq_smul dF dn c hc
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -1,0 +1,106 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.InnerProductSpace.LinearMap
+
+@[expose] public section
+
+/-!
+# Extrinsic fundamental forms in Euclidean space
+
+This small API packages the first and second fundamental forms determined by the differential of
+an immersion and a chosen normal field. The sign in the second form is the convention
+`II(v, w) = -⟪dn(v), dF(w)⟫`; consequently `dn = c • dF` corresponds to `II = (-c) • I`.
+-/
+
+open scoped RealInnerProductSpace
+
+namespace EuclideanHypersurface
+
+variable {V E : Type*} [TopologicalSpace V] [AddCommGroup V] [Module ℝ V]
+  [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The first fundamental form induced by `dF`. -/
+noncomputable def firstFundamentalFormAt (dF : V →L[ℝ] E) : LinearMap.BilinForm ℝ V :=
+  LinearMap.mk₂ ℝ (fun v w ↦ inner ℝ (dF v) (dF w))
+    (by simp [inner_add_left]) (by simp [real_inner_smul_left])
+    (by simp [inner_add_right]) (by simp [real_inner_smul_right])
+
+/-- The second fundamental form for the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
+noncomputable def secondFundamentalFormAt (dn dF : V →L[ℝ] E) :
+    LinearMap.BilinForm ℝ V :=
+  LinearMap.mk₂ ℝ (fun v w ↦ -inner ℝ (dn v) (dF w))
+    (by simp [inner_add_left, add_comm]) (by simp [real_inner_smul_left])
+    (by simp [inner_add_right, add_comm]) (by simp [real_inner_smul_right])
+
+/-- A point is umbilic when its second fundamental form is a scalar multiple of its first. -/
+def IsUmbilicByFundamentalForms (dF dn : V →L[ℝ] E) : Prop :=
+  ∃ κ : ℝ, secondFundamentalFormAt dn dF = κ • firstFundamentalFormAt dF
+
+@[simp]
+theorem firstFundamentalFormAt_apply (dF : V →L[ℝ] E) (v w : V) :
+    firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) := by
+  rfl
+
+@[simp]
+theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
+    secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) := by
+  rfl
+
+/-- A scalar normal differential gives the corresponding scalar second fundamental form.
+
+The minus sign is forced by `secondFundamentalFormAt`'s shape-operator convention. -/
+theorem isUmbilicByFundamentalForms_of_normal_deriv_eq_smul
+    (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
+    IsUmbilicByFundamentalForms dF dn := by
+  refine ⟨-c, ?_⟩
+  ext v w
+  change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
+  rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left]
+  ring
+
+/-- Under tangency hypotheses, the fundamental-form and scalar-normal-differential definitions
+of an umbilic are equivalent. The range hypothesis is exactly what rules out an undetected
+normal component of `dn`. -/
+theorem isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
+    (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
+    IsUmbilicByFundamentalForms dF dn ↔ ∃ c : ℝ, dn = c • dF := by
+  constructor
+  · rintro ⟨κ, hκ⟩
+    refine ⟨-κ, ?_⟩
+    ext v
+    obtain ⟨u, hu⟩ := htangent ⟨v, rfl⟩
+    have horth (w : V) : inner ℝ (dn v + κ • dF v) (dF w) = 0 := by
+      have h := congrArg (fun B : LinearMap.BilinForm ℝ V ↦ B v w) hκ
+      change -inner ℝ (dn v) (dF w) = κ * inner ℝ (dF v) (dF w) at h
+      rw [inner_add_left, real_inner_smul_left]
+      linarith [h]
+    have hrange : dn v + κ • dF v = dF (u + κ • v) := by
+      change dF u = dn v at hu
+      rw [map_add, map_smul, ← hu]
+    have := horth (u + κ • v)
+    rw [← hrange, real_inner_self_eq_norm_sq] at this
+    have hzero : dn v + κ • dF v = 0 := by
+      apply norm_eq_zero.mp
+      nlinarith [norm_nonneg (dn v + κ • dF v)]
+    simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
+      eq_neg_of_add_eq_zero_left hzero
+  · rintro ⟨c, hc⟩
+    exact isUmbilicByFundamentalForms_of_normal_deriv_eq_smul dF dn c hc
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -17,6 +17,7 @@ limitations under the License.
 module
 
 public import Mathlib.Analysis.InnerProductSpace.LinearMap
+public import Mathlib.LinearAlgebra.BilinearForm.Hom
 
 @[expose] public section
 
@@ -37,49 +38,45 @@ variable {V E : Type*} [TopologicalSpace V] [AddCommGroup V] [Module ℝ V]
 
 /-- The first fundamental form induced by `dF`. -/
 noncomputable def firstFundamentalFormAt (dF : V →L[ℝ] E) : LinearMap.BilinForm ℝ V :=
-  LinearMap.mk₂ ℝ (fun v w ↦ inner ℝ (dF v) (dF w))
-    (by simp [inner_add_left]) (by simp [real_inner_smul_left])
-    (by simp [inner_add_right]) (by simp [real_inner_smul_right])
+  LinearMap.BilinForm.comp (innerₗ E) dF.toLinearMap dF.toLinearMap
 
 /-- The second fundamental form for the convention `II(v,w) = -⟪dn(v),dF(w)⟫`. -/
 noncomputable def secondFundamentalFormAt (dn dF : V →L[ℝ] E) :
     LinearMap.BilinForm ℝ V :=
-  LinearMap.mk₂ ℝ (fun v w ↦ -inner ℝ (dn v) (dF w))
-    (by simp [inner_add_left, add_comm]) (by simp [real_inner_smul_left])
-    (by simp [inner_add_right, add_comm]) (by simp [real_inner_smul_right])
+  -(LinearMap.BilinForm.comp (innerₗ E) dn.toLinearMap dF.toLinearMap)
 
 /-- A point is umbilic when its second fundamental form is a scalar multiple of its first. -/
-def IsUmbilicByFundamentalForms (dF dn : V →L[ℝ] E) : Prop :=
+def IsUmbilic (dF dn : V →L[ℝ] E) : Prop :=
   ∃ κ : ℝ, secondFundamentalFormAt dn dF = κ • firstFundamentalFormAt dF
 
 @[simp]
 theorem firstFundamentalFormAt_apply (dF : V →L[ℝ] E) (v w : V) :
     firstFundamentalFormAt dF v w = inner ℝ (dF v) (dF w) := by
-  rfl
+  simp [firstFundamentalFormAt]
 
 @[simp]
 theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
     secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) := by
-  rfl
+  simp [secondFundamentalFormAt]
 
-/-- A scalar normal differential gives the corresponding scalar second fundamental form.
+/-- A scalar normal differential makes a point umbilic.
 
 The minus sign is forced by `secondFundamentalFormAt`'s shape-operator convention. -/
-theorem isUmbilicByFundamentalForms_of_normal_deriv_eq_smul
+theorem isUmbilic_of_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
-    IsUmbilicByFundamentalForms dF dn := by
+    IsUmbilic dF dn := by
   refine ⟨-c, ?_⟩
   ext v w
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
   rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left]
   ring
 
-/-- Under tangency hypotheses, the fundamental-form and scalar-normal-differential definitions
-of an umbilic are equivalent. The range hypothesis is exactly what rules out an undetected
-normal component of `dn`. -/
-theorem isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
+/-- Under a tangency hypothesis, umbilicity is equivalent to the normal differential being a
+scalar multiple of the immersion differential. The range hypothesis is exactly what rules out an
+undetected normal component of `dn`. -/
+theorem isUmbilic_iff_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
-    IsUmbilicByFundamentalForms dF dn ↔ ∃ c : ℝ, dn = c • dF := by
+    IsUmbilic dF dn ↔ ∃ c : ℝ, dn = c • dF := by
   constructor
   · rintro ⟨κ, hκ⟩
     refine ⟨-κ, ?_⟩
@@ -101,6 +98,6 @@ theorem isUmbilicByFundamentalForms_iff_normal_deriv_eq_smul
     simpa only [ContinuousLinearMap.smul_apply, neg_smul] using
       eq_neg_of_add_eq_zero_left hzero
   · rintro ⟨c, hc⟩
-    exact isUmbilicByFundamentalForms_of_normal_deriv_eq_smul dF dn c hc
+    exact isUmbilic_of_normal_deriv_eq_smul dF dn c hc
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
+++ b/FormalConjecturesForMathlib/Geometry/EuclideanHypersurface.lean
@@ -22,9 +22,8 @@ public import Mathlib.LinearAlgebra.BilinearForm.Hom
 /-!
 # Extrinsic fundamental forms in Euclidean space
 
-This small API packages the first and second fundamental forms determined by the differential of
-an immersion and a chosen normal field. The sign in the second form is the convention
-`II(v, w) = -⟪dn(v), dF(w)⟫`; consequently `dn = c • dF` corresponds to `II = (-c) • I`.
+The second fundamental form uses `II(v, w) = -⟪dn(v), dF(w)⟫`, so `dn = c • dF` corresponds
+to `II = (-c) • I`.
 -/
 
 @[expose] public section
@@ -59,9 +58,7 @@ theorem secondFundamentalFormAt_apply (dn dF : V →L[ℝ] E) (v w : V) :
     secondFundamentalFormAt dn dF v w = -inner ℝ (dn v) (dF w) :=
   rfl
 
-/-- A scalar normal differential makes a point umbilic.
-
-The minus sign is forced by `secondFundamentalFormAt`'s shape-operator convention. -/
+/-- If `dn = c • dF`, the point is umbilic with scalar `-c` under our sign convention. -/
 theorem isUmbilic_of_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (c : ℝ) (h : dn = c • dF) :
     IsUmbilic dF dn := by
@@ -70,9 +67,8 @@ theorem isUmbilic_of_normal_deriv_eq_smul
   change -inner ℝ (dn v) (dF w) = -c * inner ℝ (dF v) (dF w)
   rw [h, ContinuousLinearMap.smul_apply, real_inner_smul_left, neg_mul]
 
-/-- Under a tangency hypothesis, umbilicity is equivalent to the normal differential being a
-scalar multiple of the immersion differential. The range hypothesis is exactly what rules out an
-undetected normal component of `dn`. -/
+/-- If `dn` is tangent to the immersion, umbilicity is equivalent to `dn` being a scalar multiple
+of `dF`. -/
 theorem isUmbilic_iff_normal_deriv_eq_smul
     (dF dn : V →L[ℝ] E) (htangent : dn.range ≤ dF.range) :
     IsUmbilic dF dn ↔ ∃ c : ℝ, dn = c • dF := by

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -66,13 +66,17 @@ noncomputable def sphereNormal
 
 /-- The orientation factor contributed by the standard sphere inclusion is nonzero. -/
 private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³) 1) :
-    let b := sphereTangentBasis p
-    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-    inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
-  dsimp only
+    inner ℝ
+      (euclideanCross
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+          (sphereTangentBasis p 0))
+        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+          (sphereTangentBasis p 1)))
+      (p : ℝ³) ≠ 0 := by
   letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   let b := sphereTangentBasis p
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  change inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0
   have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
   have hιLI : LinearIndependent ℝ ![dι (b 0), dι (b 1)] := by
     have hmap := b.linearIndependent.map' dι.toLinearMap
@@ -125,7 +129,6 @@ private theorem sphereNormalRaw_ne_zero_iff
   let b := sphereTangentBasis p
   let dF := sphereAmbientMfderiv F p
   have hfactor := sphereInclusionOrientationFactor_ne_zero p
-  dsimp only at hfactor
   rw [sphereNormalRaw]
   dsimp only
   rw [smul_ne_zero_iff, and_iff_right hfactor,

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -18,6 +18,8 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Normalize
 public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame
+public import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 
 public import FormalConjecturesForMathlib.Geometry.«3d»
 
@@ -36,15 +38,9 @@ normal is independent of the chart orientation.
 @[expose] public section
 
 open Metric
-open scoped EuclideanGeometry Manifold RealInnerProductSpace
+open scoped EuclideanGeometry EuclideanSpace Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
-
-/-- The manifold derivative of a map from the unit two-sphere, with ambient codomain. -/
-noncomputable def sphereAmbientMfderiv
-    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
-  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
 
 /-- The standard basis of Mathlib's fixed model copy of `ℝ²` for the tangent space at `p`.
 
@@ -52,22 +48,33 @@ This is a coordinate basis used to evaluate the manifold derivative, not a globa
 the sphere. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) :=
-  PiLp.basisFun 2 ℝ (Fin 2)
+  (trivializationAt (EuclideanSpace ℝ (Fin 2)) (TangentSpace (𝓡 2)) p).basisAt
+    (PiLp.basisFun 2 ℝ (Fin 2)) (FiberBundle.mem_baseSet_trivializationAt' p)
 
-private theorem sphereAmbientMfderiv_inclusion_basis_apply
+/-- The basis induced by the tangent-bundle trivialization at its base point agrees with the
+standard model basis. -/
+theorem sphereTangentBasis_apply (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
+    sphereTangentBasis p i = PiLp.basisFun 2 ℝ (Fin 2) i := by
+  change
+    (trivializationAt (EuclideanSpace ℝ (Fin 2)) (TangentSpace (𝓡 2)) p).symmL ℝ p
+        (PiLp.basisFun 2 ℝ (Fin 2) i) = _
+  rw [(tangentBundleCore (𝓡 2) _).trivializationAt_symmL
+    (FiberBundle.mem_baseSet_trivializationAt' p)]
+  exact (tangentBundleCore (𝓡 2) _).coordChange_self _ p
+    ((tangentBundleCore (𝓡 2) _).mem_baseSet_at p) _
+
+private theorem mfderiv_inclusion_sphereTangentBasis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
-    letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-    sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p :
+      TangentSpace (𝓡 2) p →L[ℝ] ℝ³)
         (sphereTangentBasis p i) =
       let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
         (ne_zero_of_mem_unit_sphere (-p))).repr
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
         (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-  dsimp only
-  rw [sphereAmbientMfderiv,
-    ((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
+  rw [((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
   simp only [chartAt, fderivWithin_univ, mfld_simps]
+  rw [sphereTangentBasis_apply]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change
@@ -91,17 +98,16 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
 /-- The standard model basis maps to an orthonormal frame under the derivative of the sphere
 inclusion. -/
 @[simp]
-theorem inner_sphereAmbientMfderiv_inclusion_basis
+theorem inner_mfderiv_inclusion_sphereTangentBasis
     (p : sphere (0 : ℝ³) 1) (i j : Fin 2) :
     inner ℝ
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p i))
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p j)) =
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p (sphereTangentBasis p i))
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p (sphereTangentBasis p j)) =
       if i = j then 1 else 0 := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-  rw [sphereAmbientMfderiv_inclusion_basis_apply p i,
-    sphereAmbientMfderiv_inclusion_basis_apply p j]
+  rw [mfderiv_inclusion_sphereTangentBasis_apply p i,
+    mfderiv_inclusion_sphereTangentBasis_apply p j]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change inner ℝ
@@ -112,18 +118,19 @@ theorem inner_sphereAmbientMfderiv_inclusion_basis
 
 /-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
 family. -/
-theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³) 1) :
+theorem orthonormal_mfderiv_inclusion_sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Orthonormal ℝ fun i : Fin 2 ↦
-      sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p i) :=
-  orthonormal_iff_ite.mpr (inner_sphereAmbientMfderiv_inclusion_basis p)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p (sphereTangentBasis p i)) :=
+  orthonormal_iff_ite.mpr (inner_mfderiv_inclusion_sphereTangentBasis p)
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
 noncomputable def sphereNormalRaw
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let dF := sphereAmbientMfderiv F p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
   inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
     euclideanCross (dF (b 0)) (dF (b 1))
 
@@ -139,10 +146,10 @@ noncomputable def sphereNormal
 /-- The cross product of the inclusion frame is its radial component. -/
 private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
-    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+      mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     euclideanCross (dι (b 0)) (dι (b 1)) =
       inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) • (p : ℝ³) := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   dsimp only
   refine euclideanCross_eq_inner_smul_of_orthogonal _ _ _
     (norm_eq_of_mem_sphere p) ?_ ?_
@@ -154,13 +161,15 @@ private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
 /-- The orientation factor contributed by the standard sphere inclusion has square one. -/
 private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
-    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+      mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ^ 2 = 1 := by
   dsimp only
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
-    orthonormal_sphereAmbientMfderiv_inclusion_basis p
+    orthonormal_mfderiv_inclusion_sphereTangentBasis p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
   change s ^ 2 = 1
@@ -178,7 +187,8 @@ private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1
 theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
     sphereNormalRaw (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
   change s • c = (p : ℝ³)
@@ -188,31 +198,41 @@ theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
 @[simp]
-theorem inner_sphereNormalRaw_sphereAmbientMfderiv
+theorem inner_sphereNormalRaw_mfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
-    inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
-  rw [sphereNormalRaw, real_inner_smul_left, ← (sphereTangentBasis p).sum_repr v, map_sum]
-  simp [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
-    euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
+    inner ℝ (sphereNormalRaw F p)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0 := by
+  let b := sphereTangentBasis p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+  change inner ℝ
+    (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
+      euclideanCross (dF (b 0)) (dF (b 1))) (dF v) = 0
+  rw [real_inner_smul_left, ← b.sum_repr v, map_sum]
+  simp [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right]
 
 /-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
 @[simp]
-theorem inner_sphereNormal_sphereAmbientMfderiv
+theorem inner_sphereNormal_mfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
-    inner ℝ (sphereNormal F p) (sphereAmbientMfderiv F p v) = 0 := by
+    inner ℝ (sphereNormal F p)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0 := by
   rw [sphereNormal, NormedSpace.normalize, real_inner_smul_left,
-    inner_sphereNormalRaw_sphereAmbientMfderiv, mul_zero]
+    inner_sphereNormalRaw_mfderiv, mul_zero]
 
 /-- The raw canonical normal is nonzero exactly at the points where the manifold derivative is
 injective. -/
 private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    sphereNormalRaw F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+    sphereNormalRaw F p ≠ 0 ↔ Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³) := by
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let dF := sphereAmbientMfderiv F p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
   have hfactor : inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
     intro h
     simpa [b, dι, h] using sphere_inclusion_orientation_factor_sq p
@@ -230,14 +250,16 @@ private theorem sphereNormalRaw_ne_zero_iff
 injective. -/
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
-    sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+    sphereNormal F p ≠ 0 ↔ Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³) := by
   simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
     sphereNormalRaw_ne_zero_iff F p
 
 /-- At an immersion point, the canonical normal has unit length. -/
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : Function.Injective (sphereAmbientMfderiv F p)) :
+    (hF : Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ‖sphereNormal F p‖ = 1 := by
   simpa [sphereNormal] using
     NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
@@ -254,17 +276,19 @@ theorem sphereNormal_eq_of_raw_eq_pos_smul
 sphere inclusion has the outward radial canonical normal. -/
 theorem sphereNormal_eq_radial_of_coercive
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
-    (hnormal : ∀ v, inner ℝ (p : ℝ³) (sphereAmbientMfderiv F p v) = 0)
+    (hnormal : ∀ v, inner ℝ (p : ℝ³)
+      (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v) = 0)
     (hcoercive : ∀ v,
-      c * ‖sphereAmbientMfderiv
-          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
-        inner ℝ (sphereAmbientMfderiv F p v)
-          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+      c * ‖(show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+        (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)‖ ^ 2 ≤
+        inner ℝ (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p v)
+          (show ℝ³ from mfderiv (𝓡 2) 𝓘(ℝ, ℝ³)
+            (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
     sphereNormal F p = (p : ℝ³) := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let dF := sphereAmbientMfderiv F p
+  let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
   let u := dι (b 0)
   let v := dι (b 1)
   let x := dF (b 0)
@@ -274,10 +298,11 @@ theorem sphereNormal_eq_radial_of_coercive
   let P := inner ℝ x v
   let Q := inner ℝ y u
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
-    orthonormal_sphereAmbientMfderiv_inclusion_basis p
-  have hApos : 0 < A := hc.trans_le <| by
-    simpa [dF, dι, x, u, A, hON.norm_eq_one] using
-      hcoercive (b 0)
+    orthonormal_mfderiv_inclusion_sphereTangentBasis p
+  have hcoercive0 : c * ‖dι (b 0)‖ ^ 2 ≤ inner ℝ (dF (b 0)) (dι (b 0)) :=
+    hcoercive (b 0)
+  rw [hON.norm_eq_one 0, one_pow, mul_one] at hcoercive0
+  have hApos : 0 < A := hc.trans_le <| by simpa [A, x, u] using hcoercive0
   let s := P + Q
   let t := s • b 0 - (2 * A) • b 1
   have ht : t ≠ 0 := by

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -1,0 +1,175 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.Normed.Module.Normalize
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+
+public import FormalConjecturesForMathlib.Geometry.«3d»
+public meta import FormalConjecturesUtil.Attributes.Basic
+
+/-!
+# A canonical normal for immersed two-spheres in three-space
+
+This file constructs an orientation-compatible normal vector from the cross product of the images
+of the standard basis of the model tangent space. The sign is corrected using the standard sphere
+inclusion, so the result does not depend on whether a sphere chart preserves orientation.
+-/
+
+@[expose] public section
+
+open Metric
+open scoped EuclideanGeometry Manifold RealInnerProductSpace
+
+namespace EuclideanHypersurface
+
+/-- The manifold derivative of a map from the unit two-sphere, with ambient codomain. -/
+noncomputable def sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
+  mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
+
+/-- The standard basis of the model tangent space at a point of the unit two-sphere. -/
+noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
+    Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) := by
+  unfold TangentSpace
+  exact PiLp.basisFun 2 ℝ (Fin 2)
+
+/-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
+noncomputable def sphereNormalRaw
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF := sphereAmbientMfderiv F p
+  inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
+    euclideanCross (dF (b 0)) (dF (b 1))
+
+/-- The canonical unit normal of a map from the unit two-sphere to three-space.
+
+For a non-immersion its raw normal can vanish, in which case this definition is zero. -/
+noncomputable def sphereNormal
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
+  NormedSpace.normalize (sphereNormalRaw F p)
+
+/-- The orientation factor contributed by the standard sphere inclusion is nonzero. -/
+private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³) 1) :
+    let b := sphereTangentBasis p
+    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
+  dsimp only
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
+  have hιLI : LinearIndependent ℝ ![dι (b 0), dι (b 1)] := by
+    have hmap := b.linearIndependent.map' dι.toLinearMap
+      (LinearMap.ker_eq_bot_of_injective hι)
+    rw [show ![dι (b 0), dι (b 1)] = dι.toLinearMap ∘ b by
+      funext i
+      fin_cases i <;> rfl]
+    exact hmap
+  have hcross : euclideanCross (dι (b 0)) (dι (b 1)) ≠ 0 :=
+    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hιLI
+  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
+  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
+    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨b i, rfl⟩
+  intro hfactor
+  apply hcross
+  rw [euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) _ _ hp (horth 0) (horth 1),
+    hfactor, zero_smul]
+
+/-- The raw canonical normal is orthogonal to every image tangent vector. -/
+@[simp, category API, AMS 53]
+theorem inner_sphereNormalRaw_sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (v : TangentSpace (𝓡 2) p) :
+    inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
+  rw [sphereNormalRaw]
+  dsimp only
+  rw [real_inner_smul_left]
+  apply mul_eq_zero_of_right
+  rw [← (sphereTangentBasis p).sum_repr v]
+  rw [map_sum]
+  simp only [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
+    euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
+
+/-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
+@[simp, category API, AMS 53]
+theorem inner_sphereNormal_sphereAmbientMfderiv
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (v : TangentSpace (𝓡 2) p) :
+    inner ℝ (sphereNormal F p) (sphereAmbientMfderiv F p v) = 0 := by
+  rw [sphereNormal, NormedSpace.normalize, real_inner_smul_left,
+    inner_sphereNormalRaw_sphereAmbientMfderiv, mul_zero]
+
+/-- The raw canonical normal is nonzero exactly at the points where the manifold derivative is
+injective. -/
+private theorem sphereNormalRaw_ne_zero_iff
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    sphereNormalRaw F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+  let b := sphereTangentBasis p
+  let dF := sphereAmbientMfderiv F p
+  have hfactor := sphereInclusionOrientationFactor_ne_zero p
+  dsimp only at hfactor
+  rw [sphereNormalRaw]
+  dsimp only
+  rw [smul_ne_zero_iff, and_iff_right hfactor,
+    euclideanCross_ne_zero_iff_linearIndependent]
+  have hfamily : dF.toLinearMap ∘ b = ![dF (b 0), dF (b 1)] := by
+    funext i
+    fin_cases i <;> rfl
+  constructor
+  · intro hLI
+    apply LinearMap.injective_of_linearIndependent b.span_eq
+    rw [hfamily]
+    exact hLI
+  · intro hF
+    have hmap := b.linearIndependent.map' dF.toLinearMap
+      (LinearMap.ker_eq_bot_of_injective hF)
+    rwa [hfamily] at hmap
+
+/-- The canonical normal is nonzero exactly at the points where the manifold derivative is
+injective. -/
+@[category API, AMS 53]
+theorem sphereNormal_ne_zero_iff
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
+  rw [sphereNormal]
+  exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).trans
+    (sphereNormalRaw_ne_zero_iff F p)
+
+/-- At an immersion point, the canonical normal has unit length. -/
+@[category API, AMS 53]
+theorem norm_sphereNormal_of_injective
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : Function.Injective (sphereAmbientMfderiv F p)) :
+    ‖sphereNormal F p‖ = 1 := by
+  rw [sphereNormal]
+  exact NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
+
+/-- Normalizing a positive multiple of the radial vector recovers the radial vector. -/
+@[category API, AMS 53]
+theorem sphereNormal_eq_of_raw_eq_pos_smul
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
+    (hraw : sphereNormalRaw F p = c • (p : ℝ³)) :
+    sphereNormal F p = (p : ℝ³) := by
+  rw [sphereNormal, hraw, NormedSpace.normalize_smul_of_pos hc,
+    NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -36,7 +36,7 @@ normal is independent of the chart orientation.
 @[expose] public section
 
 open Metric
-open scoped BigOperators EuclideanGeometry Manifold RealInnerProductSpace
+open scoped EuclideanGeometry Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
 
@@ -55,10 +55,10 @@ noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
   unfold TangentSpace
   exact PiLp.basisFun 2 ℝ (Fin 2)
 
-section InclusionDerivative
-
 private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
   ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+
+section InclusionDerivative
 
 private theorem sphereAmbientMfderiv_inclusion_basis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
@@ -122,30 +122,6 @@ theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³)
   rw [orthonormal_iff_ite]
   exact inner_sphereAmbientMfderiv_inclusion_basis p
 
-/-- The derivative of the standard sphere inclusion preserves the coordinate inner product on
-Mathlib's model tangent space. -/
-theorem inner_sphereAmbientMfderiv_inclusion
-    (p : sphere (0 : ℝ³) 1) (v w : TangentSpace (𝓡 2) p) :
-    inner ℝ
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)
-      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p w) =
-      ∑ i, (sphereTangentBasis p).repr v i * (sphereTangentBasis p).repr w i := by
-  let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  have horth (i j : Fin 2) : inner ℝ (dι (b i)) (dι (b j)) =
-      if i = j then 1 else 0 := by
-    exact inner_sphereAmbientMfderiv_inclusion_basis p i j
-  change inner ℝ (dι v) (dι w) = ∑ i, b.repr v i * b.repr w i
-  calc
-    _ = inner ℝ (dι (∑ i, b.repr v i • b i)) (dι (∑ i, b.repr w i • b i)) := by
-      rw [b.sum_repr, b.sum_repr]
-    _ = _ := by
-      rw [map_sum, map_sum]
-      simp_rw [inner_sum, sum_inner, map_smul, real_inner_smul_left,
-        real_inner_smul_right]
-      simp_rw [horth]
-      simp [Fin.sum_univ_two]
-
 end InclusionDerivative
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
@@ -166,38 +142,59 @@ noncomputable def sphereNormal
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   NormedSpace.normalize (sphereNormalRaw F p)
 
-/-- The orientation factor contributed by the standard sphere inclusion is nonzero. -/
-private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³) 1) :
-    inner ℝ
-      (euclideanCross
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-          (sphereTangentBasis p 0))
-        (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-          (sphereTangentBasis p 1)))
-      (p : ℝ³) ≠ 0 := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+/-- The cross product of the inclusion frame is its radial component. -/
+private theorem sphereInclusionCross_eq_smul (p : sphere (0 : ℝ³) 1) :
+    let b := sphereTangentBasis p
+    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    euclideanCross (dι (b 0)) (dι (b 1)) =
+      inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) • (p : ℝ³) := by
+  dsimp only
+  apply euclideanCross_eq_inner_smul_of_orthogonal
+  · exact norm_eq_of_mem_sphere p
+  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨sphereTangentBasis p 0, rfl⟩
+  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨sphereTangentBasis p 1, rfl⟩
+
+/-- The orientation factor contributed by the standard sphere inclusion has square one. -/
+private theorem sphereInclusionOrientationFactor_sq (p : sphere (0 : ℝ³) 1) :
+    let b := sphereTangentBasis p
+    let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+    inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ^ 2 = 1 := by
+  dsimp only
   let b := sphereTangentBasis p
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  change inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0
-  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
-  have hιLI : LinearIndependent ℝ ![dι (b 0), dι (b 1)] := by
-    have hmap := b.linearIndependent.map' dι.toLinearMap
-      (LinearMap.ker_eq_bot_of_injective hι)
-    rw [show ![dι (b 0), dι (b 1)] = dι.toLinearMap ∘ b by
-      funext i
-      fin_cases i <;> rfl]
-    exact hmap
-  have hcross : euclideanCross (dι (b 0)) (dι (b 1)) ≠ 0 :=
-    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hιLI
+  have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
+    orthonormal_sphereAmbientMfderiv_inclusion_basis p
+  let c := euclideanCross (dι (b 0)) (dι (b 1))
+  let s := inner ℝ c (p : ℝ³)
   have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
-  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
-    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨b i, rfl⟩
-  intro hfactor
-  apply hcross
-  rw [euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) _ _ hp (horth 0) (horth 1),
-    hfactor, zero_smul]
+  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
+  change s ^ 2 = 1
+  calc
+    s ^ 2 = inner ℝ c c := by
+      simp [hc, norm_smul, hp, pow_two]
+    _ = 1 := by
+      dsimp only [c]
+      rw [inner_euclideanCross_euclideanCross]
+      simp [hON.norm_eq_one, hON.inner_eq_zero]
+
+/-- The raw canonical normal of the standard sphere inclusion is the radial vector. -/
+@[simp]
+theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
+    sphereNormalRaw (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let c := euclideanCross (dι (b 0)) (dι (b 1))
+  let s := inner ℝ c (p : ℝ³)
+  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
+  have hs : s ^ 2 = 1 := sphereInclusionOrientationFactor_sq p
+  rw [sphereNormalRaw]
+  dsimp only
+  change s • c = (p : ℝ³)
+  rw [hc, smul_smul, ← pow_two, hs, one_smul]
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
 @[simp]
@@ -229,8 +226,11 @@ private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormalRaw F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
   let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let dF := sphereAmbientMfderiv F p
-  have hfactor := sphereInclusionOrientationFactor_ne_zero p
+  have hfactor : inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
+    intro h
+    simpa [b, dι, h] using sphereInclusionOrientationFactor_sq p
   rw [sphereNormalRaw]
   dsimp only
   rw [smul_ne_zero_iff, and_iff_right hfactor,
@@ -273,29 +273,86 @@ theorem sphereNormal_eq_of_raw_eq_pos_smul
   rw [sphereNormal, hraw, NormedSpace.normalize_smul_of_pos hc,
     NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
 
+/-- A radially tangent map whose derivative is positively coercive relative to the standard
+sphere inclusion has the outward radial canonical normal. -/
+theorem sphereNormal_eq_radial_of_coercive
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
+    (hnormal : ∀ v, inner ℝ (p : ℝ³) (sphereAmbientMfderiv F p v) = 0)
+    (hcoercive : ∀ v,
+      c * ‖sphereAmbientMfderiv
+          (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v‖ ^ 2 ≤
+        inner ℝ (sphereAmbientMfderiv F p v)
+          (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
+    sphereNormal F p = (p : ℝ³) := by
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let dF := sphereAmbientMfderiv F p
+  let u := dι (b 0)
+  let v := dι (b 1)
+  let x := dF (b 0)
+  let y := dF (b 1)
+  let A := inner ℝ x u
+  let D := inner ℝ y v
+  let P := inner ℝ x v
+  let Q := inner ℝ y u
+  have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
+    orthonormal_sphereAmbientMfderiv_inclusion_basis p
+  have hι : Function.Injective dι := by
+    dsimp only [dι, sphereAmbientMfderiv]
+    exact mfderiv_coe_sphere_injective p
+  have hA : c ≤ A := by
+    simpa only [dF, dι, x, u, A, hON.norm_eq_one, one_pow, mul_one] using
+      hcoercive (b 0)
+  have hApos : 0 < A := hc.trans_le hA
+  let s := P + Q
+  let t := s • b 0 - (2 * A) • b 1
+  have ht : t ≠ 0 := by
+    intro ht
+    have htCoord := congrArg (fun z ↦ b.repr z 1) ht
+    dsimp only [t] at htCoord
+    simp at htCoord
+    linarith
+  have hdιt : dι t ≠ 0 := by
+    intro ht'
+    apply ht
+    apply hι
+    simpa only [map_zero] using ht'
+  have hquadpos : 0 < inner ℝ (dF t) (dι t) :=
+    (mul_pos hc (sq_pos_of_pos (norm_pos_iff.mpr hdιt))).trans_le (hcoercive t)
+  dsimp only [t] at hquadpos
+  simp only [map_sub, map_smul] at hquadpos
+  change 0 < inner ℝ (s • x - (2 * A) • y) (s • u - (2 * A) • v) at hquadpos
+  simp only [inner_sub_left, inner_sub_right, real_inner_smul_left,
+    real_inner_smul_right] at hquadpos
+  dsimp only [s, A, D, P, Q] at hquadpos
+  have hdetAux : 0 < 4 * A * D - (P + Q) ^ 2 := by
+    nlinarith
+  have hdet : 0 < A * D - P * Q := by
+    nlinarith [sq_nonneg (P - Q)]
+  have hcrossPos : 0 < inner ℝ (euclideanCross u v) (euclideanCross x y) := by
+    rw [inner_euclideanCross_euclideanCross]
+    rw [← real_inner_comm u x, ← real_inner_comm v y, ← real_inner_comm u y,
+      ← real_inner_comm v x]
+    change 0 < A * D - Q * P
+    nlinarith
+  have hcrossEq : euclideanCross x y =
+      inner ℝ (euclideanCross x y) (p : ℝ³) • (p : ℝ³) :=
+    euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
+      (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1))
+  apply sphereNormal_eq_of_raw_eq_pos_smul F p
+    (inner ℝ (euclideanCross u v) (euclideanCross x y)) hcrossPos
+  rw [sphereNormalRaw]
+  dsimp only
+  change inner ℝ (euclideanCross u v) (p : ℝ³) • euclideanCross x y =
+    inner ℝ (euclideanCross u v) (euclideanCross x y) • (p : ℝ³)
+  rw [hcrossEq, real_inner_smul_right]
+  module
+
 /-- The canonical normal of the standard sphere inclusion points radially outward. -/
 @[simp]
 theorem sphereNormal_inclusion (p : sphere (0 : ℝ³) 1) :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
-  let b := sphereTangentBasis p
-  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-  let c := euclideanCross (dι (b 0)) (dι (b 1))
-  let s := inner ℝ c (p : ℝ³)
-  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
-  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
-    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨b i, rfl⟩
-  have hc : c = s • (p : ℝ³) := by
-    exact euclideanCross_eq_inner_smul_of_orthogonal
-      (p : ℝ³) (dι (b 0)) (dι (b 1)) hp (horth 0) (horth 1)
-  have hs : s ≠ 0 := by
-    exact sphereInclusionOrientationFactor_ne_zero p
-  apply sphereNormal_eq_of_raw_eq_pos_smul _ p (s ^ 2) (sq_pos_of_ne_zero hs)
-  rw [sphereNormalRaw]
-  dsimp only
-  change s • c = s ^ 2 • (p : ℝ³)
-  rw [hc, smul_smul, pow_two]
+  rw [sphereNormal, sphereNormalRaw_inclusion,
+    NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -26,13 +26,9 @@ public import FormalConjecturesForMathlib.Geometry.«3d»
 /-!
 # A canonical normal for immersed two-spheres in three-space
 
-Mathlib represents every tangent space of the sphere by a copy of the fixed model space `ℝ²`.
-The basis below is the standard basis of that model space, not a continuous global tangent frame.
-The preferred sphere charts identify the geometric tangent plane with the model space through a
-possibly orientation-reversing orthonormal map. This file constructs a normal from the corresponding
-cross product and corrects its sign using the standard sphere inclusion. A change of model frame
-therefore occurs in both cross products, so its determinant appears squared and the normalized
-normal is independent of the chart orientation.
+Mathlib models each sphere tangent space on a fixed copy of `ℝ²`. We orient the cross product
+using the standard sphere inclusion; changing the model frame then contributes a squared
+determinant, which disappears after normalization.
 -/
 
 @[expose] public section
@@ -42,10 +38,7 @@ open scoped EuclideanGeometry EuclideanSpace Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
 
-/-- The standard basis of Mathlib's fixed model copy of `ℝ²` for the tangent space at `p`.
-
-This is a coordinate basis used to evaluate the manifold derivative, not a global tangent frame on
-the sphere. -/
+/-- The standard coordinate basis of the model tangent space at `p`, not a global tangent frame. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) :=
   (trivializationAt (EuclideanSpace ℝ (Fin 2)) (TangentSpace (𝓡 2)) p).basisAt
@@ -134,16 +127,13 @@ noncomputable def sphereNormalRaw
   inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) •
     euclideanCross (dF (b 0)) (dF (b 1))
 
-/-- The canonical unit normal of a map from the unit two-sphere to three-space.
-
-Its orientation is induced by the outward orientation of the domain sphere. Thus it need not be
-the outward normal of the image when `F` reverses orientation. For a non-immersion its raw normal
-can vanish, in which case this definition is zero. -/
+/-- The canonical unit normal, oriented by the outward orientation of the domain sphere.
+It may point inward on the image if `F` reverses orientation and is zero where its raw normal
+vanishes. -/
 noncomputable def sphereNormal
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   NormedSpace.normalize (sphereNormalRaw F p)
 
-/-- The cross product of the inclusion frame is its radial component. -/
 private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
@@ -158,7 +148,6 @@ private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
   · exact Submodule.mem_orthogonal_singleton_iff_inner_right.mp <|
       range_mfderiv_coe_sphere (n := 2) p ▸ ⟨sphereTangentBasis p 1, rfl⟩
 
-/-- The orientation factor contributed by the standard sphere inclusion has square one. -/
 private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι : TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
@@ -223,8 +212,6 @@ theorem inner_sphereNormal_mfderiv
   rw [sphereNormal, NormedSpace.normalize, real_inner_smul_left,
     inner_sphereNormalRaw_mfderiv, mul_zero]
 
-/-- The raw canonical normal is nonzero exactly at the points where the manifold derivative is
-injective. -/
 private theorem sphereNormalRaw_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormalRaw F p ≠ 0 ↔ Function.Injective

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -24,15 +24,19 @@ public import FormalConjecturesForMathlib.Geometry.«3d»
 /-!
 # A canonical normal for immersed two-spheres in three-space
 
-This file constructs an orientation-compatible normal vector from the cross product of the images
-of the standard basis of the model tangent space. The sign is corrected using the standard sphere
-inclusion, so the result does not depend on whether a sphere chart preserves orientation.
+Mathlib represents every tangent space of the sphere by a copy of the fixed model space `ℝ²`.
+The basis below is the standard basis of that model space, not a continuous global tangent frame.
+The preferred sphere charts identify the geometric tangent plane with the model space through a
+possibly orientation-reversing orthonormal map. This file constructs a normal from the corresponding
+cross product and corrects its sign using the standard sphere inclusion. A change of model frame
+therefore occurs in both cross products, so its determinant appears squared and the normalized
+normal is independent of the chart orientation.
 -/
 
 @[expose] public section
 
 open Metric
-open scoped EuclideanGeometry Manifold RealInnerProductSpace
+open scoped BigOperators EuclideanGeometry Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
 
@@ -42,11 +46,107 @@ noncomputable def sphereAmbientMfderiv
     TangentSpace (𝓡 2) p →L[ℝ] ℝ³ :=
   mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p
 
-/-- The standard basis of the model tangent space at a point of the unit two-sphere. -/
+/-- The standard basis of Mathlib's fixed model copy of `ℝ²` for the tangent space at `p`.
+
+This is a coordinate basis used to evaluate the manifold derivative, not a global tangent frame on
+the sphere. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) := by
   unfold TangentSpace
   exact PiLp.basisFun 2 ℝ (Fin 2)
+
+section InclusionDerivative
+
+private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
+  ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+
+private theorem sphereAmbientMfderiv_inclusion_basis_apply
+    (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
+    sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p i) =
+      let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
+        (ne_zero_of_mem_unit_sphere (-p))).repr
+      ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
+        (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
+  rw [sphereAmbientMfderiv]
+  rw [((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
+  simp only [chartAt, fderivWithin_univ, mfld_simps]
+  let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
+    (ne_zero_of_mem_unit_sphere (-p))).repr
+  change
+    (fderiv ℝ ((stereoInvFunAux (-p : ℝ³) ∘
+      (Subtype.val : (ℝ ∙ (-(p : ℝ³)))ᗮ → ℝ³)) ∘ U.symm)
+        (stereographic' 2 (-p) p)) (PiLp.basisFun 2 ℝ (Fin 2) i) =
+      ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) : (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³)
+  have hp0 : stereographic' 2 (-p) p = 0 := by
+    dsimp [stereographic']
+    simp only [EmbeddingLike.map_eq_zero_iff]
+    apply stereographic_neg_apply
+  rw [hp0]
+  have h :
+      HasFDerivAt (stereoInvFunAux (-p : ℝ³) ∘
+        (Subtype.val : (ℝ ∙ (-(p : ℝ³)))ᗮ → ℝ³))
+        (ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeL (U.symm 0) := by
+    convert hasFDerivAt_stereoInvFunAux_comp_coe (-p : ℝ³)
+    simp
+  rw [(h.comp 0 U.symm.toContinuousLinearEquiv.hasFDerivAt).fderiv]
+  rfl
+
+/-- The standard model basis maps to an orthonormal frame under the derivative of the sphere
+inclusion. -/
+@[simp]
+theorem inner_sphereAmbientMfderiv_inclusion_basis
+    (p : sphere (0 : ℝ³) 1) (i j : Fin 2) :
+    inner ℝ
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p i))
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p j)) =
+      if i = j then 1 else 0 := by
+  rw [sphereAmbientMfderiv_inclusion_basis_apply,
+    sphereAmbientMfderiv_inclusion_basis_apply]
+  let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
+    (ne_zero_of_mem_unit_sphere (-p))).repr
+  change inner ℝ
+    ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) i)))
+    ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) j))) = _
+  rw [LinearIsometry.inner_map_map, U.symm.inner_map_map]
+  exact orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
+
+/-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
+family. -/
+theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³) 1) :
+    Orthonormal ℝ fun i : Fin 2 ↦
+      sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+        (sphereTangentBasis p i) := by
+  rw [orthonormal_iff_ite]
+  exact inner_sphereAmbientMfderiv_inclusion_basis p
+
+/-- The derivative of the standard sphere inclusion preserves the coordinate inner product on
+Mathlib's model tangent space. -/
+theorem inner_sphereAmbientMfderiv_inclusion
+    (p : sphere (0 : ℝ³) 1) (v w : TangentSpace (𝓡 2) p) :
+    inner ℝ
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)
+      (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p w) =
+      ∑ i, (sphereTangentBasis p).repr v i * (sphereTangentBasis p).repr w i := by
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  have horth (i j : Fin 2) : inner ℝ (dι (b i)) (dι (b j)) =
+      if i = j then 1 else 0 := by
+    exact inner_sphereAmbientMfderiv_inclusion_basis p i j
+  change inner ℝ (dι v) (dι w) = ∑ i, b.repr v i * b.repr w i
+  calc
+    _ = inner ℝ (dι (∑ i, b.repr v i • b i)) (dι (∑ i, b.repr w i • b i)) := by
+      rw [b.sum_repr, b.sum_repr]
+    _ = _ := by
+      rw [map_sum, map_sum]
+      simp_rw [inner_sum, sum_inner, map_smul, real_inner_smul_left,
+        real_inner_smul_right]
+      simp_rw [horth]
+      simp [Fin.sum_univ_two]
+
+end InclusionDerivative
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
 noncomputable def sphereNormalRaw
@@ -59,7 +159,9 @@ noncomputable def sphereNormalRaw
 
 /-- The canonical unit normal of a map from the unit two-sphere to three-space.
 
-For a non-immersion its raw normal can vanish, in which case this definition is zero. -/
+Its orientation is induced by the outward orientation of the domain sphere. Thus it need not be
+the outward normal of the image when `F` reverses orientation. For a non-immersion its raw normal
+can vanish, in which case this definition is zero. -/
 noncomputable def sphereNormal
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) : ℝ³ :=
   NormedSpace.normalize (sphereNormalRaw F p)
@@ -170,5 +272,30 @@ theorem sphereNormal_eq_of_raw_eq_pos_smul
     sphereNormal F p = (p : ℝ³) := by
   rw [sphereNormal, hraw, NormedSpace.normalize_smul_of_pos hc,
     NormedSpace.normalize_eq_self_of_norm_eq_one (norm_eq_of_mem_sphere p)]
+
+/-- The canonical normal of the standard sphere inclusion points radially outward. -/
+@[simp]
+theorem sphereNormal_inclusion (p : sphere (0 : ℝ³) 1) :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p = (p : ℝ³) := by
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  let b := sphereTangentBasis p
+  let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
+  let c := euclideanCross (dι (b 0)) (dι (b 1))
+  let s := inner ℝ c (p : ℝ³)
+  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
+  have horth (i : Fin 2) : inner ℝ (p : ℝ³) (dι (b i)) = 0 := by
+    apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
+    rw [← range_mfderiv_coe_sphere (n := 2) p]
+    exact ⟨b i, rfl⟩
+  have hc : c = s • (p : ℝ³) := by
+    exact euclideanCross_eq_inner_smul_of_orthogonal
+      (p : ℝ³) (dι (b 0)) (dι (b 1)) hp (horth 0) (horth 1)
+  have hs : s ≠ 0 := by
+    exact sphereInclusionOrientationFactor_ne_zero p
+  apply sphereNormal_eq_of_raw_eq_pos_smul _ p (s ^ 2) (sq_pos_of_ne_zero hs)
+  rw [sphereNormalRaw]
+  dsimp only
+  change s • c = s ^ 2 • (p : ℝ³)
+  rw [hc, smul_smul, pow_two]
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -58,8 +58,6 @@ noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
 private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
   ⟨by norm_num [finrank_euclideanSpace_fin]⟩
 
-section InclusionDerivative
-
 private theorem sphereAmbientMfderiv_inclusion_basis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
     sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
@@ -68,8 +66,8 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
         (ne_zero_of_mem_unit_sphere (-p))).repr
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
         (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
-  rw [sphereAmbientMfderiv]
-  rw [((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
+  rw [sphereAmbientMfderiv,
+    ((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
   simp only [chartAt, fderivWithin_univ, mfld_simps]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
@@ -80,8 +78,7 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) : (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³)
   have hp0 : stereographic' 2 (-p) p = 0 := by
     dsimp [stereographic']
-    simp only [EmbeddingLike.map_eq_zero_iff]
-    apply stereographic_neg_apply
+    simpa only [EmbeddingLike.map_eq_zero_iff] using stereographic_neg_apply p
   rw [hp0]
   have h :
       HasFDerivAt (stereoInvFunAux (-p : ℝ³) ∘
@@ -103,26 +100,22 @@ theorem inner_sphereAmbientMfderiv_inclusion_basis
       (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
         (sphereTangentBasis p j)) =
       if i = j then 1 else 0 := by
-  rw [sphereAmbientMfderiv_inclusion_basis_apply,
-    sphereAmbientMfderiv_inclusion_basis_apply]
+  simp only [sphereAmbientMfderiv_inclusion_basis_apply]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change inner ℝ
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) i)))
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) j))) = _
-  rw [LinearIsometry.inner_map_map, U.symm.inner_map_map]
-  exact orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
+  simpa only [LinearIsometry.inner_map_map, U.symm.inner_map_map] using
+    orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
 
 /-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
 family. -/
 theorem orthonormal_sphereAmbientMfderiv_inclusion_basis (p : sphere (0 : ℝ³) 1) :
     Orthonormal ℝ fun i : Fin 2 ↦
       sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
-        (sphereTangentBasis p i) := by
-  rw [orthonormal_iff_ite]
-  exact inner_sphereAmbientMfderiv_inclusion_basis p
-
-end InclusionDerivative
+        (sphereTangentBasis p i) :=
+  orthonormal_iff_ite.mpr (inner_sphereAmbientMfderiv_inclusion_basis p)
 
 /-- The oriented, unnormalized normal of a map from the unit two-sphere to three-space. -/
 noncomputable def sphereNormalRaw
@@ -143,7 +136,7 @@ noncomputable def sphereNormal
   NormedSpace.normalize (sphereNormalRaw F p)
 
 /-- The cross product of the inclusion frame is its radial component. -/
-private theorem sphereInclusionCross_eq_smul (p : sphere (0 : ℝ³) 1) :
+private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     euclideanCross (dι (b 0)) (dι (b 1)) =
@@ -159,7 +152,7 @@ private theorem sphereInclusionCross_eq_smul (p : sphere (0 : ℝ³) 1) :
     exact ⟨sphereTangentBasis p 1, rfl⟩
 
 /-- The orientation factor contributed by the standard sphere inclusion has square one. -/
-private theorem sphereInclusionOrientationFactor_sq (p : sphere (0 : ℝ³) 1) :
+private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
     let b := sphereTangentBasis p
     let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ^ 2 = 1 := by
@@ -170,12 +163,11 @@ private theorem sphereInclusionOrientationFactor_sq (p : sphere (0 : ℝ³) 1) :
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hp : ‖(p : ℝ³)‖ = 1 := norm_eq_of_mem_sphere p
-  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
+  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
   change s ^ 2 = 1
   calc
     s ^ 2 = inner ℝ c c := by
-      simp [hc, norm_smul, hp, pow_two]
+      simp [hc, norm_smul, norm_eq_of_mem_sphere p, pow_two]
     _ = 1 := by
       dsimp only [c]
       rw [inner_euclideanCross_euclideanCross]
@@ -189,10 +181,8 @@ theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hc : c = s • (p : ℝ³) := sphereInclusionCross_eq_smul p
-  have hs : s ^ 2 = 1 := sphereInclusionOrientationFactor_sq p
-  rw [sphereNormalRaw]
-  dsimp only
+  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
+  have hs : s ^ 2 = 1 := sphere_inclusion_orientation_factor_sq p
   change s • c = (p : ℝ³)
   rw [hc, smul_smul, ← pow_two, hs, one_smul]
 
@@ -202,12 +192,9 @@ theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
     inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
-  rw [sphereNormalRaw]
-  dsimp only
-  rw [real_inner_smul_left]
+  rw [sphereNormalRaw, real_inner_smul_left]
   apply mul_eq_zero_of_right
-  rw [← (sphereTangentBasis p).sum_repr v]
-  rw [map_sum]
+  rw [← (sphereTangentBasis p).sum_repr v, map_sum]
   simp only [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
     euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
 
@@ -230,10 +217,8 @@ private theorem sphereNormalRaw_ne_zero_iff
   let dF := sphereAmbientMfderiv F p
   have hfactor : inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) ≠ 0 := by
     intro h
-    simpa [b, dι, h] using sphereInclusionOrientationFactor_sq p
-  rw [sphereNormalRaw]
-  dsimp only
-  rw [smul_ne_zero_iff, and_iff_right hfactor,
+    simpa [b, dι, h] using sphere_inclusion_orientation_factor_sq p
+  rw [sphereNormalRaw, smul_ne_zero_iff, and_iff_right hfactor,
     euclideanCross_ne_zero_iff_linearIndependent]
   have hfamily : dF.toLinearMap ∘ b = ![dF (b 0), dF (b 1)] := by
     funext i
@@ -297,56 +282,43 @@ theorem sphereNormal_eq_radial_of_coercive
   let Q := inner ℝ y u
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
-  have hι : Function.Injective dι := by
-    dsimp only [dι, sphereAmbientMfderiv]
-    exact mfderiv_coe_sphere_injective p
-  have hA : c ≤ A := by
+  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
+  have hApos : 0 < A := hc.trans_le <| by
     simpa only [dF, dι, x, u, A, hON.norm_eq_one, one_pow, mul_one] using
       hcoercive (b 0)
-  have hApos : 0 < A := hc.trans_le hA
   let s := P + Q
   let t := s • b 0 - (2 * A) • b 1
   have ht : t ≠ 0 := by
     intro ht
     have htCoord := congrArg (fun z ↦ b.repr z 1) ht
-    dsimp only [t] at htCoord
-    simp at htCoord
+    simp [t] at htCoord
     linarith
-  have hdιt : dι t ≠ 0 := by
-    intro ht'
-    apply ht
-    apply hι
-    simpa only [map_zero] using ht'
+  have hdιt : dι t ≠ 0 := (map_ne_zero_iff dι hι).mpr ht
   have hquadpos : 0 < inner ℝ (dF t) (dι t) :=
     (mul_pos hc (sq_pos_of_pos (norm_pos_iff.mpr hdιt))).trans_le (hcoercive t)
-  dsimp only [t] at hquadpos
-  simp only [map_sub, map_smul] at hquadpos
+  simp only [t, map_sub, map_smul] at hquadpos
   change 0 < inner ℝ (s • x - (2 * A) • y) (s • u - (2 * A) • v) at hquadpos
   simp only [inner_sub_left, inner_sub_right, real_inner_smul_left,
-    real_inner_smul_right] at hquadpos
-  dsimp only [s, A, D, P, Q] at hquadpos
+    real_inner_smul_right, s, A, P, Q] at hquadpos
   have hdetAux : 0 < 4 * A * D - (P + Q) ^ 2 := by
     nlinarith
   have hdet : 0 < A * D - P * Q := by
     nlinarith [sq_nonneg (P - Q)]
   have hcrossPos : 0 < inner ℝ (euclideanCross u v) (euclideanCross x y) := by
-    rw [inner_euclideanCross_euclideanCross]
-    rw [← real_inner_comm u x, ← real_inner_comm v y, ← real_inner_comm u y,
+    rw [inner_euclideanCross_euclideanCross, ← real_inner_comm u x,
+      ← real_inner_comm v y, ← real_inner_comm u y,
       ← real_inner_comm v x]
     change 0 < A * D - Q * P
-    nlinarith
+    simpa only [mul_comm Q P] using hdet
   have hcrossEq : euclideanCross x y =
       inner ℝ (euclideanCross x y) (p : ℝ³) • (p : ℝ³) :=
     euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
       (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1))
   apply sphereNormal_eq_of_raw_eq_pos_smul F p
     (inner ℝ (euclideanCross u v) (euclideanCross x y)) hcrossPos
-  rw [sphereNormalRaw]
-  dsimp only
   change inner ℝ (euclideanCross u v) (p : ℝ³) • euclideanCross x y =
     inner ℝ (euclideanCross u v) (euclideanCross x y) • (p : ℝ³)
-  rw [hcrossEq, real_inner_smul_right]
-  module
+  rw [hcrossEq, real_inner_smul_right, smul_smul, mul_comm]
 
 /-- The canonical normal of the standard sphere inclusion points radially outward. -/
 @[simp]

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -20,7 +20,6 @@ public import Mathlib.Analysis.Normed.Module.Normalize
 public import Mathlib.Geometry.Manifold.Instances.Sphere
 
 public import FormalConjecturesForMathlib.Geometry.«3d»
-public meta import FormalConjecturesUtil.Attributes.Basic
 
 /-!
 # A canonical normal for immersed two-spheres in three-space
@@ -95,7 +94,7 @@ private theorem sphereInclusionOrientationFactor_ne_zero (p : sphere (0 : ℝ³)
     hfactor, zero_smul]
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
@@ -110,7 +109,7 @@ theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
 
 /-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
-@[simp, category API, AMS 53]
+@[simp]
 theorem inner_sphereNormal_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
@@ -146,7 +145,6 @@ private theorem sphereNormalRaw_ne_zero_iff
 
 /-- The canonical normal is nonzero exactly at the points where the manifold derivative is
 injective. -/
-@[category API, AMS 53]
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
@@ -155,7 +153,6 @@ theorem sphereNormal_ne_zero_iff
     (sphereNormalRaw_ne_zero_iff F p)
 
 /-- At an immersion point, the canonical normal has unit length. -/
-@[category API, AMS 53]
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : Function.Injective (sphereAmbientMfderiv F p)) :
@@ -164,7 +161,6 @@ theorem norm_sphereNormal_of_injective
   exact NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
 
 /-- Normalizing a positive multiple of the radial vector recovers the radial vector. -/
-@[category API, AMS 53]
 theorem sphereNormal_eq_of_raw_eq_pos_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) (c : ℝ) (hc : 0 < c)
     (hraw : sphereNormalRaw F p = c • (p : ℝ³)) :

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersion.lean
@@ -51,21 +51,20 @@ noncomputable def sphereAmbientMfderiv
 This is a coordinate basis used to evaluate the manifold derivative, not a global tangent frame on
 the sphere. -/
 noncomputable def sphereTangentBasis (p : sphere (0 : ℝ³) 1) :
-    Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) := by
-  unfold TangentSpace
-  exact PiLp.basisFun 2 ℝ (Fin 2)
-
-private local instance : Fact (Module.finrank ℝ ℝ³ = 2 + 1) :=
-  ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+    Module.Basis (Fin 2) ℝ (TangentSpace (𝓡 2) p) :=
+  PiLp.basisFun 2 ℝ (Fin 2)
 
 private theorem sphereAmbientMfderiv_inclusion_basis_apply
     (p : sphere (0 : ℝ³) 1) (i : Fin 2) :
+    letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
     sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
         (sphereTangentBasis p i) =
       let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
         (ne_zero_of_mem_unit_sphere (-p))).repr
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) :
         (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³) := by
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  dsimp only
   rw [sphereAmbientMfderiv,
     ((contMDiff_coe_sphere p).mdifferentiableAt one_ne_zero).mfderiv]
   simp only [chartAt, fderivWithin_univ, mfld_simps]
@@ -78,7 +77,7 @@ private theorem sphereAmbientMfderiv_inclusion_basis_apply
       ((U.symm (PiLp.basisFun 2 ℝ (Fin 2) i) : (ℝ ∙ (-(p : ℝ³)))ᗮ) : ℝ³)
   have hp0 : stereographic' 2 (-p) p = 0 := by
     dsimp [stereographic']
-    simpa only [EmbeddingLike.map_eq_zero_iff] using stereographic_neg_apply p
+    simpa [EmbeddingLike.map_eq_zero_iff] using stereographic_neg_apply p
   rw [hp0]
   have h :
       HasFDerivAt (stereoInvFunAux (-p : ℝ³) ∘
@@ -100,14 +99,16 @@ theorem inner_sphereAmbientMfderiv_inclusion_basis
       (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
         (sphereTangentBasis p j)) =
       if i = j then 1 else 0 := by
-  simp only [sphereAmbientMfderiv_inclusion_basis_apply]
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  rw [sphereAmbientMfderiv_inclusion_basis_apply p i,
+    sphereAmbientMfderiv_inclusion_basis_apply p j]
   let U := (OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ) 2
     (ne_zero_of_mem_unit_sphere (-p))).repr
   change inner ℝ
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) i)))
     ((ℝ ∙ (-(p : ℝ³)))ᗮ.subtypeₗᵢ (U.symm (PiLp.basisFun 2 ℝ (Fin 2) j))) = _
-  simpa only [LinearIsometry.inner_map_map, U.symm.inner_map_map] using
-    orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
+  rw [LinearIsometry.inner_map_map, U.symm.inner_map_map]
+  exact orthonormal_iff_ite.mp (EuclideanSpace.basisFun (Fin 2) ℝ).orthonormal i j
 
 /-- The derivative of the sphere inclusion maps the standard model basis to an orthonormal
 family. -/
@@ -141,15 +142,14 @@ private theorem sphere_inclusion_cross_eq_smul (p : sphere (0 : ℝ³) 1) :
     let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
     euclideanCross (dι (b 0)) (dι (b 1)) =
       inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (p : ℝ³) • (p : ℝ³) := by
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   dsimp only
-  apply euclideanCross_eq_inner_smul_of_orthogonal
-  · exact norm_eq_of_mem_sphere p
-  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨sphereTangentBasis p 0, rfl⟩
-  · apply Submodule.mem_orthogonal_singleton_iff_inner_right.mp
-    rw [← range_mfderiv_coe_sphere (n := 2) p]
-    exact ⟨sphereTangentBasis p 1, rfl⟩
+  refine euclideanCross_eq_inner_smul_of_orthogonal _ _ _
+    (norm_eq_of_mem_sphere p) ?_ ?_
+  · exact Submodule.mem_orthogonal_singleton_iff_inner_right.mp <|
+      range_mfderiv_coe_sphere (n := 2) p ▸ ⟨sphereTangentBasis p 0, rfl⟩
+  · exact Submodule.mem_orthogonal_singleton_iff_inner_right.mp <|
+      range_mfderiv_coe_sphere (n := 2) p ▸ ⟨sphereTangentBasis p 1, rfl⟩
 
 /-- The orientation factor contributed by the standard sphere inclusion has square one. -/
 private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1) :
@@ -163,11 +163,11 @@ private theorem sphere_inclusion_orientation_factor_sq (p : sphere (0 : ℝ³) 1
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
   change s ^ 2 = 1
   calc
     s ^ 2 = inner ℝ c c := by
-      simp [hc, norm_smul, norm_eq_of_mem_sphere p, pow_two]
+      simp [show c = s • (p : ℝ³) from sphere_inclusion_cross_eq_smul p,
+        norm_smul, norm_eq_of_mem_sphere p, pow_two]
     _ = 1 := by
       dsimp only [c]
       rw [inner_euclideanCross_euclideanCross]
@@ -181,10 +181,10 @@ theorem sphereNormalRaw_inclusion (p : sphere (0 : ℝ³) 1) :
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let c := euclideanCross (dι (b 0)) (dι (b 1))
   let s := inner ℝ c (p : ℝ³)
-  have hc : c = s • (p : ℝ³) := sphere_inclusion_cross_eq_smul p
-  have hs : s ^ 2 = 1 := sphere_inclusion_orientation_factor_sq p
   change s • c = (p : ℝ³)
-  rw [hc, smul_smul, ← pow_two, hs, one_smul]
+  rw [show c = s • (p : ℝ³) from sphere_inclusion_cross_eq_smul p,
+    smul_smul, ← pow_two,
+    show s ^ 2 = 1 from sphere_inclusion_orientation_factor_sq p, one_smul]
 
 /-- The raw canonical normal is orthogonal to every image tangent vector. -/
 @[simp]
@@ -192,10 +192,8 @@ theorem inner_sphereNormalRaw_sphereAmbientMfderiv
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (v : TangentSpace (𝓡 2) p) :
     inner ℝ (sphereNormalRaw F p) (sphereAmbientMfderiv F p v) = 0 := by
-  rw [sphereNormalRaw, real_inner_smul_left]
-  apply mul_eq_zero_of_right
-  rw [← (sphereTangentBasis p).sum_repr v, map_sum]
-  simp only [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
+  rw [sphereNormalRaw, real_inner_smul_left, ← (sphereTangentBasis p).sum_repr v, map_sum]
+  simp [Fin.sum_univ_two, map_smul, inner_add_right, real_inner_smul_right,
     euclideanCross_inner_left, euclideanCross_inner_right, mul_zero, add_zero]
 
 /-- The canonical normal is orthogonal to every image tangent vector, even at a non-immersion. -/
@@ -224,31 +222,25 @@ private theorem sphereNormalRaw_ne_zero_iff
     funext i
     fin_cases i <;> rfl
   constructor
-  · intro hLI
-    apply LinearMap.injective_of_linearIndependent b.span_eq
-    rw [hfamily]
-    exact hLI
-  · intro hF
-    have hmap := b.linearIndependent.map' dF.toLinearMap
+  · exact fun hLI ↦ LinearMap.injective_of_linearIndependent b.span_eq (hfamily.symm ▸ hLI)
+  · exact fun hF ↦ hfamily ▸ b.linearIndependent.map' dF.toLinearMap
       (LinearMap.ker_eq_bot_of_injective hF)
-    rwa [hfamily] at hmap
 
 /-- The canonical normal is nonzero exactly at the points where the manifold derivative is
 injective. -/
 theorem sphereNormal_ne_zero_iff
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphereNormal F p ≠ 0 ↔ Function.Injective (sphereAmbientMfderiv F p) := by
-  rw [sphereNormal]
-  exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).trans
-    (sphereNormalRaw_ne_zero_iff F p)
+  simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
+    sphereNormalRaw_ne_zero_iff F p
 
 /-- At an immersion point, the canonical normal has unit length. -/
 theorem norm_sphereNormal_of_injective
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : Function.Injective (sphereAmbientMfderiv F p)) :
     ‖sphereNormal F p‖ = 1 := by
-  rw [sphereNormal]
-  exact NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
+  simpa [sphereNormal] using
+    NormedSpace.norm_normalize ((sphereNormalRaw_ne_zero_iff F p).mpr hF)
 
 /-- Normalizing a positive multiple of the radial vector recovers the radial vector. -/
 theorem sphereNormal_eq_of_raw_eq_pos_smul
@@ -269,6 +261,7 @@ theorem sphereNormal_eq_radial_of_coercive
         inner ℝ (sphereAmbientMfderiv F p v)
           (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p v)) :
     sphereNormal F p = (p : ℝ³) := by
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num [finrank_euclideanSpace_fin]⟩
   let b := sphereTangentBasis p
   let dι := sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p
   let dF := sphereAmbientMfderiv F p
@@ -282,9 +275,8 @@ theorem sphereNormal_eq_radial_of_coercive
   let Q := inner ℝ y u
   have hON : Orthonormal ℝ fun i : Fin 2 ↦ dι (b i) :=
     orthonormal_sphereAmbientMfderiv_inclusion_basis p
-  have hι : Function.Injective dι := mfderiv_coe_sphere_injective p
   have hApos : 0 < A := hc.trans_le <| by
-    simpa only [dF, dι, x, u, A, hON.norm_eq_one, one_pow, mul_one] using
+    simpa [dF, dι, x, u, A, hON.norm_eq_one] using
       hcoercive (b 0)
   let s := P + Q
   let t := s • b 0 - (2 * A) • b 1
@@ -293,7 +285,8 @@ theorem sphereNormal_eq_radial_of_coercive
     have htCoord := congrArg (fun z ↦ b.repr z 1) ht
     simp [t] at htCoord
     linarith
-  have hdιt : dι t ≠ 0 := (map_ne_zero_iff dι hι).mpr ht
+  have hdιt : dι t ≠ 0 :=
+    (map_ne_zero_iff dι (mfderiv_coe_sphere_injective p)).mpr ht
   have hquadpos : 0 < inner ℝ (dF t) (dι t) :=
     (mul_pos hc (sq_pos_of_pos (norm_pos_iff.mpr hdιt))).trans_le (hcoercive t)
   simp only [t, map_sub, map_smul] at hquadpos
@@ -309,16 +302,14 @@ theorem sphereNormal_eq_radial_of_coercive
       ← real_inner_comm v y, ← real_inner_comm u y,
       ← real_inner_comm v x]
     change 0 < A * D - Q * P
-    simpa only [mul_comm Q P] using hdet
-  have hcrossEq : euclideanCross x y =
-      inner ℝ (euclideanCross x y) (p : ℝ³) • (p : ℝ³) :=
-    euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
-      (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1))
+    simpa [mul_comm Q P] using hdet
   apply sphereNormal_eq_of_raw_eq_pos_smul F p
     (inner ℝ (euclideanCross u v) (euclideanCross x y)) hcrossPos
   change inner ℝ (euclideanCross u v) (p : ℝ³) • euclideanCross x y =
     inner ℝ (euclideanCross u v) (euclideanCross x y) • (p : ℝ³)
-  rw [hcrossEq, real_inner_smul_right, smul_smul, mul_comm]
+  rw [euclideanCross_eq_inner_smul_of_orthogonal (p : ℝ³) x y
+      (norm_eq_of_mem_sphere p) (hnormal (b 0)) (hnormal (b 1)),
+    real_inner_smul_right, smul_smul, mul_comm]
 
 /-- The canonical normal of the standard sphere inclusion points radially outward. -/
 @[simp]

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -1,0 +1,261 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Calculus
+public import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
+
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+
+/-!
+# Regularity of the canonical normal of a sphere immersion
+
+Although Mathlib's preferred sphere charts do not give a continuous global tangent frame, the
+canonical normal is regular. Locally, `inTangentCoordinates` gives a regular frame for the
+derivative. Changing from that frame to the pointwise model basis scales both cross products in the
+raw normal by the same determinant, so the raw normal scales by its positive square. Normalization
+therefore removes the coordinate dependence. In particular, a `C^(m + 1)` immersion has a `C^m`
+canonical normal.
+-/
+
+@[expose] public section
+
+open Metric Set Function
+open scoped EuclideanGeometry Manifold RealInnerProductSpace
+
+namespace EuclideanHypersurface
+
+private noncomputable def sphereModelBasis (p : sphere (0 : ℝ³) 1) :
+    Module.Basis (Fin 2) ℝ (EuclideanSpace ℝ (Fin 2)) :=
+  sphereTangentBasis p
+
+private noncomputable def basisDet {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (b : Module.Basis (Fin 2) ℝ V) (A : V →L[ℝ] V) : ℝ :=
+  b.repr (A (b 0)) 0 * b.repr (A (b 1)) 1 -
+    b.repr (A (b 0)) 1 * b.repr (A (b 1)) 0
+
+private theorem euclideanCross_comp_basis
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (b : Module.Basis (Fin 2) ℝ V) (L : V →L[ℝ] ℝ³) (A : V →L[ℝ] V) :
+    euclideanCross (L (A (b 0))) (L (A (b 1))) =
+      basisDet b A • euclideanCross (L (b 0)) (L (b 1)) := by
+  rw [← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
+  simp only [Fin.sum_univ_two, map_add, map_smul, ContinuousLinearMap.add_apply,
+    ContinuousLinearMap.smul_apply,
+    euclideanCross_self, smul_zero, add_zero, basisDet]
+  rw [← euclideanCross_anticomm (L (b 0)) (L (b 1))]
+  module
+
+private theorem contMDiffAt_normalize
+    {m : WithTop ℕ∞} {f : sphere (0 : ℝ³) 1 → ℝ³} {p : sphere (0 : ℝ³) 1}
+    (hf : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m f p) (h0 : f p ≠ 0) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (fun q ↦ NormedSpace.normalize (f q)) p := by
+  change ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (fun q ↦ ‖f q‖⁻¹ • f q) p
+  exact (((contDiffAt_norm ℝ h0).inv (norm_ne_zero_iff.mpr h0)).comp_contMDiffAt hf).smul hf
+
+private theorem inTangentCoordinates_sphere_eq_comp
+    (G : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
+    (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id G (sphereAmbientMfderiv G) p q =
+      sphereAmbientMfderiv G q ∘L
+        (tangentCoordChange (𝓡 2) p q q :
+          EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
+  rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp)]
+  simp only [tangentBundleCore_coordChange_model_space, ContinuousLinearMap.id_comp]
+  rfl
+
+private theorem tangentCoordChange_injective
+    (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    Function.Injective (tangentCoordChange (𝓡 2) p q q :
+      EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
+  intro u v huv
+  have hq' : q ∈ (extChartAt (𝓡 2) q).source := mem_extChartAt_source q
+  have hmem : q ∈ (extChartAt (𝓡 2) p).source ∩
+      (extChartAt (𝓡 2) q).source ∩ (extChartAt (𝓡 2) p).source :=
+    ⟨⟨hq, hq'⟩, hq⟩
+  have hu := congrArg (tangentCoordChange (𝓡 2) q p q :
+    EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) huv
+  simpa only [tangentCoordChange_comp hmem, tangentCoordChange_self hq] using hu
+
+private noncomputable def sphereNormalRawInCoordinates
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
+    sphere (0 : ℝ³) 1 → ℝ³ :=
+  let b := sphereModelBasis p
+  let e0 : EuclideanSpace ℝ (Fin 2) := b 0
+  let e1 : EuclideanSpace ℝ (Fin 2) := b 1
+  let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+    (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
+    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+  let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+    (sphereAmbientMfderiv F) p
+  fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
+    euclideanCross (dF q e0) (dF q e1)
+
+private theorem contMDiffAt_sphereNormalRawInCoordinates
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
+  let b := sphereModelBasis p
+  let e0 : EuclideanSpace ℝ (Fin 2) := b 0
+  let e1 : EuclideanSpace ℝ (Fin 2) := b 1
+  let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+    (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
+    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+  let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+    (sphereAmbientMfderiv F) p
+  have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
+    (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
+  have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
+    (hF p).mfderiv_const le_rfl
+  have hdι0 := hdι.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
+  have hdι1 := hdι.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
+  have hdF0 := hdF.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
+  have hdF1 := hdF.clm_apply (contMDiffAt_const :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
+  have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
+  have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
+  have hp : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
+      (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p :=
+    contMDiff_coe_sphere p
+  have hs : ContMDiffAt (𝓡 2) 𝓘(ℝ) m
+      (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³)) p :=
+    contDiff_inner.comp_contMDiffAt (hcι.prodMk_space hp)
+  rw [sphereNormalRawInCoordinates]
+  dsimp only
+  change ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
+    (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
+      euclideanCross (dF q e0) (dF q e1)) p
+  exact hs.smul hcF
+
+private theorem sphereNormalRawInCoordinates_eq_smul
+    (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
+    (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    sphereNormalRawInCoordinates F p q =
+      basisDet (sphereModelBasis p)
+          (tangentCoordChange (𝓡 2) p q q :
+            EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ^ 2 •
+        sphereNormalRaw F q := by
+  let b := sphereModelBasis p
+  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
+    tangentCoordChange (𝓡 2) p q q
+  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
+  let dF := sphereAmbientMfderiv F q
+  have hι := inTangentCoordinates_sphere_eq_comp
+    (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
+  have hF := inTangentCoordinates_sphere_eq_comp F p q hq
+  rw [sphereNormalRawInCoordinates, sphereNormalRaw]
+  dsimp only
+  change inner ℝ
+      (euclideanCross
+        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
+          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 0))
+        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
+          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 1)))
+      (q : ℝ³) •
+        euclideanCross
+          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+            (sphereAmbientMfderiv F) p q) (b 0))
+          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+            (sphereAmbientMfderiv F) p q) (b 1)) =
+      basisDet b A ^ 2 •
+        (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
+          euclideanCross (dF (b 0)) (dF (b 1)))
+  rw [hι, hF]
+  simp only [ContinuousLinearMap.comp_apply]
+  change inner ℝ (euclideanCross (dι (A (b 0))) (dι (A (b 1)))) (q : ℝ³) •
+      euclideanCross (dF (A (b 0))) (dF (A (b 1))) =
+    basisDet b A ^ 2 •
+      (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
+        euclideanCross (dF (b 0)) (dF (b 1)))
+  have hιcross := euclideanCross_comp_basis b dι A
+  have hFcross := euclideanCross_comp_basis b dF A
+  calc
+    _ = inner ℝ (basisDet b A • euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
+        (basisDet b A • euclideanCross (dF (b 0)) (dF (b 1))) :=
+      congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
+        (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
+    _ = _ := by
+      rw [real_inner_smul_left, smul_smul, smul_smul]
+      congr 1
+      ring
+
+private theorem basisDet_tangentCoordChange_ne_zero
+    (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
+    basisDet (sphereModelBasis p)
+        (tangentCoordChange (𝓡 2) p q q :
+          EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ≠ 0 := by
+  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
+  let b := sphereModelBasis p
+  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
+    tangentCoordChange (𝓡 2) p q q
+  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
+  have hA : Function.Injective A := tangentCoordChange_injective p q hq
+  have hι : Function.Injective dι := mfderiv_coe_sphere_injective q
+  have hcomp : Function.Injective (dι.comp A) := hι.comp hA
+  have hLI : LinearIndependent ℝ ![(dι.comp A) (b 0), (dι.comp A) (b 1)] := by
+    have hmap := b.linearIndependent.map' (dι.comp A).toLinearMap
+      (LinearMap.ker_eq_bot_of_injective hcomp)
+    rw [show ![(dι.comp A) (b 0), (dι.comp A) (b 1)] =
+        (dι.comp A).toLinearMap ∘ b by
+      funext i
+      fin_cases i <;> rfl]
+    exact hmap
+  have hcross : euclideanCross ((dι.comp A) (b 0)) ((dι.comp A) (b 1)) ≠ 0 :=
+    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hLI
+  intro hdet
+  apply hcross
+  simp only [ContinuousLinearMap.comp_apply]
+  change basisDet b A = 0 at hdet
+  exact (euclideanCross_comp_basis b dι A).trans (by rw [hdet, zero_smul])
+
+private theorem contMDiffAt_sphereNormal
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
+    (himm : ∀ q, Function.Injective (sphereAmbientMfderiv F q)) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
+  have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
+  have hdet := basisDet_tangentCoordChange_ne_zero p p hp
+  have hraw : sphereNormalRaw F p ≠ 0 := by
+    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 (himm p)
+    rw [sphereNormal] at hn
+    exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).mp hn
+  have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
+    rw [sphereNormalRawInCoordinates_eq_smul F p p hp]
+    exact smul_ne_zero (pow_ne_zero 2 hdet) hraw
+  have hsmooth := contMDiffAt_normalize
+    (contMDiffAt_sphereNormalRawInCoordinates F p hF) hlocal
+  apply hsmooth.congr_of_eventuallyEq
+  filter_upwards [extChartAt_source_mem_nhds (I := 𝓡 2) p] with q hq
+  rw [sphereNormal, sphereNormalRawInCoordinates_eq_smul F p q hq,
+    NormedSpace.normalize_smul_of_pos
+      (sq_pos_of_ne_zero (basisDet_tangentCoordChange_ne_zero p q hq))]
+
+/-- A `C^(m + 1)` immersion of the unit two-sphere has a `C^m` canonical unit normal. -/
+theorem contMDiff_sphereNormal
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
+    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
+  fun p ↦ contMDiffAt_sphereNormal F p hF himm
+
+end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -48,8 +48,8 @@ private theorem euclideanCross_comp_basis
     (b : Module.Basis (Fin 2) ℝ V) (L : V →L[ℝ] ℝ³) (A : V →L[ℝ] V) :
     euclideanCross (L (A (b 0))) (L (A (b 1))) =
       LinearMap.det A.toLinearMap • euclideanCross (L (b 0)) (L (b 1)) := by
-  rw [← LinearMap.det_toMatrix b, Matrix.det_fin_two]
-  rw [← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
+  rw [← LinearMap.det_toMatrix b, Matrix.det_fin_two,
+    ← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
   simp only [Fin.sum_univ_two, map_add, map_smul, ContinuousLinearMap.add_apply,
     ContinuousLinearMap.smul_apply, euclideanCross_self, smul_zero, add_zero,
     LinearMap.toMatrix_apply]
@@ -134,12 +134,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
   have hs : ContMDiffAt (𝓡 2) 𝓘(ℝ) m
       (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³)) p :=
     contDiff_inner.comp_contMDiffAt (hcι.prodMk_space hp)
-  rw [sphereNormalRawInCoordinates]
-  dsimp only
-  change ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
-    (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
-      euclideanCross (dF q e0) (dF q e1)) p
-  exact hs.smul hcF
+  simpa only [sphereNormalRawInCoordinates] using hs.smul hcF
 
 private theorem sphereNormalRawInCoordinates_eq_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
@@ -160,20 +155,12 @@ private theorem sphereNormalRawInCoordinates_eq_smul
   have hι : dιc = dι.comp A := inTangentCoordinates_sphere_eq_comp
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
   have hF : dFc = dF.comp A := inTangentCoordinates_sphere_eq_comp F p q hq
-  rw [sphereNormalRawInCoordinates, sphereNormalRaw]
-  dsimp only
   change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
       euclideanCross (dFc (b 0)) (dFc (b 1)) =
       LinearMap.det A.toLinearMap ^ 2 •
         (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
           euclideanCross (dF (b 0)) (dF (b 1)))
-  rw [hι, hF]
-  simp only [ContinuousLinearMap.comp_apply]
-  change inner ℝ (euclideanCross (dι (A (b 0))) (dι (A (b 1)))) (q : ℝ³) •
-      euclideanCross (dF (A (b 0))) (dF (A (b 1))) =
-    LinearMap.det A.toLinearMap ^ 2 •
-      (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
-        euclideanCross (dF (b 0)) (dF (b 1)))
+  simp only [hι, hF, ContinuousLinearMap.comp_apply]
   have hιcross := euclideanCross_comp_basis b dι A
   have hFcross := euclideanCross_comp_basis b dF A
   calc
@@ -183,16 +170,15 @@ private theorem sphereNormalRawInCoordinates_eq_smul
       congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
         (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
     _ = _ := by
-      rw [real_inner_smul_left, smul_smul, smul_smul]
-      congr 1
-      ring
+      rw [real_inner_smul_left]
+      module
 
 private theorem det_tangentCoordChange_ne_zero
     (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
     LinearMap.det (tangentCoordChange (𝓡 2) p q q :
       EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ≠ 0 := by
-  rw [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not]
-  exact LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
+  simpa only [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not] using
+    LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
 
 /-- At an immersion point, a locally `C^n` map has a locally `C^m` canonical unit normal when
 `m + 1 ≤ n`. -/

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -24,12 +24,9 @@ public import FormalConjecturesForMathlib.Geometry.SphereImmersion
 /-!
 # Regularity of the canonical normal of a sphere immersion
 
-Although Mathlib's preferred sphere charts do not give a continuous global tangent frame, the
-canonical normal is regular. Locally, `inTangentCoordinates` gives a regular frame for the
-derivative. Changing from that frame to the pointwise model basis scales both cross products in the
-raw normal by the same determinant, so the raw normal scales by its positive square. Normalization
-therefore removes the coordinate dependence. In particular, a `C^(m + 1)` immersion has a `C^m`
-canonical normal.
+Although the sphere charts do not give a continuous global tangent frame, `sphereNormal` is
+regular. In local tangent coordinates, a frame change scales its raw normal by a positive square,
+which normalization removes. Thus a `C^(m + 1)` immersion has a `C^m` canonical normal.
 -/
 
 @[expose] public section

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -70,8 +70,8 @@ private theorem inTangentCoordinates_sphere_eq_comp
       sphereAmbientMfderiv G q ∘L
         (tangentCoordChange (𝓡 2) p q q :
           EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
-  rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp)]
-  simp only [tangentBundleCore_coordChange_model_space, ContinuousLinearMap.id_comp]
+  rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp),
+    tangentBundleCore_coordChange_model_space, ContinuousLinearMap.id_comp]
   rfl
 
 private theorem tangentCoordChange_injective
@@ -79,13 +79,12 @@ private theorem tangentCoordChange_injective
     Function.Injective (tangentCoordChange (𝓡 2) p q q :
       EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
   intro u v huv
-  have hq' : q ∈ (extChartAt (𝓡 2) q).source := mem_extChartAt_source q
   have hmem : q ∈ (extChartAt (𝓡 2) p).source ∩
       (extChartAt (𝓡 2) q).source ∩ (extChartAt (𝓡 2) p).source :=
-    ⟨⟨hq, hq'⟩, hq⟩
-  have hu := congrArg (tangentCoordChange (𝓡 2) q p q :
-    EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) huv
-  simpa only [tangentCoordChange_comp hmem, tangentCoordChange_self hq] using hu
+    ⟨⟨hq, mem_extChartAt_source q⟩, hq⟩
+  simpa only [tangentCoordChange_comp hmem, tangentCoordChange_self hq] using
+    congrArg (tangentCoordChange (𝓡 2) q p q :
+      EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) huv
 
 private noncomputable def sphereNormalRawInCoordinates
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
@@ -105,7 +104,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
+  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
   let b := sphereModelBasis p
   let e0 : EuclideanSpace ℝ (Fin 2) := b 0
   let e1 : EuclideanSpace ℝ (Fin 2) := b 1
@@ -128,13 +127,9 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
   have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
   have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
-  have hp : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m
-      (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) p :=
-    contMDiff_coe_sphere p
-  have hs : ContMDiffAt (𝓡 2) 𝓘(ℝ) m
-      (fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³)) p :=
-    contDiff_inner.comp_contMDiffAt (hcι.prodMk_space hp)
-  simpa only [sphereNormalRawInCoordinates] using hs.smul hcF
+  simpa [sphereNormalRawInCoordinates] using
+    (contDiff_inner.comp_contMDiffAt
+      (hcι.prodMk_space (contMDiff_coe_sphere p))).smul hcF
 
 private theorem sphereNormalRawInCoordinates_eq_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
@@ -152,23 +147,21 @@ private theorem sphereNormalRawInCoordinates_eq_smul
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
     (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
   let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F (sphereAmbientMfderiv F) p q
-  have hι : dιc = dι.comp A := inTangentCoordinates_sphere_eq_comp
-    (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
-  have hF : dFc = dF.comp A := inTangentCoordinates_sphere_eq_comp F p q hq
   change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
       euclideanCross (dFc (b 0)) (dFc (b 1)) =
       LinearMap.det A.toLinearMap ^ 2 •
         (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
           euclideanCross (dF (b 0)) (dF (b 1)))
-  simp only [hι, hF, ContinuousLinearMap.comp_apply]
-  have hιcross := euclideanCross_comp_basis b dι A
-  have hFcross := euclideanCross_comp_basis b dF A
+  rw [show dιc = dι.comp A from inTangentCoordinates_sphere_eq_comp
+      (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq,
+    show dFc = dF.comp A from inTangentCoordinates_sphere_eq_comp F p q hq]
   calc
     _ = inner ℝ (LinearMap.det A.toLinearMap • euclideanCross (dι (b 0)) (dι (b 1)))
           (q : ℝ³) •
         (LinearMap.det A.toLinearMap • euclideanCross (dF (b 0)) (dF (b 1))) :=
       congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
-        (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
+        (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) (euclideanCross_comp_basis b dι A))
+        (euclideanCross_comp_basis b dF A)
     _ = _ := by
       rw [real_inner_smul_left]
       module
@@ -177,7 +170,7 @@ private theorem det_tangentCoordChange_ne_zero
     (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
     LinearMap.det (tangentCoordChange (𝓡 2) p q q :
       EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ≠ 0 := by
-  simpa only [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not] using
+  simpa [LinearMap.det_eq_zero_iff_ker_ne_bot] using
     LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
 
 /-- At an immersion point, a locally `C^n` map has a locally `C^m` canonical unit normal when
@@ -188,17 +181,13 @@ theorem contMDiffAt_sphereNormal_of_le
     (himm : Function.Injective (sphereAmbientMfderiv F p)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
-  have hdet := det_tangentCoordChange_ne_zero p p hp
-  have hraw : sphereNormalRaw F p ≠ 0 := by
-    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 himm
-    rw [sphereNormal] at hn
-    exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).mp hn
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
     rw [sphereNormalRawInCoordinates_eq_smul F p p hp]
-    exact smul_ne_zero (pow_ne_zero 2 hdet) hraw
-  have hsmooth := contMDiffAt_normalize
-    (contMDiffAt_sphereNormalRawInCoordinates F p hF hmn) hlocal
-  apply hsmooth.congr_of_eventuallyEq
+    refine smul_ne_zero (pow_ne_zero 2 (det_tangentCoordChange_ne_zero p p hp)) ?_
+    simpa [sphereNormal, NormedSpace.normalize_eq_zero_iff] using
+      (sphereNormal_ne_zero_iff F p).2 himm
+  apply (contMDiffAt_normalize
+    (contMDiffAt_sphereNormalRawInCoordinates F p hF hmn) hlocal).congr_of_eventuallyEq
   filter_upwards [extChartAt_source_mem_nhds (I := 𝓡 2) p] with q hq
   rw [sphereNormal, sphereNormalRawInCoordinates_eq_smul F p q hq,
     NormedSpace.normalize_smul_of_pos

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -34,7 +34,7 @@ canonical normal.
 
 @[expose] public section
 
-open Metric Set Function
+open Metric
 open scoped EuclideanGeometry Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
@@ -43,20 +43,16 @@ private noncomputable def sphereModelBasis (p : sphere (0 : ℝ³) 1) :
     Module.Basis (Fin 2) ℝ (EuclideanSpace ℝ (Fin 2)) :=
   sphereTangentBasis p
 
-private noncomputable def basisDet {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
-    (b : Module.Basis (Fin 2) ℝ V) (A : V →L[ℝ] V) : ℝ :=
-  b.repr (A (b 0)) 0 * b.repr (A (b 1)) 1 -
-    b.repr (A (b 0)) 1 * b.repr (A (b 1)) 0
-
 private theorem euclideanCross_comp_basis
     {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (b : Module.Basis (Fin 2) ℝ V) (L : V →L[ℝ] ℝ³) (A : V →L[ℝ] V) :
     euclideanCross (L (A (b 0))) (L (A (b 1))) =
-      basisDet b A • euclideanCross (L (b 0)) (L (b 1)) := by
+      LinearMap.det A.toLinearMap • euclideanCross (L (b 0)) (L (b 1)) := by
+  rw [← LinearMap.det_toMatrix b, Matrix.det_fin_two]
   rw [← b.sum_repr (A (b 0)), ← b.sum_repr (A (b 1))]
   simp only [Fin.sum_univ_two, map_add, map_smul, ContinuousLinearMap.add_apply,
-    ContinuousLinearMap.smul_apply,
-    euclideanCross_self, smul_zero, add_zero, basisDet]
+    ContinuousLinearMap.smul_apply, euclideanCross_self, smul_zero, add_zero,
+    LinearMap.toMatrix_apply]
   rw [← euclideanCross_anticomm (L (b 0)) (L (b 1))]
   module
 
@@ -106,8 +102,8 @@ private noncomputable def sphereNormalRawInCoordinates
     euclideanCross (dF q e0) (dF q e1)
 
 private theorem contMDiffAt_sphereNormalRawInCoordinates
-    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F) :
+    {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
   letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
   let b := sphereModelBasis p
@@ -121,7 +117,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
   have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
     (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
   have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
-    (hF p).mfderiv_const le_rfl
+    hF.mfderiv_const hmn
   have hdι0 := hdι.clm_apply (contMDiffAt_const :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e0) p)
   have hdι1 := hdι.clm_apply (contMDiffAt_const :
@@ -149,49 +145,41 @@ private theorem sphereNormalRawInCoordinates_eq_smul
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
     (hq : q ∈ (extChartAt (𝓡 2) p).source) :
     sphereNormalRawInCoordinates F p q =
-      basisDet (sphereModelBasis p)
-          (tangentCoordChange (𝓡 2) p q q :
-            EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ^ 2 •
+      LinearMap.det (tangentCoordChange (𝓡 2) p q q :
+        EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ^ 2 •
         sphereNormalRaw F q := by
   let b := sphereModelBasis p
   let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
     tangentCoordChange (𝓡 2) p q q
   let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
   let dF := sphereAmbientMfderiv F q
-  have hι := inTangentCoordinates_sphere_eq_comp
+  let dιc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
+    (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
+    (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
+  let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F (sphereAmbientMfderiv F) p q
+  have hι : dιc = dι.comp A := inTangentCoordinates_sphere_eq_comp
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) p q hq
-  have hF := inTangentCoordinates_sphere_eq_comp F p q hq
+  have hF : dFc = dF.comp A := inTangentCoordinates_sphere_eq_comp F p q hq
   rw [sphereNormalRawInCoordinates, sphereNormalRaw]
   dsimp only
-  change inner ℝ
-      (euclideanCross
-        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
-          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
-          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 0))
-        ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
-          (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
-          (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q) (b 1)))
-      (q : ℝ³) •
-        euclideanCross
-          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-            (sphereAmbientMfderiv F) p q) (b 0))
-          ((inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-            (sphereAmbientMfderiv F) p q) (b 1)) =
-      basisDet b A ^ 2 •
+  change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
+      euclideanCross (dFc (b 0)) (dFc (b 1)) =
+      LinearMap.det A.toLinearMap ^ 2 •
         (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
           euclideanCross (dF (b 0)) (dF (b 1)))
   rw [hι, hF]
   simp only [ContinuousLinearMap.comp_apply]
   change inner ℝ (euclideanCross (dι (A (b 0))) (dι (A (b 1)))) (q : ℝ³) •
       euclideanCross (dF (A (b 0))) (dF (A (b 1))) =
-    basisDet b A ^ 2 •
+    LinearMap.det A.toLinearMap ^ 2 •
       (inner ℝ (euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
         euclideanCross (dF (b 0)) (dF (b 1)))
   have hιcross := euclideanCross_comp_basis b dι A
   have hFcross := euclideanCross_comp_basis b dF A
   calc
-    _ = inner ℝ (basisDet b A • euclideanCross (dι (b 0)) (dι (b 1))) (q : ℝ³) •
-        (basisDet b A • euclideanCross (dF (b 0)) (dF (b 1))) :=
+    _ = inner ℝ (LinearMap.det A.toLinearMap • euclideanCross (dι (b 0)) (dι (b 1)))
+          (q : ℝ³) •
+        (LinearMap.det A.toLinearMap • euclideanCross (dF (b 0)) (dF (b 1))) :=
       congrArg₂ (fun (s : ℝ) (x : ℝ³) ↦ s • x)
         (congrArg (fun x ↦ inner ℝ x (q : ℝ³)) hιcross) hFcross
     _ = _ := by
@@ -199,56 +187,53 @@ private theorem sphereNormalRawInCoordinates_eq_smul
       congr 1
       ring
 
-private theorem basisDet_tangentCoordChange_ne_zero
+private theorem det_tangentCoordChange_ne_zero
     (p q : sphere (0 : ℝ³) 1) (hq : q ∈ (extChartAt (𝓡 2) p).source) :
-    basisDet (sphereModelBasis p)
-        (tangentCoordChange (𝓡 2) p q q :
-          EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) ≠ 0 := by
-  letI : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
-  let b := sphereModelBasis p
-  let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
-    tangentCoordChange (𝓡 2) p q q
-  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
-  have hA : Function.Injective A := tangentCoordChange_injective p q hq
-  have hι : Function.Injective dι := mfderiv_coe_sphere_injective q
-  have hcomp : Function.Injective (dι.comp A) := hι.comp hA
-  have hLI : LinearIndependent ℝ ![(dι.comp A) (b 0), (dι.comp A) (b 1)] := by
-    have hmap := b.linearIndependent.map' (dι.comp A).toLinearMap
-      (LinearMap.ker_eq_bot_of_injective hcomp)
-    rw [show ![(dι.comp A) (b 0), (dι.comp A) (b 1)] =
-        (dι.comp A).toLinearMap ∘ b by
-      funext i
-      fin_cases i <;> rfl]
-    exact hmap
-  have hcross : euclideanCross ((dι.comp A) (b 0)) ((dι.comp A) (b 1)) ≠ 0 :=
-    (euclideanCross_ne_zero_iff_linearIndependent _ _).2 hLI
-  intro hdet
-  apply hcross
-  simp only [ContinuousLinearMap.comp_apply]
-  change basisDet b A = 0 at hdet
-  exact (euclideanCross_comp_basis b dι A).trans (by rw [hdet, zero_smul])
+    LinearMap.det (tangentCoordChange (𝓡 2) p q q :
+      EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ≠ 0 := by
+  rw [Ne, LinearMap.det_eq_zero_iff_ker_ne_bot, not_not]
+  exact LinearMap.ker_eq_bot_of_injective (tangentCoordChange_injective p q hq)
 
-private theorem contMDiffAt_sphereNormal
-    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
-    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
-    (himm : ∀ q, Function.Injective (sphereAmbientMfderiv F q)) :
+/-- At an immersion point, a locally `C^n` map has a locally `C^m` canonical unit normal when
+`m + 1 ≤ n`. -/
+theorem contMDiffAt_sphereNormal_of_le
+    {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n)
+    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
-  have hdet := basisDet_tangentCoordChange_ne_zero p p hp
+  have hdet := det_tangentCoordChange_ne_zero p p hp
   have hraw : sphereNormalRaw F p ≠ 0 := by
-    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 (himm p)
+    have hn : sphereNormal F p ≠ 0 := (sphereNormal_ne_zero_iff F p).2 himm
     rw [sphereNormal] at hn
     exact (not_congr (NormedSpace.normalize_eq_zero_iff _)).mp hn
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
     rw [sphereNormalRawInCoordinates_eq_smul F p p hp]
     exact smul_ne_zero (pow_ne_zero 2 hdet) hraw
   have hsmooth := contMDiffAt_normalize
-    (contMDiffAt_sphereNormalRawInCoordinates F p hF) hlocal
+    (contMDiffAt_sphereNormalRawInCoordinates F p hF hmn) hlocal
   apply hsmooth.congr_of_eventuallyEq
   filter_upwards [extChartAt_source_mem_nhds (I := 𝓡 2) p] with q hq
   rw [sphereNormal, sphereNormalRawInCoordinates_eq_smul F p q hq,
     NormedSpace.normalize_smul_of_pos
-      (sq_pos_of_ne_zero (basisDet_tangentCoordChange_ne_zero p q hq))]
+      (sq_pos_of_ne_zero (det_tangentCoordChange_ne_zero p q hq))]
+
+/-- At an immersion point, a locally `C^(m + 1)` map has a locally `C^m` canonical unit normal. -/
+theorem contMDiffAt_sphereNormal
+    {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
+    (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F p)
+    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
+    ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p :=
+  contMDiffAt_sphereNormal_of_le F p hF le_rfl himm
+
+/-- A `C^n` immersion of the unit two-sphere has a `C^m` canonical unit normal when
+`m + 1 ≤ n`. -/
+theorem contMDiff_sphereNormal_of_le
+    {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
+    (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) n F) (hmn : m + 1 ≤ n)
+    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
+  fun p ↦ contMDiffAt_sphereNormal_of_le F p (hF p) hmn (himm p)
 
 /-- A `C^(m + 1)` immersion of the unit two-sphere has a `C^m` canonical unit normal. -/
 theorem contMDiff_sphereNormal
@@ -256,6 +241,6 @@ theorem contMDiff_sphereNormal
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
     (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
-  fun p ↦ contMDiffAt_sphereNormal F p hF himm
+  contMDiff_sphereNormal_of_le F hF le_rfl himm
 
 end EuclideanHypersurface

--- a/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
+++ b/FormalConjecturesForMathlib/Geometry/SphereImmersionRegularity.lean
@@ -35,13 +35,9 @@ canonical normal.
 @[expose] public section
 
 open Metric
-open scoped EuclideanGeometry Manifold RealInnerProductSpace
+open scoped EuclideanGeometry EuclideanSpace Manifold RealInnerProductSpace
 
 namespace EuclideanHypersurface
-
-private noncomputable def sphereModelBasis (p : sphere (0 : ℝ³) 1) :
-    Module.Basis (Fin 2) ℝ (EuclideanSpace ℝ (Fin 2)) :=
-  sphereTangentBasis p
 
 private theorem euclideanCross_comp_basis
     {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
@@ -66,8 +62,9 @@ private theorem contMDiffAt_normalize
 private theorem inTangentCoordinates_sphere_eq_comp
     (G : sphere (0 : ℝ³) 1 → ℝ³) (p q : sphere (0 : ℝ³) 1)
     (hq : q ∈ (extChartAt (𝓡 2) p).source) :
-    inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id G (sphereAmbientMfderiv G) p q =
-      sphereAmbientMfderiv G q ∘L
+    inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id G
+        (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) G) p q =
+      mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) G q ∘L
         (tangentCoordChange (𝓡 2) p q q :
           EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)) := by
   rw [inTangentCoordinates_eq _ _ _ (by simpa [extChartAt_source] using hq) (by simp),
@@ -89,14 +86,14 @@ private theorem tangentCoordChange_injective
 private noncomputable def sphereNormalRawInCoordinates
     (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1) :
     sphere (0 : ℝ³) 1 → ℝ³ :=
-  let b := sphereModelBasis p
+  let b := PiLp.basisFun 2 ℝ (Fin 2)
   let e0 : EuclideanSpace ℝ (Fin 2) := b 0
   let e1 : EuclideanSpace ℝ (Fin 2) := b 1
   let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
-    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
   let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-    (sphereAmbientMfderiv F) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p
   fun q ↦ inner ℝ (euclideanCross (dι q e0) (dι q e1)) (q : ℝ³) •
     euclideanCross (dF q e0) (dF q e1)
 
@@ -104,15 +101,14 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormalRawInCoordinates F p) p := by
-  have : Fact (Module.finrank ℝ ℝ³ = 2 + 1) := ⟨by norm_num⟩
-  let b := sphereModelBasis p
+  let b := PiLp.basisFun 2 ℝ (Fin 2)
   let e0 : EuclideanSpace ℝ (Fin 2) := b 0
   let e1 : EuclideanSpace ℝ (Fin 2) := b 1
   let dι := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))
-    (sphereAmbientMfderiv (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³))) p
   let dF := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
-    (sphereAmbientMfderiv F) p
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p
   have hdι : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dι p :=
     (contMDiff_coe_sphere (n := 2) (m := (⊤ : WithTop ℕ∞)) p).mfderiv_const le_top
   have hdF : ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2) →L[ℝ] ℝ³) m dF p :=
@@ -127,7 +123,7 @@ private theorem contMDiffAt_sphereNormalRawInCoordinates
     ContMDiffAt (𝓡 2) 𝓘(ℝ, EuclideanSpace ℝ (Fin 2)) m (fun _ ↦ e1) p)
   have hcι := (euclideanCross.contMDiffAt.comp p hdι0).clm_apply hdι1
   have hcF := (euclideanCross.contMDiffAt.comp p hdF0).clm_apply hdF1
-  simpa [sphereNormalRawInCoordinates] using
+  simpa [sphereNormalRawInCoordinates, b, e0, e1, dι, dF] using
     (contDiff_inner.comp_contMDiffAt
       (hcι.prodMk_space (contMDiff_coe_sphere p))).smul hcF
 
@@ -138,15 +134,19 @@ private theorem sphereNormalRawInCoordinates_eq_smul
       LinearMap.det (tangentCoordChange (𝓡 2) p q q :
         EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2)).toLinearMap ^ 2 •
         sphereNormalRaw F q := by
-  let b := sphereModelBasis p
+  let b := PiLp.basisFun 2 ℝ (Fin 2)
   let A : EuclideanSpace ℝ (Fin 2) →L[ℝ] EuclideanSpace ℝ (Fin 2) :=
     tangentCoordChange (𝓡 2) p q q
-  let dι := sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
-  let dF := sphereAmbientMfderiv F q
+  let dι : TangentSpace (𝓡 2) q →L[ℝ] ℝ³ :=
+    mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³)) q
+  let dF : TangentSpace (𝓡 2) q →L[ℝ] ℝ³ := mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F q
   let dιc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id
     (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))
-    (sphereAmbientMfderiv (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
-  let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F (sphereAmbientMfderiv F) p q
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) (fun r : sphere (0 : ℝ³) 1 ↦ (r : ℝ³))) p q
+  let dFc := inTangentCoordinates (𝓡 2) 𝓘(ℝ, ℝ³) id F
+    (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F) p q
+  rw [sphereNormalRaw]
+  rw [sphereTangentBasis_apply q 0, sphereTangentBasis_apply q 1]
   change inner ℝ (euclideanCross (dιc (b 0)) (dιc (b 1))) (q : ℝ³) •
       euclideanCross (dFc (b 0)) (dFc (b 1)) =
       LinearMap.det A.toLinearMap ^ 2 •
@@ -178,7 +178,8 @@ private theorem det_tangentCoordChange_ne_zero
 theorem contMDiffAt_sphereNormal_of_le
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) n F p) (hmn : m + 1 ≤ n)
-    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p := by
   have hp : p ∈ (extChartAt (𝓡 2) p).source := mem_extChartAt_source p
   have hlocal : sphereNormalRawInCoordinates F p p ≠ 0 := by
@@ -197,7 +198,8 @@ theorem contMDiffAt_sphereNormal_of_le
 theorem contMDiffAt_sphereNormal
     {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³) (p : sphere (0 : ℝ³) 1)
     (hF : ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F p)
-    (himm : Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiffAt (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) p :=
   contMDiffAt_sphereNormal_of_le F p hF le_rfl himm
 
@@ -206,7 +208,8 @@ theorem contMDiffAt_sphereNormal
 theorem contMDiff_sphereNormal_of_le
     {m n : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) n F) (hmn : m + 1 ≤ n)
-    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : ∀ p, Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
   fun p ↦ contMDiffAt_sphereNormal_of_le F p (hF p) hmn (himm p)
 
@@ -214,7 +217,8 @@ theorem contMDiff_sphereNormal_of_le
 theorem contMDiff_sphereNormal
     {m : WithTop ℕ∞} (F : sphere (0 : ℝ³) 1 → ℝ³)
     (hF : ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) (m + 1) F)
-    (himm : ∀ p, Function.Injective (sphereAmbientMfderiv F p)) :
+    (himm : ∀ p, Function.Injective
+      (mfderiv (𝓡 2) 𝓘(ℝ, ℝ³) F p : TangentSpace (𝓡 2) p →L[ℝ] ℝ³)) :
     ContMDiff (𝓡 2) 𝓘(ℝ, ℝ³) m (sphereNormal F) :=
   contMDiff_sphereNormal_of_le F hF le_rfl himm
 

--- a/FormalConjecturesForMathlib/Geometry/SupportFunctionSphere.lean
+++ b/FormalConjecturesForMathlib/Geometry/SupportFunctionSphere.lean
@@ -1,0 +1,434 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import Mathlib.Analysis.Convex.Basic
+public import Mathlib.Analysis.Convex.Deriv
+public import Mathlib.Analysis.Convex.Topology
+public import Mathlib.Analysis.Calculus.LocalExtr.Basic
+public import Mathlib.Analysis.Calculus.Gradient.Basic
+public import Mathlib.Analysis.InnerProductSpace.EuclideanDist
+public import Mathlib.Analysis.InnerProductSpace.Dual
+public import Mathlib.Analysis.LocallyConvex.Separation
+public import Mathlib.Geometry.Manifold.Instances.Sphere
+public import Mathlib.Topology.MetricSpace.ProperSpace
+
+@[expose] public section
+
+open Metric Set
+open scoped Gradient Topology
+
+namespace SphereSupport
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+open scoped Classical in
+/-- The degree-one radial extension of a function on the unit sphere. -/
+noncomputable def radialExtension (h : sphere (0 : E) 1 → ℝ) (x : E) : ℝ :=
+  if hx : x = 0 then 0
+  else ‖x‖ * h ⟨‖x‖⁻¹ • x, by simp [norm_smul, hx]⟩
+
+/-- The radial extension restricts to the original function on the unit sphere. -/
+@[simp]
+theorem radialExtension_coe (h : sphere (0 : E) 1 → ℝ) (p : sphere (0 : E) 1) :
+    radialExtension h (p : E) = h p := by
+  simp [radialExtension, ne_zero_of_mem_unit_sphere p, norm_eq_of_mem_sphere p]
+
+/-- The radial extension is positively homogeneous of degree one. -/
+theorem radialExtension_smul_of_pos (h : sphere (0 : E) 1 → ℝ) (x : E) {t : ℝ}
+    (ht : 0 < t) : radialExtension h (t • x) = t * radialExtension h x := by
+  by_cases hx : x = 0
+  · simp [hx, radialExtension]
+  have htx : t • x ≠ 0 := smul_ne_zero ht.ne' hx
+  have hnorm : ‖t • x‖ = t * ‖x‖ := by
+    rw [norm_smul, Real.norm_eq_abs, abs_of_pos ht]
+  have hunit (z : E) (hz : z ≠ 0) : ‖‖z‖⁻¹ • z‖ = 1 := by
+    rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (inv_nonneg.mpr (norm_nonneg z))]
+    exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr hz)
+  have hnormalized :
+      (⟨‖t • x‖⁻¹ • (t • x), by
+        rw [mem_sphere, dist_zero_right]
+        exact hunit (t • x) htx⟩ : sphere (0 : E) 1) =
+        ⟨‖x‖⁻¹ • x, by
+          rw [mem_sphere, dist_zero_right]
+          exact hunit x hx⟩ := by
+    apply Subtype.ext
+    simp only [hnorm, smul_smul]
+    congr 1
+    field_simp [ht.ne']
+  simp only [radialExtension, dif_neg htx, dif_neg hx]
+  rw [hnormalized, hnorm]
+  ring
+
+/-- The contact map associated to a differentiable positively homogeneous function on the
+ambient vector space. -/
+noncomputable def homogeneousGradient [CompleteSpace E]
+    (H : E → ℝ) (p : sphere (0 : E) 1) : E :=
+  ∇ H (p : E)
+
+/-- Euler's identity for a differentiable function that is positively homogeneous of degree
+one. This is the contact identity underlying the support-gradient construction. -/
+theorem inner_homogeneousGradient [CompleteSpace E] (H : E → ℝ) (p : sphere (0 : E) 1)
+    (hH : DifferentiableAt ℝ H (p : E))
+    (hhom : ∀ (t : ℝ), 0 < t → H (t • (p : E)) = t * H p) :
+    inner ℝ (homogeneousGradient H p) (p : E) = H p := by
+  rw [homogeneousGradient, inner_gradient_left hH]
+  have hline : HasDerivAt (fun t : ℝ ↦ H ((p : E) + t • (p : E)))
+      (fderiv ℝ H (p : E) (p : E)) 0 := by
+    have harg : HasDerivAt (fun t : ℝ ↦ (p : E) + t • (p : E)) (p : E) 0 :=
+      by
+        simpa only [Pi.add_apply, id_eq, zero_add, one_smul] using
+          (hasDerivAt_const (x := (0 : ℝ)) (p : E)).add
+            ((hasDerivAt_id (𝕜 := ℝ) 0).smul_const (p : E))
+    simpa [Function.comp_def] using
+      hH.hasFDerivAt.comp_hasDerivAt_of_eq (x := (0 : ℝ)) harg (by simp)
+  have heq : (fun t : ℝ ↦ H ((p : E) + t • (p : E))) =ᶠ[𝓝 0]
+      fun t : ℝ ↦ (1 + t) * H p := by
+    filter_upwards [Metric.ball_mem_nhds (0 : ℝ) (by norm_num : (0 : ℝ) < 1)] with t ht
+    rw [mem_ball, dist_zero_right, Real.norm_eq_abs] at ht
+    calc
+      H ((p : E) + t • (p : E)) = H ((1 + t) • (p : E)) := by rw [add_smul, one_smul]
+      _ = (1 + t) * H p := hhom (1 + t) (by linarith [(abs_lt.mp ht).1])
+  have hright : HasDerivAt (fun t : ℝ ↦ (1 + t) * H p) (H p) 0 := by
+    convert (hasDerivAt_id (𝕜 := ℝ) 0).const_add 1 |>.mul_const (H p) using 1
+    all_goals ring
+  exact (hline.congr_of_eventuallyEq heq.symm).unique hright
+
+/-- A differentiable positively homogeneous majorant has a unique contact point: its gradient.
+This is the ambient form of the first-variation argument for support functions. -/
+theorem eq_homogeneousGradient_of_global_support [CompleteSpace E] (H : E → ℝ)
+    (p : sphere (0 : E) 1) (x : E) (hH : DifferentiableAt ℝ H (p : E))
+    (hmajor : ∀ y : E, inner ℝ x y ≤ H y) (hcontact : inner ℝ x (p : E) = H p) :
+    x = homogeneousGradient H p := by
+  let G : E → ℝ := fun y ↦ H y - inner ℝ x y
+  have hmin : IsMinOn G univ (p : E) := by
+    intro y _
+    dsimp [G]
+    rw [hcontact]
+    linarith [hmajor y]
+  have hlinear : DifferentiableAt ℝ (fun y : E ↦ inner ℝ x y) (p : E) :=
+    (innerSL ℝ x).differentiableAt
+  have hderiv : fderiv ℝ H (p : E) = innerSL ℝ x := by
+    have hzero := (hmin.isLocalMin Filter.univ_mem).fderiv_eq_zero
+    have hinner_deriv :
+        fderiv ℝ (fun y : E ↦ inner ℝ x y) (p : E) = innerSL ℝ x := by
+      simpa only [innerSL_apply_apply] using (innerSL ℝ x).hasFDerivAt.fderiv
+    rw [show G = fun y : E ↦ H y - inner ℝ x y by rfl,
+      fderiv_fun_sub hH hlinear, hinner_deriv] at hzero
+    exact sub_eq_zero.mp hzero
+  apply ext_inner_right ℝ
+  intro y
+  rw [homogeneousGradient, inner_gradient_left hH, hderiv, innerSL_apply_apply]
+
+/-- The gradient of a differentiable convex function that is positively homogeneous of degree
+one lies below that function in every direction. -/
+theorem inner_homogeneousGradient_le [CompleteSpace E] (H : E → ℝ)
+    (p : sphere (0 : E) 1) (y : E)
+    (hconvex : ConvexOn ℝ univ H) (hH : DifferentiableAt ℝ H (p : E))
+    (hhom : ∀ (t : ℝ), 0 < t → H (t • (p : E)) = t * H p) :
+    inner ℝ (homogeneousGradient H p) y ≤ H y := by
+  let e : ℝ →ᵃ[ℝ] E := AffineMap.lineMap (p : E) y
+  have hline_convex : ConvexOn ℝ univ (H ∘ e) := by
+    simpa [e] using hconvex.comp_affineMap e
+  have he0 : e 0 = (p : E) := by simp [e]
+  have he1 : e 1 = y := by simp [e]
+  have he_deriv : HasDerivAt e (y - (p : E)) (0 : ℝ) := by
+    simpa [e] using (AffineMap.hasDerivAt_lineMap (𝕜 := ℝ) (E := E)
+      (a := (p : E)) (b := y) (x := (0 : ℝ)))
+  have hline_deriv : HasDerivAt (H ∘ e) (fderiv ℝ H (p : E) (y - (p : E))) 0 := by
+    exact hH.hasFDerivAt.comp_hasDerivAt_of_eq (x := (0 : ℝ)) he_deriv he0.symm
+  have hslope := hline_convex.le_slope_of_hasDerivAt (Set.mem_univ 0) (Set.mem_univ 1)
+    zero_lt_one hline_deriv
+  have heuler : fderiv ℝ H (p : E) (p : E) = H p := by
+    rw [← inner_homogeneousGradient H p hH hhom, homogeneousGradient,
+      inner_gradient_left hH]
+  have hslope' : fderiv ℝ H (p : E) (y - (p : E)) ≤ H y - H p := by
+    simpa [slope, Function.comp_apply, he0, he1] using hslope
+  rw [map_sub, heuler] at hslope'
+  rw [homogeneousGradient, inner_gradient_left hH]
+  linarith
+
+/-- Stereographic charts based at antipodal unit vectors are related by radial inversion. -/
+theorem stereoToFun_stereoInvFunAux_neg {v w : E} (hv : ‖v‖ = 1)
+    (hw : w ∈ (ℝ ∙ v)ᗮ) (hw0 : w ≠ 0) :
+    stereoToFun v (stereoInvFunAux (-v) w) =
+      (4 / ‖w‖ ^ 2) • (⟨w, hw⟩ : (ℝ ∙ v)ᗮ) := by
+  rw [stereoToFun_apply, stereoInvFunAux_apply]
+  have hprojw : (ℝ ∙ v)ᗮ.orthogonalProjection w = ⟨w, hw⟩ := by
+    simpa using (ℝ ∙ v)ᗮ.orthogonalProjection_mem_subspace_eq_self
+      (⟨w, hw⟩ : (ℝ ∙ v)ᗮ)
+  have hprojneg : (ℝ ∙ v)ᗮ.orthogonalProjection (-v) = 0 := by
+    rw [map_neg, Submodule.orthogonalProjection_orthogonalComplement_singleton_eq_zero]
+    exact neg_zero
+  have hinnerw : inner ℝ v w = 0 :=
+    Submodule.mem_orthogonal_singleton_iff_inner_right.mp hw
+  have hinnerv : inner ℝ v v = 1 := by
+    rw [real_inner_self_eq_norm_sq, hv]
+    norm_num
+  simp only [map_smul, map_add, hprojw, hprojneg, smul_zero, add_zero, innerSL_apply_apply,
+    hinnerw, hinnerv, inner_neg_right, smul_smul]
+  have hwsub : (⟨w, hw⟩ : (ℝ ∙ v)ᗮ) ≠ 0 := by
+    intro h
+    exact hw0 (congr_arg Subtype.val h)
+  rw [smul_left_inj hwsub]
+  simp only [smul_eq_mul]
+  have hdenom :
+      1 - (‖w‖ ^ 2 + 4)⁻¹ * ((‖w‖ ^ 2 - 4) * -1) =
+        2 * ‖w‖ ^ 2 / (‖w‖ ^ 2 + 4) := by
+    field_simp
+    ring
+  simp only [zero_add]
+  rw [hdenom]
+  field_simp [norm_ne_zero_iff.mpr hw0]
+
+/-- The closed convex set cut out by the supporting half-spaces prescribed by `h`. -/
+def body (h : sphere (0 : E) 1 → ℝ) : Set E :=
+  {x | ∀ p : sphere (0 : E) 1, inner ℝ (p : E) x ≤ h p}
+
+/-- A support-function body is convex. -/
+theorem body_convex (h : sphere (0 : E) 1 → ℝ) : Convex ℝ (body h) := by
+  rw [body, setOf_forall]
+  exact convex_iInter fun p ↦
+    convex_halfSpace_le (innerSL ℝ (p : E)).toLinearMap.isLinear (h p)
+
+/-- A support-function body is closed. -/
+theorem body_isClosed (h : sphere (0 : E) 1 → ℝ) : IsClosed (body h) := by
+  rw [body, setOf_forall]
+  exact isClosed_iInter fun p ↦ isClosed_Iic.preimage (innerSL ℝ (p : E)).continuous
+
+/-- If `h` is bounded below by a positive constant, its support-function body has nonempty
+interior. -/
+theorem body_interior_nonempty (h : sphere (0 : E) 1 → ℝ) {r : ℝ} (hr : 0 < r)
+    (hlower : ∀ p, r ≤ h p) : (interior (body h)).Nonempty := by
+  have hball : ball (0 : E) r ⊆ body h := by
+    intro x hx p
+    calc
+      inner ℝ (p : E) x ≤ ‖(p : E)‖ * ‖x‖ := real_inner_le_norm _ _
+      _ = ‖x‖ := by rw [norm_eq_of_mem_sphere p, one_mul]
+      _ ≤ r := (by simpa [mem_ball, dist_zero_right] using hx : ‖x‖ < r).le
+      _ ≤ h p := hlower p
+  refine ⟨0, mem_interior_iff_mem_nhds.mpr ?_⟩
+  exact Filter.mem_of_superset (ball_mem_nhds 0 hr) hball
+
+/-- A uniform upper bound on `h` bounds its support-function body. -/
+theorem body_isBounded (h : sphere (0 : E) 1 → ℝ) {R : ℝ} (hupper : ∀ p, h p ≤ R) :
+    Bornology.IsBounded (body h) := by
+  rw [Metric.isBounded_iff_subset_closedBall (0 : E)]
+  refine ⟨max R 0, ?_⟩
+  intro x hx
+  rw [mem_closedBall, dist_zero_right]
+  by_cases hx0 : x = 0
+  · simp [hx0]
+  · have hxnorm : ‖x‖ ≠ 0 := norm_ne_zero_iff.mpr hx0
+    let p : sphere (0 : E) 1 := ⟨‖x‖⁻¹ • x, by
+      simp [norm_smul, hxnorm]⟩
+    have hp : inner ℝ (p : E) x ≤ h p := hx p
+    have hinner : inner ℝ (p : E) x = ‖x‖ := by
+      change inner ℝ (‖x‖⁻¹ • x) x = ‖x‖
+      rw [real_inner_smul_left, real_inner_self_eq_norm_mul_norm]
+      calc
+        ‖x‖⁻¹ * (‖x‖ * ‖x‖) = (‖x‖⁻¹ * ‖x‖) * ‖x‖ := by ring
+        _ = ‖x‖ := by rw [inv_mul_cancel₀ hxnorm, one_mul]
+    rw [hinner] at hp
+    exact (hp.trans (hupper p)).trans (le_max_left _ _)
+
+/-- In a proper real inner-product space, a uniformly upper-bounded support function cuts out a
+compact body. -/
+theorem body_isCompact [ProperSpace E] (h : sphere (0 : E) 1 → ℝ) {R : ℝ}
+    (hupper : ∀ p, h p ≤ R) : IsCompact (body h) :=
+  Metric.isCompact_iff_isClosed_bounded.mpr ⟨body_isClosed h, body_isBounded h hupper⟩
+
+/-- A continuous function on the unit sphere cuts out a compact support-function body. -/
+theorem body_isCompact_of_continuous [ProperSpace E] (h : sphere (0 : E) 1 → ℝ)
+    (hh : Continuous h) : IsCompact (body h) := by
+  obtain ⟨R, hR⟩ := (isCompact_range hh).bddAbove
+  exact body_isCompact h fun p ↦ hR ⟨p, rfl⟩
+
+/-- Every boundary point of a closed convex body with nonempty interior admits an outward unit
+supporting normal. -/
+theorem exists_unit_supporting_normal {K : Set E} (hconvex : Convex ℝ K)
+    [CompleteSpace E] (hclosed : IsClosed K) (hinterior : (interior K).Nonempty) {x : E}
+    (hx : x ∈ frontier K) :
+    ∃ p : sphere (0 : E) 1, ∀ y ∈ K, inner ℝ (p : E) y ≤ inner ℝ (p : E) x := by
+  have hx_not_interior : x ∉ interior K := by
+    rw [frontier] at hx
+    exact hx.2
+  obtain ⟨f, hf⟩ := geometric_hahn_banach_open_point hconvex.interior isOpen_interior
+    hx_not_interior
+  have hf0 : f ≠ 0 := by
+    intro hzero
+    obtain ⟨y, hy⟩ := hinterior
+    simpa [hzero] using hf y hy
+  let v : E := (InnerProductSpace.toDual ℝ E).symm f
+  have hv0 : v ≠ 0 := (InnerProductSpace.toDual ℝ E).symm.map_ne_zero_iff.mpr hf0
+  let p : sphere (0 : E) 1 := ⟨‖v‖⁻¹ • v, by
+    simp [norm_smul, hv0]⟩
+  refine ⟨p, fun y hy ↦ ?_⟩
+  have hhalf_closed : IsClosed {z : E | f z ≤ f x} :=
+    isClosed_Iic.preimage f.continuous
+  have hhalf : closure (interior K) ⊆ {z : E | f z ≤ f x} :=
+    closure_minimal (fun z hz ↦ (hf z hz).le) hhalf_closed
+  have hclosure : closure (interior K) = K := by
+    rw [hconvex.closure_interior_eq_closure_of_nonempty_interior hinterior,
+      hclosed.closure_eq]
+  have hfy : f y ≤ f x := hhalf (hclosure.symm ▸ hy)
+  change inner ℝ (‖v‖⁻¹ • v) y ≤ inner ℝ (‖v‖⁻¹ • v) x
+  simpa only [real_inner_smul_left, v, InnerProductSpace.toDual_symm_apply] using
+    mul_le_mul_of_nonneg_left hfy (inv_nonneg.mpr (norm_nonneg v))
+
+/-- Pointwise contact and cross-support inequalities place every parametrized point in the
+support-function body and make it attain the corresponding supporting hyperplane. -/
+theorem contact_mem_body (h : sphere (0 : E) 1 → ℝ) (F : sphere (0 : E) 1 → E)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hcross : ∀ (p q : sphere (0 : E) 1), inner ℝ (F p) (q : E) ≤ h q) :
+    ∀ p, F p ∈ body h ∧ inner ℝ (F p) (p : E) = h p ∧
+      ∀ x ∈ body h, inner ℝ x (p : E) ≤ h p := by
+  intro p
+  refine ⟨fun q ↦ ?_, hcontact p, fun x hx ↦ ?_⟩
+  · simpa [real_inner_comm] using hcross p q
+  · simpa [real_inner_comm] using hx p
+
+/-- A parametrized contact point lies on the frontier of the support-function body. -/
+theorem contact_mem_frontier (h : sphere (0 : E) 1 → ℝ) (F : sphere (0 : E) 1 → E)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hcross : ∀ (p q : sphere (0 : E) 1), inner ℝ (F p) (q : E) ≤ h q) :
+    ∀ p, F p ∈ frontier (body h) := by
+  intro p
+  rw [frontier, (body_isClosed h).closure_eq]
+  refine ⟨(contact_mem_body h F hcontact hcross p).1, ?_⟩
+  intro hpinterior
+  rcases Metric.mem_nhds_iff.mp (mem_interior_iff_mem_nhds.mp hpinterior) with
+    ⟨ε, hε, hball⟩
+  let y := F p + (ε / 2) • (p : E)
+  have hyball : y ∈ ball (F p) ε := by
+    rw [mem_ball, dist_eq_norm]
+    simp [y, norm_smul, norm_eq_of_mem_sphere p]
+    rw [abs_of_pos hε]
+    linarith
+  have hybody : y ∈ body h := hball hyball
+  have hy_support := hybody p
+  have hpp : inner ℝ (p : E) (p : E) = 1 := by
+    rw [real_inner_self_eq_norm_sq, norm_eq_of_mem_sphere p]
+    norm_num
+  have hcontact' : inner ℝ (p : E) (F p) = h p := by
+    rw [real_inner_comm]
+    exact hcontact p
+  have hy_inner : inner ℝ (p : E) y = h p + ε / 2 := by
+    rw [show y = F p + (ε / 2) • (p : E) by rfl, inner_add_right,
+      hcontact', real_inner_smul_right, hpp, mul_one]
+  rw [hy_inner] at hy_support
+  linarith
+
+/-- If every exposed contact face is the prescribed singleton, the contact parametrization covers
+the whole frontier of its support-function body. -/
+theorem range_eq_frontier_of_unique_contact [CompleteSpace E]
+    (h : sphere (0 : E) 1 → ℝ) (F : sphere (0 : E) 1 → E)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hcross : ∀ (p q : sphere (0 : E) 1), inner ℝ (F p) (q : E) ≤ h q)
+    (hinterior : (interior (body h)).Nonempty)
+    (hunique : ∀ (p : sphere (0 : E) 1) (x : E), x ∈ body h →
+      inner ℝ (p : E) x = h p → x = F p) :
+    range F = frontier (body h) := by
+  apply Subset.antisymm
+  · rintro _ ⟨p, rfl⟩
+    exact contact_mem_frontier h F hcontact hcross p
+  · intro x hx
+    obtain ⟨p, hp⟩ := exists_unit_supporting_normal (body_convex h) (body_isClosed h)
+      hinterior hx
+    have hxbody : x ∈ body h := by
+      rw [frontier, (body_isClosed h).closure_eq] at hx
+      exact hx.1
+    have hFpbody := (contact_mem_body h F hcontact hcross p).1
+    have hle : h p ≤ inner ℝ (p : E) x := by
+      rw [← hcontact p, real_inner_comm]
+      exact hp (F p) hFpbody
+    have hxeq : inner ℝ (p : E) x = h p :=
+      le_antisymm (hxbody p) hle
+    exact ⟨p, (hunique p x hxbody hxeq).symm⟩
+
+/-- A contact point is uniquely determined once its displacement from the prescribed point is
+orthogonal to every tangent vector. This is the linear-algebra step in the first-variation
+argument for support parametrizations. -/
+theorem eq_contact_of_tangent_orthogonal (h : sphere (0 : E) 1 → ℝ)
+    (F : sphere (0 : E) 1 → E)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    {p : sphere (0 : E) 1} {x : E} (hxeq : inner ℝ (p : E) x = h p)
+    (htangent : ∀ v : E, v ∈ (ℝ ∙ (p : E))ᗮ → inner ℝ (x - F p) v = 0) :
+    x = F p := by
+  have hdisplacement : x - F p ∈ (ℝ ∙ (p : E))ᗮ := by
+    rw [Submodule.mem_orthogonal_singleton_iff_inner_right, inner_sub_right, hxeq]
+    have hpcontact : inner ℝ (p : E) (F p) = h p := by
+      rw [real_inner_comm]
+      exact hcontact p
+    rw [hpcontact, sub_self]
+  exact sub_eq_zero.mp (inner_self_eq_zero.mp
+    (htangent (x - F p) hdisplacement))
+
+/-- First variation at every exposed contact point, together with contact and cross-support,
+forces a parametrization to cover the whole frontier. -/
+theorem range_eq_frontier_of_first_variation [CompleteSpace E]
+    (h : sphere (0 : E) 1 → ℝ) (F : sphere (0 : E) 1 → E)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hcross : ∀ (p q : sphere (0 : E) 1), inner ℝ (F p) (q : E) ≤ h q)
+    (hinterior : (interior (body h)).Nonempty)
+    (hstationary : ∀ (p : sphere (0 : E) 1) (x : E), x ∈ body h →
+      inner ℝ (p : E) x = h p → ∀ v : E, v ∈ (ℝ ∙ (p : E))ᗮ →
+        inner ℝ (x - F p) v = 0) :
+    range F = frontier (body h) :=
+  range_eq_frontier_of_unique_contact h F hcontact hcross hinterior fun p x hx hxeq ↦
+    eq_contact_of_tangent_orthogonal h F hcontact hxeq (hstationary p x hx hxeq)
+
+/-- Contact, cross-support, and first variation produce the compact convex body represented by a
+support function. This packages the set-theoretic part of the support-gradient construction. -/
+theorem exists_compact_body_of_first_variation [ProperSpace E] [CompleteSpace E]
+    (h : sphere (0 : E) 1 → ℝ) (F : sphere (0 : E) 1 → E)
+    (hh : Continuous h) {r : ℝ} (hr : 0 < r) (hlower : ∀ p, r ≤ h p)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hcross : ∀ (p q : sphere (0 : E) 1), inner ℝ (F p) (q : E) ≤ h q)
+    (hstationary : ∀ (p : sphere (0 : E) 1) (x : E), x ∈ body h →
+      inner ℝ (p : E) x = h p → ∀ v : E, v ∈ (ℝ ∙ (p : E))ᗮ →
+        inner ℝ (x - F p) v = 0) :
+    ∃ K : Set E, Convex ℝ K ∧ IsCompact K ∧ (interior K).Nonempty ∧
+      range F = frontier K ∧ ∀ p, F p ∈ K ∧ inner ℝ (F p) (p : E) = h p ∧
+        ∀ x ∈ K, inner ℝ x (p : E) ≤ h p := by
+  refine ⟨body h, body_convex h, body_isCompact_of_continuous h hh,
+    body_interior_nonempty h hr hlower,
+    range_eq_frontier_of_first_variation h F hcontact hcross
+      (body_interior_nonempty h hr hlower) hstationary, ?_⟩
+  exact contact_mem_body h F hcontact hcross
+
+/-- Strict cross-support separates the parametrizing normals, so the contact map is injective. -/
+theorem injective_of_strictCross (h : sphere (0 : E) 1 → ℝ)
+    (F : sphere (0 : E) 1 → E)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hstrict : ∀ (p q : sphere (0 : E) 1), p ≠ q → inner ℝ (F p) (q : E) < h q) :
+    Function.Injective F := by
+  intro p q hpq
+  by_contra hpne
+  have hpq_strict := hstrict p q hpne
+  rw [hpq, hcontact q] at hpq_strict
+  exact (lt_irrefl _ hpq_strict)
+
+/-- A continuous strict contact parametrization of the unit sphere is a topological embedding. -/
+theorem isEmbedding_of_strictCross [ProperSpace E] (h : sphere (0 : E) 1 → ℝ)
+    (F : sphere (0 : E) 1 → E) (hF : Continuous F)
+    (hcontact : ∀ p, inner ℝ (F p) (p : E) = h p)
+    (hstrict : ∀ (p q : sphere (0 : E) 1), p ≠ q → inner ℝ (F p) (q : E) < h q) :
+    Topology.IsEmbedding F :=
+  (hF.isClosedEmbedding (injective_of_strictCross h F hcontact hstrict)).isEmbedding
+
+end SphereSupport

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -36,33 +36,27 @@ open EuclideanHypersurface
 
 private def positiveAxis0 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[1, 0, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis0 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[-1, 0, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis1 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, 1, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis1 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, -1, 0], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis2 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, 0, 1], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
   ⟨!₂[0, 0, -1], by
-    simp only [mem_sphere_zero_iff_norm]
-    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+    norm_num [mem_sphere_zero_iff_norm, EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -1,0 +1,97 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+module
+
+public import FormalConjecturesForMathlib.Geometry.SphereImmersion
+
+/-!
+# Sanity checks for the canonical sphere normal
+
+The canonical normal of the standard inclusion is checked explicitly at the six signed coordinate
+axes of the unit sphere.
+-/
+
+@[expose] public section
+
+open Metric
+open scoped EuclideanGeometry
+
+namespace SphereImmersionTest
+
+open EuclideanHypersurface
+
+private def positiveAxis0 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![1, 0, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def negativeAxis0 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![-1, 0, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def positiveAxis1 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, 1, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def negativeAxis1 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, -1, 0], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def positiveAxis2 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, 0, 1], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
+  ⟨WithLp.toLp 2 ![0, 0, -1], by
+    simp only [mem_sphere_zero_iff_norm]
+    norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =
+      WithLp.toLp 2 ![1, 0, 0] := by
+  simp [positiveAxis0]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis0 =
+      WithLp.toLp 2 ![-1, 0, 0] := by
+  simp [negativeAxis0]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis1 =
+      WithLp.toLp 2 ![0, 1, 0] := by
+  simp [positiveAxis1]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis1 =
+      WithLp.toLp 2 ![0, -1, 0] := by
+  simp [negativeAxis1]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis2 =
+      WithLp.toLp 2 ![0, 0, 1] := by
+  simp [positiveAxis2]
+
+example :
+    sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis2 =
+      WithLp.toLp 2 ![0, 0, -1] := by
+  simp [negativeAxis2]
+
+end SphereImmersionTest

--- a/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
+++ b/FormalConjecturesTest/ForMathlib/Geometry/SphereImmersion.lean
@@ -35,63 +35,63 @@ namespace SphereImmersionTest
 open EuclideanHypersurface
 
 private def positiveAxis0 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![1, 0, 0], by
+  ⟨!₂[1, 0, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis0 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![-1, 0, 0], by
+  ⟨!₂[-1, 0, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis1 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, 1, 0], by
+  ⟨!₂[0, 1, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis1 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, -1, 0], by
+  ⟨!₂[0, -1, 0], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def positiveAxis2 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, 0, 1], by
+  ⟨!₂[0, 0, 1], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 private def negativeAxis2 : sphere (0 : ℝ³) 1 :=
-  ⟨WithLp.toLp 2 ![0, 0, -1], by
+  ⟨!₂[0, 0, -1], by
     simp only [mem_sphere_zero_iff_norm]
     norm_num [EuclideanSpace.norm_eq, Fin.sum_univ_succ]⟩
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis0 =
-      WithLp.toLp 2 ![1, 0, 0] := by
+      !₂[1, 0, 0] := by
   simp [positiveAxis0]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis0 =
-      WithLp.toLp 2 ![-1, 0, 0] := by
+      !₂[-1, 0, 0] := by
   simp [negativeAxis0]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis1 =
-      WithLp.toLp 2 ![0, 1, 0] := by
+      !₂[0, 1, 0] := by
   simp [positiveAxis1]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis1 =
-      WithLp.toLp 2 ![0, -1, 0] := by
+      !₂[0, -1, 0] := by
   simp [negativeAxis1]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) positiveAxis2 =
-      WithLp.toLp 2 ![0, 0, 1] := by
+      !₂[0, 0, 1] := by
   simp [positiveAxis2]
 
 example :
     sphereNormal (fun q : sphere (0 : ℝ³) 1 ↦ (q : ℝ³)) negativeAxis2 =
-      WithLp.toLp 2 ![0, 0, -1] := by
+      !₂[0, 0, -1] := by
   simp [negativeAxis2]
 
 end SphereImmersionTest


### PR DESCRIPTION
Depends on #5066.

(I'm currently checking this - didn't mean to open a PR, so please ignore! - the goal is probably just to have a link to give to a formal_proof annotation)

Update: this now also proves the fundamental-form formulation added to #5066. The reusable equivalence lemmas and the corresponding counterexample adaptation are included here, so no separate follow-up PR is needed.

The Lean proof was developed with Codex and parallel proof-review agents.
