### PR TITLE
refactor(Arxiv/math.0608009): reuse JacobianConjectureProp in JacobianConjectureFor

### DIFF
--- a/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
+++ b/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
@@ -55,7 +55,7 @@ so that the canonical bracket reads $\{X_i, X_{i+n}\} = 1$; see
 
 namespace Arxiv.«math.0608009»
 
-open MvPolynomial
+open MvPolynomial JacobianConjecture
 
 variable {K : Type*} [Field K] [CharZero K]
 
@@ -76,14 +76,6 @@ algebra endomorphism preserving the Poisson bracket is again such. -/
 def PoissonConjectureFor (n : ℕ) : Prop :=
   ∀ φ : MvPolynomial (Fin n ⊕ Fin n) K →ₐ[K] MvPolynomial (Fin n ⊕ Fin n) K,
     IsPoissonEndomorphism φ → Function.Bijective φ
-
-variable (K) in
-/-- The Jacobian Conjecture in dimension `m`: every polynomial endomorphism of $K^m$ with
-unit Jacobian determinant has a polynomial inverse. This is the per-dimension form of
-`JacobianConjecture.JacobianConjectureProp`, which quantifies over arbitrary finite
-variable types. -/
-def JacobianConjectureFor (m : ℕ) : Prop :=
-  JacobianConjecture.JacobianConjectureProp K (Fin m)
 
 /--
 The **Poisson Conjecture** ([AvdE07], the characteristic zero case): for every `n`, every
@@ -144,7 +136,7 @@ The Jacobian conjecture in dimension $2n$ implies the Poisson conjecture in dime
 -/
 @[category research solved, AMS 14 17]
 theorem poisson_conjecture.variants.jacobian_implication (n : ℕ)
-    (h : JacobianConjectureFor K (2 * n)) : PoissonConjectureFor K n := by
+    (h : JacobianConjectureProp K (Fin (2 * n))) : PoissonConjectureFor K n := by
   sorry
 
 section Tests

--- a/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
+++ b/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 
+import FormalConjectures.Wikipedia.JacobianConjecture
 import FormalConjecturesUtil
 
 /-!
@@ -78,14 +79,11 @@ def PoissonConjectureFor (n : ℕ) : Prop :=
 
 variable (K) in
 /-- The Jacobian Conjecture in dimension `m`: every polynomial endomorphism of $K^m$ with
-unit Jacobian determinant has a polynomial inverse. This is the per-dimension form of the
-statement in `FormalConjectures.Wikipedia.JacobianConjecture`, which quantifies over all
-finite variable types at once. -/
+unit Jacobian determinant has a polynomial inverse. This is the per-dimension form of
+`JacobianConjecture.JacobianConjectureProp`, which quantifies over arbitrary finite
+variable types. -/
 def JacobianConjectureFor (m : ℕ) : Prop :=
-  ∀ F : RegularFunction K (Fin m) (Fin m), IsUnit F.Jacobian.det →
-    ∃ G : RegularFunction K (Fin m) (Fin m),
-      G.comp F = RegularFunction.id K (Fin m) ∧
-      F.comp G = RegularFunction.id K (Fin m)
+  JacobianConjecture.JacobianConjectureProp K (Fin m)
 
 /--
 The **Poisson Conjecture** ([AvdE07], the characteristic zero case): for every `n`, every


### PR DESCRIPTION
Follow-up to #4490, as suggested by @Paul-Lez and @mo271 in review: `JacobianConjectureFor` now reuses `JacobianConjecture.JacobianConjectureProp` from `FormalConjectures/Wikipedia/JacobianConjecture.lean` instead of restating the definition.

Checked with `lake --wfail build 'FormalConjectures.Arxiv.«math.0608009».PoissonConjecture'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9rviNpzds7nEE6StYU2qT