### PR TITLE
Mark Erdos Problem 539 square-root variants as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/539.lean
+++ b/FormalConjectures/ErdosProblems/539.lean
@@ -65,9 +65,12 @@ theorem erdos_539 :
 /-- Let $h(n)$ be maximal such that, for any set $A\subseteq \mathbb{N}$ of size $n$, the
 set$$\left\{ \frac{a}{(a,b)}: a,b\in A\right\}$$has size at least $h(n)$.
 Is $h(n) = \Theta(\sqrt{n})$? -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-539-sqrt-disproof/blob/f4b14f9ef32c111162d3fd587e1c65b27a1524d5/lean/Erdos539SqrtFC.lean#L41-L44"]
 theorem erdos_539.variants.sq :
-    (fun n ↦ (cofactorThreshold n : ℝ)) =Θ[atTop] fun n ↦ √n := by
+    answer(False) ↔
+      ((fun n ↦ (cofactorThreshold n : ℝ)) =Θ[atTop] fun n ↦ √n) := by
   sorry
 
 /-- Erdős and Szemerédi proved that$$n^{1/2} \ll h(n)$$. -/
@@ -76,10 +79,13 @@ theorem erdos_539.variants.sq_isBigO :
     (fun n : ℕ ↦ √n) =O[atTop] fun n ↦ (cofactorThreshold n : ℝ) := by
   sorry
 
-/-- To prove `erdos_539.variants.sq` it suffices to show $$ h(n)\ll n^{1/2}$$. -/
-@[category research open, AMS 5 11]
+/-- Is $h(n) = O(\sqrt{n})$? -/
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-539-sqrt-disproof/blob/f4b14f9ef32c111162d3fd587e1c65b27a1524d5/lean/Erdos539SqrtFC.lean#L36-L39"]
 theorem erdos_539.variants.isBigO_sq :
-    (fun n ↦ (cofactorThreshold n : ℝ)) =O[atTop] fun n ↦ √n := by
+    answer(False) ↔
+      ((fun n ↦ (cofactorThreshold n : ℝ)) =O[atTop] fun n ↦ √n) := by
   sorry
 
 /-- Let $h(n)$ be maximal such that, for any set $A\subseteq \mathbb{N}$ of size $n$, the

--- a/FormalConjectures/Subsets/FC100OpenSet1.lean
+++ b/FormalConjectures/Subsets/FC100OpenSet1.lean
@@ -223,6 +223,6 @@ end Subsets.FC100OpenSet1
 
 open Lean Meta ProblemAttributes in
 #eval verifyCategoryCounts Subsets.FC100OpenSet1.problems [
-  ("research open", 91),
-  ("research solved", 9)
+  ("research open", 90),
+  ("research solved", 10)
 ]


### PR DESCRIPTION
This PR marks `Erdos539.erdos_539.variants.isBigO_sq` and `Erdos539.erdos_539.variants.sq` as solved with negative answers (`answer(False) ↔ P`) and links their Lean proofs.

The main question `Erdos539.erdos_539` remains open.

The Lean formalization was prepared by [Kenta Kitamura (@KitaKen1)](https://github.com/KitaKen1).
The proof shows `h(n) / √n → ∞` and establishes the exact targets:

```lean
theorem Erdos539Sqrt.isBigO_sq_answer_false :
    answer(False) ↔
      ((fun n ↦ (Erdos539.cofactorThreshold n : ℝ)) =O[atTop]
        fun n ↦ √n)

theorem Erdos539Sqrt.sq_answer_false :
    answer(False) ↔
      ((fun n ↦ (Erdos539.cofactorThreshold n : ℝ)) =Θ[atTop]
        fun n ↦ √n)
```

Proof: [exact target theorems](https://github.com/KitaKen1/erdos-539-sqrt-disproof/blob/f4b14f9ef32c111162d3fd587e1c65b27a1524d5/lean/Erdos539SqrtFC.lean#L36-L44)

Repository: [erdos-539-sqrt-disproof](https://github.com/KitaKen1/erdos-539-sqrt-disproof)

Lean4Web: [open the proof in the live editor](https://live.lean-lang.org/#project=MathlibDemo&url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-539-sqrt-disproof%2Ff4b14f9ef32c111162d3fd587e1c65b27a1524d5%2Flean4web%2FErdos539SqrtLean4Web.lean) (Lean v4.34.0-rc2).

The final theorems use only `propext`, `Classical.choice`, and `Quot.sound`; no `sorryAx`.

AI Usage Disclosure: GPT-6 (Astra) via OpenAI Codex assisted with the proof development, formalization, and exposition.
