### PR TITLE
docs(CONTRIBUTING):  add "Use tex for math in comments" to style guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,7 @@ is outside of the scope of this repository.
   with `¬ P`.
 - Follow the same AI usage conventions as
   [Mathlib](https://leanprover-community.github.io/contribute/index.html).
+- Use tex for math in comments, e.g. `If $A \subset \mathbb{N}$ has $\sum_{n \in A}\frac 1 n = \infty$`
 
 ## Code reviews
 


### PR DESCRIPTION
Adds one line to the style guidelines.