### PR TITLE
feat(Wikipedia): add the Neumann-Lara and Tait conjectures

### DIFF
--- a/FormalConjectures/Wikipedia/NeumannLara.lean
+++ b/FormalConjectures/Wikipedia/NeumannLara.lean
@@ -1,0 +1,201 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The Neumann-Lara conjecture on the dichromatic number of planar digraphs
+
+The *dichromatic number* of a digraph `D` is the least number of colours needed
+to colour its vertices so that each colour class induces an *acyclic* subdigraph
+(no directed cycle). This is the directed analogue of the chromatic number.
+
+The *digirth* of a digraph is the length of a shortest directed cycle. Digirth
+`≥ 3` rules out loops and 2-cycles (pairs of anti-parallel arcs), i.e. it means
+the digraph is an *oriented* graph (an orientation of a simple graph).
+
+Neumann-Lara (1985), and independently Škrekovski, conjectured that every planar
+oriented graph is 2-dicolourable:
+
+> **Conjecture.** Every planar digraph of digirth at least `3` has dichromatic
+> number at most `2`.
+
+Mathlib has no `Digraph` type carrying a dichromatic number, no graph minors, and
+no planarity predicate, so we build everything from scratch. A digraph on a vertex
+type `V` is modelled as an irreflexive relation `Adj : V → V → Prop` (an arc from
+`a` to `b`). A directed cycle of length `k ≥ 1` is an injective `c : Fin k → V`
+with an arc from `c i` to `c (i + 1)` cyclically.
+
+Since Mathlib lacks planarity we define it combinatorially via **Wagner's
+theorem**: a finite graph is planar iff it has neither `K₅` nor `K₃,₃` as a minor.
+We spell out a self-contained minor notion (disjoint connected branch sets, one per
+vertex of the model, with an edge between adjacent branch sets) and use it both for
+`K₅`/`K₃,₃`-freeness (planarity) and for Steiner's `K₅`-minor-free reformulation.
+
+*References:*
+- [Wikipedia: Dichromatic number](https://en.wikipedia.org/wiki/Dichromatic_number)
+- V. Neumann-Lara, *The dichromatic number of a digraph*, J. Combin. Theory Ser.
+  B 33 (1982), 265–270. (Origin of the dichromatic number; the planar conjecture
+  is attributed to Neumann-Lara 1985 and independently to Škrekovski.)
+- [LM17] Z. Li and B. Mohar, *Planar digraphs of digirth four are 2-colorable*,
+  SIAM J. Discrete Math. 31 (2017), 2201–2205.
+  [doi:10.1137/16M108080X](https://doi.org/10.1137/16M108080X), arXiv:1606.06114.
+- [St19] R. Steiner, *A note on graphs of dichromatic number 2*, Discrete Math.
+  Theor. Comput. Sci. 21 (2019), #4. arXiv:1907.00351.
+  <https://dmtcs.episciences.org/7040>
+- P. Knauer and P. Valicov verified the conjecture for all planar digraphs on at
+  most `26` vertices.
+-/
+
+open scoped Finset
+open SimpleGraph
+
+namespace NeumannLara
+
+/-! ### Digraphs, directed cycles, digirth, and the dichromatic number -/
+
+variable {V : Type*}
+
+/-- A *digraph* on a vertex type `V`: an irreflexive relation `Adj`, where
+`Adj a b` means there is an arc from `a` to `b`. Irreflexivity forbids loops. -/
+structure Digraph (V : Type*) where
+  /-- `Adj a b` holds when there is an arc from `a` to `b`. -/
+  Adj : V → V → Prop
+  /-- There are no loops. -/
+  irrefl : ∀ a, ¬ Adj a a
+
+/-- A *directed cycle* of length `k` in `D`: an injective tour
+`c : Fin k → V` with an arc from `c i` to the cyclically next vertex `c (i + 1)`.
+We require `k ≥ 1`; note `Fin k` addition is modular, so for `k = 1` this would
+demand a loop (excluded by irreflexivity) and for `k = 2` a pair of anti-parallel
+arcs. -/
+def IsDirectedCycleOfLength (D : Digraph V) (k : ℕ) (c : Fin k → V) : Prop :=
+  1 ≤ k ∧ Function.Injective c ∧ ∀ i : Fin k, D.Adj (c i) (c (i + 1))
+
+/-- `D` *has a directed cycle* if it has a directed cycle of some length `k ≥ 1`. -/
+def HasDirectedCycle (D : Digraph V) : Prop :=
+  ∃ (k : ℕ) (c : Fin k → V), IsDirectedCycleOfLength D k c
+
+/-- `D` has *digirth at least `g`*: every directed cycle has length at least `g`.
+Equivalently, there is no directed cycle of length in `[1, g - 1]`. -/
+def DigirthGE (D : Digraph V) (g : ℕ) : Prop :=
+  ∀ (k : ℕ) (c : Fin k → V), IsDirectedCycleOfLength D k c → g ≤ k
+
+/-- The digraph induced by `D` on a vertex subset `S`: same arcs, restricted to
+`S`. Modelled on the subtype `↥S`. -/
+def induced (D : Digraph V) (S : Set V) : Digraph S where
+  Adj a b := D.Adj a b
+  irrefl a := D.irrefl a
+
+/-- A vertex subset `S` induces an *acyclic* subdigraph if the digraph `D`
+restricted to `S` has no directed cycle. -/
+def InducesAcyclic (D : Digraph V) (S : Set V) : Prop :=
+  ¬ HasDirectedCycle (D.induced S)
+
+/-- `D` is *`k`-dicolourable* (`DichromaticLE D k`): there is a colouring
+`col : V → Fin k` such that each colour class `{v | col v = c}` induces an acyclic
+subdigraph. The *dichromatic number* is the least such `k`. -/
+def DichromaticLE (D : Digraph V) (k : ℕ) : Prop :=
+  ∃ col : V → Fin k, ∀ c : Fin k, InducesAcyclic D {v | col v = c}
+
+/-! ### Underlying graph and planarity
+
+Planarity is not in Mathlib; we use the combinatorial (Wagner) predicate
+`SimpleGraph.IsPlanar` from
+`FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Planar` (no `K₅` and no
+`K₃,₃` minor), built on `SimpleGraph.IsMinor`. -/
+
+/-- The *underlying simple graph* of a digraph `D`: an (undirected) edge between
+`a` and `b` whenever there is an arc in either direction and `a ≠ b`. -/
+def underlying (D : Digraph V) : SimpleGraph V where
+  Adj a b := a ≠ b ∧ (D.Adj a b ∨ D.Adj b a)
+  symm := by
+    rintro a b ⟨hab, h⟩
+    exact ⟨hab.symm, h.symm⟩
+  loopless := by
+    rintro a ⟨h, -⟩
+    exact h rfl
+
+/-- A digraph is *planar* if its underlying simple graph is planar (in the
+combinatorial Wagner sense above). -/
+def IsPlanarDigraph (D : Digraph V) : Prop :=
+  IsPlanar D.underlying
+
+/-! ### The conjecture -/
+
+/--
+**The Neumann-Lara conjecture (1985; independently Škrekovski).**
+Every planar digraph of digirth at least `3` has dichromatic number at most `2`.
+
+We quantify over all finite vertex counts `n` and digraphs on `Fin n`.
+-/
+@[category research open, AMS 5]
+theorem neumann_lara :
+    ∀ (n : ℕ) (D : Digraph (Fin n)),
+      IsPlanarDigraph D → DigirthGE D 3 → DichromaticLE D 2 := by
+  sorry
+
+namespace variants
+
+/--
+**[LM17] Li–Mohar.** Every planar digraph of digirth at least `4` is
+2-dicolourable. This is the best digirth bound known towards the conjecture
+(which asks for digirth `≥ 3`).
+-/
+@[category research solved, AMS 5]
+theorem li_mohar_digirth_four :
+    ∀ (n : ℕ) (D : Digraph (Fin n)),
+      IsPlanarDigraph D → DigirthGE D 4 → DichromaticLE D 2 := by
+  sorry
+
+/--
+**Knauer–Valicov.** The Neumann-Lara conjecture holds for all planar digraphs on
+at most `26` vertices: every such digraph of digirth at least `3` is
+2-dicolourable.
+-/
+@[category research solved, AMS 5]
+theorem knauer_valicov_small :
+    ∀ (n : ℕ), n ≤ 26 → ∀ (D : Digraph (Fin n)),
+      IsPlanarDigraph D → DigirthGE D 3 → DichromaticLE D 2 := by
+  sorry
+
+/-- The digraph obtained by *orienting* a simple graph `G` according to a relation
+`R` (keep the arc `a → b` when `R a b` holds and `G.Adj a b`). We only assert the
+relevant properties abstractly through `IsOrientationOf` below. -/
+def IsOrientationOf (D : Digraph V) (G : SimpleGraph V) : Prop :=
+  (∀ a b, D.Adj a b → G.Adj a b) ∧
+  (∀ a b, G.Adj a b → (D.Adj a b ↔ ¬ D.Adj b a)) ∧
+  DigirthGE D 3
+
+/--
+**[St19] Steiner's equivalence.** The Neumann-Lara conjecture is *equivalent* to:
+every orientation of every `K₅`-minor-free (finite) graph is 2-dicolourable.
+
+Both sides are quantified over all finite vertex counts. The right-hand side
+speaks about orientations `D` of a `K₅`-minor-free simple graph `G`.
+-/
+@[category research solved, AMS 5]
+theorem steiner_equivalence :
+    (∀ (n : ℕ) (D : Digraph (Fin n)),
+        IsPlanarDigraph D → DigirthGE D 3 → DichromaticLE D 2)
+      ↔
+    (∀ (n : ℕ) (G : SimpleGraph (Fin n)) (D : Digraph (Fin n)),
+        ¬ HasKMinor G 5 → IsOrientationOf D G → DichromaticLE D 2) := by
+  sorry
+
+end variants
+
+end NeumannLara

--- a/FormalConjectures/Wikipedia/TaitConjecture.lean
+++ b/FormalConjectures/Wikipedia/TaitConjecture.lean
@@ -1,0 +1,91 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Tait's conjecture
+
+Tait (1884) conjectured that **every 3-connected planar cubic graph has a
+Hamiltonian cycle**. He proposed it as a route to the four colour theorem (a
+Hamiltonian cycle of such a graph yields a 4-edge/face colouring). The conjecture
+is **false**: Tutte (1946) constructed a counterexample, the 46-vertex *Tutte
+graph*, and smaller counterexamples (down to 38 vertices) are now known.
+
+A graph is *cubic* (3-regular) if every vertex has degree `3`. It is
+*3-connected* if it has more than `3` vertices and stays connected after deleting
+any two vertices. Planarity is the combinatorial (Wagner) predicate
+`SimpleGraph.IsPlanar` (no `K₅` and no `K₃,₃` minor), from
+`FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Planar`.
+
+A *Hamiltonian cycle* is a cycle visiting every vertex exactly once; we use
+Mathlib's `SimpleGraph.IsHamiltonian` on a walk / `SimpleGraph.Walk.IsHamiltonianCycle`.
+
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Tait%27s_conjecture)
+- P. G. Tait, *Listing's Topologie*, Philosophical Magazine (5th ser.) 17 (1884),
+  30–46.
+- W. T. Tutte, *On Hamiltonian circuits*, J. London Math. Soc. 21 (1946), 98–101.
+  (The counterexample refuting the conjecture.)
+-/
+
+open SimpleGraph
+
+namespace TaitConjecture
+
+variable {V : Type*}
+
+/-- A simple graph is *cubic* (3-regular) if every vertex has degree `3`. -/
+def IsCubic [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj] : Prop :=
+  ∀ v : V, G.degree v = 3
+
+/--
+**Tait's conjecture (1884), refuted.** Every 3-connected planar cubic graph has a
+Hamiltonian cycle.
+
+This is stated as a `research solved` result because it is **false**: Tutte (1946)
+gave a counterexample. The statement is phrased so that its falsity is the content
+(the `answer` is `False`).
+-/
+@[category research solved, AMS 5]
+theorem tait_conjecture :
+    answer(False) ↔
+      ∀ (n : ℕ) (G : SimpleGraph (Fin n)) [DecidableRel G.Adj],
+        G.Connected → (3 : ℕ) < n →
+        (∀ s : Finset (Fin n), s.card = 2 → (G.induce ((s : Set (Fin n))ᶜ)).Connected) →
+        IsCubic G → IsPlanar G →
+        ∃ (v : Fin n) (p : G.Walk v v), p.IsHamiltonianCycle := by
+  sorry
+
+namespace variants
+
+/--
+**Tutte's counterexample (1946).** There is a 3-connected planar cubic graph with
+no Hamiltonian cycle: the 46-vertex Tutte graph. This is the concrete witness that
+refutes Tait's conjecture.
+-/
+@[category research solved, AMS 5]
+theorem tutte_counterexample :
+    ∃ (n : ℕ) (G : SimpleGraph (Fin n)) (_ : DecidableRel G.Adj),
+      G.Connected ∧ (3 : ℕ) < n ∧
+      (∀ s : Finset (Fin n), s.card = 2 → (G.induce ((s : Set (Fin n))ᶜ)).Connected) ∧
+      IsCubic G ∧ IsPlanar G ∧
+      ¬ ∃ (v : Fin n) (p : G.Walk v v), p.IsHamiltonianCycle := by
+  sorry
+
+end variants
+
+end TaitConjecture

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -82,7 +82,9 @@ public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Johnson
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LargestInducedTree
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.LovaszTheta
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Matching
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Minor
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.PathCover
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Planar
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.QuasiLineGraph
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Ramsey
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Residue

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Minor.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Minor.lean
@@ -1,0 +1,122 @@
+-- NOTE: this file is a copy taken on 2026-09-04 from the open pull request #5196
+-- ("Add graph minors (ForMathlib) and Hadwiger's conjecture", branch
+-- henrykmichalewski:hadwiger). It is included here so the minor-dependent
+-- conjectures (Neumann-Lara, Tait) build before #5196 is merged.
+-- If the original in #5196 (or wherever `SimpleGraph.IsMinor` eventually lands
+-- in the repo/Mathlib) changes, the upstream version should be used instead of
+-- this copy, and this note removed.
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+public import Mathlib.Combinatorics.SimpleGraph.Finite
+
+@[expose] public section
+
+/-!
+# Graph minors
+
+Mathlib has no notion of graph minor (as of 2026-08). This file defines `SimpleGraph.IsMinor`
+through **minor models**: `H` is a minor of `G` if there are pairwise disjoint, nonempty,
+connected *branch sets* `B w ⊆ V(G)`, one for each vertex `w` of `H`, such that every edge
+`w w'` of `H` is witnessed by an edge of `G` between `B w` and `B w'`. This is the standard
+characterisation of `H ≼ G` (obtained from a subgraph of `G` by contracting the branch sets).
+
+We prove that the relation is reflexive and preserved under taking supergraphs of `G` and
+subgraphs of `H`.
+-/
+
+namespace SimpleGraph
+
+variable {V W : Type*}
+
+/-- A **minor model** of `H` in `G`: pairwise disjoint, nonempty, connected branch sets
+`B w ⊆ V(G)` indexed by the vertices of `H`, with every edge of `H` realised by an edge of `G`
+between the corresponding branch sets. -/
+structure IsMinorModel (H : SimpleGraph W) (G : SimpleGraph V) (B : W → Set V) : Prop where
+  nonempty : ∀ w, (B w).Nonempty
+  connected : ∀ w, (G.induce (B w)).Connected
+  disjoint : ∀ w w', w ≠ w' → Disjoint (B w) (B w')
+  adj : ∀ w w', H.Adj w w' → ∃ u ∈ B w, ∃ v ∈ B w', G.Adj u v
+
+/-- `H` is a **minor** of `G` if it has a minor model in `G`. -/
+def IsMinor (H : SimpleGraph W) (G : SimpleGraph V) : Prop :=
+  ∃ B : W → Set V, IsMinorModel H G B
+
+@[inherit_doc] scoped infixl:50 " ≼ " => IsMinor
+
+/-- The singleton branch sets form a minor model of `G` in itself. -/
+theorem isMinorModel_singleton (G : SimpleGraph V) :
+    IsMinorModel G G (fun v => {v}) where
+  nonempty v := Set.singleton_nonempty v
+  connected v := by
+    rw [connected_iff]
+    refine ⟨?_, ⟨⟨v, Set.mem_singleton v⟩⟩⟩
+    rintro ⟨a, ha⟩ ⟨b, hb⟩
+    obtain rfl := Set.mem_singleton_iff.mp ha
+    obtain rfl := Set.mem_singleton_iff.mp hb
+    exact Reachable.refl _
+  disjoint v w hvw := Set.disjoint_singleton.mpr hvw
+  adj v w h := ⟨v, Set.mem_singleton v, w, Set.mem_singleton w, h⟩
+
+/-- Every graph is a minor of itself. -/
+theorem IsMinor.refl (G : SimpleGraph V) : G.IsMinor G :=
+  ⟨_, isMinorModel_singleton G⟩
+
+/-- A minor model stays a minor model if the host graph grows. -/
+theorem IsMinorModel.mono_right {H : SimpleGraph W} {G G' : SimpleGraph V} {B : W → Set V}
+    (hG : G ≤ G') (hB : IsMinorModel H G B) : IsMinorModel H G' B where
+  nonempty := hB.nonempty
+  connected w := (hB.connected w).mono fun _ _ h => hG h
+  disjoint := hB.disjoint
+  adj w w' h := by
+    obtain ⟨u, hu, v, hv, huv⟩ := hB.adj w w' h
+    exact ⟨u, hu, v, hv, hG huv⟩
+
+/-- A minor model of `H` is a minor model of any subgraph of `H` (on the same vertex set). -/
+theorem IsMinorModel.mono_left {H H' : SimpleGraph W} {G : SimpleGraph V} {B : W → Set V}
+    (hH : H' ≤ H) (hB : IsMinorModel H G B) : IsMinorModel H' G B where
+  nonempty := hB.nonempty
+  connected := hB.connected
+  disjoint := hB.disjoint
+  adj w w' h := hB.adj w w' (hH h)
+
+/-- If `H ≼ G` and `G ≤ G'` then `H ≼ G'`. -/
+theorem IsMinor.mono_right {H : SimpleGraph W} {G G' : SimpleGraph V} (hG : G ≤ G')
+    (h : H.IsMinor G) : H.IsMinor G' :=
+  h.imp fun _ hB => hB.mono_right hG
+
+/-- If `H' ≤ H` and `H ≼ G` then `H' ≼ G`. -/
+theorem IsMinor.mono_left {H H' : SimpleGraph W} {G : SimpleGraph V} (hH : H' ≤ H)
+    (h : H.IsMinor G) : H'.IsMinor G :=
+  h.imp fun _ hB => hB.mono_left hH
+
+/-- Every subgraph (on the same vertex set) is a minor. -/
+theorem IsMinor.of_le {G G' : SimpleGraph V} (h : G ≤ G') : G.IsMinor G' :=
+  (IsMinor.refl G).mono_right h
+
+/-- A minor of a finite graph has at most as many vertices. -/
+theorem IsMinor.card_le [Fintype V] [Fintype W] {H : SimpleGraph W} {G : SimpleGraph V}
+    (h : H.IsMinor G) : Fintype.card W ≤ Fintype.card V := by
+  classical
+  obtain ⟨B, hB⟩ := h
+  choose f hf using hB.nonempty
+  refine Fintype.card_le_of_injective f fun w w' hww' => ?_
+  by_contra hne
+  exact Set.disjoint_left.mp (hB.disjoint w w' hne) (hf w) (hww' ▸ hf w')
+
+end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Planar.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Planar.lean
@@ -1,0 +1,53 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Basic
+public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Minor
+
+@[expose] public section
+
+/-!
+# Planarity of a finite simple graph (Wagner's characterization)
+
+Mathlib has no planarity predicate (as of 2026). For finite graphs we define
+planarity via **Wagner's theorem** as the *definition*: a finite graph is planar
+iff it has neither `K₅` nor `K₃,₃` as a minor. This is built on the graph-minor
+relation `SimpleGraph.IsMinor` (branch sets).
+
+*Reference:* K. Wagner, *Über eine Eigenschaft der ebenen Komplexe*, Math. Ann.
+114 (1937), 570–590.
+-/
+
+namespace SimpleGraph
+
+variable {V : Type*}
+
+/-- `G` has a `Kₙ` (complete graph on `n` vertices) minor. -/
+def HasKMinor (G : SimpleGraph V) (n : ℕ) : Prop :=
+  (⊤ : SimpleGraph (Fin n)).IsMinor G
+
+/-- `G` has a `K_{m,n}` (complete bipartite graph) minor. -/
+def HasKmnMinor (G : SimpleGraph V) (m n : ℕ) : Prop :=
+  (completeBipartiteGraph (Fin m) (Fin n)).IsMinor G
+
+/-- **Combinatorial (Wagner) planarity.** A finite graph is *planar* iff it
+contains neither `K₅` nor `K₃,₃` as a minor. Since Mathlib has no native planarity
+predicate, we take Wagner's theorem as the definition. -/
+def IsPlanar (G : SimpleGraph V) : Prop :=
+  ¬ HasKMinor G 5 ∧ ¬ HasKmnMinor G 3 3
+
+end SimpleGraph


### PR DESCRIPTION

Closes #5275.

Adds two planar-graph conjectures plus a Wagner-planarity layer (`Combinatorics/SimpleGraph/Planar.lean`: `IsPlanar` = no K5 and no K3,3 minor, on top of graph minors, since Mathlib has no planarity).

- `NeumannLara.neumann_lara` (open): every planar digraph of digirth ≥ 3 has dichromatic number ≤ 2. Variants: Li–Mohar (digirth ≥ 4), Knauer–Valicov (≤ 26 vertices), Steiner's equivalence — solved.
- `TaitConjecture.tait_conjecture` (solved, refuted): 3-connected planar cubic graphs are Hamiltonian, stated as `answer(False)`; the Tutte counterexample is a variant.

This depends on `SimpleGraph.IsMinor`. That definition is not mine: `Combinatorics/SimpleGraph/Minor.lean` is taken from the open PR #5196 by @henrykmichalewski, included here so this PR builds on its own. Once #5196 lands, that file should come from `main` and be dropped here. The file carries a header noting its origin.

Statements are `sorry` (benchmark statements); `lake --wfail build` of `SimpleGraph.Planar`, `NeumannLara`, `TaitConjecture` is clean on v4.33.1. References with DOIs are in the file docstrings.

I used AI tools for Lean/mathlib API guidance and reviewed the output.
