### PR TITLE
fix(OEIS/111291): state Colton's bound for sufficiently large x

### DIFF
--- a/FormalConjectures/OEIS/111291.lean
+++ b/FormalConjectures/OEIS/111291.lean
@@ -62,8 +62,8 @@ noncomputable def countRefactorable (x : ℝ) : ℕ :=
     0
 
 /--
-Simon Colton conjectures that the number of refactorables less than x is at least x/(2 log(x)).
-This is an asymptotic claim, so we state it for sufficiently large x.
+Simon Colton conjectures that the number of refactorable numbers less than $x$ is at least
+$\frac{x}{2\log x}$. This is an asymptotic claim, so we state it for sufficiently large $x$.
 -/
 @[category research open, AMS 11]
 theorem conjecture : ∃ x₀ : ℝ, ∀ x ≥ x₀,

--- a/FormalConjectures/OEIS/111291.lean
+++ b/FormalConjectures/OEIS/111291.lean
@@ -63,9 +63,10 @@ noncomputable def countRefactorable (x : ℝ) : ℕ :=
 
 /--
 Simon Colton conjectures that the number of refactorables less than x is at least x/(2 log(x)).
+This is an asymptotic claim, so we state it for sufficiently large x.
 -/
 @[category research open, AMS 11]
-theorem conjecture : ∀ (x : ℝ), x > 1 →
+theorem conjecture : ∃ x₀ : ℝ, ∀ x ≥ x₀,
     (countRefactorable x : ℝ) ≥ x / (2 * Real.log x) := by
   sorry
 

--- a/FormalConjectures/OEIS/111291.lean
+++ b/FormalConjectures/OEIS/111291.lean
@@ -66,7 +66,7 @@ Simon Colton conjectures that the number of refactorable numbers less than $x$ i
 $\frac{x}{2\log x}$. This is an asymptotic claim, so we state it for sufficiently large $x$.
 -/
 @[category research open, AMS 11]
-theorem conjecture : ∃ x₀ : ℝ, ∀ x ≥ x₀,
+theorem conjecture : ∀ᶠ x in Filter.atTop,
     (countRefactorable x : ℝ) ≥ x / (2 * Real.log x) := by
   sorry
 


### PR DESCRIPTION
State Colton's bound for sufficiently large x (`∃ x₀, ∀ x ≥ x₀`); the ∀ x > 1 version is trivially false near the log singularity.

Fixes #5227