### PR TITLE
fix(GreensOpenProblems/24): render one-third correctly

### DIFF
--- a/FormalConjectures/GreensOpenProblems/24.lean
+++ b/FormalConjectures/GreensOpenProblems/24.lean
@@ -47,7 +47,7 @@ noncomputable def max013AffineTranslates (n : ℕ) : ℕ :=
 If $A$ is a set of $n$ integers, what is the maximum number of affine translates of the set
 $\lbrace 0,1,3 \rbrace$ that $A$ can contain?
 
-Conjectured in [Aa19] p.579: $\left({1}{3} + o(1)\right) n^2$.
+Conjectured in [Aa19] p.579: $\left(\frac{1}{3} + o(1)\right) n^2$.
 -/
 @[category research open, AMS 5 11]
 theorem green_24 : ∀ n, max013AffineTranslates n = answer(sorry) := by
@@ -82,7 +82,7 @@ theorem upper_HL : gamma ≤ 3/4 := by
 theorem lower_HL : gamma ≥ 1/12 := by
   sorry
 
-/-- Conjecture p.579 in [Aa19]: $\left({1}{3} + o(1)\right) n^2$. -/
+/-- Conjecture p.579 in [Aa19]: $\left(\frac{1}{3} + o(1)\right) n^2$. -/
 @[category research open, AMS 5 11]
 theorem conjecture : gamma = 1/3 := by
   sorry


### PR DESCRIPTION
The two Green 24 docstrings write the conjectured constant as

```tex
{1}{3}
```

which renders as `13`. They now use

```tex
\frac{1}{3}
```

matching the Lean statement `gamma = 1 / 3` and the cited source. This also corrects the prose rendered from this file on downstream problem pages.

Verification: `lake --wfail build 'FormalConjectures.GreensOpenProblems.«24»'` passes, and no malformed `{1}{3}` occurrence remains in the file.

AI assistance disclosure: GPT-5.6 Pro helped identify and draft this correction. I reviewed the source file and compiled the change locally.
