### PR TITLE
Mark Erdos Problem 354(ii) as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/354.lean
+++ b/FormalConjectures/ErdosProblems/354.lean
@@ -44,8 +44,10 @@ theorem erdos_354.parts.i : answer(sorry) ↔ ∀ᵉ (α > 0) (β > 0), Irration
 /-- Let $\alpha,\beta\in \mathbb{R}_{>0}$ such that $\alpha/\beta$ is irrational. Is
 $$\{ \lfloor \alpha\rfloor,\lfloor \gamma\alpha\rfloor,\lfloor \gamma^2\alpha\rfloor,\ldots\}\cup
 \{ \lfloor \beta\rfloor,\lfloor \gamma\beta\rfloor,\lfloor \gamma^2\beta\rfloor,\ldots\}$$ complete? -/
-@[category research open, AMS 11]
-theorem erdos_354.parts.ii : answer(sorry) ↔ ∃ γ ∈ Set.Ioo (1 : ℝ) 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-354-part-ii/blob/5536b1874d734cfaac522a379722b8cd828dd343/lean/Erdos354PartIIFC.lean#L362-L380"]
+theorem erdos_354.parts.ii : answer(True) ↔ ∃ γ ∈ Set.Ioo (1 : ℝ) 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
     IsAddCompleteNatSeq' (FloorMultiples.interleave α β γ) := by
   sorry
 


### PR DESCRIPTION
This PR changes `Erdos354.erdos_354.parts.ii` from `answer(sorry)` to `answer(True)` and links a kernel-checked Lean proof.

It leaves `Erdos354.erdos_354.parts.i`, where the base is fixed to `2`, open.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact affirmative target:

```lean
theorem Erdos354PartIIProof.erdos_354_part_ii_solved : answer(True) ↔
    ∃ γ ∈ Set.Ioo (1 : ℝ) 2, ∀ᵉ (α > 0) (β > 0), Irrational (α / β) →
      IsAddCompleteNatSeq' (Erdos354.FloorMultiples.interleave α β γ)
```

The proof gives the explicit witness

```text
γ = √((1 + √5) / 2) ∈ (1, 2).
```

It proves the stronger fact that, for every `α > 0`, the single sequence `n ↦ ⌊γ^n α⌋` is complete; the second sequence and the irrationality assumption are therefore not needed for this witness.

Proof: https://github.com/KitaKen1/erdos-354-part-ii/blob/5536b1874d734cfaac522a379722b8cd828dd343/lean/Erdos354PartIIFC.lean#L362-L380

Repository: https://github.com/KitaKen1/erdos-354-part-ii

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-354-part-ii%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos354PartIILean4Web.lean

Both the Formal Conjectures version and the standalone Lean4Web version build successfully. `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx` in the external proof.

AI Usage Disclosure: This formalization was developed with assistance from ChatGPT and OpenAI Codex, using GPT-6 (Astra).