### PR TITLE
chore: don't abuse the `Set` defeq when using `count`

### DIFF
--- a/FormalConjectures/ErdosProblems/1201.lean
+++ b/FormalConjectures/ErdosProblems/1201.lean
@@ -45,7 +45,7 @@ theorem erdos_1201 :
     answer(sorry) ↔
       ∀ ε > 0, ∀ η > 0, ∃ k : ℕ,
         atTop.liminf (fun x : ℕ ↦
-          (((count (Erdos1201Set ε k) x : ℝ) / (x : ℝ)) : EReal)) ≥ (1 - η : EReal) := by
+          (((count (· ∈ Erdos1201Set ε k) x : ℝ) / (x : ℝ)) : EReal)) ≥ (1 - η : EReal) := by
   sorry
 
 open scoped Classical in
@@ -56,7 +56,7 @@ Erdős wrote he could prove this for $\epsilon=1/2$.
 theorem erdos_1201.variants.epsilon_half :
     ∀ η > 0, ∃ k : ℕ,
       atTop.liminf (fun x : ℕ ↦
-        (((count (Erdos1201Set (1 / 2 : ℝ) k) x : ℝ) / (x : ℝ)) : EReal)) ≥ (1 - η : EReal) := by
+        (((count (· ∈ Erdos1201Set (1 / 2 : ℝ) k) x : ℝ) / (x : ℝ)) : EReal)) ≥ (1 - η : EReal) := by
   sorry
 
 end Erdos1201

--- a/FormalConjectures/ErdosProblems/16.lean
+++ b/FormalConjectures/ErdosProblems/16.lean
@@ -43,7 +43,7 @@ A set of natural numbers has density 0.
 -/
 def density_zero (S : Set ℕ) : Prop :=
   open scoped Classical in
-  Tendsto (fun x : ℕ ↦ (count S x : ℝ) / (x : ℝ)) atTop (𝓝 0)
+  Tendsto (fun x : ℕ ↦ (count (· ∈ S) x : ℝ) / (x : ℝ)) atTop (𝓝 0)
 
 /--
 Is the set of odd integers not of the form $2^k+p$ the union of an infinite arithmetic progression
@@ -68,7 +68,7 @@ A set of natural numbers has positive lower density.
 -/
 def positive_lower_density (S : Set ℕ) : Prop :=
   open scoped Classical in
-  0 < atTop.liminf (fun n : ℕ ↦ ((count S n : ℝ) / (n : ℝ) : EReal))
+  0 < atTop.liminf (fun n : ℕ ↦ ((count (· ∈ S) n : ℝ) / (n : ℝ) : EReal))
 
 /--
 Romanoff [Ro34] showed that the set of odd integers of this form has positive density.

--- a/FormalConjectures/ErdosProblems/331.lean
+++ b/FormalConjectures/ErdosProblems/331.lean
@@ -45,8 +45,8 @@ This was formalized in Lean by van Doorn using Aristotle.
 theorem erdos_331 :
     answer(False) ↔
       ∀ A B : Set ℕ,
-      (fun (n : ℕ) ↦ (n : ℝ) ^ (1 / 2 : ℝ)) =O[atTop] (fun (n : ℕ) ↦ (count A n : ℝ)) →
-      (fun (n : ℕ) ↦ (n : ℝ) ^ (1 / 2 : ℝ)) =O[atTop] (fun (n : ℕ) ↦ (count B n : ℝ)) →
+      (fun (n : ℕ) ↦ (n : ℝ) ^ (1 / 2 : ℝ)) =O[atTop] (fun (n : ℕ) ↦ (count (· ∈ A) n : ℝ)) →
+      (fun (n : ℕ) ↦ (n : ℝ) ^ (1 / 2 : ℝ)) =O[atTop] (fun (n : ℕ) ↦ (count (· ∈ B) n : ℝ)) →
       { s : ℕ × ℕ × ℕ × ℕ | let ⟨a₁, a₂, b₁, b₂⟩ := s
         a₁ ∈ A ∧ a₂ ∈ A ∧ b₁ ∈ B ∧ b₂ ∈ B ∧
         a₁ ≠ a₂ ∧ a₁ + b₂ = a₂ + b₁ }.Infinite := by
@@ -62,8 +62,8 @@ for $B$.
 theorem erdos_331.variants.ruzsa :
     answer(sorry) ↔
       ∀ A B : Set ℕ,
-      (∃ c_A > 0, (fun (n : ℕ) ↦ (count A n : ℝ)) ~[atTop] (fun (n : ℕ) ↦ c_A * (n : ℝ) ^ (1 / 2 : ℝ))) →
-      (∃ c_B > 0, (fun (n : ℕ) ↦ (count B n : ℝ)) ~[atTop] (fun (n : ℕ) ↦ c_B * (n : ℝ) ^ (1 / 2 : ℝ))) →
+      (∃ c_A > 0, (fun (n : ℕ) ↦ (count (· ∈ A) n : ℝ)) ~[atTop] (fun (n : ℕ) ↦ c_A * (n : ℝ) ^ (1 / 2 : ℝ))) →
+      (∃ c_B > 0, (fun (n : ℕ) ↦ (count (· ∈ B) n : ℝ)) ~[atTop] (fun (n : ℕ) ↦ c_B * (n : ℝ) ^ (1 / 2 : ℝ))) →
       { s : ℕ × ℕ × ℕ × ℕ | let ⟨a₁, a₂, b₁, b₂⟩ := s
         a₁ ∈ A ∧ a₂ ∈ A ∧ b₁ ∈ B ∧ b₂ ∈ B ∧
         a₁ ≠ a₂ ∧ a₁ + b₂ = a₂ + b₁ }.Infinite := by

--- a/FormalConjectures/ErdosProblems/955.lean
+++ b/FormalConjectures/ErdosProblems/955.lean
@@ -128,7 +128,7 @@ $\lvert A\cap [1,x]\rvert\leq x^{1/2+o(1)}$ then $s^{-1}(A)$ has density $0$.
 theorem erdos_955.variants.pollack_pomerance_thompson_bound :
     ∀ (A : Set ℕ) (ε : ℕ → ℝ),
       Tendsto ε atTop (𝓝 0) →
-      (∀ᶠ n : ℕ in atTop, (count A n : ℝ) ≤ (n : ℝ) ^ ((1 / 2 : ℝ) + ε n)) →
+      (∀ᶠ n : ℕ in atTop, (count (· ∈ A) n : ℝ) ≤ (n : ℝ) ^ ((1 / 2 : ℝ) + ε n)) →
       { x | s x ∈ A }.HasDensity 0 := by
   sorry
 


### PR DESCRIPTION
`count` expects a predicate, not a set.