### PR TITLE
Erdős 730: mark solved and record the registered formal proof

### DIFF
--- a/FormalConjectures/ErdosProblems/730.lean
+++ b/FormalConjectures/ErdosProblems/730.lean
@@ -22,6 +22,12 @@ import FormalConjecturesUtil
 *References:*
   - [erdosproblems.com/730](https://www.erdosproblems.com/730)
   - [A129515](https://oeis.org/A129515)
+  - [PALOMAR-2026-08-22-000001](https://palomar-registry.org/entry.html?id=PALOMAR-2026-08-22-000001&version=1):
+    a Lean 4 proof that there are infinitely many such pairs, checked by Comparator
+    against the statement `S.Infinite` below and registered with the Palomar registry.
+    The proof follows an argument posted on the erdosproblems.com forum
+    (Liam Price, 24 June 2026), which shows that there are infinitely many
+    consecutive pairs $(n, n+1)$.
 -/
 namespace Erdos730
 
@@ -32,9 +38,13 @@ abbrev S :=
 /--
 Are there infinitely many pairs of integers $n < m$ such that $\binom{2n}{n}$
 and $\binom{2m}{m}$ have the same set of prime divisors?
+
+Yes: there are infinitely many consecutive pairs $(n, n+1)$. The formal proof
+registered as [PALOMAR-2026-08-22-000001] proves `S.Infinite` for this `S`.
 -/
-@[category research open, AMS 11]
-theorem erdos_730 : answer(sorry) ↔ S.Infinite := by
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/williamjblair/lean-proofs/blob/03729c9cbb0b602f5a828bb850c85e84c5a6d460/ErdosProblems/Erdos730/FullDensityTheorem.lean#L40"]
+theorem erdos_730 : answer(True) ↔ S.Infinite := by
   sorry
 
 /--


### PR DESCRIPTION
Marks Erdős Problem 730 as solved and records the formal proof.

## The proof

A Lean 4 proof that

```lean
{(n, m) : ℕ × ℕ | n < m ∧ n.centralBinom.primeFactors = m.centralBinom.primeFactors}
```

is infinite is registered with the Palomar registry as [PALOMAR-2026-08-22-000001](https://palomar-registry.org/entry.html?id=PALOMAR-2026-08-22-000001&version=1). Palomar recompiled the statement on its own against Mathlib `db584cd6` (Lean v4.33.0), checked the proof with both the Lean kernel and NanoDa under the axioms `propext`, `Quot.sound`, `Classical.choice`, and its editorial review found no problems. The registered Challenge inlines this file's `S` verbatim and states `S.Infinite`.

It shows that there are infinitely many consecutive pairs `(n, n+1)`, following the argument Liam Price posted on the [erdosproblems.com forum](https://www.erdosproblems.com/forum/thread/730) on 24 June 2026; the analytic steps are reconstructed in the formalisation. The proof was produced with AI assistance, as the registry record's provenance states.

## For the `formal_proof` checklist in `PROOFS.md`

1. Linked declaration: [`Erdos730.FullDensityTheorem.pairSet_infinite`](https://github.com/williamjblair/lean-proofs/blob/03729c9cbb0b602f5a828bb850c85e84c5a6d460/ErdosProblems/Erdos730/FullDensityTheorem.lean#L40) in `williamjblair/lean-proofs` at `03729c9c`.
2. Its statement is `FullDensityCore.PairSet.Infinite`, where [`PairSet`](https://github.com/williamjblair/lean-proofs/blob/03729c9cbb0b602f5a828bb850c85e84c5a6d460/ErdosProblems/Erdos730/FullDensityCore.lean#L147) is `{z | z.1 < z.2 ∧ z.1.centralBinom.primeFactors = z.2.centralBinom.primeFactors}`, this file's `S` with the pair written as `z`. The registered [Solution](https://github.com/williamjblair/lean-proofs/blob/03729c9cbb0b602f5a828bb850c85e84c5a6d460/PalomarSolutions/Erdos730.lean) proves the Challenge's inlined set with `pairSet_infinite` itself, so both kernels checked that `PairSet` and `S` agree by definitional equality ([verification run 32546908101](https://github.com/PalomarRegistry/PalomarSubmission/actions/runs/32546908101)).
3. No `sorry`, no custom axioms anywhere in the closure (`scripts/check_axioms.sh` in that repository gates every headline theorem).
4. `#print axioms`: `[propext, Classical.choice, Quot.sound]`.
5. Kind `lean4`, commit-pinned link.

## Changes

- `erdos_730`: `research open` → `research solved`, `answer(sorry)` → `answer(True)`, `@[formal_proof using lean4 at …]`; the `sorry` stays.
- References: the registry entry.

Source status checked on 9 September 2026: [erdosproblems.com/730](https://www.erdosproblems.com/730) now describes the problem as solved. The linked Palomar record remains explicitly version 1; its [machine-readable record](https://data.palomar-registry.org/entries/PALOMAR-2026-08-22-000001-v1.json) identifies source commit `03729c9cbb0b602f5a828bb850c85e84c5a6d460`. Registration is proof evidence; FC maintainers still decide this status change.

Merged with current `main` on 17 September; no conflicts in this module. Validation: `lake --wfail build 'FormalConjectures.ErdosProblems.«730»'`. The changed module builds without warnings. This mathematical correction is independently mergeable.

