### PR TITLE
fix(ErdosProblems/354): use gamma in part ii

### DIFF
--- a/FormalConjectures/ErdosProblems/354.lean
+++ b/FormalConjectures/ErdosProblems/354.lean
@@ -33,9 +33,9 @@ noncomputable def FloorMultiples.interleave (a b γ : ℝ) (n : ℕ) : ℤ :=
   else
     FloorMultiples b γ (n / 2)
 
-/-- Let $\alpha,\beta\in \mathbb{R}_{>0}$ such that $\alpha/\beta$ is irrational. Is
-$$\{ \lfloor \alpha\rfloor,\lfloor \gamma\alpha\rfloor,\lfloor \gamma^2\alpha\rfloor,\ldots\}\cup
-\{ \lfloor \beta\rfloor,\lfloor \gamma\beta\rfloor,\lfloor \gamma^2\beta\rfloor,\ldots\}$$ complete?-/
+/-- Let $\alpha,\beta\in \mathbb{R}_{>0}$ such that $\alpha/\beta$ is irrational. Is the multiset
+$$\{ \lfloor \alpha\rfloor,\lfloor 2\alpha\rfloor,\lfloor 4\alpha\rfloor,\ldots\}\cup
+\{ \lfloor \beta\rfloor,\lfloor 2\beta\rfloor,\lfloor 4\beta\rfloor,\ldots\}$$ complete? -/
 @[category research open, AMS 11]
 theorem erdos_354.parts.i : answer(sorry) ↔ ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
     IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2) := by
@@ -46,7 +46,7 @@ $$\{ \lfloor \alpha\rfloor,\lfloor \gamma\alpha\rfloor,\lfloor \gamma^2\alpha\rf
 \{ \lfloor \beta\rfloor,\lfloor \gamma\beta\rfloor,\lfloor \gamma^2\beta\rfloor,\ldots\}$$ complete? -/
 @[category research open, AMS 11]
 theorem erdos_354.parts.ii : answer(sorry) ↔ ∃ γ ∈ Set.Ioo (1 : ℝ) 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
-    IsAddCompleteNatSeq' (FloorMultiples.interleave α β 2) := by
+    IsAddCompleteNatSeq' (FloorMultiples.interleave α β γ) := by
   sorry
 
 end Erdos354


### PR DESCRIPTION
This fixes two direct transcription errors in Erdős 354.

1. Part (i) uses base `2` in the Lean statement, but its docstring displayed powers of an unbound `γ`. The docstring now displays `α, 2α, 4α, …` and `β, 2β, 4β, …`, matching the source and the theorem.
2. Part (ii) binds `γ ∈ (1, 2)` but passed the literal `2` to `FloorMultiples.interleave`. The quantified `γ` therefore had no effect and part (ii) repeated part (i). It now calls `FloorMultiples.interleave α β γ`.

Source: https://www.erdosproblems.com/354

Verification: `lake --wfail build 'FormalConjectures.ErdosProblems.«354»'` passes.

AI assistance disclosure: GPT-5.6 Pro helped with the source audit, Lean checks, and drafting. I checked the source, reviewed the change, and compiled it locally.
