### PR TITLE
ErdosProblems: link formal proofs for 10 solved problems

### DIFF
--- a/FormalConjectures/ErdosProblems/1077.lean
+++ b/FormalConjectures/ErdosProblems/1077.lean
@@ -35,7 +35,8 @@ Let $ε, α > 0$ and $D$ and $n$ be sufficiently large. If $G$ is a graph on $n$
 least $n^{1+α}$ edges, then must $G$ contain a $D$-balanced subgraph on $m > n^{1-α}$ vertices with
 at least $εm^{1+α}$ edges?
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos1077.lean#L265"]
 theorem erdos_1077 :
     answer(False) ↔ ∀ ε > (0 : ℝ), ε < 1 → ∀ α > (0 : ℝ), α < 1 → ∀ᶠ D in atTop, ∀ᶠ n in atTop,
       ∀ G : SimpleGraph (Fin n), G.edgeSet.ncard > (n : ℝ) ^ (1 + α) →

--- a/FormalConjectures/ErdosProblems/1096.lean
+++ b/FormalConjectures/ErdosProblems/1096.lean
@@ -42,7 +42,8 @@ Is it true that, provided $\epsilon>0$ is sufficiently small, $x_{k+1}-x_k \to 0
 This was solved affirmatively by Erdős and Komornik [ErKo98], who proved the conclusion
 whenever $1<q<\sqrt{q_1}$, where $q_1$ is the second Pisot-Vijayaraghavan number.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos1096.lean#L44"]
 theorem erdos_1096 :
     answer(True) ↔ ∃ ε > 0, ∀ q, 1 < q → q < 1 + ε →
     ∀ x : ℕ → ℝ, StrictMono x → Set.range x = { ∑ i ∈ S, q ^ i | S : Finset ℕ } →

--- a/FormalConjectures/ErdosProblems/615.lean
+++ b/FormalConjectures/ErdosProblems/615.lean
@@ -53,7 +53,8 @@ or an independent set on at least $n/\log n$ vertices?
 
 The answer is no, as shown by Fox, Loh, and Zhao [FLZ15].
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos615.lean#L492"]
 theorem erdos_615 : answer(False) ↔
     ∃ c : ℝ, 0 < c ∧ ∀ᶠ (n : ℕ) in atTop,
       ∀ G : SimpleGraph (Fin n), (1 / 8 - c) * n ^ 2 ≤ G.edgeFinset.card →

--- a/FormalConjectures/ErdosProblems/755.lean
+++ b/FormalConjectures/ErdosProblems/755.lean
@@ -85,7 +85,8 @@ $T_6(n) = (1/27 + o(1)) n^3$. The unit-triangle upper bound follows as a
 corollary, since unit equilateral triangles are a subset of equilateral
 triangles of any positive side length: $T_\mathrm{unit} \leq T_\mathrm{anysize}$.
 -/
-@[category research solved, AMS 52]
+@[category research solved, AMS 52,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos755.lean#L1344"]
 theorem erdos_755 :
     answer(True) ↔ ∃ o : ℕ → ℝ,
       o =o[atTop] (fun _ : ℕ => (1 : ℝ)) ∧

--- a/FormalConjectures/ErdosProblems/825.lean
+++ b/FormalConjectures/ErdosProblems/825.lean
@@ -34,7 +34,8 @@ This has been solved in the affirmative by Larsen - in fact, for any $\epsilon>0
 such that if $n$ has only prime divisors $>L$ and $\sigma(n)>(2+\epsilon)n$ then $n$ is the distinct
 sum of proper divisors of $n$.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos825.lean#L5893"]
 theorem erdos_825 :
     answer(True) ↔ ∃ (C : ℝ) (_ : C > 0),
       ∀ (n) (_ : σ 1 n > C * n),

--- a/FormalConjectures/ErdosProblems/847.lean
+++ b/FormalConjectures/ErdosProblems/847.lean
@@ -47,7 +47,8 @@ $0<\mu<1/2$, there exists $A\subseteq \mathbb{N}$ such that every finite colouri
 a three-term arithmetic progression, and yet every subset of $A$ of size $n$ contains a subset of
 size $\geq \mu n$ without a three-term arithmetic progression.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos847.lean#L113"]
 theorem erdos_847 : answer(False) ↔ ∀ (A : Set ℕ), Infinite A → HasFew3APs A →
     ∃ n, ∃ (S : Fin n → Set ℕ), (∀ i, ThreeAPFree (S i)) ∧ A = ⋃ i : Fin n, S i := by
   sorry

--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -50,7 +50,8 @@ $a\leq b\leq c\leq d\in A$ are such that $abcd$ is a square then $ad=bc$?
 
 This was proved by GPT-5.5 Pro (prompted by Chojecki).
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos888.lean#L47"]
 theorem erdos_888 :
     (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ)) =Θ[atTop]
       (fun n : ℕ ↦ (n : ℝ) * Real.log (Real.log n) / Real.log n) := by

