### PR TITLE
docs: AGENTS.md names the import problem files actually use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Put each problem in `FormalConjectures/<Source>/`. Keep closely related variants
 file. Put reusable mathematics in `FormalConjecturesForMathlib/`. That directory must not
 contain `sorry`.
 
-Problem files normally import only `FormalConjectures.Util.ProblemImports`.
+Problem files normally import only `FormalConjecturesUtil`.
 `FormalConjecturesForMathlib/` files import only the required Mathlib modules.
 
 ## State the source faithfully


### PR DESCRIPTION
`FormalConjectures.Util.ProblemImports` moved into the `FormalConjecturesUtil` library in #4433, but `AGENTS.md` line 26 still instructs importing the old module name, which no longer resolves. Every problem file in the tree imports `FormalConjecturesUtil` (1,186 of 1,188 as of `d55751dc`); this makes the instruction match them.

`AGENTS.md` is the file agents follow literally, so a stale module name there turns directly into a failing import for anyone obeying it.
