### PR TITLE
fix(scripts): classify erdosproblems.com status from its structured fields

### DIFF
--- a/scripts/check_erdos_status.py
+++ b/scripts/check_erdos_status.py
@@ -5,6 +5,9 @@ Downloads the latest problems.yaml from teorth/erdosproblems and compares
 each problem's status against the @[category research open/solved] annotation
 on the main theorem in the corresponding .lean file.
 
+The upstream side is read from the `informal_status` and `formal_status` fields, not from the
+`status` string that joins them.
+
 Usage:
   python check_erdos_status.py               # Print mismatches as JSON
   python check_erdos_status.py --create-issues  # Also create GitHub issues
@@ -42,6 +45,11 @@ FORMAL_PROOF_ATTR = re.compile(
     re.MULTILINE,
 )
 
+# `informal_status.state` is the mathematical status, and these two sets are the whole of its
+# vocabulary. `formal_status.state` separately says whether a machine-checked proof exists.
+# Upstream also publishes the two joined into `status.state` ("proved (Lean)"), but that is a
+# product of two vocabularies and gains a value whenever either side does, so read the fields
+# rather than enumerating their combinations.
 OPEN_STATES = {"open", "falsifiable", "verifiable"}
 SOLVED_STATES = {
     "solved",
@@ -52,11 +60,7 @@ SOLVED_STATES = {
     "independent",
     "decidable",
 }
-FORMALLY_SOLVED_STATES = {
-    "solved (Lean)",
-    "proved (Lean)",
-    "disproved (Lean)",
-}
+UNFORMALIZED_STATE = "unformalized"
 
 
 def fetch_yaml():
@@ -68,18 +72,40 @@ def fetch_yaml():
         return yaml.safe_load(resp.read())
 
 
-def yaml_status_to_category(state):
-    """Map a YAML status.state value to 'open', 'solved', 'formally solved', or None.
+def problem_status(problem):
+    """The (informal, formal) status states of a YAML problem.
 
-    Returns None for unrecognized states.
+    Each default claims the least. An absent formal state means no formalisation is recorded,
+    which degrades a settled problem to 'solved' rather than inventing a proof. An absent
+    informal state is not a status at all, so it falls into the warn-and-skip path below
+    instead of asserting that the problem is open.
     """
-    if state in OPEN_STATES:
+    informal = (problem.get("informal_status") or {}).get("state")
+    formal = (problem.get("formal_status") or {}).get("state", UNFORMALIZED_STATE)
+    return informal, formal
+
+
+def yaml_status_to_category(informal_state, formal_state):
+    """Map a problem's YAML status states to 'open', 'solved', 'formally solved', or None.
+
+    A problem is 'formally solved' when it is settled and upstream records a formalisation.
+    An open problem stays open even when a Lean statement of it exists, which is how
+    `scan_lean_files` reads this repository: it upgrades a problem to 'formally solved' only
+    when the category is already 'solved'.
+
+    Returns None for an informal state this script does not know, which means "we cannot read
+    this problem", not "this problem agrees with us".
+    """
+    if informal_state in OPEN_STATES:
         return "open"
-    if state in FORMALLY_SOLVED_STATES:
-        return "formally solved"
-    if state in SOLVED_STATES:
+    if informal_state in SOLVED_STATES:
+        if formal_state != UNFORMALIZED_STATE:
+            return "formally solved"
         return "solved"
-    print(f"WARNING: unrecognized YAML status state: {state!r}", file=sys.stderr)
+    print(
+        f"WARNING: unrecognized YAML informal status state: {informal_state!r}",
+        file=sys.stderr,
+    )
     return None  # unrecognized — skip comparison
 
 
@@ -162,7 +188,7 @@ def classifiable():
     return {
         str(p["number"])
         for p in fetch_yaml()
-        if yaml_status_to_category(p.get("status", {}).get("state", "open")) is not None
+        if yaml_status_to_category(*problem_status(p)) is not None
     }
 
 
@@ -171,8 +197,7 @@ def find_mismatches():
     yaml_statuses = {}
     for p in problems:
         num = str(p["number"])
-        state = p.get("status", {}).get("state", "open")
-        cat = yaml_status_to_category(state)
+        cat = yaml_status_to_category(*problem_status(p))
         if cat is not None:
             yaml_statuses[num] = cat
 

--- a/scripts/check_erdos_status.py
+++ b/scripts/check_erdos_status.py
@@ -48,18 +48,28 @@ FORMAL_PROOF_ATTR = re.compile(
 # `informal_status.state` is the mathematical status, and these two sets are the whole of its
 # vocabulary. `formal_status.state` separately says whether a machine-checked proof exists.
 # Upstream also publishes the two joined into `status.state` ("proved (Lean)"), but that is a
-# product of two vocabularies and gains a value whenever either side does, so read the fields
-# rather than enumerating their combinations.
-OPEN_STATES = {"open", "falsifiable", "verifiable"}
-SOLVED_STATES = {
-    "solved",
-    "proved",
-    "disproved",
+# product of two vocabularies and gains a value whenever either side does, so the code reads
+# the two fields instead of their combinations.
+#
+# The split below follows the definitions in the upstream CONTRIBUTING.md. Three of these
+# states name a problem that is still open: "decidable" is "both falsifiable and verifiable,
+# but not yet solved", and "not provable" and "not disprovable" are each "open in general",
+# with a model of set theory that settles the problem one way. "independent" is a resolution,
+# so it counts as solved.
+OPEN_STATES = {
+    "open",
+    "falsifiable",
+    "verifiable",
+    "decidable",
     "not provable",
     "not disprovable",
-    "independent",
-    "decidable",
 }
+SOLVED_STATES = {"solved", "proved", "disproved", "independent"}
+
+# Upstream states this value explicitly and never leaves it blank, and every other value
+# names a proof assistant. CONTRIBUTING.md reserves the right to add assistants, and 6
+# problems already carry an undocumented "formalized", so the code tests this one value
+# rather than a list that would skip a problem whenever upstream adds a name.
 UNFORMALIZED_STATE = "unformalized"
 
 
@@ -75,13 +85,13 @@ def fetch_yaml():
 def problem_status(problem):
     """The (informal, formal) status states of a YAML problem.
 
-    Each default claims the least. An absent formal state means no formalisation is recorded,
-    which degrades a settled problem to 'solved' rather than inventing a proof. An absent
-    informal state is not a status at all, so it falls into the warn-and-skip path below
-    instead of asserting that the problem is open.
+    Each default claims the least. An absent, null or empty formal state records no
+    formalisation, so a settled problem degrades to 'solved' and the code does not invent
+    a proof. An absent informal state is not a status at all, so it falls into the
+    warn-and-skip path below and does not assert that the problem is open.
     """
     informal = (problem.get("informal_status") or {}).get("state")
-    formal = (problem.get("formal_status") or {}).get("state", UNFORMALIZED_STATE)
+    formal = (problem.get("formal_status") or {}).get("state") or UNFORMALIZED_STATE
     return informal, formal
 
 

--- a/scripts/test_check_erdos_status.py
+++ b/scripts/test_check_erdos_status.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for which sync issues `check_erdos_status.py` decides to close."""
+"""Tests for how `check_erdos_status.py` reads upstream statuses and closes issues."""
 
+import contextlib
+import io
 import unittest
 
-from check_erdos_status import issues_to_close
+from check_erdos_status import issues_to_close, problem_status, yaml_status_to_category
 
 
 def issue(number, problem, repo="solved", site="formally solved"):
@@ -25,6 +27,87 @@ def issue(number, problem, repo="solved", site="formally solved"):
         "title": f"Erdős Problem {problem}: status mismatch "
                  f"(repo={repo}, erdosproblems.com={site})",
     }
