### PR TITLE
feat: add three oriented-matroid conjectures (Roudneff, Las Vergnas simplex, two-colored triangle)

### DIFF
--- a/FormalConjectures/Arxiv/2303.14212/Roudneff.lean
+++ b/FormalConjectures/Arxiv/2303.14212/Roudneff.lean
@@ -1,0 +1,114 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The Roudneff conjecture on complete cells of pseudohyperplane arrangements
+
+An *arrangement* of `n` pseudohyperplanes in projective `d`-space `ℙ^d` cuts the
+space into cells. A cell is *complete* if it is bounded by **all** `n` of the
+pseudohyperplanes. Equivalently, on the oriented-matroid side, a complete cell is a
+*tope* `T` (a maximal covector) such that flipping `T` at any single coordinate
+again gives a tope. This is strictly stronger than a *simplicial cell* / *mutation*,
+which is bounded by exactly `d + 1` hyperplanes (a simplex): a complete cell need not
+be a simplex, and a simplicial cell is generally not complete. Roudneff [Rou91]
+conjectured a sharp upper bound on the number of complete cells; the paper at
+arXiv:2303.14212 extends the conjecture to arrangements of pseudohyperplanes
+(equivalently, to rank-`(d+1)` oriented matroids) and studies it there.
+
+**Conjecture 1.1 (Roudneff).** Every arrangement of `n ≥ 2d + 1 ≥ 5`
+pseudohyperplanes in `ℙ^d` has at most `∑_{i=0}^{d-2} binomial(n-1, i)` complete
+cells.
+
+We phrase this over *oriented matroids* via their **chirotopes**, using the shared
+definitions in `FormalConjecturesForMathlib.Combinatorics.OrientedMatroid.Chirotope`
+(`Chirotope`, `IsUniformChirotope`, `IsTope`, `IsCompleteCell`, `numCompleteCells`).
+A rank-`r` uniform chirotope on `Fin n` is the oriented matroid of an arrangement of
+`n` pseudohyperplanes in general position in `ℙ^{r-1}`. Setting `r = d + 1`, the
+complete cells of the arrangement are the complete cells of the chirotope (topes all
+of whose single-coordinate flips are again topes), counted up to antipode as cells in
+`ℙ^d`, so Roudneff's conjecture is an upper bound on `numCompleteCells` of a uniform
+chirotope.
+
+*References:*
+- [HKMS24] R. Hernández-Ortiz, K. Knauer, L. P. Montejano, and M. Scheucher,
+  *Roudneff's conjecture in dimension 4*, Experimental Mathematics (2024),
+  [doi:10.1080/10586458.2024.2334379](https://doi.org/10.1080/10586458.2024.2334379).
+  Open-access version:
+  [arXiv:2303.14212](https://arxiv.org/abs/2303.14212). States and studies
+  Conjecture 1.1 for pseudohyperplane arrangements / oriented matroids.
+- [Rou91] J.-P. Roudneff, *Cells with many facets in arrangements of hyperplanes*,
+  Discrete Mathematics 98(3) (1991), 185–191. The original conjecture.
+- [BLSWZ99] A. Björner, M. Las Vergnas, B. Sturmfels, N. White, and G. M. Ziegler,
+  *Oriented Matroids*, Encyclopedia of Mathematics and its Applications 46,
+  Cambridge University Press, 2nd ed., 1999. Source of the chirotope axioms.
+-/
+
+open Finset OrientedMatroid
+
+namespace Roudneff
+
+variable {r n : ℕ}
+
+/--
+**The Roudneff conjecture (Conjecture 1.1 of arXiv:2303.14212).** For every
+dimension `d ≥ 2` and every `n ≥ 2d + 1`, an arrangement of `n` pseudohyperplanes
+in general position in `ℙ^d` — equivalently, a uniform chirotope of rank `r = d+1`
+on `Fin n` — has at most `∑_{i=0}^{d-2} binomial(n-1, i)` complete cells (topes all
+of whose single-coordinate flips are again topes, counted up to antipode). The sum
+`i = 0, …, d-2` is `Finset.range (d - 1)`.
+-/
+@[category research open, AMS 52 5]
+theorem roudneff (d n : ℕ) (hd : 2 ≤ d) (hn : 2 * d + 1 ≤ n)
+    (χ : Chirotope (d + 1) n) (hχ : IsUniformChirotope (d + 1) n χ) :
+    numCompleteCells χ ≤ ∑ i ∈ Finset.range (d - 1), Nat.choose (n - 1) i := by
+  sorry
+
+namespace variants
+
+/--
+**The Roudneff bound is tight.** For every `d ≥ 2` and `n ≥ 2d + 1` the bound
+`∑_{i=0}^{d-2} binomial(n-1, i)` is attained: there is a uniform chirotope of rank
+`d + 1` on `Fin n` (the *cyclic* / alternating oriented matroid, realized by the
+cyclic hyperplane arrangement) whose number of complete cells equals the bound.
+Hence the conjectured inequality cannot be improved.
+-/
+@[category research solved, AMS 52 5]
+theorem roudneff_tight (d n : ℕ) (hd : 2 ≤ d) (hn : 2 * d + 1 ≤ n) :
+    ∃ χ : Chirotope (d + 1) n, IsUniformChirotope (d + 1) n χ ∧
+      numCompleteCells χ = ∑ i ∈ Finset.range (d - 1), Nat.choose (n - 1) i := by
+  sorry
+
+/--
+**The planar case `d = 2`.** The `d = 2` instance of `roudneff`: for a uniform
+chirotope of rank `3` on `Fin n` with `n ≥ 5` (an arrangement of `n` pseudolines
+in the projective plane), the conjectured bound is
+`∑_{i=0}^{0} binomial(n-1, i) = binomial(n-1, 0) = 1`, i.e.
+`Finset.range (2 - 1) = Finset.range 1`: at most one complete cell in `ℙ^2`. This
+does *not* contradict the fact that a rank-`3` arrangement has at least `n`
+simplicial cells (mutations), because a complete cell is a different object from a
+simplicial cell.
+-/
+@[category research open, AMS 52 5]
+theorem roudneff_dim_two (n : ℕ) (hn : 5 ≤ n)
+    (χ : Chirotope 3 n) (hχ : IsUniformChirotope 3 n χ) :
+    numCompleteCells χ ≤ ∑ i ∈ Finset.range 1, Nat.choose (n - 1) i := by
+  sorry
+
+end variants
+
+end Roudneff

--- a/FormalConjectures/Arxiv/2601.20574/TwoColoredTriangle.lean
+++ b/FormalConjectures/Arxiv/2601.20574/TwoColoredTriangle.lean
@@ -1,0 +1,122 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The Two-Colored (Bichromatic) Triangle Conjecture
+
+A *simple* arrangement of `n` pseudolines in the projective plane is a rank-`3`
+uniform oriented matroid, encoded here by a uniform chirotope
+`χ : (Fin 3 → Fin n) → SignType`. The pseudolines are the ground-set elements
+`Fin n`. A *triangle* (triangular cell) of the arrangement is a simplicial cell
+bounded by three of the pseudolines; in the oriented-matroid language these are
+exactly the *mutations* of `χ`, the flippable `3`-subsets `I` with `|I| = 3`.
+
+Now `2`-color the pseudolines by `col : Fin n → Bool` (say `false` = red,
+`true` = blue). The coloring is *non-trivial* if it uses both colors: at least one
+red element and at least one blue element. A triangle `I` (a mutation, `|I| = 3`)
+is *bichromatic* if its three bounding lines are not all the same color, i.e. `I`
+contains both a red and a blue element.
+
+**Two-Colored Triangle Conjecture.** Every non-trivial `2`-coloring of a simple
+pseudoline arrangement has at least one bichromatic triangle. Equivalently, in the
+negated (SAT-counterexample) form: no rank-`3` uniform chirotope admits a
+non-trivial `2`-coloring in which *every* triangle (mutation) is monochromatic.
+
+We reuse the shared chirotope infrastructure from
+`FormalConjecturesForMathlib.Combinatorics.OrientedMatroid.Chirotope`
+(`OrientedMatroid.Chirotope`, `IsUniformChirotope`, `IsMutation`, …); it is
+reachable through `FormalConjecturesUtil`.
+
+*References:*
+- [RKL26] Y. A. Radtke, B. Keszegh, and R. Lauff, *On triangles in colored
+  pseudoline arrangements*, [arXiv:2601.20574](https://arxiv.org/abs/2601.20574),
+  which states this as the **Two-Colored Triangle Conjecture**.
+- [FS21] S. Felsner and M. Scheucher, *Arrangements of pseudocircles: triangles
+  and drawings*, Discrete Comput. Geom. 65 (2021), 261–278.
+  [doi:10.1007/s00454-020-00173-4](https://doi.org/10.1007/s00454-020-00173-4),
+  arXiv:1708.06449.
+- [BLSWZ93] A. Björner, M. Las Vergnas, B. Sturmfels, N. White, and G. M. Ziegler,
+  *Oriented Matroids*, Encyclopedia of Mathematics and its Applications 46,
+  Cambridge University Press, 1993 (the conjecture is stated there, near the
+  simplicial-tope material, §4 / p. 280).
+-/
+
+open OrientedMatroid
+
+namespace TwoColoredTriangle
+
+variable {n : ℕ}
+
+/-- A triangle `I` (an `r`-subset of the ground set) is **monochromatic** for the
+`2`-coloring `col : Fin n → Bool` if all of its incident elements have the same
+color: any two of its bounding lines share a color. -/
+def IsMonochromatic (col : Fin n → Bool) (I : Finset (Fin n)) : Prop :=
+  ∀ x ∈ I, ∀ y ∈ I, col x = col y
+
+/-- A triangle `I` (an `r`-subset of the ground set) is **bichromatic** for the
+`2`-coloring `col : Fin n → Bool` if it contains both a red element (`col x = false`)
+and a blue element (`col y = true`); equivalently, its bounding lines are not all
+the same color. For a nonempty `I` this is exactly `¬ IsMonochromatic col I`. -/
+def IsBichromatic (col : Fin n → Bool) (I : Finset (Fin n)) : Prop :=
+  (∃ x ∈ I, col x = false) ∧ (∃ y ∈ I, col y = true)
+
+/--
+**The Two-Colored Triangle Conjecture (arXiv:2601.20574).** Every non-trivial
+`2`-coloring of a simple pseudoline arrangement has a bichromatic triangle. Here
+the arrangement is a uniform chirotope `χ` of rank `3` on `Fin n`, a triangle is a
+mutation (`IsMutation χ I`, an `I` with `|I| = 3`), and the coloring
+`col : Fin n → Bool` is non-trivial (`hred`, `hblue` provide a red and a blue
+element). The size hypothesis `3 ≤ n` ensures triangles can exist.
+
+Equivalent negated form: no rank-`3` uniform chirotope with a non-trivial
+`2`-coloring has all triangles (mutations) monochromatic (`IsMonochromatic`).
+-/
+@[category research open, AMS 52 5]
+theorem two_colored_triangle (n : ℕ) (hn : 3 ≤ n) (χ : Chirotope 3 n)
+    (hχ : IsUniformChirotope 3 n χ) (col : Fin n → Bool)
+    (hred : ∃ x, col x = false) (hblue : ∃ y, col y = true) :
+    ∃ I : Finset (Fin n), IsMutation χ I ∧ IsBichromatic col I := by
+  sorry
+
+namespace variants
+
+/--
+**The realizable (straight-line) case, known.** For a genuine arrangement of `n`
+straight lines in the real projective plane — a *realizable* rank-`3` uniform
+oriented matroid — every non-trivial `2`-coloring has a bichromatic triangle. We
+model realizability by exhibiting `n` points `p : Fin n → ℝ × ℝ` whose induced
+orientation chirotope equals `χ`: for every tuple, `χ t` is the sign of the triple
+orientation `orient (p (t 0)) (p (t 1)) (p (t 2))`, the standard `2×2` determinant
+`(b.1 - a.1) * (c.2 - a.2) - (b.2 - a.2) * (c.1 - a.1)` measuring the turn
+direction of `a → b → c`. The straight-line case has a simple direct argument and
+is known to hold.
+-/
+@[category research solved, AMS 52 5]
+theorem two_colored_triangle_realizable (n : ℕ) (hn : 3 ≤ n) (χ : Chirotope 3 n)
+    (hχ : IsUniformChirotope 3 n χ)
+    (hreal : ∃ p : Fin n → ℝ × ℝ, ∀ t : Fin 3 → Fin n,
+      let orient : ℝ × ℝ → ℝ × ℝ → ℝ × ℝ → ℝ :=
+        fun a b c => (b.1 - a.1) * (c.2 - a.2) - (b.2 - a.2) * (c.1 - a.1)
+      χ t = SignType.sign (orient (p (t 0)) (p (t 1)) (p (t 2))))
+    (col : Fin n → Bool) (hred : ∃ x, col x = false) (hblue : ∃ y, col y = true) :
+    ∃ I : Finset (Fin n), IsMutation χ I ∧ IsBichromatic col I := by
+  sorry
+
+end variants
+
+end TwoColoredTriangle

--- a/FormalConjectures/Paper/LasVergnasSimplex.lean
+++ b/FormalConjectures/Paper/LasVergnasSimplex.lean
@@ -1,0 +1,93 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjecturesUtil
+
+/-!
+# Las Vergnas simplex conjecture
+
+A *tope* of an oriented matroid is a maximal covector (a chamber of the associated
+pseudohyperplane arrangement). A tope is *simplicial* when it is bounded by exactly
+`r` pseudohyperplanes, i.e. it is a simplex. In terms of the chirotope, simplicial
+topes are exactly the *mutations*: the flippable `r`-subsets `I` of the ground set,
+where reversing the sign of `χ` on `I` again yields a (uniform) chirotope. See
+`OrientedMatroid.IsMutation`.
+
+**Las Vergnas' simplex conjecture** asserts that every uniform (simple) oriented
+matroid of rank `r ≥ 1` has at least one simplicial tope, equivalently at least one
+mutation. It is open in general; the rank-`3` case is a classical theorem of Levi
+(and Shannon): every simple arrangement of `n` pseudolines has at least `n`
+simplicial cells (triangles), so in particular at least one.
+
+The realizable case (a genuine arrangement of hyperplanes) is also classical, but the
+shared chirotope infrastructure carries no `realizable` predicate, so that variant is
+omitted here rather than encoded artificially.
+
+*References:*
+- A. Björner, M. Las Vergnas, B. Sturmfels, N. White, G. M. Ziegler,
+  *Oriented Matroids*, Encyclopedia of Mathematics and its Applications 46,
+  Cambridge University Press, 1993/1999 (Exercise 7.29; §2.3 for topes).
+- F. Levi, *Die Teilung der projektiven Ebene durch Gerade oder Pseudogerade*,
+  Ber. Math.-Phys. Kl. Sächs. Akad. Wiss. **78** (1926), 256–267.
+- R. W. Shannon, *Simplicial cells in arrangements of hyperplanes*,
+  Geom. Dedicata **8** (1979), 179–187.
+-/
+
+open OrientedMatroid
+
+namespace LasVergnasSimplex
+
+/--
+**Las Vergnas simplex conjecture.** Every uniform (simple) chirotope of rank `r`
+on the ground set `Fin n`, with `1 ≤ r ≤ n`, admits at least one mutation, i.e.
+at least one simplicial tope: there is an `r`-subset `I` of the ground set that is
+flippable. This is open in general.
+-/
+@[category research open, AMS 52 5]
+theorem las_vergnas_simplex (r n : ℕ) (hr : 1 ≤ r) (hn : r ≤ n)
+    (χ : Chirotope r n) (hχ : IsUniformChirotope r n χ) :
+    ∃ I : Finset (Fin n), IsMutation χ I := by
+  sorry
+
+namespace variants
+
+/--
+**Rank-3 case (Levi–Shannon).** Every uniform chirotope of rank `3` on `Fin n`
+(with `3 ≤ n`) has a mutation, i.e. every simple arrangement of `n` pseudolines has
+a simplicial cell (triangle). This is the classical, solved specialization of the
+Las Vergnas simplex conjecture; Levi and Shannon in fact guarantee at least `n` such
+triangles.
+-/
+@[category research solved, AMS 52 5]
+theorem rank_three (n : ℕ) (hn : 3 ≤ n)
+    (χ : Chirotope 3 n) (hχ : IsUniformChirotope 3 n χ) :
+    ∃ I : Finset (Fin n), IsMutation χ I := by
+  sorry
+
+/--
+**Rank-3 lower bound (Levi–Shannon).** Every simple arrangement of `n ≥ 3`
+pseudolines has at least `n` simplicial cells (triangles): the number of mutations of
+a uniform rank-`3` chirotope on `Fin n` is at least `n`. This sharper, solved bound
+implies `rank_three`.
+-/
+@[category research solved, AMS 52 5]
+theorem rank_three_lower_bound (n : ℕ) (hn : 3 ≤ n)
+    (χ : Chirotope 3 n) (hχ : IsUniformChirotope 3 n χ) :
+    n ≤ numMutations χ := by
+  sorry
+
+end variants
+
+end LasVergnasSimplex

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -51,6 +51,7 @@ public import FormalConjecturesForMathlib.Combinatorics.Hypergraph.ThreeUniform
 public import FormalConjecturesForMathlib.Combinatorics.LatinSquare
 public import FormalConjecturesForMathlib.Combinatorics.LimitObjects.Graphon
 public import FormalConjecturesForMathlib.Combinatorics.LimitObjects.Tournamenton
+public import FormalConjecturesForMathlib.Combinatorics.OrientedMatroid.Chirotope
 public import FormalConjecturesForMathlib.Combinatorics.Ramsey
 public import FormalConjecturesForMathlib.Combinatorics.Ramsey.Diagonal
 public import FormalConjecturesForMathlib.Combinatorics.SetFamily.PropertyB

--- a/FormalConjecturesForMathlib/Combinatorics/OrientedMatroid/Chirotope.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/OrientedMatroid/Chirotope.lean
@@ -1,0 +1,178 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Sign.Basic
+public import Mathlib.GroupTheory.Perm.Sign
+public import Mathlib.Data.Finset.Powerset
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.Fintype.Powerset
+
+@[expose] public section
+
+/-!
+# Chirotopes (oriented matroids)
+
+Mathlib has no oriented matroids (as of 2026). This file defines a *chirotope* of
+rank `r` on the ground set `Fin n`: a map `χ : (Fin r → Fin n) → SignType`
+(a sign `{-1, 0, +1}` per `r`-tuple) that is *alternating* and satisfies the
+*3-term Grassmann–Plücker relations*. This encodes a rank-`r` oriented matroid on
+`n` elements. A *uniform* chirotope is nonzero on all injective tuples (general
+position). A *mutation* is a flippable `r`-subset; mutations correspond to the
+*simplicial* cells (simplicial topes) of the associated pseudohyperplane
+arrangement, bounded by exactly `r` hyperplanes. This is distinct from a *complete
+cell* (a tope bounded by all `n` hyperplanes; see `IsCompleteCell` below).
+
+*Reference:* A. Björner, M. Las Vergnas, B. Sturmfels, N. White, G. M. Ziegler,
+*Oriented Matroids*, Encyclopedia of Mathematics and its Applications 46,
+Cambridge University Press, 1993/1999.
+-/
+
+open Finset
+
+namespace OrientedMatroid
+
+variable {r n : ℕ}
+
+/-- A *chirotope candidate* of rank `r` on the ground set `Fin n`: a map assigning
+a sign in `{-1, 0, +1}` (a `SignType`) to every `r`-tuple of ground-set elements. -/
+abbrev Chirotope (r n : ℕ) : Type := (Fin r → Fin n) → SignType
+
+/-- **Alternating axiom.** Permuting the `r` slots of a tuple multiplies the sign
+by the sign of the permutation (`perm_sign`). -/
+def IsAlternating (χ : Chirotope r n) : Prop :=
+  ∀ (t : Fin r → Fin n) (σ : Equiv.Perm (Fin r)),
+    χ (t ∘ σ) = SignType.sign (Equiv.Perm.sign σ : ℤ) * χ t
+
+/-- **Uniformity / non-degeneracy.** The sign is nonzero on every tuple whose `r`
+entries are pairwise distinct: the general-position case (a uniform oriented
+matroid, an arrangement with no special incidences). -/
+def IsUniform (χ : Chirotope r n) : Prop :=
+  ∀ t : Fin r → Fin n, Function.Injective t → χ t ≠ 0
+
+/-- **3-term Grassmann–Plücker relations** (`satisfies_3term_gp`): for any two
+ground-set elements `b₁ b₂` and any injective tuple `a` disjoint from `{b₁, b₂}`,
+if `χ(b₁,a₂,…) = χ(a₁,b₂,a₃,…)` and `χ(b₂,a₂,…) = χ(b₁,a₁,a₃,…)`, then
+`χ(a₁,…,a_r) = χ(b₁,b₂,a₃,…)`. -/
+def Satisfies3TermGP (χ : Chirotope r n) : Prop :=
+  ∀ (hr : 2 ≤ r) (b₁ b₂ : Fin n) (a : Fin r → Fin n),
+    Function.Injective a → b₁ ∉ Set.range a → b₂ ∉ Set.range a → b₁ ≠ b₂ →
+      let i0 : Fin r := ⟨0, by omega⟩
+      let i1 : Fin r := ⟨1, by omega⟩
+      χ (Function.update a i0 b₁) = χ (Function.update a i1 b₂) →
+      χ (Function.update a i0 b₂) = χ (Function.update (Function.update a i0 (a i1)) i1 b₁) →
+        χ a = χ (Function.update (Function.update a i0 b₁) i1 b₂)
+
+/-- A **chirotope** of rank `r` on `Fin n`: alternating and satisfying the 3-term
+Grassmann–Plücker relations. Encodes a rank-`r` oriented matroid on `n` elements. -/
+def IsChirotope (r n : ℕ) (χ : Chirotope r n) : Prop :=
+  IsAlternating χ ∧ Satisfies3TermGP χ
+
+/-- A **uniform chirotope**: a chirotope that is additionally uniform. This is the
+oriented matroid of an arrangement of `n` pseudohyperplanes in general position in
+`ℙ^{r-1}`. -/
+def IsUniformChirotope (r n : ℕ) (χ : Chirotope r n) : Prop :=
+  IsChirotope r n χ ∧ IsUniform χ
+
+/-- Negate the sign of `χ` on every tuple whose underlying `r`-set equals `I`
+(keeping all other tuples fixed). Since a chirotope is alternating, this is the
+natural "sign flip at `I`" (`flip_sign_at`). -/
+def flipAt (χ : Chirotope r n) (I : Finset (Fin n)) : Chirotope r n :=
+  fun t => if (Finset.univ.image t = I) then - χ t else χ t
+
+/-- **Mutation (simplicial cell).** An `r`-subset `I` is a *mutation* of a uniform
+chirotope `χ` if flipping the sign of `χ` on `I` again yields a uniform chirotope.
+Mutations are the *flippable* `r`-subsets, in bijection with the simplicial cells
+(simplicial topes) of the arrangement, bounded by exactly `r` hyperplanes. See
+`IsCompleteCell` for the (different) notion bounded by all `n`. -/
+def IsMutation (χ : Chirotope r n) (I : Finset (Fin n)) : Prop :=
+  I.card = r ∧ IsUniformChirotope r n (flipAt χ I)
+
+open Classical in
+/-- The **number of mutations** (simplicial cells / simplicial topes) of `χ`: the
+number of `r`-subsets of the ground set that are mutations. -/
+noncomputable def numMutations (χ : Chirotope r n) : ℕ :=
+  (Finset.univ.filter (fun I : Finset (Fin n) => IsMutation χ I)).card
+
+/-! ### Topes and complete cells
+
+A *tope* of an oriented matroid is a maximal covector: a full-support sign vector
+`T : Fin n → SignType` (no zero entries) that is orthogonal to every circuit. For a
+uniform rank-`r` chirotope every circuit is supported on an `(r+1)`-subset and its
+signs are the alternating minors of the chirotope. Concretely, for an `(r+1)`-subset
+`C = {c₀ < c₁ < … < c_r}` the circuit sign on `cⱼ` is
+`(-1)^j · χ(c₀,…,ĉⱼ,…,c_r)` (delete the `j`-th element). A sign vector `T` is
+*orthogonal* to a circuit `X` if either their supports meet in a coordinate where the
+signs agree and in another where they disagree, or they are disjoint. On a full-support
+`T` and a circuit the disjoint case cannot arise, so orthogonality means: `T` and `X`
+agree on at least one coordinate of the circuit support and disagree on at least one.
+
+A *complete cell* (Roudneff) is a tope `T` bounded by **all** `n` pseudohyperplanes:
+flipping `T` at any single coordinate again gives a tope. This is strictly stronger
+than a *mutation* / simplicial cell (bounded by exactly `r = d+1` hyperplanes) and is
+the object of Roudneff's conjecture. Cf. `Complete_cells` logic of arXiv:2303.14212. -/
+
+/-- A **tope candidate** on the ground set `Fin n`: a full-support sign vector, i.e. a
+map `T : Fin n → SignType` with no zero entry (equivalently `T : Fin n → {-1, +1}`). -/
+def IsSignVector (T : Fin n → SignType) : Prop := ∀ i, T i ≠ 0
+
+/-- The signed **circuit** on an `(r+1)`-subset `C = {c₀ < … < c_r}` of the ground set,
+evaluated at the `j`-th element `c_j`: the alternating minor
+`(-1)^j · χ(c₀,…,ĉⱼ,…,c_r)`, where `c : Fin (r+1) → Fin n` lists `C` in increasing
+order and `Fin.succAbove j` skips the `j`-th slot. Off the support the circuit is `0`
+(handled in `IsOrthogonalToCircuit`). This is the standard cofactor formula giving the
+oriented circuit of a uniform chirotope (BLSWZ99, Ch. 3). -/
+def circuitSign (χ : Chirotope r n) (c : Fin (r + 1) → Fin n) (j : Fin (r + 1)) :
+    SignType :=
+  (-1) ^ (j : ℕ) * χ (fun k : Fin r => c (j.succAbove k))
+
+/-- **Orthogonality of a full-support sign vector `T` to the circuit on `c`.** The
+circuit is supported on the image of `c : Fin (r+1) → Fin n`. For a full-support `T`
+the disjoint-support case never occurs, so the covector–circuit orthogonality axiom
+reduces to: among the `r+1` support coordinates, the product `T · (circuit sign)` takes
+the value `+1` on at least one and `-1` on at least one (an *agreement* and a
+*disagreement*). Cf. `min(H, S) > 0` in the reference `Complete_cells`. -/
+def IsOrthogonalToCircuit (χ : Chirotope r n) (T : Fin n → SignType)
+    (c : Fin (r + 1) → Fin n) : Prop :=
+  (∃ j, T (c j) * circuitSign χ c j = 1) ∧ (∃ j, T (c j) * circuitSign χ c j = -1)
+
+/-- **`T` is a tope of `χ`.** A full-support sign vector that is orthogonal to every
+circuit, i.e. a maximal covector of the oriented matroid. Circuits range over all
+increasing `(r+1)`-tuples `c : Fin (r+1) → Fin n` (strictly monotone), one per
+`(r+1)`-subset of the ground set. -/
+def IsTope (χ : Chirotope r n) (T : Fin n → SignType) : Prop :=
+  IsSignVector T ∧
+    ∀ c : Fin (r + 1) → Fin n, StrictMono c → IsOrthogonalToCircuit χ T c
+
+/-- **Complete cell (Roudneff).** A tope `T` of `χ` such that flipping `T` at *any*
+single coordinate `i` again yields a tope: the cell is bounded by *all* `n`
+pseudohyperplanes. This is the notion whose count Roudneff's conjecture bounds, and it
+is strictly stronger than a mutation (`IsMutation`, bounded by exactly `r` hyperplanes).
+-/
+def IsCompleteCell (χ : Chirotope r n) (T : Fin n → SignType) : Prop :=
+  IsTope χ T ∧ ∀ i : Fin n, IsTope χ (Function.update T i (- T i))
+
+open Classical in
+/-- The **number of complete cells** of `χ`, counted **up to antipode** (as cells in
+projective space `ℙ^{r-1}`). If `T` is a complete cell then so is its antipode `-T`, and
+`T`, `-T` are the two sign vectors of the *same* projective cell; the reference program
+`Roudneff_cc` counts full-support topes and its bound is exactly twice the projective
+bound `∑_{i} binomial(n-1, i)` of Conjecture 1.1. We therefore halve the count of
+complete-cell sign vectors to count projective complete cells. -/
+noncomputable def numCompleteCells (χ : Chirotope r n) : ℕ :=
+  (Finset.univ.filter (fun T : Fin n → SignType => IsCompleteCell χ T)).card / 2
+
+end OrientedMatroid


### PR DESCRIPTION

Closes #5274.

Adds a shared chirotope layer (`Combinatorics/OrientedMatroid/Chirotope.lean`: chirotopes, uniform chirotopes, mutations, topes, complete cells — from scratch, since Mathlib has no oriented matroids) and three conjectures built on it.

- `Roudneff.roudneff` (open): a pseudohyperplane arrangement has at most `∑_{i=0}^{d-2} C(n-1,i)` complete cells. Variants: `roudneff_dim_two` (open), `roudneff_tight` (solved).
- `LasVergnasSimplex.las_vergnas_simplex` (open): every uniform oriented matroid has a simplicial tope. Variants: rank-3 case and `≥ n` bound (Levi–Shannon, solved).
- `TwoColoredTriangle.two_colored_triangle` (open): a non-trivial 2-coloring of a simple pseudoline arrangement has a bichromatic triangle. Variant: realizable case (solved).

Statements are `sorry` (benchmark statements); `lake --wfail build` of `OrientedMatroid.Chirotope`, `Roudneff`, `LasVergnasSimplex`, `TwoColoredTriangle` is clean on v4.33.1. References with DOIs are in the file docstrings.

I used AI tools for Lean/mathlib API guidance and reviewed the output.
