### PR TITLE
Restrict the Erdős 769 growth-rate cutoff condition to positive dimensions

### DIFF
--- a/FormalConjectures/ErdosProblems/769.lean
+++ b/FormalConjectures/ErdosProblems/769.lean
@@ -86,11 +86,13 @@ What refuting $c(n)\gg n^n$ leaves open: give good bounds for $c(n)$. Asked here
 scale the problem itself sets, $n^n$: does $c$ have a well-defined order
 $$\lim_{n\to\infty}\frac{\log c(n)}{n\log n}?$$
 The refuted conjecture would have forced this limit to be at least $1$.
+The cutoff condition is restricted to positive dimensions: in dimension zero,
+exact coverage permits only one tile, so no cutoff exists.
 -/
 @[category research open, AMS 52]
 theorem erdos_769.variants.growth_rate :
     answer(sorry) ↔
-      ∃ c : ℕ → ℕ, (∀ n, IsCutoff n (c n)) ∧
+      ∃ c : ℕ → ℕ, (∀ n, 0 < n → IsCutoff n (c n)) ∧
         ∃ γ : ℝ, Tendsto (fun n : ℕ => Real.log (c n) / (n * Real.log n)) atTop (𝓝 γ) := by
   sorry
 


### PR DESCRIPTION
Change `(∀ n, IsCutoff n (c n))` to `(∀ n, 0 < n → IsCutoff n (c n))`. At dimension zero, every cube-membership condition is vacuous, so exact coverage permits only one tile. Consequently no cutoff can make every sufficiently large tile count admissible.

This follows the [existing boundary-case report](https://github.com/google-deepmind/formal-conjectures/issues/4896#issuecomment-5490112353). The cutoff function remains defined on all naturals and the asymptotic expression is unchanged. The repaired growth-rate conjecture remains open. Positive dimensions is a proposed convention consistent with the source's positive examples; maintainer confirmation of that domain is requested. The docstring explains the excluded zero-dimensional case. No other declaration changes.

The complete proposed file and the separate regression `PublicationRegression769.no_cutoff_zero : ∀ m : ℕ, ¬IsCutoff 0 m` passed targeted `lake --wfail build` against Formal Conjectures commit `8323e878b83fcd7f4a448256069352a265460d75` with Lean 4.33.1. The regression also passed exact-statement comparison and Lean kernel replay with only `propext`, `Classical.choice` and `Quot.sound`. These checks establish the old obstruction and the edited file's well-formedness, not the repaired conjecture. The regression was extracted from a GLM 5.3 Flash refutation; human mathematical review is not claimed.

- [Validated source before the explanatory docstring addition](https://github.com/thepriceisright/publications/blob/8d748831e3c65c7656abc31bc5349c45e73fbbc0/erdos/769/769.lean)
- [Statement-only patch](https://github.com/thepriceisright/publications/blob/8d748831e3c65c7656abc31bc5349c45e73fbbc0/erdos/769/769.patch)
- [Standalone regression proof](https://github.com/thepriceisright/publications/blob/8d748831e3c65c7656abc31bc5349c45e73fbbc0/erdos/769/Regression769.lean)
- [Verification inputs and successful replay log](https://github.com/thepriceisright/publications/tree/8d748831e3c65c7656abc31bc5349c45e73fbbc0/verification/769)
- [Reproduction instructions](https://github.com/thepriceisright/publications/blob/8d748831e3c65c7656abc31bc5349c45e73fbbc0/verification/README.md)

The final PR file also passed the targeted warning-as-error build with the explanatory docstring added.

These public links are pinned to publication commit `8d748831e3c65c7656abc31bc5349c45e73fbbc0`.
