### PR TITLE
fix(ErdosProblems/757): require at least five differences

### DIFF
--- a/FormalConjectures/ErdosProblems/757.lean
+++ b/FormalConjectures/ErdosProblems/757.lean
@@ -30,10 +30,12 @@ open Filter
 
 namespace Erdos757
 
-/-- We say that `c` is admissible if for any finit set `A` such that for any subset `B` of size `4`,
-`(B - B).card = 11`, there exists a Sidon subset `S` of size at least `c * A.ncard`. -/
+/-- We say that `c` is admissible if, for any finite set `A` such that every four-element
+subset `B` determines at least five positive differences, there exists a Sidon subset `S`
+of size at least `c * A.ncard`. The difference condition is equivalent to
+`11 ≤ (B - B).ncard`. -/
 def IsAdmissible (c : ℝ) : Prop := ∀ {A : Set ℝ}, A.Finite → (∀ B ⊆ A,
-  B.ncard = 4 → (B - B).ncard = 11) → ∃ S ⊆ A, IsSidon S ∧ c * A.ncard ≤ (S.ncard : ℝ)
+  B.ncard = 4 → 11 ≤ (B - B).ncard) → ∃ S ⊆ A, IsSidon S ∧ c * A.ncard ≤ (S.ncard : ℝ)
 
 /-- What is the supremum of the set of admissible numbers? -/
 @[category research open, AMS 5]


### PR DESCRIPTION
Fixes the Erdős 757 item tracked in #4896.

The source assumes that every four-element `B ⊆ A` satisfies

```text
|B - B| ≥ 11.
```

The current helper instead requires `|B - B| = 11`. For a four-element set, `B - B` contains zero and both signs of every positive difference, so these conditions mean "at least five" and "exactly five" positive differences respectively. A four-element Sidon set has all six positive differences and therefore `|B - B| = 13`: it satisfies the source condition but is rejected by the current equality.

This replaces `(B - B).ncard = 11` with `11 ≤ (B - B).ncard` and updates the docstring accordingly.

Source: https://www.erdosproblems.com/757

Verification: the focused build and the full `lake --wfail build` both pass.

AI assistance disclosure: GPT-5.6 Pro helped with the source audit, Lean counterexample, and drafting. I checked the source, reviewed the change, and compiled it locally.
