### PR TITLE
chore(Util/StubLinter): correctly handle Prop-valued instances

### DIFF
--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -49,7 +49,7 @@ open Module (finrank)
 Consequently, the rank is always finite, so `finrank ℤ E⟮K⟯ = 0` really means that the group of
 rational points is torsion, not that it is of infinite rank. -/
 @[category research solved, AMS 11 14]
-theorem mordell_weil {K} [Field K] [NumberField K] [DecidableEq K] (E : WeierstrassCurve K)
+instance mordell_weil {K} [Field K] [NumberField K] [DecidableEq K] (E : WeierstrassCurve K)
     [E.IsElliptic] : Module.Finite ℤ E⟮K⟯ := by
   sorry
 

--- a/FormalConjecturesTest/Util/Linters/StubLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/StubLinter.lean
@@ -83,3 +83,34 @@ def MyNormalType : Type := Nat
 
 #guard_msgs in
 theorem MyTheoremWithSorry : 1 = 1 := by sorry
+
+/-- A `Prop`-valued class: its instances are statements, not data. -/
+class MyPropClass (α : Type) : Prop where
+  out : α = α
+
+/-- A data-valued class: its instances carry data. -/
+class MyDataClass (α : Type) where
+  out : α
+
+-- A `Prop`-valued instance proved by `sorry` states a conjecture, just like a `theorem` does.
+#guard_msgs in
+instance myPropInstance : MyPropClass Nat := by sorry
+
+#guard_msgs in
+instance : MyPropClass Bool := by sorry
+
+/--
+warning: Placeholder definitions (e.g., `def foo : Type := sorry`) are not allowed.
+
+Note: This linter can be disabled with `set_option linter.style.stubs false`
+-/
+#guard_msgs(warning) in
+instance myDataInstance : MyDataClass Nat := by sorry
+
+/--
+warning: Placeholder definitions (e.g., `def foo : Type := sorry`) are not allowed.
+
+Note: This linter can be disabled with `set_option linter.style.stubs false`
+-/
+#guard_msgs(warning) in
+instance : MyDataClass Bool := by sorry

--- a/FormalConjecturesUtil/Linters/StubLinter.lean
+++ b/FormalConjecturesUtil/Linters/StubLinter.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 module
 
+public meta import Mathlib.Tactic.DeclarationNames
 public import Mathlib.Tactic.Linter.Header
 
 /-! # The Stub Linter
@@ -44,6 +45,46 @@ def hasSorry (stx : Syntax) : Bool :=
                    s.getId.eraseMacroScopes == `sorry || s.getId.eraseMacroScopes == `sorryAx))
   ) != none
 
+/-- The `declId` of a declaration, if it has one: an `instance` may be anonymous. -/
+def declId? (decl : Syntax) : Option Syntax :=
+  decl.getArgs.findSome? fun arg =>
+    if arg.isOfKind ``Lean.Parser.Command.declId then some arg
+    -- `instance` wraps its `declId` in an `optional`, hence in a null node.
+    else if arg.isOfKind nullKind then arg.getArgs.find? (·.isOfKind ``Lean.Parser.Command.declId)
+    else none
+
+/-- The names introduced by the declaration command `stx`, whose declaration node is `decl`.
+That is the single name given by its `declId`, resolved the way `CategoryLinter` resolves it, or,
+for an anonymous `instance`, the auto-generated names recorded at or after the position of `stx`. -/
+def declNames (stx decl : Syntax) : CommandElabM (Array Name) := do
+  let some declId := declId? decl
+    | let some pos := stx.getPos? | return #[]
+      return (← Mathlib.Linter.getNamesFrom pos).map (·.getId)
+  let modifiers ← elabModifiers ⟨stx[0]⟩
+  let (shortName, _) := Lean.Elab.expandDeclIdCore declId
+  let currNamespace ← getCurrNamespace
+  let env ← getEnv
+  let declName :=
+    if (`_root_).isPrefixOf shortName then shortName.replacePrefix `_root_ .anonymous
+    else currNamespace ++ shortName
+  return #[if modifiers.isPrivate then mkPrivateName env declName else declName]
+
+/-- Whether every declaration in `declNames` is `Prop`-valued, and there is at least one.
+
+A `Prop`-valued declaration whose proof is `sorry` is a statement waiting to be proved, exactly
+like a `theorem`, rather than a placeholder definition. This is what lets a `Prop`-valued
+`instance`, such as `instance mordell_weil : Module.Finite ℤ E.Point := by sorry`, state a
+conjecture. -/
+def isPropValued (declNames : Array Name) : CommandElabM Bool := do
+  let declNames := declNames.filter (!·.isInternal)
+  if declNames.isEmpty then return false
+  let env ← getEnv
+  liftTermElabM <| declNames.allM fun declName => do
+    -- `findAsync?` rather than `find?` so that this also sees a declaration of the file being
+    -- elaborated; `toConstantVal` only needs the signature, which is available right away.
+    let some info := env.findAsync? declName | return false
+    isProp info.toConstantVal.type
+
 /-- Checks a declaration command for stubs, placeholder definitions, and axioms. -/
 def checkDecl (stx : Syntax) : CommandElabM Unit := do
   if stx.getKind == ``Lean.Parser.Command.declaration then
@@ -59,7 +100,7 @@ def checkDecl (stx : Syntax) : CommandElabM Unit := do
             kind == ``Lean.Parser.Command.abbrev ||
             kind == ``Lean.Parser.Command.instance ||
             kind == ``Lean.Parser.Command.structure then
-      if hasSorry decl then
+      if hasSorry decl && !(← isPropValued (← declNames stx decl)) then
         logLintIf linter.style.stubs stx
           "Placeholder definitions (e.g., `def foo : Type := sorry`) are not allowed."
 


### PR DESCRIPTION
These should not be considered stub definitions since they are Prop-valued.