### PR TITLE
feat(Paper): add the Tu-Deng conjecture

### DIFF
--- a/FormalConjectures/Paper/TuDengConjecture.lean
+++ b/FormalConjectures/Paper/TuDengConjecture.lean
@@ -1,0 +1,56 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjecturesUtil
+
+/-!
+# Tu-Deng Conjecture
+
+*References:*
+* [Tu, Z., Deng, Y., *A conjecture about binary strings and its applications on constructing
+  Boolean functions with optimal algebraic immunity*, Des. Codes Cryptogr. **60** (2011),
+  1–14](https://doi.org/10.1007/s10623-010-9413-9)
+* [IACR ePrint 2009/272](https://eprint.iacr.org/2009/272)
+
+For an integer `k ≥ 2`, identify the residues modulo `2 ^ k - 1` with the integers
+`0, 1, …, 2 ^ k - 2`, and let `w a` denote the binary weight of `a` (the number of ones in
+its binary expansion). The Tu-Deng conjecture states that for every residue `t ≠ 0`,
+
+$$\#\{(a, b) : a + b \equiv t \pmod{2^k - 1},\ w(a) + w(b) \le k - 1\} \le 2^{k-1}.$$
+
+Tu and Deng showed that this combinatorial statement implies that their constructions of
+Boolean functions (a bent class and a balanced class) achieve optimal algebraic immunity,
+which is the motivation for the conjecture. They verified the conjecture numerically for
+`k ≤ 29` (Remark 3.1 of the ePrint version).
+-/
+
+namespace TuDengConjecture
+
+/-- The binary weight of a natural number: the number of ones in its binary expansion. -/
+def binaryWeight (n : ℕ) : ℕ := (Nat.digits 2 n).sum
+
+/--
+**The Tu-Deng conjecture.** For `k ≥ 2` and a nonzero residue `t` modulo `2 ^ k - 1`, there
+are at most `2 ^ (k - 1)` pairs of residues `(a, b)` with `a + b = t` whose binary weights
+(of their representatives in `0, …, 2 ^ k - 2`) sum to at most `k - 1`.
+-/
+@[category research open, AMS 5 11 94]
+theorem tu_deng_conjecture (k : ℕ) (hk : 2 ≤ k) (t : ZMod (2 ^ k - 1)) (ht : t ≠ 0) :
+    {p : ZMod (2 ^ k - 1) × ZMod (2 ^ k - 1) |
+        p.1 + p.2 = t ∧ binaryWeight p.1.val + binaryWeight p.2.val ≤ k - 1}.ncard
+      ≤ 2 ^ (k - 1) := by
+  sorry
+
+end TuDengConjecture

--- a/FormalConjectures/Paper/TuDengConjecture.lean
+++ b/FormalConjectures/Paper/TuDengConjecture.lean
@@ -24,16 +24,16 @@ import FormalConjecturesUtil
   1–14](https://doi.org/10.1007/s10623-010-9413-9)
 * [IACR ePrint 2009/272](https://eprint.iacr.org/2009/272)
 
-For an integer `k ≥ 2`, identify the residues modulo `2 ^ k - 1` with the integers
-`0, 1, …, 2 ^ k - 2`, and let `w a` denote the binary weight of `a` (the number of ones in
-its binary expansion). The Tu-Deng conjecture states that for every residue `t ≠ 0`,
+For an integer $k \ge 2$, identify the residues modulo $2^k - 1$ with the integers
+$0, 1, \dots, 2^k - 2$, and let $w(a)$ denote the binary weight of $a$ (the number of ones in
+its binary expansion). The Tu-Deng conjecture states that for every residue $t \ne 0$,
 
 $$\#\{(a, b) : a + b \equiv t \pmod{2^k - 1},\ w(a) + w(b) \le k - 1\} \le 2^{k-1}.$$
 
 Tu and Deng showed that this combinatorial statement implies that their constructions of
 Boolean functions (a bent class and a balanced class) achieve optimal algebraic immunity,
 which is the motivation for the conjecture. They verified the conjecture numerically for
-`k ≤ 29` (Remark 3.1 of the ePrint version).
+$k \le 29$ (Remark 3.1 of the ePrint version).
 -/
 
 namespace TuDengConjecture
@@ -42,9 +42,9 @@ namespace TuDengConjecture
 def binaryWeight (n : ℕ) : ℕ := (Nat.digits 2 n).sum
 
 /--
-**The Tu-Deng conjecture.** For `k ≥ 2` and a nonzero residue `t` modulo `2 ^ k - 1`, there
-are at most `2 ^ (k - 1)` pairs of residues `(a, b)` with `a + b = t` whose binary weights
-(of their representatives in `0, …, 2 ^ k - 2`) sum to at most `k - 1`.
+**The Tu-Deng conjecture.** For $k \ge 2$ and a nonzero residue $t$ modulo $2^k - 1$, there
+are at most $2^{k-1}$ pairs of residues $(a, b)$ with $a + b = t$ whose binary weights
+(of their representatives in $0, \dots, 2^k - 2$) sum to at most $k - 1$.
 -/
 @[category research open, AMS 5 11 94]
 theorem tu_deng_conjecture (k : ℕ) (hk : 2 ≤ k) (t : ZMod (2 ^ k - 1)) (ht : t ≠ 0) :


### PR DESCRIPTION
Adds the Tu-Deng conjecture (Tu & Deng, Des. Codes Cryptogr. 60 (2011), 1-14; IACR ePrint 2009/272) as `FormalConjectures/Paper/TuDengConjecture.lean`.

**What:** For `k ≥ 2` and a nonzero residue `t` modulo `2^k - 1`, the number of pairs of residues `(a, b)` with `a + b = t` and `w(a) + w(b) ≤ k - 1` (binary weight of the representatives in `0, …, 2^k - 2`) is at most `2^(k-1)`. Stated over `ZMod (2^k - 1)` with `Set.ncard`; binary weight is `(Nat.digits 2 n).sum`.

**Why:** The conjecture underlies Tu and Deng's constructions of Boolean functions with optimal algebraic immunity and is open. It was not yet in the repository (no hits for Tu-Deng in code, issues, or PRs).

**Faithfulness:** Statement checked against the source (ePrint §3, "Conjecture"): `k > 1`, `a, b ∈ Z_{2^k−1}`, `0 < t < 2^k − 1`, `w(a) + w(b) ⩽ k − 1`, bound `2^{k−1}`. The formalized set semantics were additionally brute-force checked in Python for all `t` at `k = 2, …, 12` (no violations of the bound, and the equality cases match the known min-cyclic-gap characterization).

**How checked:** The statement was verified against the source text and brute-forced numerically as above. I could not complete a local `lake --wfail build` (mathlib cache download is impractically slow on my connection), so CI is the build check here; I will fix promptly if it flags anything.
