### PR TITLE
Erdős 470: record a formal proof of variants.abundancy_index

### DIFF
--- a/FormalConjectures/ErdosProblems/470.lean
+++ b/FormalConjectures/ErdosProblems/470.lean
@@ -122,7 +122,8 @@ theorem erdos_470.variants.odd_weird_prime_div :
 /--
 If there are no odd weird numbers then every weird number has abundancy index < 4.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/HowieHwong/lean-erdos-proofs/blob/40216cfee225ec5c9f122a48703e671a9f47db90/Erdos/P470.lean#L88"]
 theorem erdos_470.variants.abundancy_index :
     (∀ n : ℕ, n.Weird → ¬Odd n) → ∀ n, n.Weird → AbundancyIndex n < 4 := by
   sorry


### PR DESCRIPTION
Records a `formal_proof` link for `erdos_470.variants.abundancy_index`:

> If there are no odd weird numbers then every weird number has abundancy index `< 4`.

The statement is unchanged and the `sorry` stays. Per `PROOFS.md` the proof is long (154 lines), so it lives in an external repository rather than here:

**https://github.com/HowieHwong/lean-erdos-proofs/blob/40216cfee225ec5c9f122a48703e671a9f47db90/Erdos/P470.lean#L88**

### Checks from PROOFS.md

- **The linked statement is the repository statement.** Byte-identical, including `AbundancyIndex`, which the linked file defines exactly as `ErdosProblems/470.lean` does. `Nat.Weird`, `Nat.Pseudoperfect` and `Nat.Abundant` come from Mathlib and are unchanged between `v4.27.0` (this repo) and `v4.32.0` (the linked proof) apart from an added `deriving Decidable`, which does not change the propositions.
- **No `sorry` and no custom axioms.** Every declaration in the linked file:

  ```
  #print axioms Erdos470.erdos_470.variants.abundancy_index
  -- [propext, Classical.choice, Quot.sound]
  ```

  Also clean for `abundancyIndex_eq`, `pseudoperfect_of_dvd`, `abundancyIndex_lt_two_mul_odd`, `odd_weird_divisor_of_weird` and `abundancyIndex_sharp`. No `native_decide`.
- **Pinned.** Lean `v4.32.0`, Mathlib [`81a5d257`](https://github.com/leanprover-community/mathlib4/tree/81a5d257c8e410db227a6665ed08f64fea08e997).

### On novelty

The mathematics is not new and is not claimed to be. The dichotomy is Weisenberg's observation, recorded at [erdosproblems.com/825](https://www.erdosproblems.com/825): *if `n` is a weird number with an abundancy index `≥ 4` then it is divisible by an odd weird number.* The contribution here is only the machine-checked proof.

The linked file also proves `abundancyIndex_sharp`, a quantitative sharpening of the same bound. It is not an upstream statement and nothing here depends on it.

### Provenance

The proof was produced by **Levain-7**, an unreleased autonomous research agent, and checked with `#print axioms` before submission.