### PR TITLE
feat(FormalConjecturesUtil): linter for answer(sorry) in solved statements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,6 +335,13 @@ is outside of the scope of this repository.
   problem has been solved, `answer(sorry)` should be replaced by
   `answer(True)` or `answer(False)` accordingly.
 
+  The `linter.style.category_answer` linter enforces this: it warns when a
+  declaration tagged `@[category research solved]` still uses `answer(sorry)`.
+  A statement that deliberately keeps the placeholder, for instance because the
+  problem is independent of ZFC or because the answer is a constant that is not
+  known explicitly, can opt out with
+  `set_option linter.style.category_answer false in`.
+
   If the problem is not stated as a question, the following style is preferred:
 
   ```lean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,13 +335,6 @@ is outside of the scope of this repository.
   problem has been solved, `answer(sorry)` should be replaced by
   `answer(True)` or `answer(False)` accordingly.
 
-  The `linter.style.category_answer` linter enforces this: it warns when a
-  declaration tagged `@[category research solved]` still uses `answer(sorry)`.
-  A statement that deliberately keeps the placeholder, for instance because the
-  problem is independent of ZFC or because the answer is a constant that is not
-  known explicitly, can opt out with
-  `set_option linter.style.category_answer false in`.
-
   If the problem is not stated as a question, the following style is preferred:
 
   ```lean

--- a/FormalConjectures/ErdosProblems/1007.lean
+++ b/FormalConjectures/ErdosProblems/1007.lean
@@ -36,6 +36,9 @@ variable {V : Type*}
 /-- The complete tripartite graph $K_{1,3,3}$. -/
 abbrev K133 := SimpleGraph.completeMultipartiteGraph fun i : Fin 3 => Fin (![1, 3, 3] i)
 
+-- The headline keeps the question form; the answer is recorded in
+-- `erdos_1007.variants.dimension_four` below.
+set_option linter.style.category_answer false in
 /--
 The dimension of a graph $G$ is the minimal $n$ such that $G$ can be embedded in $\mathbb{R}^n$
 such that every edge of $G$ is a unit line segment.

--- a/FormalConjectures/ErdosProblems/1007.lean
+++ b/FormalConjectures/ErdosProblems/1007.lean
@@ -36,30 +36,18 @@ variable {V : Type*}
 /-- The complete tripartite graph $K_{1,3,3}$. -/
 abbrev K133 := SimpleGraph.completeMultipartiteGraph fun i : Fin 3 => Fin (![1, 3, 3] i)
 
--- The headline keeps the question form; the answer is recorded in
--- `erdos_1007.variants.dimension_four` below.
-set_option linter.style.category_answer false in
 /--
 The dimension of a graph $G$ is the minimal $n$ such that $G$ can be embedded in $\mathbb{R}^n$
 such that every edge of $G$ is a unit line segment.
 
 What is the smallest number of edges in a graph with dimension $4$?
 
-The smallest number of edges is $9$, achieved solely by $K_{3,3}$, proved by House [Ho13]. An
+Answer: The smallest number of edges is $9$, achieved solely by $K_{3,3}$, proved by House [Ho13]. An
 alternative proof was given by Chaffee and Noble [ChNo16], who also prove that the smallest
 number of edges in a graph of dimension $5$ is $15$ (achieved by $K_6$ and $K_{1,3,3}$).
 -/
