### PR TITLE
Mark Green's Open Problem 29 as solved

### DIFF
--- a/FormalConjectures/GreensOpenProblems/29.lean
+++ b/FormalConjectures/GreensOpenProblems/29.lean
@@ -36,9 +36,11 @@ namespace Green29
 
 /-- Suppose that $A$ is a $K$-approximate group (not necessarily abelian). Is there $S \subset A$,
 $|S| \gg K^{-O(1)} |A|$, with $S^8 \subset A^4$? -/
-@[category research open, AMS 20]
+@[category research solved, AMS 20,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/green-29-counterexample/blob/1cbf80c3d5a333b2b79c203c0d60129924c8c712/lean/Green29FC.lean#L280-L287"]
 theorem green_29 :
-    answer(sorry) ↔
+    answer(False) ↔
       ∃ C c : ℝ, 0 < C ∧ 0 < c ∧
         ∀ {G : Type*} [Group G] [DecidableEq G] (K : ℝ) (A : Finset G),
           1 ≤ K → IsApproximateSubgroup K (A : Set G) →

--- a/FormalConjectures/GreensOpenProblems/29.lean
+++ b/FormalConjectures/GreensOpenProblems/29.lean
@@ -35,7 +35,11 @@ open scoped Pointwise
 namespace Green29
 
 /-- Suppose that $A$ is a $K$-approximate group (not necessarily abelian). Is there $S \subset A$,
-$|S| \gg K^{-O(1)} |A|$, with $S^8 \subset A^4$? -/
+$|S| \gg K^{-O(1)} |A|$, with $S^8 \subset A^4$?
+
+The answer is negative. A counterexample is given, for arbitrarily large finite groups `H`, by
+`A = ({-1} × H) ∪ ({1} × H) ∪ {(0, 1)}` in `Multiplicative ℤ × H`.
+-/
 @[category research solved, AMS 20,
   formal_proof using lean4 at
     "https://github.com/KitaKen1/green-29-counterexample/blob/1cbf80c3d5a333b2b79c203c0d60129924c8c712/lean/Green29FC.lean#L280-L287"]


### PR DESCRIPTION
This PR changes `Green29.green_29` from `answer(sorry)` to `answer(False)` and links a kernel-checked Lean proof.

It leaves the already-solved declaration `Green29.green_29.variant` unchanged.

The FC-facing Lean formalization and repository were prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem green_29_solved :
    answer(False) ↔
      ∃ C c : ℝ, 0 < C ∧ 0 < c ∧
        ∀ {G : Type*} [Group G] [DecidableEq G] (K : ℝ) (A : Finset G),
          1 ≤ K → IsApproximateSubgroup K (A : Set G) →
            ∃ S ⊆ A, C * K ^ (-c) * (A.card : ℝ) ≤ (S.card : ℝ) ∧
            S ^ 8 ⊆ A ^ 4
```

Proof: https://github.com/KitaKen1/green-29-counterexample/blob/1cbf80c3d5a333b2b79c203c0d60129924c8c712/lean/Green29FC.lean#L280-L287

Repository: https://github.com/KitaKen1/green-29-counterexample

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Fgreen-29-counterexample%2Frefs%2Fheads%2Fmain%2Flean4web%2FGreen29Lean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx`.

AI Usage Disclosure: The proof and repository were developed with assistance from OpenAI Codex.