### PR TITLE
fix(ErdosProblems/41): allow repeated summands

### DIFF
--- a/FormalConjectures/ErdosProblems/41.lean
+++ b/FormalConjectures/ErdosProblems/41.lean
@@ -28,17 +28,25 @@ namespace Erdos41
 variable {α : Type} [AddCommMonoid α]
 
 /--
-For a given set `A`, the n-tuple sums `a₁ + ... + aₙ` are all distinct for `a₁, ..., aₙ` in `A`
-(aside from the trivial coincidences).
+`NtupleCondition A n` says that the sum of `n` elements of `A` determines the summands,
+counted with multiplicity and up to permutation.
+
+Multisets allow a summand to occur more than once, while multiset equality identifies precisely the
+trivial coincidences obtained by reordering the summands.
 -/
-def NtupleCondition (A : Set α) (n : ℕ) : Prop := ∀ (I : Finset α) (J : Finset α),
-  ↑I ⊆ A ∧ ↑J ⊆ A ∧ I.card = n ∧ J.card = n ∧
-  (∑ i ∈ I, i = ∑ j ∈ J, j) → I = J
+def NtupleCondition (A : Set α) (n : ℕ) : Prop :=
+  ∀ I J : Multiset α,
+    (∀ i ∈ I, i ∈ A) →
+    (∀ j ∈ J, j ∈ A) →
+    I.card = n →
+    J.card = n →
+    I.sum = J.sum →
+    I = J
 
 /--
-Let `A ⊆ ℕ` be an infinite set such that the triple sums `a + b + c` are all distinct for
-`a, b, c` in `A` (aside from the trivial coincidences). Is it true that
-`liminf n → ∞ |A ∩ {1, …, N}| / N^(1/3) = 0`?
+Let $A \subset \mathbb{N}$ be an infinite set such that the triple sums $a+b+c$ are all distinct
+for $a,b,c \in A$ (aside from the trivial coincidences). Is it true that
+$$\liminf_{N \to \infty} \frac{\lvert A \cap \{1,\ldots,N\}\rvert}{N^{1/3}}=0?$$
 -/
 @[category research open, AMS 11]
 theorem erdos_41 (A : Set ℕ) (h_triple : NtupleCondition A 3) (h_infinite : A.Infinite) :
@@ -46,10 +54,9 @@ theorem erdos_41 (A : Set ℕ) (h_triple : NtupleCondition A 3) (h_infinite : A.
   sorry
 
 /--
-Erdős proved the following pairwise version.
-Let `A ⊆ ℕ` be an infinite set such that the pairwise sums `a + b` are all distinct for `a, b`
-in `A` (aside from the trivial coincidences).
-Is it true that `liminf n → ∞ |A ∩ {1, …, N}| / N^(1/2) = 0`?
+Erdős proved that if the pairwise sums $a+b$ are all distinct aside from the trivial
+coincidences, then
+$$\liminf_{N \to \infty} \frac{\lvert A \cap \{1,\ldots,N\}\rvert}{N^{1/2}}=0.$$
 -/
 @[category research solved, AMS 11]
 theorem erdos_41.variants.pairwise (A : Set ℕ) (hA₂ : NtupleCondition A 2) (hA : A.Infinite) :


### PR DESCRIPTION
The source asks for uniqueness of sums `a + b + c` with `a, b, c ∈ A`, apart from reordering. It does not require the three summands to be distinct.

The current helper represents a representation by a `Finset`. That removes multiplicity, so terms such as `a + a + b` cannot be represented at all. In particular, a collision such as `1 + 1 + 3 = 1 + 2 + 2` lies outside the current predicate.

This changes `NtupleCondition` to use `Multiset`:

- membership still requires every summand to lie in `A`;
- `card = n` still records the number of summands;
- multiplicities are preserved;
- multiset equality identifies exactly the trivial coincidences obtained by permutation.

The two theorem statements continue to use the same helper and remain open; this only repairs the hypothesis they express.

Source: https://www.erdosproblems.com/41

Verification: `lake --wfail build 'FormalConjectures.ErdosProblems.«41»'` passes, and repeated-summand/permutation examples were checked in Lean.

AI assistance disclosure: GPT-5.6 Pro helped with the source audit, Lean examples, and drafting. I checked the source, reviewed the change, and compiled it locally.
