### PR TITLE
Add the Petersen graph (ForMathlib) and the Petersen colouring conjecture

### DIFF
--- a/FormalConjectures/Wikipedia/PetersenColoringConjecture.lean
+++ b/FormalConjectures/Wikipedia/PetersenColoringConjecture.lean
@@ -1,0 +1,96 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The Petersen colouring conjecture (Jaeger 1988)
+
+*References:*
+* [Wikipedia](https://en.wikipedia.org/wiki/Petersen_graph#Petersen_coloring_conjecture)
+* [Ja88] Jaeger, F. (1988). "Nowhere-zero flow problems." In *Selected Topics in Graph
+  Theory 3*, Academic Press, pp. 71--95.
+* [Mk16] Mkrtchyan, V. V. (2013). "A remark on the Petersen coloring conjecture of Jaeger."
+  *Australas. J. Combin.* 56, pp. 145--151.
+* [HS15] Hägglund, J. and Steffen, E. (2014). "Petersen-colorings and some families of
+  snarks." *Ars Math. Contemp.* 7, pp. 161--173.
+* [Zh97] Zhang, C.-Q. (1997). *Integer flows and cycle covers of graphs.* Marcel Dekker.
+-/
+
+open SimpleGraph Finset
+
+namespace PetersenColoringConjecture
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A map `φ` on the edges of `G` into the edges of the Petersen graph `P` is a
+**Petersen colouring** if for every vertex `v` of `G` there is a vertex `w` of `P` such that
+`φ` maps the edges at `v` onto the edges at `w` (so in particular `φ` is a proper edge
+colouring with the `15` edges of `P` as colours and every pair of adjacent edges goes to a pair
+of adjacent edges). -/
+def IsPetersenColoring (G : SimpleGraph V) [DecidableRel G.Adj]
+    (φ : Sym2 V → Sym2 PetersenVertex) : Prop :=
+  ∀ v : V, ∃ w : PetersenVertex,
+    (G.incidenceFinset v).image φ = petersenGraph.incidenceFinset w ∧
+      Set.InjOn φ (G.incidenceFinset v : Set (Sym2 V))
+
+/--
+**The Petersen colouring conjecture (Jaeger 1988).**
+
+Every bridgeless cubic graph has a Petersen colouring: an edge colouring by the edges of the
+Petersen graph such that the three edges at each vertex are mapped onto the three edges at
+some vertex of the Petersen graph. Jaeger showed that this conjecture implies both the
+Berge–Fulkerson conjecture and the cycle double cover conjecture.
+-/
+@[category research open, AMS 5]
+theorem petersen_coloring_conjecture : answer(sorry) ↔
+    ∀ {V : Type} [Fintype V] [DecidableEq V] (G : SimpleGraph V) [DecidableRel G.Adj],
+      (∀ v, G.degree v = 3) → G.IsBridgeless →
+      ∃ φ : Sym2 V → Sym2 PetersenVertex, IsPetersenColoring G φ := by
+  sorry
+
+/--
+**Jaeger's reformulation: normal `5`-edge-colourings.**
+
+A proper `5`-edge-colouring of a cubic graph is *normal* if every edge, together with its four
+neighbouring edges, sees either exactly `3` or exactly `5` colours. Jaeger showed that a cubic
+graph has a Petersen colouring iff it has a normal `5`-edge-colouring.
+
+*Reference:* [Ja88].
+-/
+@[category research solved, AMS 5]
+theorem petersen_coloring_conjecture.variants.normal_five_edge_coloring
+    {V : Type} [Fintype V] [DecidableEq V] (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hcubic : ∀ v, G.degree v = 3) :
+    (∃ φ : Sym2 V → Sym2 PetersenVertex, IsPetersenColoring G φ) ↔
+    ∃ c : Sym2 V → Fin 5,
+      (∀ e ∈ G.edgeFinset, ∀ f ∈ G.edgeFinset, e ≠ f → (∃ v, v ∈ e ∧ v ∈ f) → c e ≠ c f) ∧
+      ∀ e ∈ G.edgeFinset,
+        ((G.edgeFinset.filter fun f => ∃ v, v ∈ e ∧ v ∈ f).image c).card = 3 ∨
+        ((G.edgeFinset.filter fun f => ∃ v, v ∈ e ∧ v ∈ f).image c).card = 5 := by
+  sorry
+
+/--
+**The Petersen graph has a Petersen colouring: the identity.**
+
+Taking `φ = id`, every vertex `v` of `P` witnesses its own incidence set.
+-/
+@[category research solved, AMS 5]
+theorem petersen_coloring_conjecture.variants.petersenGraph :
+    IsPetersenColoring petersenGraph id := fun v =>
+  ⟨v, Finset.image_id, Set.injOn_id _⟩
+
+end PetersenColoringConjecture

--- a/FormalConjectures/Wikipedia/PetersenColoringConjecture.lean
+++ b/FormalConjectures/Wikipedia/PetersenColoringConjecture.lean
@@ -56,7 +56,7 @@ some vertex of the Petersen graph. Jaeger showed that this conjecture implies bo
 Berge–Fulkerson conjecture and the cycle double cover conjecture.
 -/
 @[category research open, AMS 5]
-theorem petersen_coloring_conjecture : answer(sorry) ↔
+theorem petersen_coloring_conjecture :
     ∀ {V : Type} [Fintype V] [DecidableEq V] (G : SimpleGraph V) [DecidableRel G.Adj],
       (∀ v, G.degree v = 3) → G.IsBridgeless →
       ∃ φ : Sym2 V → Sym2 PetersenVertex, IsPetersenColoring G φ := by
@@ -88,7 +88,7 @@ theorem petersen_coloring_conjecture.variants.normal_five_edge_coloring
 
 Taking `φ = id`, every vertex `v` of `P` witnesses its own incidence set.
 -/
-@[category research solved, AMS 5]
+@[category test, AMS 5]
 theorem petersen_coloring_conjecture.variants.petersenGraph :
     IsPetersenColoring petersenGraph id := fun v =>
   ⟨v, Finset.image_id, Set.injOn_id _⟩

--- a/FormalConjectures/WrittenOnTheWallII/Test.lean
+++ b/FormalConjectures/WrittenOnTheWallII/Test.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 This file contains tests for graph invariants on 5 specific concrete graphs:
 1. `HouseGraph`: A graph on 5 vertices.
 2. `K4`: The complete graph on 4 vertices.
-3. `PetersenGraph`: The Petersen graph on 10 vertices.
+3. `PetersenGraph`: The Petersen graph on 10 vertices (`SimpleGraph.petersenGraph`).
 4. `C6`: The cycle graph on 6 vertices.
 5. `Star5`: The star graph with 5 leaves (6 vertices total).
 
@@ -53,16 +53,9 @@ abbrev HouseGraph : SimpleGraph (Fin 5) :=
 /-- K4: Complete graph on 4 vertices. -/
 abbrev K4 : SimpleGraph (Fin 4) := completeGraph (Fin 4)
 
-/-- Petersen Graph on 10 vertices. -/
-abbrev PetersenGraph : SimpleGraph (Fin 10) :=
-  SimpleGraph.fromEdgeSet {
-    -- Outer Cycle
-    s(0, 1), s(1, 2), s(2, 3), s(3, 4), s(4, 0),
-    -- Spokes
-    s(0, 5), s(1, 6), s(2, 7), s(3, 8), s(4, 9),
-    -- Inner Star
-    s(5, 7), s(7, 9), s(9, 6), s(6, 8), s(8, 5)
-  }
+/-- Petersen Graph on 10 vertices (the Kneser graph `K(5,2)` from
+`FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Petersen`). -/
+abbrev PetersenGraph : SimpleGraph PetersenVertex := petersenGraph
 
 /-- C6: Cycle graph on 6 vertices. -/
 abbrev C6 : SimpleGraph (Fin 6) := cycleGraph 6
@@ -346,34 +339,34 @@ theorem petersen_matching : matchingNumber PetersenGraph = 5 := by
   have hbdd : BddAbove (Set.image (fun M : Subgraph PetersenGraph => (M.edgeSet.toFinset.card : ℝ)) {M | M.IsMatching}) := by
     refine ⟨(Fintype.card (Fin 10) : ℝ), ?_⟩
     rintro x ⟨M, hM, rfl⟩
-    show (M.edgeSet.toFinset.card : ℝ) ≤ Fintype.card (Fin 10)
+    show (M.edgeSet.toFinset.card : ℝ) ≤ Fintype.card PetersenVertex
     have hb := matching_card_bound PetersenGraph M hM
-    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ Fintype.card (Fin 10))
+    exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ Fintype.card PetersenVertex)
   unfold matchingNumber
   apply le_antisymm
   · apply csSup_le (Set.Nonempty.image _ ⟨⊥, by simp [Subgraph.IsMatching]⟩)
     rintro x ⟨M, hM, rfl⟩
     show (M.edgeSet.toFinset.card : ℝ) ≤ 5
     have hb := matching_card_bound PetersenGraph M hM
