### PR TITLE
refactor(ErdosProblems/756): reuse the ForMathlib distance definitions

### DIFF
--- a/FormalConjectures/ErdosProblems/756.lean
+++ b/FormalConjectures/ErdosProblems/756.lean
@@ -36,15 +36,9 @@ open scoped EuclideanGeometry Asymptotics
 
 namespace Erdos756
 
-/-- The number of unordered pairs of distinct points of `A` which are at distance exactly `d`.
-The division by two accounts for `Finset.offDiag` listing each unordered pair twice. -/
-noncomputable def distanceMultiplicity (A : Finset ℝ²) (d : ℝ) : ℕ :=
-  (A.offDiag.filter fun pair : ℝ² × ℝ² => dist pair.1 pair.2 = d).card / 2
-
 /-- The distances determined by `A` which occur for at least `k` many pairs of points of `A`. -/
 noncomputable def richDistances (A : Finset ℝ²) (k : ℕ) : Finset ℝ :=
-  (A.offDiag.image fun pair : ℝ² × ℝ² => dist pair.1 pair.2).filter
-    fun d => k ≤ distanceMultiplicity A d
+  (distanceSet A).filter fun d => k ≤ distanceMultiplicity A d
 
 /-- The largest number of distinct distances that a set of `n` points in $\mathbb{R}^2$ can
 determine, each of which occurs for more than `n` many pairs of points of the set. -/


### PR DESCRIPTION
`Erdos756.distanceMultiplicity` is a ℝ²-specialised duplicate of the `MetricSpace` definition that #5063 moved into `FormalConjecturesForMathlib/Geometry/Metric.lean`, and `richDistances` re-inlined the body of `distanceSet`. This deletes the local definition and states `richDistances` in terms of the shared ones.

The change is definitional, not just extensional. Restating the deleted definitions verbatim and comparing:

```lean
example (A : Finset ℝ²) (d : ℝ) :
    oldDistanceMultiplicity A d = distanceMultiplicity A d := rfl

example (A : Finset ℝ²) (k : ℕ) :
    oldRichDistances A k = richDistances A k := rfl
```

Both typecheck, so every statement in the file means exactly what it meant before. That also matters for `erdos_756.variants.bhowmick`, which carries a `formal_proof using lean4 at` link: the external proof still establishes the same proposition.

No new import is needed. `FormalConjecturesUtil` already re-exports these, the same way problems 94 and 958 use them.

`lake --wfail build FormalConjectures.ErdosProblems.«756»` is clean, 8889 jobs, zero warnings.