### PR TITLE
fix(ErdosProblems/394): correct lower-bound direction

### DIFF
--- a/FormalConjectures/ErdosProblems/394.lean
+++ b/FormalConjectures/ErdosProblems/394.lean
@@ -107,7 +107,7 @@ Since $t_2(p)=p-1$ for prime $p$ it is trivial that $\sum_{n\leq x}t_2(n)\gg \fr
 -/
 @[category research solved, AMS 11]
 theorem erdos_394.variants.lower_bound :
-    (fun x ↦ x ^ 2 / Real.log x) ≫
+    (fun x ↦ x ^ 2 / Real.log x) ≪
     (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊, (t 2 n : ℝ)) := by
   sorry
 


### PR DESCRIPTION
Fix the direction of the lower bound to match its docstring.

Resolves https://github.com/google-deepmind/formal-conjectures/issues/5062