### PR TITLE
Link external Lean 4 proof for ABφθSpec.existsUnique

### DIFF
--- a/FormalConjectures/Wikipedia/MovingSofa.lean
+++ b/FormalConjectures/Wikipedia/MovingSofa.lean
@@ -150,7 +150,8 @@ def ABφθSpec (A B φ θ : ℝ) : Prop :=
   (A + π / 2 - φ - θ) - (B - (θ - φ) * (1 + A) / 2 - (θ - φ)^2 / 4) = 0
 
 /-- There exist unique constants $A$, $B$, $\varphi$, and $\theta$ satisfying the spec. -/
-@[category textbook, AMS 49]
+@[category textbook, AMS 49,
+  formal_proof using lean4 at "https://github.com/dawidmtrela-dotcom/GerverSofaLean/blob/v1.0.0/GerverSofa/KernelOnly/PartE/E24KC6KernelFinalClosure.lean"]
 theorem ABφθSpec.existsUnique : ∃! ABφθ : ℝ × ℝ × ℝ × ℝ,
     ABφθSpec ABφθ.1 ABφθ.2.1 ABφθ.2.2.1 ABφθ.2.2.2 :=
   sorry


### PR DESCRIPTION
Links an external kernel-checked Lean 4 proof of
`MovingSofa.GerversSofa.ABφθSpec.existsUnique` using the repository's
`formal_proof` mechanism for long external proofs.

External proof:
https://github.com/dawidmtrela-dotcom/GerverSofaLean

Frozen release:
https://github.com/dawidmtrela-dotcom/GerverSofaLean/releases/tag/v1.0.0

Verification summary:

- final theorem: PASS
- 8713 / 8713 global-exclusion obligations have kernel-checked proof providers
- audited local import closure: 907 Lean source files
- no `sorry`, `admit`, `native_decide`, custom `axiom`, or `unsafe` in the final audited local source closure
- `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`
- reproducibility evidence and SHA-256 manifests are included in the release

The PR changes only the metadata on the existing theorem; the long proof remains externally hosted.

Closes #5263