-@[category research solved, AMS 5 52]
-theorem erdos_1007 :
-    IsLeast {m | ∃ (n : ℕ) (G : SimpleGraph (Fin n)), G.HasDimension 4 ∧ G.edgeSet.ncard = m}
-      answer(sorry) := by
-  sorry
-
-/--
-The smallest number of edges in a graph of dimension $4$ is $9$.
--/
 @[category research solved, AMS 5 52, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1007.lean"]
-theorem erdos_1007.variants.dimension_four :
+theorem erdos_1007 :
     IsLeast {m | ∃ (n : ℕ) (G : SimpleGraph (Fin n)), G.HasDimension 4 ∧ G.edgeSet.ncard = m}
       9 := by
   sorry

--- a/FormalConjectures/ErdosProblems/1026.lean
+++ b/FormalConjectures/ErdosProblems/1026.lean
@@ -56,6 +56,9 @@ def admissibleConstants : Set ℝ :=
   {c : ℝ | ∀ ε : ℝ, 0 < ε → ∀ᶠ n : ℕ in atTop, ∀ x : Fin n → ℝ, Function.Injective x →
     ∃ S ∈ monotonicSubsequenceSums x, (c - ε) / Real.sqrt (n : ℝ) * (∑ i, x i) ≤ S}
 
+-- The headline keeps the question form; the answer is recorded in
+-- `erdos_1026.variants.eq_one` below.
+set_option linter.style.category_answer false in
 /--
 Let $x_1,\ldots,x_n$ be a sequence of distinct real numbers. Determine
 $$

--- a/FormalConjectures/ErdosProblems/1026.lean
+++ b/FormalConjectures/ErdosProblems/1026.lean
@@ -56,9 +56,6 @@ def admissibleConstants : Set ℝ :=
   {c : ℝ | ∀ ε : ℝ, 0 < ε → ∀ᶠ n : ℕ in atTop, ∀ x : Fin n → ℝ, Function.Injective x →
     ∃ S ∈ monotonicSubsequenceSums x, (c - ε) / Real.sqrt (n : ℝ) * (∑ i, x i) ≤ S}
 
--- The headline keeps the question form; the answer is recorded in
--- `erdos_1026.variants.eq_one` below.
-set_option linter.style.category_answer false in
 /--
 Let $x_1,\ldots,x_n$ be a sequence of distinct real numbers. Determine
 $$
@@ -86,14 +83,7 @@ and is also implicit in work of Wagner [Wa17]. A proof was given and formalised 
 $c=1$.
 -/
 @[category research solved, AMS 5]
-theorem erdos_1026 : IsGreatest admissibleConstants answer(sorry) := by
-  sorry
-
-/--
-In particular, this shows that $c=1$.
--/
-@[category research solved, AMS 5]
-theorem erdos_1026.variants.eq_one : IsGreatest admissibleConstants 1 := by
+theorem erdos_1026 : IsGreatest admissibleConstants 1 := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/1119.lean
+++ b/FormalConjectures/ErdosProblems/1119.lean
@@ -35,6 +35,8 @@ open scoped Cardinal
 
 namespace Erdos1119
 
+-- The question is independent of ZFC (see the docstring), so the answer stays a placeholder.
+set_option linter.style.category_answer false in
 /--
 Let $\mathfrak{m}$ be an infinite cardinal with $\aleph_0 < \mathfrak{m} < \mathfrak{c} =
 2^{\aleph_0}$. Let $\{f_\alpha\}$ be a family of entire functions such that, for every

--- a/FormalConjectures/ErdosProblems/1175.lean
+++ b/FormalConjectures/ErdosProblems/1175.lean
@@ -53,6 +53,9 @@ theorem erdos_1175 : answer(sorry) ↔
           ∃ (H : G.Subgraph), H.coe.CliqueFree 3 ∧ H.coe.chromaticCardinal = κ := by
   sorry
 
+-- A consistency statement, not a ZFC theorem (see the formalization caveat in the docstring),
+-- so the answer stays a placeholder.
+set_option linter.style.category_answer false in
 /--
 **Shelah's consistency result**: it is consistent with ZFC that there exists a graph $G$ with
 chromatic number $\aleph_1$ such that every triangle-free subgraph of $G$ has chromatic number

--- a/FormalConjectures/ErdosProblems/416.lean
+++ b/FormalConjectures/ErdosProblems/416.lean
@@ -69,6 +69,8 @@ theorem erdos_416.variants.Erdos : ∃ f : ℝ → ℝ, f =o[atTop] (1 : ℝ →
     ∀ᶠ x in Filter.atTop, V x = x * x.log ^ (-1 + f x) := by
   sorry
 
+-- The constant `C` is not known explicitly, so the answer stays a placeholder.
+set_option linter.style.category_answer false in
 /--
 Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
 `V(x)=x/logx * e^((C+o(1))(log log log x)^2)`, for some explicit constant `C>0`.
@@ -81,6 +83,8 @@ theorem erdos_416.variants.Maier_Pomerance :
       ∀ᶠ x in Filter.atTop, (V x : ℝ) = x / x.log * (rexp <| (C + f x) * x.log.log.log ^ 2) := by
   sorry
 
+-- The constants `C₁, C₂, C₃` are not known explicitly, so the answer stays a placeholder.
+set_option linter.style.category_answer false in
 /--
 Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
 `V(x) ≍ x/log x*e^(C_1*(log log log x − log log log log x)^2+C_2 log log log x − C_3 log log log log x)`

--- a/FormalConjectures/ErdosProblems/416.lean
+++ b/FormalConjectures/ErdosProblems/416.lean
@@ -69,7 +69,7 @@ theorem erdos_416.variants.Erdos : ∃ f : ℝ → ℝ, f =o[atTop] (1 : ℝ →
     ∀ᶠ x in Filter.atTop, V x = x * x.log ^ (-1 + f x) := by
   sorry
 
--- The constant `C` is not known explicitly, so the answer stays a placeholder.
+-- TODO: define the constant from the paper, 0.8178146... here and add it in the statement
 set_option linter.style.category_answer false in
 /--
 Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.
@@ -83,7 +83,7 @@ theorem erdos_416.variants.Maier_Pomerance :
       ∀ᶠ x in Filter.atTop, (V x : ℝ) = x / x.log * (rexp <| (C + f x) * x.log.log.log ^ 2) := by
   sorry
 
--- The constants `C₁, C₂, C₃` are not known explicitly, so the answer stays a placeholder.
+-- TODO: add the constants `C₁, C₂, C₃` from the paper here
 set_option linter.style.category_answer false in
 /--
 Let `V(x)` count the number of `n≤x` such that `ϕ(m)=n` is solvable.

--- a/FormalConjectures/ErdosProblems/975.lean
+++ b/FormalConjectures/ErdosProblems/975.lean
@@ -72,6 +72,9 @@ theorem erdos_975.variants.lower_bound (f : ℤ[X]) (hf : Irreducible f) (hfdeg 
     (fun x ↦ x * log x) =O[atTop] Erdos975Sum f := by
   sorry
 
+-- The constant is only known in terms of Hurwitz class numbers, which are not yet formalized
+-- (see the `TODO` below), so the answer stays a placeholder.
+set_option linter.style.category_answer false in
 /--
 When $f$ is an irreducible quadratic polynomial, the question is answered first by Hooley [Ho63].
 More compact expression of the constant in terms of Hurwitz class numbers (when $a = 1$)

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -29,6 +29,9 @@ open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
+-- TODO: this statement is tagged `solved` but does not record the answer; determine it and
+-- replace `answer(sorry)` with `answer(True)` or `answer(False)`.
+set_option linter.style.category_answer false in
 /--
 WOWII [Conjecture 34](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 

--- a/FormalConjecturesTest/Util/Linters/CategoryAnswerLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/CategoryAnswerLinter.lean
@@ -72,11 +72,4 @@ theorem not_flagged_explicit_answer : answer(True) ↔ 1 + 1 = 2 := by
 theorem not_flagged_open_answer_sorry : answer(sorry) ↔ 1 + 1 = 2 := by
   sorry
 
-set_option linter.style.category_answer false in
-#guard_msgs in
-/-- A deliberate placeholder can opt out of the linter. -/
-@[category research solved]
-theorem not_flagged_opt_out : answer(sorry) ↔ 1 + 1 = 2 := by
-  sorry
-
 end CategoryAnswerLinter

--- a/FormalConjecturesTest/Util/Linters/CategoryAnswerLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/CategoryAnswerLinter.lean
@@ -1,0 +1,82 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public meta import FormalConjecturesUtil.Linters.CategoryAnswerLinter
+public import FormalConjecturesUtil.Answer
+
+@[expose] public section
+
+-- Off by default; on here because this file is what tests it.
+set_option linter.style.category_answer true
+
+namespace CategoryAnswerLinter
+
+/--
+warning: Declarations tagged `@[category research solved]` should not use `answer(sorry)`: the answer should be filled in explicitly, e.g. `answer(True)`.
+
+Note: This linter can be disabled with `set_option linter.style.category_answer false`
+-/
+#guard_msgs in
+/-- A solved problem should not leave its answer unfilled. -/
+@[category research solved]
+theorem flagged_solved_answer_sorry : answer(sorry) ↔ 1 + 1 = 2 := by
+  sorry
+
+/--
+warning: Declarations tagged `@[category research solved]` should not use `answer(sorry)`: the answer should be filled in explicitly, e.g. `answer(True)`.
+
+Note: This linter can be disabled with `set_option linter.style.category_answer false`
+-/
+#guard_msgs in
+/-- The `sorry` is still a placeholder when it carries a type ascription. -/
+@[category research solved]
+theorem flagged_ascribed_answer_sorry : answer((sorry : Nat)) = 2 := by
+  sorry
+
+/--
+warning: Declarations tagged `@[category research solved]` should not use `answer(sorry)`: the answer should be filled in explicitly, e.g. `answer(True)`.
+
+Note: This linter can be disabled with `set_option linter.style.category_answer false`
+-/
+#guard_msgs in
+/-- An answer bound by a `let` is flagged too. -/
+@[category research solved]
+theorem flagged_let_answer_sorry :
+    let c : Nat := answer(sorry)
+    0 < c := by
+  sorry
+
+#guard_msgs in
+/-- A solved problem with an explicit answer is fine. -/
+@[category research solved]
+theorem not_flagged_explicit_answer : answer(True) ↔ 1 + 1 = 2 := by
+  simp
+
+#guard_msgs in
+/-- An open problem may leave its answer unfilled. -/
+@[category research open]
+theorem not_flagged_open_answer_sorry : answer(sorry) ↔ 1 + 1 = 2 := by
+  sorry
+
+set_option linter.style.category_answer false in
+#guard_msgs in
+/-- A deliberate placeholder can opt out of the linter. -/
+@[category research solved]
+theorem not_flagged_opt_out : answer(sorry) ↔ 1 + 1 = 2 := by
+  sorry
+
+end CategoryAnswerLinter

--- a/FormalConjecturesUtil.lean
+++ b/FormalConjecturesUtil.lean
@@ -20,6 +20,7 @@ public import FormalConjecturesForMathlib
 public import FormalConjecturesUtil.Answer
 public import FormalConjecturesUtil.Linters.AMSLinter
 public import FormalConjecturesUtil.Linters.AnswerLinter
+public import FormalConjecturesUtil.Linters.CategoryAnswerLinter
 public import FormalConjecturesUtil.Linters.CategoryDocstringLinter
 public import FormalConjecturesUtil.Linters.CategoryLinter
 public import FormalConjecturesUtil.Linters.CopyrightLinter

--- a/FormalConjecturesUtil/Attributes/Basic.lean
+++ b/FormalConjecturesUtil/Attributes/Basic.lean
@@ -287,6 +287,32 @@ def Syntax.toCategory (stx : TSyntax ``CategorySyntax) : CoreM Category := do
 
 syntax (name := Category_attr) "category" CategorySyntax : attr
 
+section
+open Command Parser Term
+
+/-- Extract the `category` attributes from a declaration's modifiers. -/
+def toCategorySyntax
+    (stx : TSyntax ``Command.declModifiers) :
+    CommandElabM (Array <| TSyntax ``attrInstance) := do
+  match stx with
+  | `(declModifiers| $(_)? @[$[$atts],*] $(_)? $(_)? $(_)? $(_)?) =>
+    atts.filterM fun att ↦ do
+      match att with
+      | `(attrInstance | category $_) => return true
+      | _ => return false
+  | _ => return #[]
+
+/-- Extract the categories from a declaration's modifiers. -/
+def toCategories
+    (stx : TSyntax ``Command.declModifiers) :
+    CommandElabM (Array Category) := do
+  let cats ← toCategorySyntax stx
+  cats.mapM fun
+    | `(attrInstance | category $s) => liftCoreM <| Syntax.toCategory s
+    | _ => throwUnsupportedSyntax
+
+end
+
 /-- Specifies the type of a statement.
 
 This is used as follows: `@[category my_cat]` where `my_cat` is one of:

--- a/FormalConjecturesUtil/Linters/CategoryAnswerLinter.lean
+++ b/FormalConjecturesUtil/Linters/CategoryAnswerLinter.lean
@@ -1,0 +1,78 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import FormalConjecturesUtil.Attributes.Basic
+public import FormalConjecturesUtil.Answer.Syntax
+public import Mathlib.Tactic.Lemma
+
+/-! # The Category Answer Linter
+
+The `CategoryAnswerLinter` ensures that declarations tagged `@[category research solved]`
+do not leave `answer(sorry)` in their statement: once a problem is solved, the answer should
+be filled in explicitly, e.g. `answer(True)`.
+
+The check is syntactic. Under the default `google.answer` setting, `answer(sorry)` at `Prop`
+elaborates to a bare `True` carrying no annotation, so the placeholder is no longer visible
+in the elaborated term.
+
+A statement that deliberately keeps `answer(sorry)` (for instance because the problem is
+independent of ZFC, or because the answer is a constant that is not known explicitly) can opt
+out with `set_option linter.style.category_answer false in`.
+-/
+
+public meta section
+
+open Lean Elab Meta Linter Command Parser Term ProblemAttributes
+
+register_option linter.style.category_answer : Bool := {
+  defValue := false
+  descr := "enable the linter checking for `answer(sorry)` in solved statements"
+}
+
+namespace CategoryAnswerLinter
+
+/-- Whether `stx` contains a `sorry` anywhere. -/
+partial def containsSorry (stx : Syntax) : Bool :=
+  stx.isOfKind ``Lean.Parser.Term.sorry || stx.getArgs.any containsSorry
+
+/-- The `answer(..)` nodes in `stx` whose answer is still a `sorry`. -/
+partial def answerSorries (stx : Syntax) : Array Syntax :=
+  let nested := stx.getArgs.foldl (init := #[]) fun acc arg => acc ++ answerSorries arg
+  if stx.isOfKind ``Google.answer && containsSorry stx[1] then nested.push stx else nested
+
+/-- Whether the given category is `research solved`. -/
+def categoryNeedsAnswer (cat : ProblemAttributes.Category) : Bool :=
+  cat == .research .solved
+
+/-- The linter checking that solved statements do not use `answer(sorry)`. -/
+def categoryAnswerLinter : Linter where
+  run := withSetOptionIn fun stx => do
+    match stx with
+    | `(command| $mods:declModifiers theorem $_:declId $sig:declSig $_:declVal)
+    | `(command| $mods:declModifiers lemma $_:declId $sig:declSig $_:declVal) =>
+      let cats ← ProblemAttributes.toCategories mods
+      if cats.any categoryNeedsAnswer then
+        for answer in answerSorries sig.raw do
+          logLintIf linter.style.category_answer answer
+            "Declarations tagged `@[category research solved]` should not use `answer(sorry)`: \
+            the answer should be filled in explicitly, e.g. `answer(True)`."
+    | _ => return
+
+initialize do
+  addLinter categoryAnswerLinter
+
+end CategoryAnswerLinter

--- a/FormalConjecturesUtil/Linters/CategoryDocstringLinter.lean
+++ b/FormalConjecturesUtil/Linters/CategoryDocstringLinter.lean
@@ -35,27 +35,6 @@ register_option linter.style.category_docstring : Bool := {
 
 namespace CategoryDocstringLinter
 
-/-- Extract the `category` attributes from a declaration's modifiers. -/
-def toCategorySyntax
-    (stx : TSyntax ``Command.declModifiers) :
-    CommandElabM (Array <| TSyntax ``attrInstance) := do
-  match stx with
-  | `(declModifiers| $(_)? @[$[$atts],*] $(_)? $(_)? $(_)? $(_)?) =>
-    atts.filterM fun att ↦ do
-      match att with
-      | `(attrInstance | category $_) => return true
-      | _ => return false
-  | _ => return #[]
-
-/-- Extract the categories from a declaration's modifiers. -/
-def toCategories
-    (stx : TSyntax ``Command.declModifiers) :
-    CommandElabM (Array ProblemAttributes.Category) := do
-  let cats ← toCategorySyntax stx
-  cats.mapM fun
-    | `(attrInstance | category $s) => liftCoreM <| ProblemAttributes.Syntax.toCategory s
-    | _ => throwUnsupportedSyntax
-
 /-- Whether the given category requires a docstring. -/
 def categoryNeedsDocstring : ProblemAttributes.Category → Bool
   | .research .open | .research .solved | .textbook => true

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -56,6 +56,7 @@ warn.sorry = false
 # our own linters which only make sense for the problems themselves
 weak.linter.style.ams_attribute = true
 weak.linter.style.category_attribute = true
+weak.linter.style.category_answer = true
 weak.linter.style.conditional_formal_proof = true
 weak.linter.style.moduleDocstring = true
 weak.linter.style.latex_docstring = true
@@ -70,6 +71,7 @@ warn.sorry = false
 # our own linters which only make sense for the problems themselves
 weak.linter.style.ams_attribute = true
 weak.linter.style.category_attribute = true
+weak.linter.style.category_answer = true
 weak.linter.style.conditional_formal_proof = true
 weak.linter.style.moduleDocstring = true
 weak.linter.style.latex_docstring = true


### PR DESCRIPTION
follow-up pr to #4965: a linter that catches the `answer(sorry)` placeholders that
PR fixed by hand. Part of #1407.

`linter.style.category_answer` warns when a declaration tagged `@[category research solved]`
still writes `answer(sorry)`. The check has to be syntactic: under the default `google.answer`
setting, `answer(sorry)` at `Prop` elaborates to a bare `True`, so by the time the term exists
the placeholder is gone. It scans the whole `declSig`, so it also catches value-position
answers such as `IsGreatest S answer(sorry)`, not just `answer(sorry) ↔ …`.

This is the category-aware complement to #1958's `AnswerLinter`, which checks quantifier
scoping but does not read the category.

- The shared `toCategorySyntax`/`toCategories` helpers move from `CategoryDocstringLinter` into
  `Attributes/Basic` so both linters use them.
- Six statements deliberately keep the placeholder and opt out with
  `set_option linter.style.category_answer false in`, each with a comment giving the reason:
  independence of ZFC (1119, 1175), constants not known explicitly (416, twice, and 975), and a
  TODO in `GraphConjecture34`.
- In 1007 and 1026 the question-form headline and the answered variant say the same thing twice,
  so this PR merges each pair into one theorem carrying the answer, rather than opting out.
- Off by default; enabled repo-wide through `weak.linter.style.category_answer` in
  `lakefile.toml`, matching how the other style linters are switched on.
- A repo-wide scan finds no `research solved` declaration with a surviving `answer(sorry)`
  beyond those six. For reference, `main` currently has 1575 such declarations with 8 carrying
  the placeholder; this branch has 1573 with none, the difference being the two merged pairs.

Re-verified on current `main` at v4.33.1 after the 08-23 toolchain bumps:

- [x] `lake --wfail build FormalConjecturesForMathlib FormalConjecturesUtil` — clean (8896 jobs)
- [x] `lake --wfail test` — clean (8903 jobs); the new
      `FormalConjecturesTest/Util/Linters/CategoryAnswerLinter.lean` pins both the firing and the
      silent cases with `#guard_msgs`
- [x] Negative control: temporarily removing one opt-out makes the linter fire at the expected
      line, and restoring it silences the warning again