-    simp only [Fintype.card_fin] at hb
+    simp only [card_petersenVertex] at hb
     exact_mod_cast (by omega : M.edgeSet.toFinset.card ≤ 5)
   · apply le_csSup hbdd
-    refine ⟨PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 0 5 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 1 6 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 2 7 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 3 8 by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj 4 9 by decide), ?_, ?_⟩
+    refine ⟨PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj (⟨{0, 1}, by decide⟩ : PetersenVertex) (⟨{2, 3}, by decide⟩ : PetersenVertex) by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj (⟨{0, 2}, by decide⟩ : PetersenVertex) (⟨{3, 4}, by decide⟩ : PetersenVertex) by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj (⟨{0, 3}, by decide⟩ : PetersenVertex) (⟨{1, 4}, by decide⟩ : PetersenVertex) by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj (⟨{0, 4}, by decide⟩ : PetersenVertex) (⟨{1, 2}, by decide⟩ : PetersenVertex) by decide) ⊔ PetersenGraph.subgraphOfAdj (show PetersenGraph.Adj (⟨{1, 3}, by decide⟩ : PetersenVertex) (⟨{2, 4}, by decide⟩ : PetersenVertex) by decide), ?_, ?_⟩
     · apply Subgraph.IsMatching.sup
       · apply Subgraph.IsMatching.sup
         · apply Subgraph.IsMatching.sup
           · exact (Subgraph.IsMatching.subgraphOfAdj _).sup (Subgraph.IsMatching.subgraphOfAdj _)
