### PR TITLE
Mark OEIS A049473 conjecture as solved

### DIFF
--- a/FormalConjectures/OEIS/49473.lean
+++ b/FormalConjectures/OEIS/49473.lean
@@ -185,7 +185,9 @@ A049473 consists solely of $0$'s and $1$'s, in positions given by the nonhomogen
 sequences A001954 and A001953, respectively.
 - Clark Kimberling, Oct 05 2014
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/oeis-a049473-zeta3-beatty/blob/b3a74bf/lean/OeisA49473FC.lean#L667-L673"]
 theorem conjecture :
     (∀ n : ℕ, 1 ≤ n → s (a n) < 1 / (n : ℝ) ^ 2 ∧ 1 / (n : ℝ) ^ 2 < s (a n - 1)) ∧
     (∀ n : ℕ, 1 ≤ n →


### PR DESCRIPTION
This PR changes `OeisA49473.conjecture` from `@[category research open]` to `@[category research solved]` and links a kernel-checked Lean proof. The statement itself is unchanged.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target proposition:

```lean
theorem OeisA49473Proof.oeis_a049473_conjecture_solved :
    (∀ n : ℕ, 1 ≤ n →
      s (a n) < 1 / (n : ℝ) ^ 2 ∧ 1 / (n : ℝ) ^ 2 < s (a n - 1)) ∧
    (∀ n : ℕ, 1 ≤ n →
      let diff : ℕ := a n - a (n - 1)
      (diff = 0 ↔ n - 1 ∈ A001954) ∧ (diff = 1 ↔ n - 1 ∈ A001953))
```

Proof: https://github.com/KitaKen1/oeis-a049473-zeta3-beatty/blob/b3a74bf/lean/OeisA49473FC.lean#L667-L673

Repository: https://github.com/KitaKen1/oeis-a049473-zeta3-beatty

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Foeis-a049473-zeta3-beatty%2Frefs%2Fheads%2Fmain%2Flean4web%2FOeisA49473Lean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`, `native_decide`, custom axiom, or `unsafe` declaration.

AI Usage Disclosure: This formalization was assisted by OpenAI Codex.