### PR TITLE
feat: add discrete-geometry conjectures (k-holes, big-line-big-clique, higher-dimensional holes)

### DIFF
--- a/FormalConjectures/Arxiv/2105.08406/HigherDimHoles.lean
+++ b/FormalConjectures/Arxiv/2105.08406/HigherDimHoles.lean
@@ -1,0 +1,103 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Higher-dimensional holes: the Erdős–Szekeres problem in `ℝ³`
+
+This file formalizes questions about `k`-holes of finite point sets in
+`d`-dimensional Euclidean space `ℝ^d`, and in particular the case `d = 3`, from
+[Sch20].
+
+A `k`-gon is a set of `k` points in *convex position* (convex independent, i.e.
+no point lies in the convex hull of the others). A `k`-hole is a `k`-gon whose
+convex hull contains no other point of the set. A finite point set is in
+*general position* in `ℝ^d` if no `d + 1` of its points lie on a common
+hyperplane; we encode this by requiring every `(d + 1)`-subset to be affinely
+independent. In the plane this is the empty variant of the Erdős–Szekeres problem
+(the Happy Ending problem, `FormalConjectures.ErdosProblems.«107»`), and the
+counting question for planar `k`-holes is `FormalConjectures.Arxiv.«2603.18484».EmptyKGons`.
+
+Let `H(d)` be the largest `k` such that every sufficiently large point set in
+general position in `ℝ^d` contains a `k`-hole. For the plane `H(2) = 6`: Horton
+constructed arbitrarily large sets with no `7`-hole, while the empty-hexagon
+theorem guarantees a `6`-hole in every sufficiently large set. For `ℝ³` [Sch20]
+proves
+
+* `h^{(3)}(7) ≤ 14`: every set of at least `14` points in general position in
+  `ℝ³` contains a `7`-hole (so `H(3) ≥ 7`), and
+* there are arbitrarily large sets in general position in `ℝ³` with no
+  `23`-hole (so `H(3) ≤ 22`).
+
+Hence `7 ≤ H(3) ≤ 22`. Whether every sufficiently large set in general position
+in `ℝ³` contains an `8`-hole, i.e. whether `H(3) ≥ 8`, is **open** (a question of
+Valtr).
+
+*References:*
+- [Sch] M. Scheucher, *A SAT attack on Erdős–Szekeres numbers in `ℝ^d` and the
+  empty hexagon theorem*, Computing in Geometry and Topology 2(1) (2023),
+  [doi:10.57717/cgt.v2i1.12](https://doi.org/10.57717/cgt.v2i1.12). Preprint (as
+  *A SAT attack on higher dimensional Erdős–Szekeres numbers*), arXiv:2105.08406.
+  Establishes `h^{(3)}(7) ≤ 14` and `7 ≤ H(3) ≤ 22`; existence of `8`-holes in
+  `ℝ³` (Valtr's question) is open.
+-/
+
+open scoped Finset
+
+open EuclideanGeometry
+
+namespace HigherDimHoles
+
+/-- `ℝ^d`, `d`-dimensional Euclidean space; the dimension-generic
+`EuclideanGeometry.EDim`. -/
+abbrev Space (d : ℕ) := EDim d
+
+/--
+**Valtr's question (open).** Do `8`-holes always eventually appear in `ℝ³`?
+That is, is there a bound `N` such that every set of at least `N` points in
+general position in `ℝ³` contains an `8`-hole (equivalently `H(3) ≥ 8`)?
+
+This is the central open problem of [Sch20]; it is currently unknown. Known:
+`7 ≤ H(3) ≤ 22` (see `h3_7_upper_bound` and `no_23_hole_arbitrarily_large`).
+-/
+@[category research open, AMS 52]
+theorem eightHoles_in_space3 :
+    answer(sorry) ↔
+      ∃ N : ℕ, ∀ P : Finset (Space 3),
+        InGenPos P → N ≤ P.card → HasKHole 8 (↑P) := by
+  sorry
+
+/--
+`h^{(3)}(7) ≤ 14`: every set of at least `14` points in general position in `ℝ³`
+contains a `7`-hole [Sch20]. In particular `H(3) ≥ 7`.
+-/
+@[category research solved, AMS 52]
+theorem h3_7_upper_bound :
+    ∀ P : Finset (Space 3), InGenPos P → 14 ≤ P.card → HasKHole 7 (↑P) := by
+  sorry
+
+/--
+There are arbitrarily large point sets in general position in `ℝ³` with no
+`23`-hole [Sch20]. In particular `H(3) ≤ 22`.
+-/
+@[category research solved, AMS 52]
+theorem no_23_hole_arbitrarily_large :
+    ∀ N : ℕ, ∃ P : Finset (Space 3),
+      InGenPos P ∧ N ≤ P.card ∧ ¬ HasKHole 23 (↑P) := by
+  sorry
+
+end HigherDimHoles

--- a/FormalConjectures/Arxiv/2603.18484/EmptyKGons.lean
+++ b/FormalConjectures/Arxiv/2603.18484/EmptyKGons.lean
@@ -1,0 +1,195 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Number of `k`-holes in planar point sets
+
+A `k`-hole of a finite planar point set `P` (in general position, i.e. no three
+points on a line) is a convex `k`-gon with vertices in `P` whose interior
+contains no point of `P`. It is the *empty* variant of the Erdős–Szekeres `k`-gon
+problem (the Happy Ending problem, `FormalConjectures.Wikipedia.HappyEndingProblem`
+and `FormalConjectures.ErdosProblems.«107»`). Let `h_k(n)` be the minimum number
+of `k`-holes over all `n`-point sets in general position (`minKHoles` in
+`FormalConjecturesForMathlib.Geometry.2d`).
+
+It is known that `h_k(n) = Θ(n²)` for `k ∈ {3, 4, 5}` in the sense that both an
+`Ω(·)` and an `O(n²)` bound hold — except that for `k = 5` the quadratic lower
+bound is *not* known: the best known lower bounds are super-linear but
+sub-quadratic. The three open conjectures below concern the leading constant of
+the quadratic term.
+
+- For `k = 3` and `k = 4` quadratic growth is established; only the value of the
+  leading constant is open.
+- For `k = 5` even `h₅(n) = Ω(n²)` is open. The current record lower bound is
+  `Ω(n^{20/11})`, proved in the paper this folder is named after.
+
+*References:*
+- [ASP26] O. Astudillo-Marbán and O. Solé-Pi, *There are many 5-holes*,
+  arXiv:2603.18484 (2026). The `Ω(n^{20/11})` bound, and a survey of the
+  conjectures below (their Problems 1 and 2).
+- [BK00] I. Bárány and G. Károlyi, *Problems and results around the
+  Erdős–Szekeres convex polygon theorem*, Japanese Conference on Discrete and
+  Computational Geometry (2000), 91–105.
+  [doi:10.1007/3-540-47738-1_7](https://doi.org/10.1007/3-540-47738-1_7).
+  Source of the 3-hole conjecture (Problem 1).
+- [BMP05] P. Brass, W. Moser, and J. Pach, *Research Problems in Discrete
+  Geometry*, Springer (2005), Chapter 8.4, Problem 5.
+  [doi:10.1007/0-387-29929-7](https://doi.org/10.1007/0-387-29929-7).
+- [Ai09] O. Aichholzer, *[Empty] [colored] k-gons. Recent results on some
+  Erdős–Szekeres type problems*, Proc. XIII Encuentros de Geometría
+  Computacional, Zaragoza (2009), 43–52.
+- [ABHKPSVV20] O. Aichholzer, M. Balko, T. Hackl, J. Kynčl, I. Parada, M. Scheucher,
+  P. Valtr, and B. Vogtenhuber, *A superlinear lower bound on the number of
+  5-holes*, J. Combin. Theory Ser. A 173 (2020), 105236.
+  [doi:10.1016/j.jcta.2020.105236](https://doi.org/10.1016/j.jcta.2020.105236),
+  arXiv:1703.05253. The `Ω(n · log^{4/5} n)` bound.
+- [Deh87] K. Dehnhardt, *Leere konvexe Vielecke in ebenen Punktmengen*, PhD thesis,
+  TU Braunschweig, 1987 (in German). First study of the numbers `h_3`, `h_4`, `h_5`.
+- [Sch18] M. Scheucher, *Two disjoint 5-holes in point sets*,
+  [arXiv:1807.10848](https://arxiv.org/abs/1807.10848) (2018). SAT encoding for
+  hole-counting searches.
+- OEIS sequences of minimum k-hole counts: [A063541](https://oeis.org/A063541)
+  (3-holes), [A063542](https://oeis.org/A063542) (4-holes),
+  [A276096](https://oeis.org/A276096) (5-holes).
+- [Wikipedia: Empty triangle](https://en.wikipedia.org/wiki/Empty_triangle)
+-/
+
+open EuclideanGeometry
+
+namespace EmptyKGons
+
+/-!
+## The three open conjectures on the leading constant
+
+Each is phrased, following [ASP26] and [BMP05], as the existence of a constant
+improving on the trivial quadratic leading term. `minKHoles k n` is `h_k(n)`.
+
+The three problems are tightly linked. Writing `c_k` for the leading constant of
+`h_k(n)` (its `n²`-coefficient, `leadingConst k` below), Pinchasi, Radoičić and
+Sharir proved `c₅ ≥ c₃ - 1` and `c₄ ≥ c₃ - 1/2`. In particular, resolving the
+3-hole problem in the affirmative (`c₃ > 1`) resolves all three at once: it forces
+`c₄ > 1/2` and `c₅ > 0` (so `h₅(n) = Ω(n²)`). All three are widely believed to
+hold. See `variants` below.
+-/
+
+/-- The leading constant `c_k` of `h_k(n)`: the `n²`-coefficient of the number of
+`k`-holes, defined as `liminf_{n→∞} h_k(n) / n²`. -/
+noncomputable def leadingConst (k : ℕ) : ℝ :=
+  Filter.liminf (fun n => (minKHoles k n : ℝ) / (n : ℝ) ^ 2) Filter.atTop
+
+/--
+**Problem 1 (Bárány–Károlyi).** Is there an absolute constant `ε > 0` such that
+`h₃(n) ≥ (1 + ε) n²` for every sufficiently large `n`?
+
+The known lower bound is `h₃(n) ≥ n² - O(n)` (so `c₃ ≥ 1`); the question is
+whether the leading constant can be pushed above `1`.
+-/
+@[category research open, AMS 52]
+theorem h3_leading_constant :
+    answer(sorry) ↔
+      ∃ ε : ℝ, 0 < ε ∧ ∀ᶠ n in Filter.atTop,
+        (1 + ε) * (n : ℝ) ^ 2 ≤ minKHoles 3 n := by
+  sorry
+
+/--
+**Problem 2, part 1.** Is there a constant `ε₁ > 0` such that
+`h₄(n) ≥ (1/2 + ε₁) n²` for every sufficiently large `n`?
+
+The known lower bound is `h₄(n) ≥ (1/2) n² - o(n²)` (so `c₄ ≥ 1/2`); the question
+is whether the leading constant exceeds `1/2`.
+-/
+@[category research open, AMS 52]
+theorem h4_leading_constant :
+    answer(sorry) ↔
+      ∃ ε : ℝ, 0 < ε ∧ ∀ᶠ n in Filter.atTop,
+        (1 / 2 + ε) * (n : ℝ) ^ 2 ≤ minKHoles 4 n := by
+  sorry
+
+/--
+**Problem 2, part 2.** Is there a constant `ε₂ > 0` such that
+`h₅(n) ≥ ε₂ n²` for every sufficiently large `n`? Equivalently: is
+`h₅(n) = Ω(n²)`?
+
+Unlike `k = 3, 4`, no quadratic lower bound is known for `k = 5`; only
+super-linear bounds (see `variants` below).
+-/
+@[category research open, AMS 52]
+theorem h5_quadratic :
+    answer(sorry) ↔
+      ∃ ε : ℝ, 0 < ε ∧ ∀ᶠ n in Filter.atTop,
+        ε * (n : ℝ) ^ 2 ≤ minKHoles 5 n := by
+  sorry
+
+namespace variants
+
+/--
+Matching quadratic upper bounds: for `k ∈ {3, 4, 5}` there are `n`-point sets in
+general position with only `O(n²)` `k`-holes (Bárány–Valtr constructions). Hence
+the conjectures above are about the leading constant of a genuinely quadratic
+quantity.
+-/
+@[category research solved, AMS 52]
+theorem quadratic_upper_bound (k : ℕ) (hk : k ∈ ({3, 4, 5} : Set ℕ)) :
+    ∃ C : ℝ, 0 < C ∧ ∀ᶠ n in Filter.atTop,
+      (minKHoles k n : ℝ) ≤ C * (n : ℝ) ^ 2 := by
+  sorry
+
+/--
+**Pinchasi–Radoičić–Sharir relation, 4-holes vs 3-holes.** The leading constants
+satisfy `c₄ ≥ c₃ - 1/2`. Hence `c₃ > 1` implies `c₄ > 1/2`.
+
+[PRS06] R. Pinchasi, R. Radoičić, and M. Sharir, *On empty convex polygons in a
+planar point set*, J. Combin. Theory Ser. A 113(3) (2006), 385–419, p. 4.
+[doi:10.1016/j.jcta.2005.03.007](https://doi.org/10.1016/j.jcta.2005.03.007).
+-/
+@[category research solved, AMS 52]
+theorem c4_ge_c3_sub_half : leadingConst 4 ≥ leadingConst 3 - 1 / 2 := by
+  sorry
+
+/--
+**Pinchasi–Radoičić–Sharir relation, 5-holes vs 3-holes.** The leading constants
+satisfy `c₅ ≥ c₃ - 1`. Hence `c₃ > 1` implies `c₅ > 0`, i.e. `h₅(n) = Ω(n²)`
+(Valtr's implication). [PRS06], p. 4.
+-/
+@[category research solved, AMS 52]
+theorem c5_ge_c3_sub_one : leadingConst 5 ≥ leadingConst 3 - 1 := by
+  sorry
+
+/--
+[ABHKPSVV20] proved the first super-linear lower bound on the number of 5-holes:
+`h₅(n) = Ω(n · (log n)^{4/5})`.
+-/
+@[category research solved, AMS 52]
+theorem h5_superlinear :
+    ∃ c : ℝ, 0 < c ∧ ∀ᶠ n in Filter.atTop,
+      c * (n : ℝ) * Real.log n ^ (4 / 5 : ℝ) ≤ minKHoles 5 n := by
+  sorry
+
+/--
+[ASP26] improved the 5-hole lower bound to `h₅(n) = Ω(n^{20/11})`, the current
+record. This is the paper this folder is named after.
+-/
+@[category research solved, AMS 52]
+theorem h5_astudillo_sole :
+    ∃ c : ℝ, 0 < c ∧ ∀ᶠ n in Filter.atTop,
+      c * (n : ℝ) ^ (20 / 11 : ℝ) ≤ minKHoles 5 n := by
+  sorry
+
+end variants
+
+end EmptyKGons

--- a/FormalConjectures/Wikipedia/BigLineBigClique.lean
+++ b/FormalConjectures/Wikipedia/BigLineBigClique.lean
@@ -1,0 +1,90 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The big-line-big-clique conjecture
+
+A "big line" in a finite planar point set is a set of `ℓ` collinear points. A
+"big clique" is a set of `k` points that are pairwise *visible*: two points are
+visible if the open segment between them contains no other point of the set,
+i.e. they form a clique in the *visibility graph*.
+
+Kára, Pór, and Wood (2005) conjectured that these are the only two obstructions
+to unbounded structure: for all `k` and `ℓ` there is an `n` such that every
+`n`-point set contains `ℓ` collinear points or `k` pairwise-visible points (or
+both). This is a Ramsey-type statement in the Erdős–Szekeres family.
+
+The conjecture is open in general. It is known for `ℓ ≤ 3`: point sets with no
+three collinear (general position) always contain a big clique, by the
+Erdős–Szekeres / happy-ending theorem (`FormalConjectures.Wikipedia.HappyEndingProblem`,
+`FormalConjectures.ErdosProblems.«107»`) together with the fact that in convex
+position all points are mutually visible.
+
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Big-line-big-clique_conjecture)
+- [KPW05] J. Kára, A. Pór, and D. R. Wood, *On the chromatic number of the
+  visibility graph of a set of points in the plane*, Discrete & Computational
+  Geometry 34 (2005), 497–506.
+  [doi:10.1007/s00454-005-1177-z](https://doi.org/10.1007/s00454-005-1177-z).
+-/
+
+open EuclideanGeometry
+
+namespace BigLineBigClique
+
+/-- `S` contains a *big clique* of size `k`: a `k`-element subset whose points
+are pairwise visible in `S` (a clique of size `k` in the visibility graph). The
+visibility relation `EuclideanGeometry.Visible` lives in `Geometry.2d`. -/
+def HasBigClique (k : ℕ) (S : Set ℝ²) : Prop :=
+  ∃ C : Finset ℝ², C.card = k ∧ ↑C ⊆ S ∧
+    (C : Set ℝ²).Pairwise (Visible S)
+
+/-- `S` contains a *big line* of size `ℓ`: `ℓ` collinear points of `S`. This is the
+negation of `EuclideanGeometry.NonCollinearFor ℓ` (which says no `ℓ` points of `S`
+are collinear); we keep the positive "big line" phrasing here for readability. -/
+def HasBigLine (ℓ : ℕ) (S : Set ℝ²) : Prop :=
+  ∃ L : Finset ℝ², L.card = ℓ ∧ ↑L ⊆ S ∧ Collinear ℝ (L : Set ℝ²)
+
+/--
+**The big-line-big-clique conjecture (Kára–Pór–Wood).**
+For all `k` and `ℓ` there is an `n` such that every planar point set with at
+least `n` points contains `ℓ` collinear points or `k` pairwise-visible points.
+-/
+@[category research open, AMS 52]
+theorem big_line_big_clique :
+    ∀ k ℓ : ℕ, ∃ n : ℕ, ∀ S : Finset ℝ², n ≤ S.card →
+      HasBigLine ℓ (↑S) ∨ HasBigClique k (↑S) := by
+  sorry
+
+namespace variants
+
+/--
+The conjecture holds for `ℓ ≤ 3`: if a point set has no three collinear points
+(general position), it contains an arbitrarily large clique in the visibility
+graph. Equivalently, for every `k` there is an `n` such that every set of `n`
+points contains `3` collinear points or a big clique of size `k`.
+-/
+@[category research solved, AMS 52]
+theorem big_line_big_clique_line_three (k : ℕ) :
+    ∃ n : ℕ, ∀ S : Finset ℝ², n ≤ S.card →
+      HasBigLine 3 (↑S) ∨ HasBigClique k (↑S) := by
+  sorry
+
+end variants
+
+end BigLineBigClique

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -128,6 +128,7 @@ public import FormalConjecturesForMathlib.Data.ZMod.Fp
 public import FormalConjecturesForMathlib.Data.ZMod.PerfectDifferenceSet
 public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
+public import FormalConjecturesForMathlib.Geometry.Holes
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»

--- a/FormalConjecturesForMathlib/Geometry/2d.lean
+++ b/FormalConjecturesForMathlib/Geometry/2d.lean
@@ -23,6 +23,7 @@ public import Mathlib.Data.Set.Card
 public import Mathlib.Geometry.Euclidean.Sphere.Basic
 
 public import FormalConjecturesForMathlib.Geometry.Metric
+public import FormalConjecturesForMathlib.Geometry.Holes
 public import FormalConjecturesForMathlib.Logic.Equiv.Fin.Rotate
 public import FormalConjecturesForMathlib.Data.Set.Triplewise
 
@@ -73,14 +74,56 @@ lemma NonCollinearFor.subset {n : ℕ} {S T : Set P} (h : S ⊆ T) (hS : NonColl
 
 /-- `ConvexIndep S` means that `S` consists of extremal points of its convex hull,
 i.e., the point set encloses a convex shape.
-Also known as a "convex-independent set". -/
+Also known as a "convex-independent set". This is the planar (`d = 2`) case of the
+dimension-generic `ConvexPos`. -/
 def ConvexIndep (S : Set ℝ²) : Prop :=
-  ∀ a ∈ S, a ∉ convexHull ℝ (S \ {a})
+  ConvexPos (d := 2) S
+
+/-- Two points `p q` of a set `S` are *visible* in `S` if the open segment between
+them contains no other point of `S`. This is the edge relation of the *visibility
+graph* of `S`. -/
+def Visible (S : Set ℝ²) (p q : ℝ²) : Prop :=
+  ∀ r ∈ S, r ≠ p → r ≠ q → r ∉ openSegment ℝ p q
 
 /-- The set `P` contains a convex `n`-gon.
 See also `IsConvexPolygon`. -/
 def HasConvexNGon (n : ℕ) (P : Set ℝ²) : Prop :=
   ∃ S : Finset ℝ², S.card = n ∧ ↑S ⊆ P ∧ ConvexIndep S
+
+/-- `EmptyShapeIn S P` means that `S` carves out an *empty* shape inside `P`:
+the convex hull of `S` contains no point of `P` other than the points of `S`
+themselves. This is the planar (`d = 2`) case of the dimension-generic
+`EmptyIn`. -/
+def EmptyShapeIn (S P : Set ℝ²) : Prop :=
+  EmptyIn (d := 2) S P
+
+/-- `ConvexEmptyIn S P` means that `S` is in convex position and forms an empty
+region in `P`, i.e. `S` is the vertex set of a convex polygon (a "hole") whose
+convex hull contains no point of `P` other than the points of `S`. When `P` is in
+general position (no three collinear) this is exactly "no point of `P` in the
+interior". This is the planar (`d = 2`) case of the dimension-generic
+`IsHoleIn`. -/
+def ConvexEmptyIn (S P : Set ℝ²) : Prop :=
+  IsHoleIn (d := 2) S P
+
+/-- The set `P` contains an *empty* convex `k`-gon (a `k`-hole): a `k`-element
+subset in convex position whose convex hull contains no other point of `P`.
+This is the empty (hole) analogue of `HasConvexNGon`, and the planar (`d = 2`)
+case of the dimension-generic `HasKHole`. -/
+def HasEmptyKGon (k : ℕ) (P : Set ℝ²) : Prop :=
+  HasKHole (d := 2) k P
+
+open Classical in
+/-- The number of `k`-holes of a finite point set `P`: the number of `k`-element
+subsets of `P` that are in convex position and empty in `P`. Written `h_k` for a
+fixed set; the extremal quantity `h_k(n)` is `minKHoles` below. -/
+noncomputable def numKHoles (k : ℕ) (P : Finset ℝ²) : ℕ :=
+  ((P.powersetCard k).filter (fun S : Finset ℝ² => ConvexEmptyIn ↑S ↑P)).card
+
+/-- `minKHoles k n` is the classical function `h_k(n)`: the minimum number of
+`k`-holes over all sets of `n` points in the plane with no three on a line. -/
+noncomputable def minKHoles (k n : ℕ) : ℕ :=
+  sInf {m | ∃ P : Finset ℝ², P.card = n ∧ NonTrilinear (P : Set ℝ²) ∧ numKHoles k P = m}
 
 /-- The statement that a sequence of points form a counter-clockwise convex polygon. -/
 def IsCcwConvexPolygon (p : Fin n → P) : Prop :=

--- a/FormalConjecturesForMathlib/Geometry/Holes.lean
+++ b/FormalConjecturesForMathlib/Geometry/Holes.lean
@@ -1,0 +1,79 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Analysis.Convex.Hull
+public import Mathlib.LinearAlgebra.AffineSpace.Independent
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+
+@[expose] public section
+
+/-!
+# `k`-holes in Euclidean space (dimension-generic)
+
+This file collects the dimension-generic definitions of *convex position*,
+*empty convex polytopes* and *`k`-holes* of finite point sets in `d`-dimensional
+Euclidean space `ℝ^d`. They are used both for the plane (`d = 2`, see
+`FormalConjecturesForMathlib.Geometry.2d`) and for higher dimensions (e.g.
+`d = 3`, see `FormalConjectures.Arxiv.2105.08406.HigherDimHoles`).
+
+A `k`-gon is a set of `k` points in *convex position* (`ConvexPos`), meaning no
+point lies in the convex hull of the others. A `k`-hole is a `k`-gon whose convex
+hull contains no other point of the set (`IsHoleIn`). A finite point set is in
+*general position* in `ℝ^d` (`InGenPos`) if no `d + 1` of its points lie on a
+common hyperplane, encoded by requiring every `(d + 1)`-subset to be affinely
+independent.
+-/
+
+open scoped Finset
+
+namespace EuclideanGeometry
+
+/-- `ℝ^d`, `d`-dimensional Euclidean space. -/
+abbrev EDim (d : ℕ) := EuclideanSpace ℝ (Fin d)
+
+/-- A set `S` in `ℝ^d` is in **convex position** (convex independent): no point of
+`S` lies in the convex hull of the remaining points. Also known as a
+"convex-independent set"; the point set encloses a convex shape. -/
+def ConvexPos {d : ℕ} (S : Set (EDim d)) : Prop :=
+  ∀ a ∈ S, a ∉ convexHull ℝ (S \ {a})
+
+/-- `EmptyIn S P` means that `S` carves out an *empty* shape inside `P`: no point
+of `P` outside `S` lies in the convex hull of `S`. -/
+def EmptyIn {d : ℕ} (S P : Set (EDim d)) : Prop :=
+  ∀ p ∈ P \ S, p ∉ convexHull ℝ S
+
+/-- `IsHoleIn S P` means that `S` is a **hole** of `P`: the points of `S` are in
+convex position, and no point of `P` outside `S` lies in the convex hull of `S`
+(the hole is *empty*). `S` is the vertex set of a convex polytope whose convex
+hull contains no other point of `P`. -/
+def IsHoleIn {d : ℕ} (S P : Set (EDim d)) : Prop :=
+  ConvexPos S ∧ EmptyIn S P
+
+/-- `HasKHole k P` means the point set `P ⊆ ℝ^d` contains a **`k`-hole**: a
+`k`-element subset in convex position whose convex hull contains no other point
+of `P`. -/
+def HasKHole {d : ℕ} (k : ℕ) (P : Set (EDim d)) : Prop :=
+  ∃ S : Finset (EDim d), S.card = k ∧ ↑S ⊆ P ∧ IsHoleIn ↑S P
+
+/-- A finite point set `P` in `ℝ^d` is in **general position** if no `d + 1` of
+its points lie on a common hyperplane, encoded by requiring every `(d + 1)`-point
+subset to be affinely independent. -/
+def InGenPos {d : ℕ} (P : Finset (EDim d)) : Prop :=
+  ∀ T : Finset (EDim d), T ⊆ P → T.card = d + 1 →
+    AffineIndependent ℝ (fun x : (T : Set (EDim d)) => (x : EDim d))
+
+end EuclideanGeometry


### PR DESCRIPTION
Closes #5272.

Adds several Erdős–Szekeres-type conjectures plus a shared dimension-generic hole layer (`Geometry/Holes.lean`). A k-hole is the empty variant of the classic Erdős–Szekeres k-gon problem, already in the repo as the Happy Ending problem (`ErdosProblems/107`).

**Three conjectures on k-holes** (`Arxiv/2603.18484/EmptyKGons.lean`), on the quadratic term `c_k` of `h_k(n)` (min number of k-holes over n points in general position):

| Declaration | Content | Status |
|---|---|---|
| `h3_leading_constant` | `c_3 > 1` (Bárány–Károlyi 2000) | research open |
| `h4_leading_constant` | `c_4 > 1/2` (Brass–Moser–Pach 2005) | research open |
| `h5_quadratic` | `c_5 > 0`, i.e. `h_5(n) = Ω(n²)` | research open |

They interlock: the Pinchasi–Radoičić–Sharir relations `c_4 ≥ c_3 − 1/2`, `c_5 ≥ c_3 − 1` mean `c_3 > 1` settles all three. For `k = 3, 4` quadratic growth is known; for `k = 5` even that is open. Known bounds (O(n²), the PRS relations, `Ω(n·log^{4/5}n)`, `Ω(n^{20/11})`) are on file as `variants`. (`h_6` is similarly open but never stated explicitly, since 6-hole existence itself was open until Gerken/Nicolás 2006; `h_k = 0` for `k ≥ 7` by Horton 1983.)

**Big-line-big-clique** (`Wikipedia/BigLineBigClique.lean`, Kára–Pór–Wood 2005): many points in the plane either have many collinear points or many mutually visible ones.

**Higher-dimensional holes** (`Arxiv/2105.08406/HigherDimHoles.lean`, Scheucher 2023): in the plane `H(2)=6`; in 3-space the existence of 8-holes is open (Valtr). With `h^(3)(7) ≤ 14` and no-23-hole (`H(3) ≤ 22`) as variants.

Statements are `sorry` (benchmark statements); `lake --wfail build` of the touched modules is clean on v4.33.1. References with DOIs are in the file docstrings.

I used AI tools for Lean/mathlib API guidance and reviewed the output.
