### PR TITLE
fix(ErdosProblems/479): quantify integer k

### DIFF
--- a/FormalConjectures/ErdosProblems/479.lean
+++ b/FormalConjectures/ErdosProblems/479.lean
@@ -25,11 +25,12 @@ import FormalConjecturesUtil
 namespace Erdos479
 
 /--
-Is it true that, for all $k\neq 1$, there are infinitely many $n$ such that
+Is it true that, for every integer $k\neq 1$, there are infinitely many $n$ such that
 $2^n\equiv k\pmod{n}$?
 -/
 @[category research open, AMS 11]
-theorem erdos_479 : answer(sorry) ↔ ∀ᵉ (k > 1), { n | 2 ^ n ≡ k [MOD n]}.Infinite := by
+theorem erdos_479 : answer(sorry) ↔ ∀ᵉ (k : ℤ) (k ≠ 1),
+    { n : ℕ | (2 : ℤ) ^ n ≡ k [ZMOD (n : ℤ)] }.Infinite := by
   sorry
 
 end Erdos479


### PR DESCRIPTION
The source asks about every integer `k ≠ 1`. Its remarks explicitly include the known case `k = -1`, so negative integers are part of the problem.

The current statement uses `Nat.ModEq`, which infers `k : ℕ`, and additionally restricts it to `k > 1`. This omits all negative integers and `k = 0`.

This patch:

- quantifies `k : ℤ` with the source's guard `k ≠ 1`;
- keeps the solution index `n : ℕ`;
- states the congruence in `ℤ` as `(2 : ℤ) ^ n ≡ k [ZMOD (n : ℤ)]`.

At `n = 0`, integer congruence modulo zero is equality; because `2 ^ 0 = 1` and `k ≠ 1`, zero is not included. Thus the statement has no extra zero-modulus solution.

Source: https://www.erdosproblems.com/479

Verification: `lake --wfail build 'FormalConjectures.ErdosProblems.«479»'` passes.

AI assistance disclosure: GPT-5.6 Pro helped with the source audit, Lean checks, and drafting. I checked the source, reviewed the change, and compiled it locally.