+
+
+def category(problem):
+    """The category the script reads a YAML problem as, with warnings swallowed."""
+    with contextlib.redirect_stderr(io.StringIO()):
+        return yaml_status_to_category(*problem_status(problem))
+
+
+class ProblemStatusTest(unittest.TestCase):
+
+    def test_reads_both_status_fields(self):
+        self.assertEqual(
+            category({"informal_status": {"state": "proved"},
+                      "formal_status": {"state": "Lean"}}), "formally solved")
+
+    def test_a_missing_formal_status_claims_no_formalisation(self):
+        # Guessing a formalisation would attach the `formalisation exists elsewhere`
+        # label to an issue with nothing behind it.
+        self.assertEqual(category({"informal_status": {"state": "proved"}}), "solved")
+
+    def test_a_missing_informal_status_is_unreadable(self):
+        # Not "open". Defaulting an absent field to a real status is a positive claim:
+        # if upstream ever renames this field, every problem reads as open. That
+        # reports 205 false mismatches and makes every open problem's issue closable.
+        self.assertIsNone(category({"formal_status": {"state": "Lean"}}))
+
+    def test_a_null_status_block_is_unreadable(self):
+        # PyYAML turns `informal_status:` with no body into None, not into {}.
+        self.assertIsNone(category({"informal_status": None}))
+
+
+class YamlStatusToCategoryTest(unittest.TestCase):
+
+    def test_reads_an_unsettled_problem_as_open(self):
+        self.assertEqual(yaml_status_to_category("open", "unformalized"), "open")
+
+    def test_reads_a_settled_problem_with_no_formalisation_as_solved(self):
+        self.assertEqual(yaml_status_to_category("proved", "unformalized"), "solved")
+
+    def test_a_lean_proof_makes_a_settled_problem_formally_solved(self):
+        self.assertEqual(yaml_status_to_category("proved", "Lean"), "formally solved")
+
+    def test_any_formal_state_other_than_unformalized_counts(self):
+        # Upstream writes both 'Lean' and 'formalized'. Matching only the 'Lean'
+        # spelling is what silently skipped Erdős 1, 74 and 126.
+        self.assertEqual(
+            yaml_status_to_category("disproved", "formalized"), "formally solved")
+
+    def test_a_formalised_open_problem_is_still_open(self):
+        # `scan_lean_files` calls a problem here 'formally solved' only when it is
+        # solved AND carries a formal_proof, so an open problem with a Lean statement
+        # of it must stay open on both sides. 26 problems in this repository are open
+        # and carry a formal_proof; the other reading mismatches every one of them.
+        self.assertEqual(yaml_status_to_category("open", "Lean"), "open")
+
+    def test_the_other_open_states_are_open(self):
+        self.assertEqual(
+            [yaml_status_to_category(s, "unformalized")
+             for s in ("falsifiable", "verifiable")],
+            ["open", "open"])
+
+    def test_the_less_obvious_solved_states_are_solved(self):
+        # Spelled out rather than looped over `SOLVED_STATES`, so that dropping one
+        # from the set fails here instead of being tracked silently.
+        self.assertEqual(
+            [yaml_status_to_category(s, "unformalized")
+             for s in ("not provable", "not disprovable", "independent", "decidable")],
+            ["solved", "solved", "solved", "solved"])
+
+    def test_it_reads_the_informal_state_first(self):
+        # Both arguments are strings, so swapping them at a call site type-checks.
+        # Reversed, nothing classifies and the script acts on nothing.
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(yaml_status_to_category("unformalized", "open"))
+
+    def test_an_unknown_informal_state_is_unreadable(self):
+        # None, not a guess. `classifiable` turns this into "leave the issue alone".
+        # The warning goes to stderr; swallow it so it does not read as a failure.
+        with contextlib.redirect_stderr(io.StringIO()) as warning:
+            self.assertIsNone(yaml_status_to_category("something new", "unformalized"))
+        self.assertIn("something new", warning.getvalue())
 
 
 class IssuesToCloseTest(unittest.TestCase):
