### PR TITLE
fix(ErdosProblems/996): correct Fourier partial sums and tails

### DIFF
--- a/FormalConjectures/ErdosProblems/996.lean
+++ b/FormalConjectures/ErdosProblems/996.lean
@@ -33,7 +33,7 @@ namespace Erdos996
 
 noncomputable def fourierPartial {T : ℝ} [hT : Fact (0 < T)] (f : Lp ℂ 2 (@haarAddCircle T hT))
     (k : ℕ) : AddCircle T → ℂ :=
-  fun x => ∑ i ∈ Icc (-k : ℤ) k, fourierCoeff f k • fourier i x
+  fun x => ∑ i ∈ Icc (-k : ℤ) k, fourierCoeff f i • fourier i x
 
 /-- Does there exists a positive constant `C` such that for all `f ∈ L²[0,1]` and all lacunary
 sequences `n`, if `‖f - fₖ‖₂ = O(1 / log log log k ^ C)`, then for almost every `x`,
@@ -42,7 +42,7 @@ sequences `n`, if `‖f - fₖ‖₂ = O(1 / log log log k ^ C)`, then for almos
 theorem erdos_996 : answer(sorry) ↔
     ∃ (C : ℝ), 0 < C ∧ ∀ (f : Lp ℂ 2 (haarAddCircle (T := 1))) (n : ℕ → ℕ),
     IsLacunary n →
-    (fun k => (eLpNorm (fourierPartial f k) 2 (haarAddCircle (T := 1))).toReal) =O[atTop]
+    (fun k => (eLpNorm (⇑f - fourierPartial f k) 2 (haarAddCircle (T := 1))).toReal) =O[atTop]
     (fun k => 1 / (log (log (log k))) ^ C)
     →
     ∀ᵐ x, Tendsto (fun N => (∑ k ∈ .range N, f (n k • x)) / N) atTop
@@ -54,7 +54,7 @@ theorem erdos_996 : answer(sorry) ↔
 theorem erdos_996.variants.log2 : ∀ (C : ℝ), 0.5 < C →
     ∀ (f : Lp ℂ 2 (haarAddCircle (T := 1))) (n : ℕ → ℕ),
     IsLacunary n →
-    (fun k => (eLpNorm (fourierPartial f k) 2 (haarAddCircle (T := 1))).toReal) =O[atTop]
+    (fun k => (eLpNorm (⇑f - fourierPartial f k) 2 (haarAddCircle (T := 1))).toReal) =O[atTop]
     (fun k => 1 / (log (log k)) ^ C)
     →
     ∀ᵐ x, Tendsto (fun N => (∑ k ∈ .range N, f (n k • x)) / N) atTop


### PR DESCRIPTION
Fixes the Erdős 996 item tracked in #4896.

There are two independent transcription errors in the current file.

First, `fourierPartial` sums over `i ∈ [-k, k]` but every summand uses `fourierCoeff f k`. The result is one fixed coefficient multiplied by a sum of basis functions, rather than the `k`th Fourier partial sum. The coefficient now uses the summation index: `fourierCoeff f i`.

Second, the source hypothesis controls the Fourier tail

```text
‖f - f_k‖₂,
```

but both Lean statements take the norm of `fourierPartial f k` itself. Both now use

```lean
eLpNorm (⇑f - fourierPartial f k) 2 (haarAddCircle (T := 1)).
```

This corrects the helper and the hypotheses in both the main problem and the neighboring `log2` result.

Source: https://www.erdosproblems.com/996

Verification: the focused build and the full `lake --wfail build` both pass (10,097 jobs for the full build), with a clean `git diff --check`.

AI assistance disclosure: GPT-5.6 Pro helped with the source audit, Lean checks, and drafting. I checked the source, reviewed the change, and compiled the full repository locally.
