### PR TITLE
Erdős 287: formal_proof link for gap_at_least_two + kernel-clean best_possible test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Moritz Firsching
 Michael Rothgang
 Mirek Olšák
 Paul Lezeau
+Reza Ramji
 Salvatore Mercuri
 Seewoo Lee
 Sunsu Jeong

--- a/FormalConjectures/ErdosProblems/287.lean
+++ b/FormalConjectures/ErdosProblems/287.lean
@@ -47,7 +47,9 @@ theorem erdos_287 : answer(sorry) ↔
 The lower bound of $\geq 2$ is equivalent to saying that $1$ is not the sum of reciprocals of
 consecutive integers, proved by Erdős [Er32].
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/Zed-Rez/erdos-287-lean/blob/8bf27b1915ffbd155f071acbc57ba223451dc8ef/P287/gap_full.lean#L276-L281"]
 theorem erdos_287.variants.gap_at_least_two :
     ∀ (k : ℕ) (_ : 2 ≤ k) (s : Fin k → ℕ),
     StrictMono s → 1 < s ⟨0, by omega⟩ →
@@ -73,7 +75,7 @@ theorem erdos_287.test.best_possible :
   · norm_num [Fin.sum_univ_three, max_gap, show (![2, 3, 6] : Fin 3 → ℕ) 0 = 2 from rfl,
       show (![2, 3, 6] : Fin 3 → ℕ) 1 = 3 from rfl,
       show (![2, 3, 6] : Fin 3 → ℕ) 2 = 6 from rfl]
-  · native_decide
+  · rfl
 
 /--
 For all large $N$, there exists a prime $p \in [N, 2N]$ such that $\frac{p+1}{2}$ is also prime.


### PR DESCRIPTION
## What

1. **`erdos_287.variants.gap_at_least_two`** (tagged `research solved`, previously a bare `sorry`): adds a `formal_proof using lean4` attribute linking a kernel-checked proof in the exact statement shape — same `max_gap` definition (byte-identical), same ℝ-valued sum, same binders:
   [gap_full.lean#L276-L281](https://github.com/Zed-Rez/erdos-287-lean/blob/8bf27b1915ffbd155f071acbc57ba223451dc8ef/P287/gap_full.lean#L276-L281) (permalink). `#print axioms` gives exactly `[propext, Classical.choice, Quot.sound]`; no `sorry`, no `native_decide`. The linked repo's CI rebuilds the proof against Mathlib and re-runs the axiom audit on every commit.

2. **`erdos_287.test.best_possible`**: replaces `native_decide` with `rfl`, removing `Lean.ofReduceBool`/`Lean.trustCompiler` from the test's axioms. (The sup is over `Fin 2`; the kernel reduces it directly.)

3. Adds Reza Ramji to AUTHORS.

## Note on `prime_conjecture_implies`

We also have a kernel-checked proof of the mathematical content of `erdos_287.variants.prime_conjecture_implies` — hypothesis in the plain `∃ N₀, …` form rather than `type_of% erdos_287.variants.prime_conjecture` (which, as an `answer(sorry) ↔ …` statement, does not literally yield the existential): [Part3.lean#L39-L48](https://github.com/Zed-Rez/erdos-287-lean/blob/8bf27b1915ffbd155f071acbc57ba223451dc8ef/P287/Part3.lean#L39-L48). Happy to attach a `formal_proof` attribute for it too, or adapt to whatever encoding you prefer — deferring to maintainers on how to record it.

## Provenance

The linked proofs are AI-generated (autonomous Claude loop, human orchestration by @Zed-Rez), kernel-verified, and independently rebuilt from source on separate hardware. Per PROOFS.md, verification is by the kernel: the statements are short and the axiom audit is CI-enforced in the linked repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwndFzrnCZ8EtbvhRLE27o