@@ -38,7 +121,7 @@ class IssuesToCloseTest(unittest.TestCase):
             issues_to_close([issue(100, "71")], still_open={"71"}, known={"71"}), [])
 
     def test_keeps_one_whose_status_cannot_be_read(self):
-        # A problem missing from `known` has a YAML state the script does not recognise.
+        # A problem missing from `known` is one the classifier returned None for.
         # That is "we cannot tell", which must not be read as "resolved".
         self.assertEqual(
             issues_to_close([issue(100, "71")], still_open=set(), known=set()), [])

--- a/scripts/test_check_erdos_status.py
+++ b/scripts/test_check_erdos_status.py
@@ -30,9 +30,14 @@ def issue(number, problem, repo="solved", site="formally solved"):
 
 
 def category(problem):
-    """The category the script reads a YAML problem as, with warnings swallowed."""
-    with contextlib.redirect_stderr(io.StringIO()):
-        return yaml_status_to_category(*problem_status(problem))
+    """The category the script reads a YAML problem as, with any warning discarded."""
+    return category_and_warning(problem)[0]
+
+
+def category_and_warning(problem):
+    """The category the script reads a YAML problem as, and what it wrote to stderr."""
+    with contextlib.redirect_stderr(io.StringIO()) as warning:
+        return yaml_status_to_category(*problem_status(problem)), warning.getvalue()
 
 
 class ProblemStatusTest(unittest.TestCase):
