### PR TITLE
Add the rank 31 curve found by ranksunbounded aka Claude-Alpöge-Howell

### DIFF
--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -154,10 +154,20 @@ theorem twentyone_le_rank_height_count_asymptotic :
   sorry
 
 /-- Is there an elliptic curve over ℚ of rank at least 31?
-The largest known rank of an elliptic curve over ℚ as of 2026 is at least 30.
-See https://elliptic-rank.icarm.cloud/curve/273. -/
-@[category research open, AMS 11 14]
+
+The answer is yes: such a curve was found by Claude, Levent Alpöge and Ava Howell in 2026.
+See https://elliptic-rank.icarm.cloud/curve/302 and `WeierstrassCurve.claudeAlpogeHowell31`
+below. -/
+@[category research solved, AMS 11 14]
 theorem exists_rank_ge_thirtyone : ∃ E : RatEllipticCurve, 31 ≤ E.rank := by
+  sorry
+
+/-- Is there an elliptic curve over ℚ of rank at least 32?
+The largest known rank of an elliptic curve over ℚ as of 2026 is at least 31 (and exactly
+31 assuming the generalized Riemann hypothesis and Birch and Swinnerton-Dyer conjecture).
+See https://elliptic-rank.icarm.cloud/curve/302. -/
+@[category research open, AMS 11 14]
+theorem exists_rank_ge_thirtytwo : ∃ E : RatEllipticCurve, 32 ≤ E.rank := by
   sorry
 
 end RatEllipticCurve
@@ -165,6 +175,42 @@ end RatEllipticCurve
 namespace WeierstrassCurve
 
 /-  See https://en.wikipedia.org/wiki/Rank_of_an_elliptic_curve#Largest_known_ranks -/
+
+/-- The elliptic curve over ℚ of rank at least 31 found by Claude, Levent Alpöge and
+Ava Howell in 2026. It has rank exactly 31 assuming the generalized Riemann hypothesis and
+Birch and Swinnerton-Dyer conjecture. -/
+def claudeAlpogeHowell31 : Affine ℚ where
+  a₁ := 1
+  a₂ := 1
+  a₃ := 1
+  a₄ := -1284727764113567728281797636015784768866707681415849262157224232063
+  a₆ := 560368321454261339256859338901915312332769858684945406858043869199456710681989058863306170127006181
+
+/-- See https://elliptic-rank.icarm.cloud/curve/302. -/
+@[category test, AMS 11 14]
+theorem Δ_claudeAlpogeHowell31 : claudeAlpogeHowell31.Δ =
+    2 ^ 15 * 3 ^ 4 * 5 ^ 4 * 7 ^ 6 * 11 ^ 4 * 13 ^ 5 * 19 ^ 2 * 23 ^ 2 * 29 ^ 3 * 37 ^ 2 * 41 ^ 2 *
+    73 ^ 2 * 131 ^ 2 * 167 ^ 2 * 7547 * 632881 * 966509 * 18145679437533309132469 *
+    767028866604834801397681553 *
+    30580600452196904409276223329355584892025407195996968868775951126238056443210297 := by
+  rw [claudeAlpogeHowell31, Δ, b₂, b₄, b₆, b₈]; norm_num
+
+@[category test, AMS 11 14]
+instance : claudeAlpogeHowell31.IsElliptic where
+  isUnit := by rw [Δ_claudeAlpogeHowell31]; norm_num
+
+/-- The rank of the Claude–Alpöge–Howell curve is at least 31. -/
+@[category research solved, AMS 11 14]
+theorem thirtyone_le_rank_claudeAlpogeHowell31 : 31 ≤ finrank ℤ claudeAlpogeHowell31.Point := by
+  sorry
+
+/-- The rank of the Claude–Alpöge–Howell curve is exactly 31.
+It has rank exactly 31 assuming the generalized Riemann hypothesis and the
+Birch and Swinnerton-Dyer conjecture.
+-/
+@[category research open, AMS 11 14]
+theorem rank_claudeAlpogeHowell31 : finrank ℤ claudeAlpogeHowell31.Point = 31 := by
+  sorry
 
 /-- The elliptic curve over ℚ of rank at least 30 found by user `ranksunbounded` in 2026.
 It has rank exactly 30 assuming the generalized Riemann hypothesis and Birch and Swinnerton-Dyer

--- a/FormalConjectures/Wikipedia/EllipticCurveRank.lean
+++ b/FormalConjectures/Wikipedia/EllipticCurveRank.lean
@@ -186,7 +186,10 @@ def claudeAlpogeHowell31 : Affine ℚ where
   a₄ := -1284727764113567728281797636015784768866707681415849262157224232063
   a₆ := 560368321454261339256859338901915312332769858684945406858043869199456710681989058863306170127006181
 
-/-- See https://elliptic-rank.icarm.cloud/curve/302. -/
+/-- See https://elliptic-rank.icarm.cloud/curve/302.
+User profile: https://elliptic-rank.icarm.cloud/user/18
+        and   https://elliptic-rank.icarm.cloud/user/53
+-/
 @[category test, AMS 11 14]
 theorem Δ_claudeAlpogeHowell31 : claudeAlpogeHowell31.Δ =
     2 ^ 15 * 3 ^ 4 * 5 ^ 4 * 7 ^ 6 * 11 ^ 4 * 13 ^ 5 * 19 ^ 2 * 23 ^ 2 * 29 ^ 3 * 37 ^ 2 * 41 ^ 2 *
@@ -213,6 +216,7 @@ theorem rank_claudeAlpogeHowell31 : finrank ℤ claudeAlpogeHowell31.Point = 31 
   sorry
 
 /-- The elliptic curve over ℚ of rank at least 30 found by user `ranksunbounded` in 2026.
+User profile: https://elliptic-rank.icarm.cloud/user/18
 It has rank exactly 30 assuming the generalized Riemann hypothesis and Birch and Swinnerton-Dyer
 conjecture. -/
 def ranksunbounded30 : Affine ℚ where


### PR DESCRIPTION
Hello formal conjectures team, this is my first contribution to this repo ahead of the workshop in a few weeks time, which i wanted to get a headstart on.

I wanted to add the new rank 31 curve found a few days ago here: https://elliptic-rank.icarm.cloud/curve/302

I followed the existing format of the rank 30 curve, found by the same group.

It builds and there are blue check marks.

I've done the other things in the contributing section on the docs, including signing the CLA.

Please let me know if I should do anything else for this PR!