-              (by rw [support_subgraphOfAdj, support_subgraphOfAdj]; simp [Set.disjoint_left])
+              (by rw [support_subgraphOfAdj, support_subgraphOfAdj]; (simp [Set.disjoint_left]; decide))
           · exact Subgraph.IsMatching.subgraphOfAdj _
           · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
-            simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
+            (simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]; decide)
         · exact Subgraph.IsMatching.subgraphOfAdj _
         · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
-          simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
+          (simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]; decide)
       · exact Subgraph.IsMatching.subgraphOfAdj _
       · apply Set.disjoint_of_subset (Subgraph.support_subset_verts _) (Subgraph.support_subset_verts _)
-        simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]
-    · simp
+        (simp [Subgraph.verts_sup, subgraphOfAdj_verts, Set.disjoint_left]; decide)
+    · simp; norm_cast
 
 @[category test, AMS 5]
 theorem petersen_residue : residue PetersenGraph = 3 := by

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -83,6 +83,7 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LargestInduc
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LovaszTheta
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Matching
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.PathCover
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Petersen
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.QuasiLineGraph
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Ramsey
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Residue

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Petersen.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Petersen.lean
@@ -1,0 +1,54 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+public import Mathlib.Data.Fintype.Powerset
+
+@[expose] public section
+
+/-!
+# The Petersen graph
+
+The **Petersen graph** as the Kneser graph $K(5, 2)$: vertices are the $2$-element subsets of a
+$5$-element set, adjacent when disjoint. We record that it has $10$ vertices and is cubic.
+-/
+
+namespace SimpleGraph
+
+/-- The vertex type of the Petersen graph: `2`-element subsets of `Fin 5`. -/
+abbrev PetersenVertex : Type := {s : Finset (Fin 5) // s.card = 2}
+
+/-- The **Petersen graph** $K(5,2)$: two `2`-subsets of `Fin 5` are adjacent iff disjoint. -/
+def petersenGraph : SimpleGraph PetersenVertex where
+  Adj s t := Disjoint s.1 t.1
+  symm := ⟨fun _ _ h => h.symm⟩
+  loopless := ⟨fun s h => by
+    have hc := s.2
+    rw [disjoint_self.mp h] at hc
+    simp at hc⟩
+
+instance : DecidableRel petersenGraph.Adj := fun s t =>
+  inferInstanceAs (Decidable (Disjoint s.1 t.1))
+
+/-- The Petersen graph has `10` vertices. -/
+theorem card_petersenVertex : Fintype.card PetersenVertex = 10 := by decide
+
+/-- The Petersen graph is cubic. -/
+theorem petersenGraph_degree (v : PetersenVertex) : petersenGraph.degree v = 3 := by
+  revert v; decide
+
+end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Petersen.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Petersen.lean
@@ -44,6 +44,11 @@ def petersenGraph : SimpleGraph PetersenVertex where
 instance : DecidableRel petersenGraph.Adj := fun s t =>
   inferInstanceAs (Decidable (Disjoint s.1 t.1))
 
+/-- A canonical vertex `{0, 1}` of the Petersen graph. -/
+def petersenVertex01 : PetersenVertex := ⟨{0, 1}, by decide⟩
+
+instance : Nonempty PetersenVertex := ⟨petersenVertex01⟩
+
 /-- The Petersen graph has `10` vertices. -/
 theorem card_petersenVertex : Fintype.card PetersenVertex = 10 := by decide
 


### PR DESCRIPTION
Adds Jaeger's Petersen colouring conjecture, together with the Petersen graph (absent from Mathlib and upstream).

**ForMathlib** — new `FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Petersen.lean`: `petersenGraph` as the Kneser graph $K(5,2)$ on `PetersenVertex` (2-subsets of `Fin 5`), with a `DecidableRel` instance; `card_petersenVertex : card = 10` and `petersenGraph_degree : ∀ v, degree v = 3`, both by `decide`.

**Problem file** — `FormalConjectures/Wikipedia/PetersenColoringConjecture.lean`:

| Declaration | Content | Status |
|---|---|---|
| `IsPetersenColoring` | edges of $G$ → edges of $P$, mapping each vertex's incident edges onto those of some vertex of $P$ | definition |
| `petersen_coloring_conjecture` | every bridgeless cubic graph has a Petersen colouring | `research open` |
| `.variants.normal_five_edge_coloring` | Jaeger's equivalence with normal 5-edge-colourings | `sorry` + reference |
| `.variants.petersenGraph` | $P$ Petersen-colours itself via the identity | **proved** |

Umbrella regenerated with `scripts/mk_all_formathlib.sh` and included in the commit.

### Verification
`lake build` of both modules on v4.33.1: clean, all linters pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)