### PR TITLE
Formalize the perfect-play value of chess

### DIFF
--- a/FormalConjectures/Books/Chess.lean
+++ b/FormalConjectures/Books/Chess.lean
@@ -1,0 +1,640 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Perfect play in chess
+
+This file models the part of the FIDE Laws of Chess needed to assign a game-theoretic value to
+the standard initial position. It includes legal moves, checkmate, stalemate, dead positions,
+draw claims, fivefold repetition, and the 75-move rule. It excludes clocks, resignation, and
+draws by agreement because these are not properties of the abstract game tree.
+
+The conjecture says that both White and Black have strategies that avoid a loss. Equivalently,
+the game-theoretic value of the initial position is a draw.
+
+An early published version of this conjecture appears in the 1775 *Traité des Amateurs*. Its
+authors argue that, when both sides play correctly, the game is drawn. The present statement uses
+the current FIDE rules.
+
+*References:*
+- [Société d'Amateurs, *Traité théorique et pratique du jeu des échecs*, pp. 162–163
+  (1775)](https://archive.org/details/traitthoriqueet00damgoog)
+- [FIDE Laws of Chess](https://rcc.fide.com/fide-laws-of-chess_fulltexthtml/)
+- [Wikipedia, Solving chess](https://en.wikipedia.org/wiki/Solving_chess)
+- [Wikipedia, First-move advantage in chess](https://en.wikipedia.org/wiki/First-move_advantage_in_chess)
+-/
+
+namespace Chess
+
+/-- The two players in a game of chess. -/
+inductive Color
+  | white
+  | black
+  deriving DecidableEq
+
+/-- The opponent of a player. -/
+def Color.other : Color → Color
+  | .white => .black
+  | .black => .white
+
+/-- The six kinds of chess piece. -/
+inductive PieceKind
+  | king
+  | queen
+  | rook
+  | bishop
+  | knight
+  | pawn
+  deriving DecidableEq
+
+/-- A chess piece has a color and a kind. -/
+structure Piece where
+  color : Color
+  kind : PieceKind
+  deriving DecidableEq
+
+/-- A file or rank on an $8 \times 8$ chessboard. -/
+abbrev BoardIndex := Fin 8
+
+/-- A square on an $8 \times 8$ chessboard. -/
+structure Square where
+  file : BoardIndex
+  rank : BoardIndex
+  deriving DecidableEq, Fintype
+
+/-- A chessboard records the optional piece on every square. -/
+abbrev Board := Square → Option Piece
+
+/-- The two sides on which a player can castle. -/
+inductive CastleSide
+  | kingside
+  | queenside
+  deriving DecidableEq
+
+/-- The castling rights that have not been lost during play. -/
+structure CastlingRights where
+  whiteKingside : Bool
+  whiteQueenside : Bool
+  blackKingside : Bool
+  blackQueenside : Bool
+  deriving DecidableEq
+
+namespace CastlingRights
+
+/-- Initially both players may castle on either side. -/
+def initial : CastlingRights := ⟨true, true, true, true⟩
+
+/-- Whether the specified castling right is present. -/
+def has (rights : CastlingRights) : Color → CastleSide → Bool
+  | .white, .kingside => rights.whiteKingside
+  | .white, .queenside => rights.whiteQueenside
+  | .black, .kingside => rights.blackKingside
+  | .black, .queenside => rights.blackQueenside
+
+/-- Remove the kingside castling right of one player. -/
+def removeKingside (rights : CastlingRights) : Color → CastlingRights
+  | .white => { rights with whiteKingside := false }
+  | .black => { rights with blackKingside := false }
+
+/-- Remove the queenside castling right of one player. -/
+def removeQueenside (rights : CastlingRights) : Color → CastlingRights
+  | .white => { rights with whiteQueenside := false }
+  | .black => { rights with blackQueenside := false }
+
+/-- Remove both castling rights of one player. -/
+def removeBoth (rights : CastlingRights) (color : Color) : CastlingRights :=
+  (rights.removeKingside color).removeQueenside color
+
+end CastlingRights
+
+/-- A requested half-move, including the requested promotion piece when applicable. -/
+structure Ply where
+  src : Square
+  dst : Square
+  promotion : Option PieceKind := none
+  deriving DecidableEq
+
+/-- The information needed to determine legal moves from a chess position. -/
+structure Position where
+  board : Board
+  turn : Color
+  castlingRights : CastlingRights
+  enPassantTarget : Option Square
+  halfmoveClock : ℕ
+
+/-- The distance between the files of two squares. -/
+def fileDistance (a b : Square) : ℕ := Nat.dist a.file b.file
+
+/-- The distance between the ranks of two squares. -/
+def rankDistance (a b : Square) : ℕ := Nat.dist a.rank b.rank
+
+/-- Whether $x$ lies strictly between $a$ and $b$. -/
+def StrictlyBetween (a b x : ℕ) : Prop :=
+  min a b < x ∧ x < max a b
+
+/-- Whether a square lies strictly inside the straight segment between two other squares. -/
+def OnOpenSegment (src dst square : Square) : Prop :=
+  (src.file = dst.file ∧ square.file = src.file ∧
+      StrictlyBetween src.rank dst.rank square.rank) ∨
+    (src.rank = dst.rank ∧ square.rank = src.rank ∧
+      StrictlyBetween src.file dst.file square.file) ∨
+    (fileDistance src dst = rankDistance src dst ∧
+      fileDistance src square = rankDistance src square ∧
+      StrictlyBetween src.file dst.file square.file ∧
+      StrictlyBetween src.rank dst.rank square.rank)
+
+/-- Whether every square strictly between `src` and `dst` is empty. -/
+def PathClear (board : Board) (src dst : Square) : Prop :=
+  ∀ square, OnOpenSegment src dst square → board square = none
+
+/-- Whether a pawn of `color` attacks `dst` from `src`. -/
+def PawnAttacks (color : Color) (src dst : Square) : Prop :=
+  fileDistance src dst = 1 ∧
+    match color with
+    | .white => src.rank.val + 1 = dst.rank.val
+    | .black => dst.rank.val + 1 = src.rank.val
+
+/-- Whether a piece attacks a square, without regard to whether moving it would expose its king. -/
+def PieceAttacks (board : Board) (piece : Piece) (src dst : Square) : Prop :=
+  match piece.kind with
+  | .pawn => PawnAttacks piece.color src dst
+  | .knight =>
+      (fileDistance src dst = 1 ∧ rankDistance src dst = 2) ∨
+        (fileDistance src dst = 2 ∧ rankDistance src dst = 1)
+  | .bishop =>
+      src ≠ dst ∧ fileDistance src dst = rankDistance src dst ∧ PathClear board src dst
+  | .rook =>
+      src ≠ dst ∧ (src.file = dst.file ∨ src.rank = dst.rank) ∧ PathClear board src dst
+  | .queen =>
+      src ≠ dst ∧
+        (src.file = dst.file ∨ src.rank = dst.rank ∨
+          fileDistance src dst = rankDistance src dst) ∧
+        PathClear board src dst
+  | .king =>
+      src ≠ dst ∧ fileDistance src dst ≤ 1 ∧ rankDistance src dst ≤ 1
+
+/-- Whether `square` is attacked by a piece of `color`. -/
+def IsAttackedBy (board : Board) (color : Color) (square : Square) : Prop :=
+  ∃ src piece, board src = some piece ∧ piece.color = color ∧
+    PieceAttacks board piece src square
+
+/-- Whether the king of `color` is in check. -/
+def InCheck (board : Board) (color : Color) : Prop :=
+  ∃ square, board square = some ⟨color, .king⟩ ∧ IsAttackedBy board color.other square
+
+/-- The initial square of a king. -/
+def kingHome : Color → Square
+  | .white => ⟨4, 0⟩
+  | .black => ⟨4, 7⟩
+
+/-- The initial square of a rook used for castling. -/
+def rookHome : Color → CastleSide → Square
+  | .white, .kingside => ⟨7, 0⟩
+  | .white, .queenside => ⟨0, 0⟩
+  | .black, .kingside => ⟨7, 7⟩
+  | .black, .queenside => ⟨0, 7⟩
+
+/-- The king's destination when castling. -/
+def castleKingDestination : Color → CastleSide → Square
+  | .white, .kingside => ⟨6, 0⟩
+  | .white, .queenside => ⟨2, 0⟩
+  | .black, .kingside => ⟨6, 7⟩
+  | .black, .queenside => ⟨2, 7⟩
+
+/-- The square crossed by the king when castling. -/
+def castleKingTransit : Color → CastleSide → Square
+  | .white, .kingside => ⟨5, 0⟩
+  | .white, .queenside => ⟨3, 0⟩
+  | .black, .kingside => ⟨5, 7⟩
+  | .black, .queenside => ⟨3, 7⟩
+
+/-- The rook's destination when castling. -/
+def castleRookDestination : Color → CastleSide → Square
+  | .white, .kingside => ⟨5, 0⟩
+  | .white, .queenside => ⟨3, 0⟩
+  | .black, .kingside => ⟨5, 7⟩
+  | .black, .queenside => ⟨3, 7⟩
+
+/-- Detect a castling-shaped king ply. -/
+def castleSide? (piece : Piece) (ply : Ply) : Option CastleSide :=
+  if piece.kind ≠ .king then
+    none
+  else if ply.src = kingHome piece.color ∧
+      ply.dst = castleKingDestination piece.color .kingside then
+    some .kingside
+  else if ply.src = kingHome piece.color ∧
+      ply.dst = castleKingDestination piece.color .queenside then
+    some .queenside
+  else
+    none
+
+/-- The square occupied by the pawn captured en passant. -/
+def enPassantCapturedSquare (ply : Ply) : Square := ⟨ply.dst.file, ply.src.rank⟩
+
+/-- Whether a ply has the board shape of an en-passant capture. -/
+def IsEnPassant (position : Position) (piece : Piece) (ply : Ply) : Prop :=
+  piece.kind = .pawn ∧ PawnAttacks piece.color ply.src ply.dst ∧
+    position.enPassantTarget = some ply.dst ∧ position.board ply.dst = none ∧
+    position.board (enPassantCapturedSquare ply) = some ⟨piece.color.other, .pawn⟩
+
+/-- Whether a pawn makes a one-square non-capturing move. -/
+def IsPawnAdvance (board : Board) (color : Color) (src dst : Square) : Prop :=
+  src.file = dst.file ∧ board dst = none ∧
+    match color with
+    | .white => src.rank.val + 1 = dst.rank.val
+    | .black => dst.rank.val + 1 = src.rank.val
+
+/-- Whether a pawn makes its initial two-square non-capturing move. -/
+def IsPawnDoubleAdvance (board : Board) (color : Color) (src dst : Square) : Prop :=
+  src.file = dst.file ∧ board dst = none ∧ PathClear board src dst ∧
+    match color with
+    | .white => src.rank = 1 ∧ dst.rank = 3
+    | .black => src.rank = 6 ∧ dst.rank = 4
+
+/-- Whether a pawn makes an ordinary capture. -/
+def IsPawnCapture (board : Board) (piece : Piece) (src dst : Square) : Prop :=
+  PawnAttacks piece.color src dst ∧
+    ∃ captured, board dst = some captured ∧ captured.color = piece.color.other ∧
+      captured.kind ≠ .king
+
+section
+
+attribute [local instance] Classical.propDecidable
+
+/-- Whether the requested promotion is exactly the one required by this ply. -/
+noncomputable def ValidPromotion (piece : Piece) (ply : Ply) : Prop :=
+  let reachesLastRank :=
+    piece.kind = .pawn ∧
+      match piece.color with
+      | .white => ply.dst.rank = 7
+      | .black => ply.dst.rank = 0
+  if reachesLastRank then
+    ∃ kind, ply.promotion = some kind ∧ kind ≠ .king ∧ kind ≠ .pawn
+  else
+    ply.promotion = none
+
+end
+
+/-- Whether the destination is empty or occupied by a non-king opponent piece. -/
+def DestinationAllowed (position : Position) (ply : Ply) : Prop :=
+  match position.board ply.dst with
+  | none => True
+  | some piece => piece.color = position.turn.other ∧ piece.kind ≠ .king
+
+/-- Whether a king ply is castling legally except for safety on its destination square. -/
+def IsCastling (position : Position) (piece : Piece) (ply : Ply) : Prop :=
+  ∃ side,
+    piece = ⟨position.turn, .king⟩ ∧
+      ply.src = kingHome position.turn ∧
+      ply.dst = castleKingDestination position.turn side ∧
+      position.castlingRights.has position.turn side = true ∧
+      position.board (rookHome position.turn side) = some ⟨position.turn, .rook⟩ ∧
+      PathClear position.board ply.src (rookHome position.turn side) ∧
+      ¬IsAttackedBy position.board position.turn.other ply.src ∧
+      ¬IsAttackedBy position.board position.turn.other (castleKingTransit position.turn side)
+
+/-- Whether a piece has a movement pattern permitted by its kind. -/
+def PieceMovement (position : Position) (piece : Piece) (ply : Ply) : Prop :=
+  match piece.kind with
+  | .pawn =>
+      IsPawnAdvance position.board piece.color ply.src ply.dst ∨
+        IsPawnDoubleAdvance position.board piece.color ply.src ply.dst ∨
+        IsPawnCapture position.board piece ply.src ply.dst ∨
+        IsEnPassant position piece ply
+  | .knight =>
+      (fileDistance ply.src ply.dst = 1 ∧ rankDistance ply.src ply.dst = 2) ∨
+        (fileDistance ply.src ply.dst = 2 ∧ rankDistance ply.src ply.dst = 1)
+  | .bishop =>
+      fileDistance ply.src ply.dst = rankDistance ply.src ply.dst ∧
+        PathClear position.board ply.src ply.dst
+  | .rook =>
+      (ply.src.file = ply.dst.file ∨ ply.src.rank = ply.dst.rank) ∧
+        PathClear position.board ply.src ply.dst
+  | .queen =>
+      (ply.src.file = ply.dst.file ∨ ply.src.rank = ply.dst.rank ∨
+          fileDistance ply.src ply.dst = rankDistance ply.src ply.dst) ∧
+        PathClear position.board ply.src ply.dst
+  | .king =>
+      (fileDistance ply.src ply.dst ≤ 1 ∧ rankDistance ply.src ply.dst ≤ 1) ∨
+        IsCastling position piece ply
+
+/-- Whether a requested ply obeys all rules except the moving player's final king safety. -/
+def IsPseudoLegal (position : Position) (ply : Ply) : Prop :=
+  ∃ piece,
+    position.board ply.src = some piece ∧ piece.color = position.turn ∧
+      ply.src ≠ ply.dst ∧ DestinationAllowed position ply ∧
+      ValidPromotion piece ply ∧ PieceMovement position piece ply
+
+/-- The piece obtained after applying a requested promotion. -/
+def movedPiece (piece : Piece) (ply : Ply) : Piece :=
+  match ply.promotion with
+  | some kind => ⟨piece.color, kind⟩
+  | none => piece
+
+section
+
+attribute [local instance] Classical.propDecidable
+
+/-- Apply the board effect of a ply. Validation is kept separate. -/
+noncomputable def applyBoard (position : Position) (ply : Ply) : Board :=
+  match position.board ply.src with
+  | none => position.board
+  | some piece => fun square =>
+      if square = ply.dst then
+        some (movedPiece piece ply)
+      else if square = ply.src then
+        none
+      else
+        match castleSide? piece ply with
+        | some side =>
+            if square = castleRookDestination piece.color side then
+              some ⟨piece.color, .rook⟩
+            else if square = rookHome piece.color side then
+              none
+            else
+              position.board square
+        | none =>
+            if IsEnPassant position piece ply ∧ square = enPassantCapturedSquare ply then
+              none
+            else
+              position.board square
+
+end
+
+/-- Whether a ply is legal in the given position. -/
+def IsLegalPly (position : Position) (ply : Ply) : Prop :=
+  IsPseudoLegal position ply ∧ ¬InCheck (applyBoard position ply) position.turn
+
+/-- Remove the castling right associated with a rook's home square. -/
+def removeRookRightAt
+    (rights : CastlingRights) (color : Color) (square : Square) : CastlingRights :=
+  if square = rookHome color .kingside then
+    rights.removeKingside color
+  else if square = rookHome color .queenside then
+    rights.removeQueenside color
+  else
+    rights
+
+/-- Update castling rights after a ply. -/
+def nextCastlingRights (position : Position) (ply : Ply) : CastlingRights :=
+  match position.board ply.src with
+  | none => position.castlingRights
+  | some piece =>
+      let afterMove :=
+        if piece.kind = .king then
+          position.castlingRights.removeBoth piece.color
+        else if piece.kind = .rook then
+          removeRookRightAt position.castlingRights piece.color ply.src
+        else
+          position.castlingRights
+      match position.board ply.dst with
+      | some captured =>
+          if captured.kind = .rook then removeRookRightAt afterMove captured.color ply.dst
+          else afterMove
+      | none => afterMove
+
+section
+
+attribute [local instance] Classical.propDecidable
+
+/-- The en-passant target created by a double pawn advance, if any. -/
+noncomputable def nextEnPassantTarget (position : Position) (ply : Ply) : Option Square :=
+  match position.board ply.src with
+  | some piece =>
+      if piece.kind = .pawn ∧
+          IsPawnDoubleAdvance position.board piece.color ply.src ply.dst then
+        match piece.color with
+        | .white => some ⟨ply.src.file, 2⟩
+        | .black => some ⟨ply.src.file, 5⟩
+      else
+        none
+  | none => none
+
+end
+
+/-- Whether the ply captures a piece. -/
+def IsCapture (position : Position) (ply : Ply) : Prop :=
+  position.board ply.dst ≠ none ∨
+    ∃ piece, position.board ply.src = some piece ∧ IsEnPassant position piece ply
+
+section
+
+attribute [local instance] Classical.propDecidable
+
+/-- Apply a ply to a position, including all historical position data. -/
+noncomputable def applyPly (position : Position) (ply : Ply) : Position :=
+  let isPawn := ∃ piece, position.board ply.src = some piece ∧ piece.kind = .pawn
+  { board := applyBoard position ply
+    turn := position.turn.other
+    castlingRights := nextCastlingRights position ply
+    enPassantTarget := nextEnPassantTarget position ply
+    halfmoveClock := if isPawn ∨ IsCapture position ply then 0 else position.halfmoveClock + 1 }
+
+end
+
+/-- The back-rank piece on a given file in the initial position. -/
+def initialBackRankPiece (color : Color) (file : BoardIndex) : Piece :=
+  ⟨color, match file with
+    | 0 | 7 => .rook
+    | 1 | 6 => .knight
+    | 2 | 5 => .bishop
+    | 3 => .queen
+    | _ => .king⟩
+
+/-- The standard initial chessboard. -/
+def initialBoard : Board := fun square =>
+  match square.rank with
+  | 0 => some (initialBackRankPiece .white square.file)
+  | 1 => some ⟨.white, .pawn⟩
+  | 6 => some ⟨.black, .pawn⟩
+  | 7 => some (initialBackRankPiece .black square.file)
+  | _ => none
+
+/-- The standard initial chess position. -/
+def initialPosition : Position :=
+  { board := initialBoard
+    turn := .white
+    castlingRights := .initial
+    enPassantTarget := none
+    halfmoveClock := 0 }
+
+/-- Whether the side to move has a legal ply. -/
+def HasLegalPly (position : Position) : Prop :=
+  ∃ ply, IsLegalPly position ply
+
+/-- Whether the side to move is checkmated. -/
+def IsCheckmate (position : Position) : Prop :=
+  InCheck position.board position.turn ∧ ¬HasLegalPly position
+
+/-- Whether the side to move is stalemated. -/
+def IsStalemate (position : Position) : Prop :=
+  ¬InCheck position.board position.turn ∧ ¬HasLegalPly position
+
+/-- One legal ply relates a position to its successor. -/
+def Position.Next (source target : Position) : Prop :=
+  ∃ ply, IsLegalPly source ply ∧ target = applyPly source ply
+
+/-- A dead position is one from which no legal continuation can end in checkmate. -/
+def IsDeadPosition (position : Position) : Prop :=
+  ∀ target, Relation.ReflTransGen Position.Next position target → ¬IsCheckmate target
+
+/-- Two positions are the same for the purposes of the FIDE repetition rules. -/
+def SamePosition (first second : Position) : Prop :=
+  (∀ square, first.board square = second.board square) ∧
+    first.turn = second.turn ∧ first.castlingRights = second.castlingRights ∧
+    ∀ ply,
+      (IsLegalPly first ply ∧ ∃ piece, first.board ply.src = some piece ∧
+          IsEnPassant first piece ply) ↔
+        (IsLegalPly second ply ∧ ∃ piece, second.board ply.src = some piece ∧
+          IsEnPassant second piece ply)
+
+/-- A played position together with all earlier positions, newest first. -/
+structure Game where
+  current : Position
+  previous : List Position
+
+namespace Game
+
+/-- A game at the standard initial position. -/
+def initial : Game := ⟨initialPosition, []⟩
+
+/-- All positions that have occurred in a game, newest first. -/
+def positions (game : Game) : List Position := game.current :: game.previous
+
+/-- Extend a played game by one ply. -/
+noncomputable def play (game : Game) (ply : Ply) : Game :=
+  ⟨applyPly game.current ply, game.current :: game.previous⟩
+
+/-- Whether the current position has occurred at least `n` times. -/
+def RepeatedAtLeast (n : ℕ) (game : Game) : Prop :=
+  ∃ indices : Fin n → Fin game.positions.length,
+    Function.Injective indices ∧
+      ∀ i, SamePosition (game.positions.get (indices i)) game.current
+
+end Game
+
+/-- A player may claim a draw when the current or announced next position is a third occurrence. -/
+def CanClaimThreefold (game : Game) : Prop :=
+  game.RepeatedAtLeast 3 ∨
+    ∃ ply, IsLegalPly game.current ply ∧ (game.play ply).RepeatedAtLeast 3
+
+/-- A player may claim a draw when the current or announced next ply reaches 100 half-moves. -/
+def CanClaimFiftyMove (game : Game) : Prop :=
+  100 ≤ game.current.halfmoveClock ∨
+    ∃ ply, IsLegalPly game.current ply ∧ 100 ≤ (applyPly game.current ply).halfmoveClock
+
+/-- Whether the side to move may claim a draw under a claim-based FIDE rule. -/
+def CanClaimDraw (game : Game) : Prop :=
+  CanClaimThreefold game ∨ CanClaimFiftyMove game
+
+/-- The possible game-theoretic outcomes of chess. -/
+inductive Outcome
+  | win (color : Color)
+  | draw
+  deriving DecidableEq
+
+/-- An outcome imposed by the board, history, or an automatic FIDE draw rule. -/
+inductive AutomaticOutcome (game : Game) : Outcome → Prop
+  | checkmate (h : IsCheckmate game.current) : AutomaticOutcome game (.win game.current.turn.other)
+  | stalemate (h : IsStalemate game.current) : AutomaticOutcome game .draw
+  | deadPosition (h : IsDeadPosition game.current) : AutomaticOutcome game .draw
+  | fivefoldRepetition (hCheckmate : ¬IsCheckmate game.current)
+      (h : game.RepeatedAtLeast 5) : AutomaticOutcome game .draw
+  | seventyFiveMoveRule (hCheckmate : ¬IsCheckmate game.current)
+      (h : 150 ≤ game.current.halfmoveClock) : AutomaticOutcome game .draw
+
+/-- A choice available to the player whose turn it is. -/
+inductive Action
+  | play (ply : Ply)
+  | claimDraw
+  deriving DecidableEq
+
+/-- Whether an action is available in a nonterminal played game. -/
+def IsLegalAction (game : Game) : Action → Prop
+  | .play ply => (¬∃ outcome, AutomaticOutcome game outcome) ∧ IsLegalPly game.current ply
+  | .claimDraw => (¬∃ outcome, AutomaticOutcome game outcome) ∧ CanClaimDraw game
+
+/-- Games reachable from the initial game without moving after an automatic result. -/
+inductive Reachable : Game → Prop
+  | initial : Reachable .initial
+  | play {game : Game} {ply : Ply} (hReachable : Reachable game)
+      (hLegal : IsLegalAction game (.play ply)) : Reachable (game.play ply)
+
+/-- A pure strategy selects an action from every played game. -/
+abbrev Strategy := Game → Action
+
+/-- A strategy always selects a legal action when its player must act in a reachable game. -/
+def IsLegalStrategy (color : Color) (strategy : Strategy) : Prop :=
+  ∀ game, Reachable game → game.current.turn = color →
+    (¬∃ outcome, AutomaticOutcome game outcome) → IsLegalAction game (strategy game)
+
+/-- Select the strategy of the player whose turn it is. -/
+def selectedAction (white black : Strategy) (game : Game) : Action :=
+  match game.current.turn with
+  | .white => white game
+  | .black => black game
+
+/-- The finite result produced by a pair of strategies. -/
+inductive ResultsIn (white black : Strategy) : Game → Outcome → Prop
+  | automatic {game : Game} {outcome : Outcome} (h : AutomaticOutcome game outcome) :
+      ResultsIn white black game outcome
+  | claimDraw {game : Game}
+      (hSelected : selectedAction white black game = .claimDraw)
+      (hLegal : IsLegalAction game .claimDraw) : ResultsIn white black game .draw
+  | play {game : Game} {outcome : Outcome} {ply : Ply}
+      (hSelected : selectedAction white black game = .play ply)
+      (hLegal : IsLegalAction game (.play ply))
+      (hNext : ResultsIn white black (game.play ply) outcome) :
+      ResultsIn white black game outcome
+
+/-- White has a strategy that guarantees the outcome is not a Black win. -/
+def WhiteCanAvoidLoss : Prop :=
+  ∃ white, IsLegalStrategy .white white ∧
+    ∀ black, IsLegalStrategy .black black →
+      ∃ outcome, ResultsIn white black .initial outcome ∧ outcome ≠ .win .black
+
+/-- Black has a strategy that guarantees the outcome is not a White win. -/
+def BlackCanAvoidLoss : Prop :=
+  ∃ black, IsLegalStrategy .black black ∧
+    ∀ white, IsLegalStrategy .white white →
+      ∃ outcome, ResultsIn white black .initial outcome ∧ outcome ≠ .win .white
+
+/-- The initial position has the standard side to move, kings, and half-move clock. -/
+@[category test, AMS 68 91]
+theorem initial_position_sanity :
+    initialPosition.turn = .white ∧
+      initialPosition.board (kingHome .white) = some ⟨.white, .king⟩ ∧
+      initialPosition.board (kingHome .black) = some ⟨.black, .king⟩ ∧
+      initialPosition.halfmoveClock = 0 := by
+  exact ⟨rfl, rfl, rfl, rfl⟩
+
+/--
+Under perfect play from the standard initial position, chess ends in a draw: both White and Black
+have a strategy that avoids losing.
+
+This is a current-rules version of the conclusion stated in the 1775 *Traité des Amateurs*.
+
+References: [Société d'Amateurs, *Traité théorique et pratique du jeu des échecs*, pp. 162–163
+(1775)](https://archive.org/details/traitthoriqueet00damgoog) and
+[Wikipedia, First-move advantage in chess](https://en.wikipedia.org/wiki/First-move_advantage_in_chess)
+-/
+@[category research open, AMS 68 91]
+theorem perfect_play_results_in_draw : WhiteCanAvoidLoss ∧ BlackCanAvoidLoss := by
+  sorry
+
+end Chess


### PR DESCRIPTION
## Summary

This adds a self-contained model of standard chess under the current FIDE rules and states that its perfect-play value is a draw: each player has a strategy that avoids losing from the initial position.

The model covers legal moves, checkmate, stalemate, dead positions, repetition, and the 50- and 75-move rules. It leaves out clocks, resignation, and agreed draws, since those are not part of the abstract game tree.

The file is under `Books/` because the earliest source cited is the 1775 *Traité des Amateurs*. For now, the chess-specific definitions stay in the problem file.

Addresses #5154.

## Review notes

I would especially appreciate feedback on:

- whether a self-contained model of this size is appropriate here;
- whether `WhiteCanAvoidLoss ∧ BlackCanAvoidLoss` is the right statement;
- whether any of the game definitions should move to `FormalConjecturesForMathlib/`.

## Testing

`lake --wfail build FormalConjectures.Books.Chess`

## AI assistance

I used Codex to help develop the Lean code. I reviewed the final definitions, statement, sources, and diff.
