### PR TITLE
feat(Wikipedia): add the emirp infinitude question

### DIFF
--- a/FormalConjectures/Wikipedia/Emirp.lean
+++ b/FormalConjectures/Wikipedia/Emirp.lean
@@ -1,0 +1,79 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Emirps
+
+An emirp is a prime whose decimal reversal is a different prime. It is unknown whether there are
+infinitely many emirps.
+
+*References:*
+* [Wikipedia, Emirp](https://en.wikipedia.org/wiki/Emirp)
+* [OEIS A006567](https://oeis.org/A006567)
+-/
+
+namespace Emirp
+
+/-- Reverse the base-ten digits of a natural number. -/
+def reverse10 (n : ℕ) : ℕ :=
+  Nat.ofDigits 10 (Nat.digits 10 n).reverse
+
+/-- A natural number is an emirp if it and its distinct decimal reversal are both prime. -/
+def IsEmirp (p : ℕ) : Prop :=
+  p.Prime ∧ (reverse10 p).Prime ∧ reverse10 p ≠ p
+
+@[category test, AMS 11]
+theorem reverse10_13 : reverse10 13 = 31 := by
+  norm_num [reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem reverse10_17 : reverse10 17 = 71 := by
+  norm_num [reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem reverse10_120 : reverse10 120 = 21 := by
+  norm_num [reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem a_13 : IsEmirp 13 := by
+  norm_num [IsEmirp, reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem a_17 : IsEmirp 17 := by
+  norm_num [IsEmirp, reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem a_31 : IsEmirp 31 := by
+  norm_num [IsEmirp, reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem a_37 : IsEmirp 37 := by
+  norm_num [IsEmirp, reverse10, Nat.ofDigits]
+
+@[category test, AMS 11]
+theorem not_a_11 : ¬ IsEmirp 11 := by
+  norm_num [IsEmirp, reverse10, Nat.ofDigits]
+
+/-- [Wikipedia's article on emirps](https://en.wikipedia.org/wiki/Emirp) states: "It is not known
+whether there are infinitely many emirps." -/
+@[category research open, AMS 11]
+theorem infinitude_question :
+    answer(sorry) ↔ {p : ℕ | IsEmirp p}.Infinite := by
+  sorry
+
+end Emirp


### PR DESCRIPTION
Closes #5163

## Summary

This PR formalizes decimal digit reversal, the emirp predicate, and Wikipedia's open question of
whether infinitely many emirps exist. Tests cover reversal of `13`, `17`, and the trailing-zero
case `120`, the canonical emirps `13`, `17`, `31`, and `37`, and rejection of the palindromic
prime `11`.

## Formalization choices

Decimal reversal is defined with Mathlib's established little-endian digit representation:

```lean
def reverse10 (n : ℕ) : ℕ :=
  Nat.ofDigits 10 (Nat.digits 10 n).reverse
```

Reversing the little-endian digit list before rebuilding the natural number produces ordinary
base-ten reversal and handles a trailing decimal zero by dropping the resulting leading zero, as
usual.

The predicate requires three separate facts:

```lean
def IsEmirp (p : ℕ) : Prop :=
  p.Prime ∧ (reverse10 p).Prime ∧ reverse10 p ≠ p
```

The inequality is essential: without it, every palindromic prime would incorrectly count as an
emirp. The source presents infinitude as an open question, so the main theorem preserves that
grammar:

```lean
answer(sorry) ↔ {p : ℕ | IsEmirp p}.Infinite
```

The definitions remain self-contained; no `FormalConjecturesForMathlib` addition is needed.

## Intentional proof gap

The decimal-reversal definition and all positive, negative, and boundary tests are complete. The
only open declaration is `infinitude_question`, with the unknown `answer(sorry)` and its intended
benchmark proof `sorry`.

## Verification

Current contribution head:
`e4e94ac56ce4721ac6f60683944ade5cb125559e`, rebased onto upstream `169abb8e`.

Local checks on the rebased head:

- exact-head static preflight passed for `FormalConjectures/Wikipedia/Emirp.lean`;
- the committed diff contains only that file and has no whitespace, metadata, proof-gap,
  banned-construct, or line-length findings.

The source-identical pre-rebase head
`64ca73a6b1235e123f2da8beda8cbcbcf5046394`
passed focused Lean elaboration and the following target on Lean 4.33.1:

```text
env LEAN_NUM_THREADS=2 lake --wfail build FormalConjectures.Wikipedia.Emirp
```

After upstream advanced through unrelated PR #5159, this branch was rebased without source
changes. Per author direction, current-head Lean and repository-wide verification were delegated
to PR CI. On this exact head, `Build project`, `Test scripts`, `check-copyright`, `check-changes`,
`scan-pr`, `labeler`, and `cla/google` succeeded; inapplicable jobs were skipped.

## AI use

AI assistance was used for source research, Lean design, draft text, implementation, and local
verification support. Before publication I will personally review the completed digit-reversal
model, examples, exact-head verification record, and final PR text, and I will take responsibility
for the submitted content.