@@ -43,15 +48,32 @@ class ProblemStatusTest(unittest.TestCase):
                       "formal_status": {"state": "Lean"}}), "formally solved")
 
     def test_a_missing_formal_status_claims_no_formalisation(self):
-        # Guessing a formalisation would attach the `formalisation exists elsewhere`
-        # label to an issue with nothing behind it.
+        # A guessed formalisation attaches the `formalisation exists elsewhere` label
+        # to an issue with nothing behind it.
         self.assertEqual(category({"informal_status": {"state": "proved"}}), "solved")
 
-    def test_a_missing_informal_status_is_unreadable(self):
-        # Not "open". Defaulting an absent field to a real status is a positive claim:
-        # if upstream ever renames this field, every problem reads as open. That
-        # reports 205 false mismatches and makes every open problem's issue closable.
-        self.assertIsNone(category({"formal_status": {"state": "Lean"}}))
+    def test_a_null_formal_status_block_claims_no_formalisation(self):
+        # PyYAML turns `formal_status:` with no body into None, so the `or {}` guard
+        # carries this case. Without it the script dies on an AttributeError.
+        self.assertEqual(
+            category({"informal_status": {"state": "proved"}, "formal_status": None}),
+            "solved")
+
+    def test_a_null_formal_state_claims_no_formalisation(self):
+        # `state:` with no value is a present key, so a `.get` default never fires for
+        # it. Read as a formalisation, it labels an issue with a proof that is not there.
+        self.assertEqual(
+            category({"informal_status": {"state": "proved"},
+                      "formal_status": {"state": None}}), "solved")
+
+    def test_a_missing_informal_status_warns_and_is_unreadable(self):
+        # Not "open". A real status for an absent field is a positive claim: if upstream
+        # ever renames this field, every problem reads as open. That reports 205 false
+        # mismatches and makes every open problem's issue closable. The warning is the
+        # only signal a human gets, so assert that half of warn-and-skip too.
+        cat, warning = category_and_warning({"formal_status": {"state": "Lean"}})
+        self.assertIsNone(cat)
+        self.assertIn("unrecognized YAML informal status state", warning)
 
     def test_a_null_status_block_is_unreadable(self):
         # PyYAML turns `informal_status:` with no body into None, not into {}.
@@ -70,8 +92,8 @@ class YamlStatusToCategoryTest(unittest.TestCase):
         self.assertEqual(yaml_status_to_category("proved", "Lean"), "formally solved")
 
     def test_any_formal_state_other_than_unformalized_counts(self):
-        # Upstream writes both 'Lean' and 'formalized'. Matching only the 'Lean'
-        # spelling is what silently skipped Erdős 1, 74 and 126.
+        # Upstream writes both 'Lean' and 'formalized', and CONTRIBUTING.md documents
+        # only 'Lean'. A match on that spelling alone skipped Erdős 1, 74 and 126.
         self.assertEqual(
             yaml_status_to_category("disproved", "formalized"), "formally solved")
 
@@ -88,13 +110,26 @@ class YamlStatusToCategoryTest(unittest.TestCase):
              for s in ("falsifiable", "verifiable")],
             ["open", "open"])
 
-    def test_the_less_obvious_solved_states_are_solved(self):
-        # Spelled out rather than looped over `SOLVED_STATES`, so that dropping one
-        # from the set fails here instead of being tracked silently.
+    def test_decidable_is_open(self):
+        # Upstream defines it as "both falsifiable and verifiable, but not yet solved".
+        # Both of those are open above, so their conjunction cannot be solved. Read as
+        # solved, it kept false sync issues open for Erdős 506 and 742.
+        self.assertEqual(yaml_status_to_category("decidable", "unformalized"), "open")
+
+    def test_the_set_theoretic_undecided_states_are_open(self):
+        # Upstream defines both as "open in general", with a model of set theory that
+        # settles the problem one way. Read as solved, they mismatch every repository
+        # file that correctly says open, as they did for Erdős 1176.
         self.assertEqual(
             [yaml_status_to_category(s, "unformalized")
-             for s in ("not provable", "not disprovable", "independent", "decidable")],
-            ["solved", "solved", "solved", "solved"])
+             for s in ("not provable", "not disprovable")],
+            ["open", "open"])
+
+    def test_independence_is_a_resolution(self):
+        # The one set-theoretic state that settles a problem, so it stays solved.
+        # Erdős 1119 is `research solved` in this repository and agrees.
+        self.assertEqual(
+            yaml_status_to_category("independent", "unformalized"), "solved")
 
     def test_it_reads_the_informal_state_first(self):
         # Both arguments are strings, so swapping them at a call site type-checks.


