### PR TITLE
fix(OEIS/110854): quantify over A004275 per definition

### DIFF
--- a/FormalConjectures/OEIS/110854.lean
+++ b/FormalConjectures/OEIS/110854.lean
@@ -95,9 +95,9 @@ theorem a_4 : a 4 = 4 := by
 
 /--
 Do the absolute values cover A004275?
-A004275 is 1 together with the nonnegative even numbers.
-The conjecture asks whether every member of A004275 occurs as the absolute value
-of some term $a(n)$.
+A004275 is $1$ together with the nonnegative even numbers.
+The conjecture asks whether every member of A004275 occurs as $|a(n)|$ for some
+term of the sequence.
 -/
 @[category research open, AMS 11]
 theorem conjecture :

--- a/FormalConjectures/OEIS/110854.lean
+++ b/FormalConjectures/OEIS/110854.lean
@@ -95,14 +95,13 @@ theorem a_4 : a 4 = 4 := by
 
 /--
 Do the absolute values cover A004275?
-A004275 is the set of all differences between two prime numbers.
-The conjecture asks whether every possible difference between two prime numbers
-occurs as the absolute value of some term $a(n)$.
+A004275 is 1 together with the nonnegative even numbers.
+The conjecture asks whether every member of A004275 occurs as the absolute value
+of some term $a(n)$.
 -/
 @[category research open, AMS 11]
 theorem conjecture :
-  ∀ d > 0, (∃ p1 p2 : ℕ, p1.Prime ∧ p2.Prime ∧ d = (p1 - p2 : ℤ).natAbs) →
-  ∃ n > 0, d = (a n).natAbs := by
+  ∀ d : ℕ, (d = 1 ∨ Even d) → ∃ n > 0, d = (a n).natAbs := by
   sorry
 
 end OeisA110854


### PR DESCRIPTION
Quantify over A004275, instead of differences of two primes. I don't know why this was ever made the differences of two primes.

Fixes #5226