### PR TITLE
Add graph minors (ForMathlib) and Hadwiger's conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/HadwigerConjecture.lean
+++ b/FormalConjectures/Wikipedia/HadwigerConjecture.lean
@@ -50,7 +50,7 @@ Every finite graph $G$ with chromatic number $\chi(G) \ge k$ has the complete gr
 minor. Equivalently, $\chi(G) \le h(G)$ where $h(G)$ is the Hadwiger number.
 -/
 @[category research open, AMS 5]
-theorem hadwiger_conjecture : answer(sorry) ↔
+theorem hadwiger_conjecture :
     ∀ {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ),
       (k : ℕ∞) ≤ G.chromaticNumber → (completeGraph (Fin k)).IsMinor G := by
   sorry
@@ -77,7 +77,8 @@ by Appel and Haken (1976) and Robertson, Sanders, Seymour and Thomas (1997).
 
 *Reference:* [Wa37].
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using other_system at
+"https://github.com/rocq-community/fourcolor"]
 theorem hadwiger_conjecture.variants.five
     {V : Type} [Fintype V] (G : SimpleGraph V)
     (h : (5 : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin 5)).IsMinor G := by
@@ -95,14 +96,13 @@ theorem hadwiger_conjecture.variants.six
   sorry
 
 /--
-**The linear Hadwiger conjecture (open).**
+**The linear Hadwiger conjecture.**
 
-There is a constant $C$ such that every graph with no $K_k$ minor is $Ck$-colourable. The best
-known bound is $O(k \log \log k)$ (Delcourt–Postle [DP21]), improving Kostochka's and
-Thomason's $O(k \sqrt{\log k})$ [Ko84].
+There is a constant $C$ such that every graph with no $K_k$ minor is $Ck$-colourable
+(see [DP21], [Ko84]).
 -/
 @[category research open, AMS 5]
-theorem hadwiger_conjecture.variants.linear : answer(sorry) ↔
+theorem hadwiger_conjecture.variants.linear :
     ∃ C : ℕ, ∀ {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ),
       ¬ (completeGraph (Fin k)).IsMinor G → G.chromaticNumber ≤ C * k := by
   sorry
@@ -128,7 +128,7 @@ theorem hadwiger_conjecture.variants.kostochka_thomason :
 `K_0` is a minor of every graph (empty family of branch sets), and `K_1` is a minor of every
 graph with a vertex, which is guaranteed by $\chi(G) \ge 1$.
 -/
-@[category research solved, AMS 5]
+@[category test, AMS 5]
 theorem hadwiger_conjecture.variants.le_one
     {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ) (hk : k ≤ 1)
     (h : (k : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin k)).IsMinor G := by
@@ -154,7 +154,7 @@ theorem hadwiger_conjecture.variants.le_one
 A graph with chromatic number at least $2$ has an edge, and the two endpoints of an edge form
 a $K_2$-model.
 -/
-@[category research solved, AMS 5]
+@[category test, AMS 5]
 theorem hadwiger_conjecture.variants.two
     {V : Type} [Fintype V] (G : SimpleGraph V)
     (h : (2 : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin 2)).IsMinor G := by