### PR DESCRIPTION
`check_erdos_status.py` classified the upstream side of the comparison by matching
`problem["status"]["state"]` against a hardcoded set of compound strings. That field is a
product of two independent vocabularies, so the set gains a value whenever either side does.

- **Three states are missing today**, and eight problems carry them: `proved (formalized)` (4),
  `disproved (formalized)` (2), `open (Lean)` (2). `yaml_status_to_category` returns `None` for
  each, which skips the problem entirely. The scheduled job runs the script as
  `--create-issues || true`, so the `WARNING:` never reaches anyone.
- **This reads `informal_status.state` and `formal_status.state` instead.** The informal field
  takes ten values across all 1217 problems, and they are exactly `OPEN_STATES | SOLVED_STATES`,
  so the compound enumeration is deleted rather than extended and `FORMALLY_SOLVED_STATES` goes
  away. An unrecognized state now means a genuinely new informal status, not a new combination.
- **Nothing that was classified changes.** Measured against the live `problems.yaml`:
  classification changes for exactly the eight problems that returned `None`, and for no others.
  The mismatch count goes 56 to 59, and nothing stops being reported.
- **Both defaults in `problem_status` claim the least.** An absent formal state means no recorded
  formalisation, which degrades a settled problem to `solved` rather than inventing a proof. An
  absent informal state is not a status at all, so it warns and skips rather than asserting the
  problem is open. That direction matters: were `informal_status` ever renamed upstream, the other
  reading would file 205 false mismatches and make every open problem's sync issue auto-closable.

**The three added mismatches are real and have never been reported.** Erdős 1 and 74 are marked
`research open` here while upstream records them as `disproved`; Erdős 126 is `research open` here
and `proved` upstream. Erdős 1 and 74 carry $500 prizes, 126 carries $250. Each classifies as
`formally solved`, so `create_issues` attaches `formalisation exists elsewhere` alongside
`erdos-status-sync`. No open sync issue exists for any of the eight problems, so nothing is
auto-closed; the hourly job will file the three on its next run.

An open problem stays `open` even when upstream records a Lean formalisation of it. That matches
`scan_lean_files`, which upgrades a problem to `formally solved` only when its category is already
`solved`. 26 problems here are `open` and carry a `formal_proof`; the other reading would report a
false mismatch on every one of them.

**Prior art.** #4827 patched the enumeration and its author closed it, preferring to replace the
scanner. This is orthogonal to #4828, which reworks the *Lean* side to read extract metadata; this
reworks the *upstream* side and touches neither `scan_lean_files` nor the extract schema. #4367
also touches this file, in `scan_lean_files` and a new `apply_fixes`, with no overlap in the region
changed here.

## Test plan

- [x] `python3 -m unittest discover -s scripts -p 'test_*.py' -v` passes, standard library only,
      26 to 39 tests. `yaml_status_to_category` and `problem_status` had no coverage before this;
      the new cases pin the `formalized` spelling, the open-with-a-Lean-statement case, both
      missing-key defaults, and the argument order. `import yaml` stays inside `fetch_yaml`, so the
      `scripts` CI job still imports the module without pyyaml.
- [x] Live run against `teorth/erdosproblems`: exit 1, 59 mismatches, **no** `WARNING:` on stderr
      (was 8). Differential of the old and new classifiers over all 1217 problems: 8 changed, all
      from `None`, none previously classified.

To reproduce:

```
pip install pyyaml
git checkout main && python scripts/check_erdos_status.py > /tmp/before.json 2> /tmp/before.err; true
git checkout <this branch> && python scripts/check_erdos_status.py > /tmp/after.json 2> /tmp/after.err; true
diff /tmp/before.json /tmp/after.json
```

Expect three added entries (1, 74, 126), each `lean_status: open` / `yaml_status: formally solved`,
no removals, 8 `WARNING:` lines in `before.err` and none in `after.err`. The script exits 1 when
mismatches exist, hence the `; true`.
