### PR TITLE
Mark OEIS A070823 as solved

### DIFF
--- a/FormalConjectures/OEIS/70823.lean
+++ b/FormalConjectures/OEIS/70823.lean
@@ -75,10 +75,16 @@ theorem a_5 : a 5 = 243 := by
 /--
 $a(n) \equiv 0 \pmod 3$ if $n > 2$. Is $a(n)$ always of the form $2^j \cdot 3^k \cdot s$
 where $s$ is a squarefree number?
+
+Answer: False
 -/
-@[category research open, AMS 11]
-theorem conjecture (n : ℕ) (hn : 2 < n) :
-    a n ≡ 0 [MOD 3] ∧ ∃ j k s : ℕ, a n = 2 ^ j * 3 ^ k * s ∧ Squarefree s := by
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a070823-counterexample/blob/51399770e734616c6463be034e41f7469991d752/lean/OeisA70823CounterexampleFC.lean#L72-L81"]
+theorem conjecture :
+    answer(False) ↔ ∀ n : ℕ, 2 < n →
+      a n ≡ 0 [MOD 3] ∧
+        ∃ j k s : ℕ, a n = 2 ^ j * 3 ^ k * s ∧ Squarefree s := by
   sorry
 
 end OeisA70823

--- a/FormalConjectures/OEIS/70823.lean
+++ b/FormalConjectures/OEIS/70823.lean
@@ -76,7 +76,7 @@ theorem a_5 : a 5 = 243 := by
 $a(n) \equiv 0 \pmod 3$ if $n > 2$. Is $a(n)$ always of the form $2^j \cdot 3^k \cdot s$
 where $s$ is a squarefree number?
 
-Answer: False
+Answer: False, $a(20)$ is divisible by $13^2$ but not by $13^3$.
 -/
 @[category research solved, AMS 11,
   formal_proof using lean4 at


### PR DESCRIPTION
This PR keeps the existing single `OeisA70823.conjecture` target and changes it from `research open` to a solved `answer(False)` statement. It does not introduce an additional target.

The counterexample is `n = 20`.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the single corrected target:

```lean
theorem formal_conjectures_answer_false :
    answer(False) ↔
      ∀ n : ℕ, 2 < n →
        OeisA70823.a n ≡ 0 [MOD 3] ∧
          ∃ j k s : ℕ,
            OeisA70823.a n = 2 ^ j * 3 ^ k * s ∧ Squarefree s
```

Proof: https://github.com/KitaKen1/oeis-a070823-counterexample/blob/51399770e734616c6463be034e41f7469991d752/lean/OeisA70823CounterexampleFC.lean#L72-L81

Repository: https://github.com/KitaKen1/oeis-a070823-counterexample

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a070823-counterexample%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA70823CounterexampleLean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: This formalization was developed with assistance from OpenAI Codex.