### PR TITLE
chore: remove uses of `push_neg`

### DIFF
--- a/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_5.lean
+++ b/FormalConjectures/Books/BugeaudDistributionModuloOne/Problem10_5.lean
@@ -86,7 +86,7 @@ theorem problem_10_5_of_moreover (h : type_of% problem_10_5_moreover) :
       rw [Filter.le_limsup_iff hcob hb]
       exact fun a ha => MapClusterPt.frequently hcluster (eventually_gt_nhds ha)
     linarith [hy.1]
-  · push_neg at hε1
+  · push Not at hε1
     have h0 : (0 : ℝ) ≤ limsup (fun n => Int.fract (ξ * (t n : ℝ))) atTop :=
       le_limsup_of_frequently_le
         ((Filter.Eventually.of_forall

--- a/FormalConjectures/ErdosProblems/1063.lean
+++ b/FormalConjectures/ErdosProblems/1063.lean
@@ -90,8 +90,7 @@ theorem erdos_1063.variants.small_values :
     · apply le_csInf ⟨9, by decide⟩
       rintro b hb
       have hb8 : 8 ≤ b := by have := hb.1; omega
-      by_contra h
-      push_neg at h
+      by_contra! h
       interval_cases b
       · exact absurd hb (by decide)
   · -- n 5 = 12 : the candidates below 12 are m = 10, 11, both of which fail
@@ -100,8 +99,7 @@ theorem erdos_1063.variants.small_values :
     · apply le_csInf ⟨12, by decide⟩
       rintro b hb
       have hb10 : 10 ≤ b := by have := hb.1; omega
-      by_contra h
-      push_neg at h
+      by_contra! h
       interval_cases b
       · exact absurd hb (by decide)
       · exact absurd hb (by decide)

--- a/FormalConjectures/ErdosProblems/1142.lean
+++ b/FormalConjectures/ErdosProblems/1142.lean
@@ -66,7 +66,7 @@ local macro "prove_erdos_1142_prop" bound:num : tactic =>
   `(tactic| (
     refine ⟨by omega, fun k hk hlt => ?_⟩
     have : k ≤ $bound := by
-      by_contra h; push_neg at h
+      by_contra! h
       exact absurd (Nat.pow_le_pow_right (by omega : 1 ≤ 2) h) (by omega)
     interval_cases k <;> simp_all (config := { decide := true })))
 

--- a/FormalConjectures/ErdosProblems/168.lean
+++ b/FormalConjectures/ErdosProblems/168.lean
@@ -79,8 +79,7 @@ lemma F_eq_card (N : ℕ) (S : Finset ℕ) (hS : S ⊆ Finset.Icc 1 N) (hS' : No
     refine Finset.sup_le ?_
     intro T hT
     rw [mem_IntervalNonTernarySets_iff] at hT
-    by_contra h_lt
-    push_neg at h_lt
+    by_contra! h_lt
     have h_eq := hS'' T hT.2 hT.1 (by omega)
     omega
   omega

--- a/FormalConjectures/ErdosProblems/17.lean
+++ b/FormalConjectures/ErdosProblems/17.lean
@@ -121,8 +121,7 @@ theorem isClusterPrime_97_isLeast_non_cluster : IsLeast {p : ℕ | p.Prime ∧ �
   · -- `97` is a lower bound: every prime `< 97` is a cluster prime, so cannot lie
     -- in the set of non-cluster primes.
     rintro b ⟨hbp, hbnc⟩
-    by_contra hlt
-    push_neg at hlt
+    by_contra! hlt
     interval_cases b <;>
       first
         | exact absurd hbp (by decide)

--- a/FormalConjectures/ErdosProblems/18.lean
+++ b/FormalConjectures/ErdosProblems/18.lean
@@ -84,8 +84,7 @@ theorem practicalH_six : practicalH 6 = 2 := by
     apply le_csInf
     · exact ⟨2, {1, 3}, by rw [hdiv]; decide, by decide, {1, 3}, by simp, by decide⟩
     · rintro k ⟨D, hDsub, hDcard, B, hBsub, hBsum⟩
-      by_contra hk
-      push_neg at hk
+      by_contra! hk
       interval_cases k
       · -- D.card = 0 : D = ∅, so B = ∅ and the sum is 0 ≠ 4.
         rw [Finset.card_eq_zero] at hDcard
@@ -132,8 +131,7 @@ theorem practicalH_twelve : practicalH 12 = 3 := by
     apply le_csInf
     · exact ⟨3, {1, 4, 6}, by rw [hdiv]; decide, by decide, {1, 4, 6}, by simp, by decide⟩
     · rintro k ⟨D, hDsub, hDcard, B, hBsub, hBsum⟩
-      by_contra hk
-      push_neg at hk
+      by_contra! hk
       interval_cases k
       · rw [Finset.card_eq_zero] at hDcard
         subst hDcard
@@ -176,7 +174,7 @@ theorem factorial_isPractical (n : ℕ) : Nat.IsPractical n.factorial := by
     by_cases hle : m ≤ n.factorial
     · exact subsetSums_mono (by exact_mod_cast (Nat.divisors_subset_of_dvd
         (Nat.factorial_ne_zero _) (Nat.factorial_dvd_factorial n.le_succ))) (ih m hle)
-    · push_neg at hle; rw [Nat.factorial_succ] at hm
+    · push Not at hle; rw [Nat.factorial_succ] at hm
       set q := m / (n + 1); set r := m % (n + 1)
       have h_div : m = (n + 1) * q + r := (Nat.div_add_mod m (n + 1)).symm
       have h_r_lt : r < n + 1 := Nat.mod_lt m (Nat.succ_pos n)

--- a/FormalConjectures/ErdosProblems/317.lean
+++ b/FormalConjectures/ErdosProblems/317.lean
@@ -68,7 +68,7 @@ $$\frac{1}{2}-\frac{1}{3}-\frac{1}{4}=-\frac{1}{12}.$$
 theorem erdos_317.variants.counterexample : ¬ (∀  δ : (Fin 4) → ℚ, δ '' Set.univ ⊆ {-1,0,1} →
     letI lhs := |∑ k, ((δ k : ℚ) / (k + 1))|
     lhs ≠ 0 → lhs > (1 : ℚ) / ((Icc 1 4).lcm id : ℕ)) := by
-  push_neg
+  push Not
   use ![0, 1, -1, -1]
   norm_num [Finset.sum]
   exact ⟨by grind, by simp; rfl⟩

--- a/FormalConjectures/ErdosProblems/389.lean
+++ b/FormalConjectures/ErdosProblems/389.lean
@@ -46,8 +46,7 @@ theorem erdos_389.variants.mehta_four :
       207 := by
   refine ⟨⟨by norm_num, by native_decide⟩, ?_⟩
   intro k ⟨_, hdvd⟩
-  by_contra hlt
-  push_neg at hlt
+  by_contra! hlt
   interval_cases k <;> revert hdvd <;> native_decide
 
 end Erdos389

--- a/FormalConjectures/ErdosProblems/394.lean
+++ b/FormalConjectures/ErdosProblems/394.lean
@@ -45,8 +45,7 @@ theorem t_eq_of {n k v : ℕ} (hv : 0 < v)
     (hlt : ∀ m ∈ range v, 0 < m → ¬ (n ∣ ∏ i ∈ range k, (m + i))) :
     t k n = v := by
   refine le_antisymm (Nat.sInf_le ⟨hv, hdvd⟩) ?_
-  by_contra hc
-  push_neg at hc
+  by_contra! hc
   have hne : { m : ℕ | 0 < m ∧ n ∣ ∏ i ∈ range k, (m + i) }.Nonempty := ⟨v, hv, hdvd⟩
   obtain ⟨hpos, hd⟩ := Nat.sInf_mem hne
   exact hlt _ (mem_range.mpr hc) hpos hd

--- a/FormalConjectures/ErdosProblems/593.lean
+++ b/FormalConjectures/ErdosProblems/593.lean
@@ -180,8 +180,7 @@ particular, $\chi(H) > \aleph_0$ implies `H` has at least one hyperedge.
 theorem erdos_593.variants.nonempty_edges_if_large_chromatic
     {V : Type} (H : ThreeUniformHypergraph V) (hχ : ℵ₀ < H.chromaticCardinal) :
     H.edges.Nonempty := by
-  by_contra hempty
-  push_neg at hempty
+  by_contra! hempty
   -- H has no edges (hempty : H.edges = ∅), so any coloring is proper.
   have hprop : H.IsProperColoring (fun _ : V => (0 : Fin 1)) := by
     intro e he

--- a/FormalConjectures/ErdosProblems/686.lean
+++ b/FormalConjectures/ErdosProblems/686.lean
@@ -71,7 +71,7 @@ theorem erdos_686.variants.four_two :
       (4 : ℚ) = (∏ i ∈ Finset.Icc 1 2, (m + i)) / (∏ i ∈ Finset.Icc 1 2, (n + i)) := by
   simp only [Finset.prod_Icc_succ_top (by decide : 1 ≤ 2), Finset.Icc_self,
     Finset.prod_singleton]
-  push_neg
+  push Not
   intro n m hm
   rw [ne_eq, eq_div_iff (by positivity : (↑((n + 1) * (n + (1 + 1))) : ℚ) ≠ 0)]
   push_cast

--- a/FormalConjectures/ErdosProblems/700.lean
+++ b/FormalConjectures/ErdosProblems/700.lean
@@ -151,7 +151,7 @@ theorem erdos_700.variants.prime_pow (p a : ℕ) (hp : p.Prime) (ha : 2 ≤ a) :
       · rw [pow_zero, Nat.dvd_one] at hpg; omega
       · exact hj0
     have hj2 : j ≤ 1 := by
-      by_contra h; push_neg at h
+      by_contra! h
       exact hp2g ((Nat.pow_dvd_pow_iff_le_right hp.one_lt).2 h)
     rw [hjeq, show j = 1 from by omega, pow_one]
   have hle : f (p ^ a) ≤ p := by

--- a/FormalConjectures/ErdosProblems/939.lean
+++ b/FormalConjectures/ErdosProblems/939.lean
@@ -100,7 +100,7 @@ $$27^5+84^5+110^5+133^5=144^5$$.
 @[category research solved, AMS 11]
 theorem erdos_939.variants.euler : ¬ (∀ k ≥ 4, ∀ S : Finset ℕ, S.card = k - 1 →
     ¬ (∃ q, ∑ s ∈ S, s ^ k = q ^k)) := by
-  push_neg
+  push Not
   use 5
   norm_num
   use {27, 84, 110, 133}

--- a/FormalConjectures/ErdosProblems/961.lean
+++ b/FormalConjectures/ErdosProblems/961.lean
@@ -46,7 +46,7 @@ theorem erdos_961.variants.sylvester_schur_1_1 : Erdos961Prop 1 1 := by
   constructor
   · simp
   · rw [Nat.mem_smoothNumbers]
-    push_neg
+    push Not
     intro hm0
     obtain ⟨p, hp, hpm⟩ := Nat.exists_prime_and_dvd (by omega : m ≠ 1)
     exact ⟨p, (Nat.mem_primeFactorsList hm0).mpr ⟨hp, hpm⟩, hp.two_le⟩

--- a/FormalConjectures/OEIS/56777.lean
+++ b/FormalConjectures/OEIS/56777.lean
@@ -126,7 +126,7 @@ theorem mod_72_of_comesFromPrimeQuadruple {n : ℕ} (h : ComesFromPrimeQuadruple
     n % 72 = 65 := by
   obtain ⟨p, hp, hp2, hp6, hp8, rfl⟩ := h
   have hp5 : 5 ≤ p := by
-    by_contra hlt; push_neg at hlt
+    by_contra! hlt
     interval_cases p <;> simp_all (config := { decide := true })
   have h2 : ¬ (2 ∣ p) := by
     intro hdvd; cases hp.eq_one_or_self_of_dvd 2 hdvd with | inl h => omega | inr h => omega
@@ -160,7 +160,7 @@ theorem mod_100_of_comesFromPrimeQuadruple {n : ℕ} (h65 : 65 < n) (h : ComesFr
     n % 100 = 9 := by
   obtain ⟨p, hp, hp2, hp6, hp8, rfl⟩ := h
   have hp5 : 5 ≤ p := by
-    by_contra hlt; push_neg at hlt
+    by_contra hlt; push Not at hlt
     interval_cases p <;> simp_all (config := { decide := true })
   have h2 : ¬ (2 ∣ p) := by
     intro hdvd; cases hp.eq_one_or_self_of_dvd 2 hdvd with | inl h => omega | inr h => omega

--- a/FormalConjectures/Paper/CasasAlvero.lean
+++ b/FormalConjectures/Paper/CasasAlvero.lean
@@ -80,7 +80,7 @@ theorem hasCasasAlveroProp_iffᵣ {P : K[X]} [IsAlgClosed K] :
   refine ⟨?_, HasCasasAlveroPropᵣ.hasCasasAlveroProp⟩
   simp_rw [HasCasasAlveroProp, HasCasasAlveroPropᵣ,
     isCoprime_iff_aeval_ne_zero_of_isAlgClosed K K, coe_aeval_eq_eval]
-  push_neg
+  push Not
   exact (· · ·)
 
 universe u in

--- a/FormalConjectures/Wikipedia/EulerSumOfPowers.lean
+++ b/FormalConjectures/Wikipedia/EulerSumOfPowers.lean
@@ -41,7 +41,7 @@ theorem eulers_sum_of_powers_conjecture (n k b : ℕ) (hn : 1 < n) (hk : 5 < k) 
 @[category research solved, AMS 11]
 theorem eulers_sum_of_powers_conjecture.false_for_k4 : ¬ (∀ (n b : ℕ) (_ : 1 < n)
     (a: Fin n → ℕ) (_ : ∀ i, a i > 0) (_ : ∑ i, (a i) ^ 4 = b ^ 4), 4 ≤ n) := by
-  push_neg
+  push Not
   use 3, 422481
   norm_num
   use ![95800, 217519, 414560]
@@ -51,7 +51,7 @@ theorem eulers_sum_of_powers_conjecture.false_for_k4 : ¬ (∀ (n b : ℕ) (_ : 
 @[category research solved, AMS 11]
 theorem eulers_sum_of_powers_conjecture.false_for_k5 : ¬ (∀ (n b : ℕ) (_ : 1 < n)
     (a: Fin n → ℕ) (_ : ∀ i, a i > 0) (_ : ∑ i, (a i) ^ 5 = b ^ 5), 5 ≤ n) := by
-  push_neg
+  push Not
   use 4, 144
   norm_num
   use ![27, 84, 110, 133]

--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture315.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture315.lean
@@ -97,7 +97,7 @@ since no vertex has a neighbor in the empty edge set. -/
 @[category test, AMS 5]
 example : ¬IsTotalDominatingSet (⊥ : SimpleGraph (Fin 2)) Finset.univ := by
   unfold IsTotalDominatingSet
-  push_neg
+  push Not
   exact ⟨0, fun w _ => by simp⟩
 
 end WrittenOnTheWallII.GraphConjecture315

--- a/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
+++ b/FormalConjecturesForMathlib/Probability/FiniteMethod.lean
@@ -63,8 +63,7 @@ If `∑ x ∈ s, f x < s.card`, then there exists `a ∈ s` with `f a = 0`.
 theorem Finset.exists_eq_zero_of_sum_lt_card
     {α : Type*} {s : Finset α} {f : α → ℕ} (h : ∑ x ∈ s, f x < s.card) :
     ∃ a ∈ s, f a = 0 := by
-  by_contra hne
-  push_neg at hne
+  by_contra! hne
   have hge : ∀ a ∈ s, 1 ≤ f a :=
     fun a ha => Nat.one_le_iff_ne_zero.mpr (hne a ha)
   have hbound : s.card ≤ ∑ x ∈ s, f x := by


### PR DESCRIPTION
All uses can now either be swallowed in `by_contra!` or replaced by `push Not`.