--- a/FormalConjectures/Wikipedia/HadwigerConjecture.lean
+++ b/FormalConjectures/Wikipedia/HadwigerConjecture.lean
@@ -1,0 +1,151 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Hadwiger's conjecture (1943)
+
+*References:*
+* [Wikipedia](https://en.wikipedia.org/wiki/Hadwiger_conjecture_(graph_theory))
+* [Ha43] Hadwiger, H. (1943). "Über eine Klassifikation der Streckenkomplexe."
+  *Vierteljschr. Naturforsch. Ges. Zürich* 88, pp. 133--142.
+* [Wa37] Wagner, K. (1937). "Über eine Eigenschaft der ebenen Komplexe." *Math. Ann.* 114,
+  pp. 570--590.
+* [RST93] Robertson, N., Seymour, P. and Thomas, R. (1993). "Hadwiger's conjecture for
+  $K_6$-free graphs." *Combinatorica* 13, pp. 279--361.
+* [Ko84] Kostochka, A. V. (1984). "Lower bound of the Hadwiger number of graphs by their
+  average degree." *Combinatorica* 4, pp. 307--316.
+* [DP21] Delcourt, M. and Postle, L. (2021). "Reducing linear Hadwiger's conjecture to
+  coloring small graphs." [arXiv:2108.01633](https://arxiv.org/abs/2108.01633)
+* [Se16] Seymour, P. (2016). "Hadwiger's conjecture." In *Open Problems in Mathematics*,
+  Springer, pp. 417--437.
+-/
+
+open SimpleGraph
+
+namespace HadwigerConjecture
+
+/-- The **Hadwiger number** `h(G)`: the largest `k` such that `K_k` is a minor of `G`. -/
+noncomputable def hadwigerNumber {V : Type*} [Fintype V] (G : SimpleGraph V) : ℕ :=
+  sSup {k | (completeGraph (Fin k)).IsMinor G}
+
+/--
+**Hadwiger's conjecture (1943).**
+
+Every finite graph $G$ with chromatic number $\chi(G) \ge k$ has the complete graph $K_k$ as a
+minor. Equivalently, $\chi(G) \le h(G)$ where $h(G)$ is the Hadwiger number.
+-/
+@[category research open, AMS 5]
+theorem hadwiger_conjecture : answer(sorry) ↔
+    ∀ {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ),
+      (k : ℕ∞) ≤ G.chromaticNumber → (completeGraph (Fin k)).IsMinor G := by
+  sorry
+
+/--
+**The cases $k \le 4$ (Hadwiger 1943; Dirac).**
+
+The conjecture holds for $k \le 4$: graphs with no $K_4$ minor are series–parallel and hence
+$3$-colourable.
+
+*Reference:* [Ha43].
+-/
+@[category research solved, AMS 5]
+theorem hadwiger_conjecture.variants.le_four
+    {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ) (hk : k ≤ 4)
+    (h : (k : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin k)).IsMinor G := by
+  sorry
+
+/--
+**The case $k = 5$ (Wagner 1937; equivalent to the four colour theorem).**
+
+Wagner showed that the case $k = 5$ is equivalent to the four colour theorem, which was proved
+by Appel and Haken (1976) and Robertson, Sanders, Seymour and Thomas (1997).
+
+*Reference:* [Wa37].
+-/
+@[category research solved, AMS 5]
+theorem hadwiger_conjecture.variants.five
+    {V : Type} [Fintype V] (G : SimpleGraph V)
+    (h : (5 : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin 5)).IsMinor G := by
+  sorry
+
+/--
+**The case $k = 6$ (Robertson–Seymour–Thomas 1993).**
+
+*Reference:* [RST93].
+-/
+@[category research solved, AMS 5]
+theorem hadwiger_conjecture.variants.six
+    {V : Type} [Fintype V] (G : SimpleGraph V)
+    (h : (6 : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin 6)).IsMinor G := by
+  sorry
+
+/--
+**The linear Hadwiger conjecture (open).**
+
+There is a constant $C$ such that every graph with no $K_k$ minor is $Ck$-colourable. The best
+known bound is $O(k \log \log k)$ (Delcourt–Postle [DP21]), improving Kostochka's and
+Thomason's $O(k \sqrt{\log k})$ [Ko84].
+-/
+@[category research open, AMS 5]
+theorem hadwiger_conjecture.variants.linear : answer(sorry) ↔
+    ∃ C : ℕ, ∀ {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ),
+      ¬ (completeGraph (Fin k)).IsMinor G → G.chromaticNumber ≤ C * k := by
+  sorry
+
+/--
+**Kostochka / Thomason (1984): $O(k\sqrt{\log k})$ colours.**
+
+There is a constant $C$ such that every graph with no $K_k$ minor ($k \ge 2$) has chromatic
+number at most $C k \sqrt{\log k}$.
+
+*Reference:* [Ko84].
+-/
+@[category research solved, AMS 5]
+theorem hadwiger_conjecture.variants.kostochka_thomason :
+    ∃ C : ℝ, 0 < C ∧ ∀ {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ), 2 ≤ k →
+      ¬ (completeGraph (Fin k)).IsMinor G →
+      (G.chromaticNumber.toNat : ℝ) ≤ C * k * Real.sqrt (Real.log k) := by
+  sorry
+
+/--
+**The cases $k \le 1$.**
+
+`K_0` is a minor of every graph (empty family of branch sets), and `K_1` is a minor of every
+graph with a vertex, which is guaranteed by $\chi(G) \ge 1$.
+-/
+@[category research solved, AMS 5]
+theorem hadwiger_conjecture.variants.le_one
+    {V : Type} [Fintype V] (G : SimpleGraph V) (k : ℕ) (hk : k ≤ 1)
+    (h : (k : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin k)).IsMinor G := by
+  interval_cases k
+  · exact ⟨fun i => Fin.elim0 i, ⟨fun i => Fin.elim0 i, fun i => Fin.elim0 i,
+      fun i => Fin.elim0 i, fun i => Fin.elim0 i⟩⟩
+  · -- `χ(G) ≥ 1` forces a vertex; its singleton is a `K₁`-model.
+    have hV : Nonempty V := by
+      by_contra hV
+      rw [not_nonempty_iff] at hV
+      have : G.chromaticNumber = 0 := chromaticNumber_eq_zero_of_isEmpty
+      rw [this] at h
+      exact absurd h (by simp)
+    obtain ⟨v⟩ := hV
+    refine ⟨fun _ => {v}, ⟨fun _ => Set.singleton_nonempty v, fun _ => ?_,
+      fun i j hij => absurd (Subsingleton.elim i j) hij, fun i j hij => ?_⟩⟩
+    · exact (isMinorModel_singleton G).connected v
+    · exact absurd (Subsingleton.elim i j) hij.ne
+
+end HadwigerConjecture

--- a/FormalConjectures/Wikipedia/HadwigerConjecture.lean
+++ b/FormalConjectures/Wikipedia/HadwigerConjecture.lean
@@ -148,4 +148,41 @@ theorem hadwiger_conjecture.variants.le_one
     · exact (isMinorModel_singleton G).connected v
     · exact absurd (Subsingleton.elim i j) hij.ne
 
+/--
+**The case $k = 2$.**
+
+A graph with chromatic number at least $2$ has an edge, and the two endpoints of an edge form
+a $K_2$-model.
+-/
+@[category research solved, AMS 5]
+theorem hadwiger_conjecture.variants.two
+    {V : Type} [Fintype V] (G : SimpleGraph V)
+    (h : (2 : ℕ∞) ≤ G.chromaticNumber) : (completeGraph (Fin 2)).IsMinor G := by
+  -- `χ(G) ≥ 2` forces an edge: otherwise `G = ⊥` is `1`-colourable.
+  obtain ⟨u, v, huv⟩ : ∃ u v, G.Adj u v := by
+    by_contra hno
+    push Not at hno
+    have hbot : G = ⊥ := by
+      ext a b
+      simp [hno a b]
+    have h1 : G.chromaticNumber ≤ 1 := by
+      subst hbot
+      exact_mod_cast Colorable.chromaticNumber_le ⟨⟨fun _ => 0, fun h => by simp at h⟩⟩
+    exact absurd (h.trans h1) (by decide)
+  refine ⟨fun i => if i = 0 then {u} else {v}, ?_, ?_, ?_, ?_⟩
+  · intro i
+    split <;> exact Set.singleton_nonempty _
+  · intro i
+    by_cases hi : i = 0
+    · rw [if_pos hi]; exact (isMinorModel_singleton G).connected u
+    · rw [if_neg hi]; exact (isMinorModel_singleton G).connected v
+  · intro i j hij
+    fin_cases i <;> fin_cases j <;> simp at hij ⊢
+    · exact G.ne_of_adj huv
+    · exact (G.ne_of_adj huv).symm
+  · intro i j hij
+    fin_cases i <;> fin_cases j <;> simp at hij ⊢
+    · exact huv
+    · exact huv.symm
+
 end HadwigerConjecture

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -82,6 +82,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Johnson
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LargestInducedTree
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LovaszTheta
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Matching
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Minor
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.PathCover
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.QuasiLineGraph
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Ramsey

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Minor.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Minor.lean
@@ -1,0 +1,115 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+
+@[expose] public section
+
+/-!
+# Graph minors
+
+Mathlib has no notion of graph minor (as of 2026-08). This file defines `SimpleGraph.IsMinor`
+through **minor models**: `H` is a minor of `G` if there are pairwise disjoint, nonempty,
+connected *branch sets* `B w ⊆ V(G)`, one for each vertex `w` of `H`, such that every edge
+`w w'` of `H` is witnessed by an edge of `G` between `B w` and `B w'`. This is the standard
+characterisation of `H ≼ G` (obtained from a subgraph of `G` by contracting the branch sets).
+
+We prove that the relation is reflexive and preserved under taking supergraphs of `G` and
+subgraphs of `H`.
+-/
+
+namespace SimpleGraph
+
+variable {V W : Type*}
+
+/-- A **minor model** of `H` in `G`: pairwise disjoint, nonempty, connected branch sets
+`B w ⊆ V(G)` indexed by the vertices of `H`, with every edge of `H` realised by an edge of `G`
+between the corresponding branch sets. -/
+structure IsMinorModel (H : SimpleGraph W) (G : SimpleGraph V) (B : W → Set V) : Prop where
+  nonempty : ∀ w, (B w).Nonempty
+  connected : ∀ w, (G.induce (B w)).Connected
+  disjoint : ∀ w w', w ≠ w' → Disjoint (B w) (B w')
+  adj : ∀ w w', H.Adj w w' → ∃ u ∈ B w, ∃ v ∈ B w', G.Adj u v
+
+/-- `H` is a **minor** of `G` if it has a minor model in `G`. -/
+def IsMinor (H : SimpleGraph W) (G : SimpleGraph V) : Prop :=
+  ∃ B : W → Set V, IsMinorModel H G B
+
+@[inherit_doc] scoped infixl:50 " ≼ " => IsMinor
+
+/-- The singleton branch sets form a minor model of `G` in itself. -/
+theorem isMinorModel_singleton (G : SimpleGraph V) :
+    IsMinorModel G G (fun v => {v}) where
+  nonempty v := Set.singleton_nonempty v
+  connected v := by
+    rw [connected_iff]
+    refine ⟨?_, ⟨⟨v, Set.mem_singleton v⟩⟩⟩
+    rintro ⟨a, ha⟩ ⟨b, hb⟩
+    obtain rfl := Set.mem_singleton_iff.mp ha
+    obtain rfl := Set.mem_singleton_iff.mp hb
+    exact Reachable.refl _
+  disjoint v w hvw := Set.disjoint_singleton.mpr hvw
+  adj v w h := ⟨v, Set.mem_singleton v, w, Set.mem_singleton w, h⟩
+
+/-- Every graph is a minor of itself. -/
+theorem IsMinor.refl (G : SimpleGraph V) : G.IsMinor G :=
+  ⟨_, isMinorModel_singleton G⟩
+
+/-- A minor model stays a minor model if the host graph grows. -/
+theorem IsMinorModel.mono_right {H : SimpleGraph W} {G G' : SimpleGraph V} {B : W → Set V}
+    (hG : G ≤ G') (hB : IsMinorModel H G B) : IsMinorModel H G' B where
+  nonempty := hB.nonempty
+  connected w := (hB.connected w).mono fun _ _ h => hG h
+  disjoint := hB.disjoint
+  adj w w' h := by
+    obtain ⟨u, hu, v, hv, huv⟩ := hB.adj w w' h
+    exact ⟨u, hu, v, hv, hG huv⟩
+
+/-- A minor model of `H` is a minor model of any subgraph of `H` (on the same vertex set). -/
+theorem IsMinorModel.mono_left {H H' : SimpleGraph W} {G : SimpleGraph V} {B : W → Set V}
+    (hH : H' ≤ H) (hB : IsMinorModel H G B) : IsMinorModel H' G B where
+  nonempty := hB.nonempty
+  connected := hB.connected
+  disjoint := hB.disjoint
+  adj w w' h := hB.adj w w' (hH h)
+
+/-- If `H ≼ G` and `G ≤ G'` then `H ≼ G'`. -/
+theorem IsMinor.mono_right {H : SimpleGraph W} {G G' : SimpleGraph V} (hG : G ≤ G')
+    (h : H.IsMinor G) : H.IsMinor G' :=
+  h.imp fun _ hB => hB.mono_right hG
+
+/-- If `H' ≤ H` and `H ≼ G` then `H' ≼ G`. -/
+theorem IsMinor.mono_left {H H' : SimpleGraph W} {G : SimpleGraph V} (hH : H' ≤ H)
+    (h : H.IsMinor G) : H'.IsMinor G :=
+  h.imp fun _ hB => hB.mono_left hH
+
+/-- Every subgraph (on the same vertex set) is a minor. -/
+theorem IsMinor.of_le {G G' : SimpleGraph V} (h : G ≤ G') : G.IsMinor G' :=
+  (IsMinor.refl G).mono_right h
+
+/-- A minor of a finite graph has at most as many vertices. -/
+theorem IsMinor.card_le [Fintype V] [Fintype W] {H : SimpleGraph W} {G : SimpleGraph V}
+    (h : H.IsMinor G) : Fintype.card W ≤ Fintype.card V := by
+  classical
+  obtain ⟨B, hB⟩ := h
+  choose f hf using hB.nonempty
+  refine Fintype.card_le_of_injective f fun w w' hww' => ?_
+  by_contra hne
+  exact Set.disjoint_left.mp (hB.disjoint w w' hne) (hf w) (hww' ▸ hf w')
+
+end SimpleGraph


### PR DESCRIPTION
Adds Hadwiger's conjecture, together with the graph-minor infrastructure it needs (Mathlib has no notion of minor as of 2026-08).

**ForMathlib** — new `FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Minor.lean`: `IsMinorModel H G B` (pairwise disjoint, nonempty, connected branch sets `B w ⊆ V(G)` with every edge of `H` realised between branch sets) and `IsMinor H G` (scoped notation `≼`). Proved: `IsMinor.refl`, `IsMinor.mono_left` / `mono_right`, `IsMinor.of_le`, and `IsMinor.card_le`.

**Problem file** — `FormalConjectures/Wikipedia/HadwigerConjecture.lean`:

| Declaration | Content | Status |
|---|---|---|
| `hadwigerNumber` | $h(G) = \max\{k : K_k \preccurlyeq G\}$ | definition |
| `hadwiger_conjecture` | $\chi(G) \ge k \Rightarrow K_k \preccurlyeq G$ | `research open` |
| `.variants.le_four`, `.five`, `.six` | Hadwiger/Dirac; Wagner ⇔ 4CT; Robertson–Seymour–Thomas 1993 | `sorry` + references |
| `.variants.linear` | linear Hadwiger conjecture | `research open` |
| `.variants.kostochka_thomason` | $O(k\sqrt{\log k})$ colours | `sorry` + reference |
| `.variants.le_one` | the cases $k \le 1$ | **proved** |

Umbrella regenerated with `scripts/mk_all_formathlib.sh`.

### Verification
`lake build` of both modules on v4.33.1: clean, all linters pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)