--- a/FormalConjectures/ErdosProblems/899.lean
+++ b/FormalConjectures/ErdosProblems/899.lean
@@ -41,7 +41,8 @@ The answer is yes, proved by Ruzsa [Ru78].
 
 [Ru78] Ruzsa, I. Z., _On the cardinality of {$A+A$}\ and {$A-A$}_. (1978), 933--938.
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos899.lean#L793"]
 theorem erdos_899 : answer(True) ↔ ∀ (A : Set ℕ), A.Infinite →
     Tendsto (fun N => (A ∩ Icc 1 N |>.ncard : ℝ) / N) atTop (𝓝 0) →
     atTop.limsup (fun N => ((A - A : Set ℕ) ∩ Icc 1 N |>.ncard : EReal) /

--- a/FormalConjectures/ErdosProblems/937.lean
+++ b/FormalConjectures/ErdosProblems/937.lean
@@ -47,7 +47,8 @@ there are infinitely many four-term arithmetic progressions of pairwise coprime 
 (Without coprimality this is easy, and by a theorem of Fermat there are no four *squares* in
 arithmetic progression.)
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos937.lean#L1031"]
 theorem erdos_937 :
     answer(True) ↔ {p : ℕ × ℕ | IsCoprimePowerfulAP4 p.1 p.2}.Infinite := by
   sorry

--- a/FormalConjectures/ErdosProblems/965.lean
+++ b/FormalConjectures/ErdosProblems/965.lean
@@ -39,7 +39,8 @@ all sums $a + b$ for $a, b ∈ A, a ≠ b$ have the same colour.
 In [Ko16] Péter Komjáth constructed a counterexample.
 The same result was proven independently in [SWCol] by Sokoup and Weiss.
 -/
-@[category research solved, AMS 3 5]
+@[category research solved, AMS 3 5,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/dfe2d78128b493c572cf525b1b8edf4897fb7664/src/latest/ErdosProblems/Erdos965.lean#L42"]
 theorem erdos_965 :
     answer(False) ↔ ∀ f : ℝ → Fin 2, ∃ A : Set ℝ, ¬ A.Countable ∧
       ∀ᵉ (a ∈ A) (b ∈ A) (c ∈ A) (d ∈ A), a ≠ b → c ≠ d → f (a + b) = f (c + d) := by


### PR DESCRIPTION
The status bot filed issues #5140–#5151 and #5207 after erdosproblems.com marked a batch of problems `formally solved` (Lean). The proofs are Boris Alexeev's (@plby), in [plby/lean-proofs](https://github.com/plby/lean-proofs), which states them against this repository's formulations.

This PR adds `formal_proof using lean4 at "<permalink>"` to the main theorem of the 10 problems where the match is exact, with links pinned to commit `dfe2d78` and anchored at the proved theorem.

**Verification done per problem** (615, 755, 825, 847, 888, 899, 937, 965, 1077, 1096):

- The proved proposition is token-identical to the statement here (modulo `↦`/`=>` and line breaks), with the right polarity: `answer(True) ↔ P` linked to a proof of `P`, `answer(False) ↔ P` linked to a proof of `¬P` (the linked files also carry `alias`es to the `erdos_N` names used here).
- Local supporting definitions were compared as well, not just the theorem line: `TUnit`/`unitEquilateralTriangleCount` (755), `HasFew3APs` (847), `RequiredCondition`/`p` (888, defined in the proof's `Foundations` module with `extremalSize` defeq to `Nat.findGreatest (p n) n`), `IsCoprimePowerfulAP4` (937), `IsBalanced` (1077, matches `FormalConjecturesForMathlib`). All identical.
- The linked files contain no `sorry` and no `axiom` declarations, and end with `#print axioms` checks.

**Deliberately not included:**

- **#5151 (1128):** the external proof of the main statement is token-identical too, but `erdos_1128` is derived in-repo from the sorried `erdos_1128.prikryMills`, and the build linter (correctly) rejects `formal_proof` on a statement not proved exactly `by sorry` — the first push failed CI on exactly this. The attribute belongs on `prikryMills`, but plby's construction is inlined in his `not_erdos_1128` rather than exposed as a lemma matching that ∃-statement, so I could not verify a link for it. Left open.
- **#5144 (868):** the proved statements for both parts are token-identical, but the statement's `IsAsymptoticAddBasisOfOrder` is not defined in this repository while the proof carries its own local definition (`∀ᶠ m in cofinite, m ∈ o • A`), and I could not pin down where the name resolves from here to certify the two agree. Left open rather than linked on an unverified identification.
- **#5207 (problem 2):** the proof there establishes a uniform-bound form in its own covering-system vocabulary rather than this repository's `StrictCoveringSystem ℤ` formulation; commented on the issue with the details.

This is an attribute-only change; I have not run `lake build` locally (slow connection to the Mathlib cache here), so CI is the build gate — the 10 remaining files built cleanly on the previous run (only 1128 failed, now dropped). Prepared with Claude Code (agent-assisted); the statement and definition comparisons described above were all performed against the fetched sources.

Fixes #5140, fixes #5141, fixes #5142, fixes #5143, fixes #5145, fixes #5146, fixes #5147, fixes #5148, fixes #5149, fixes #5150
