### PR TITLE
Erdős 257: add the coprimality-free summable-support theorem (Erdős 1968, p. 222, stated without proof)

### DIFF
--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -37,6 +37,34 @@ theorem erdos_257 : answer(sorry) ↔ ∀ (A : Set ℕ), A.Infinite →
   sorry
 
 /--
+Let $b \ge 2$ be an integer and let $A \subseteq \mathbb{N}$ be an infinite set with
+$\sum_{a \in A} \frac{1}{a} < \infty$. Then
+$$
+\sum_{a \in A} \frac{1}{b^a - 1}
+$$
+is irrational.
+
+[Er68] proves this on p. 222 for pairwise coprime $A$, at every integer base $b \ge 2$.
+The next sentence of that paper states that pairwise coprimality can be removed by a more
+complicated argument, which is not printed there. The linked proof establishes the
+coprimality-free statement.
+
+Consequently, any infinite $A$ for which $\sum_{a \in A} \frac{1}{2^a - 1}$ is rational has
+$\sum_{a \in A} \frac{1}{a} = \infty$. This does not decide `erdos_257`.
+
+As in `erdos_257`, the term at $a = 0$ contributes $0$ under Lean's division convention.
+
+[Er68] Erdős, P., _On the irrationality of certain series_. Math. Student 36 (1968), 222-226.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-erdos/blob/c94b23bb94fd29186bece8aea70de195f81fd8ab/adapters/FormalConjecturesVariants.lean#L663-L673"]
+theorem erdos_257.variants.summable_reciprocal_support
+    (b : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hA : A.Infinite)
+    (hsum : Summable fun a : A => (1 : ℝ) / (a : ℕ)) :
+    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
 Show that
 $$
 \sum_{n} \frac{1}{2^n - 1} = \sum_{n} \frac{d(n)}{2^n},


### PR DESCRIPTION
Closes #5289

## Statement

$$
b \in \mathbb{N},\; b \ge 2,\quad A \subseteq \mathbb{N} \text{ infinite},\quad \sum_{a \in A} \frac{1}{a} < \infty \quad \Longrightarrow \quad \sum_{a \in A} \frac{1}{b^a - 1} \notin \mathbb{Q}
$$

There is no coprimality, periodicity, or density hypothesis.

## Context

[Er68] Erdős, P., *On the irrationality of certain series*, Math. Student 36 (1968), 222-226, proves this on p. 222 for pairwise coprime $A$ at every integer base $b \ge 2$. The next sentence of that paper states that pairwise coprimality can be removed by a more complicated argument, which is not printed there; p. 226 repeats the boundary. The linked proof establishes the coprimality-free statement. This carries no priority or novelty claim.

## Relation to `erdos_257`

Any infinite $A$ for which $\sum_{a \in A} 1/(2^a - 1)$ is rational satisfies $\sum_{a \in A} 1/a = \infty$. Every counterexample to `erdos_257` therefore has divergent reciprocal mass. This does not decide `erdos_257`, which remains `research open`.

## Verification

The upstream declaration keeps `sorry` and links the external proof through `@[formal_proof using lean4 at ...]`, following CONTRIBUTING for proofs longer than 25-50 lines.

The proof lives in `wcook04/plectis-erdos`, pinned at commit `c94b23bb94fd29186bece8aea70de195f81fd8ab`:

- `Erdos249257/ReciprocalSupportIrrationality.lean`, the base-2 theorem.
- `Erdos249257/AllBaseReciprocalSupportIrrationality.lean`, the transport to every integer base $b \ge 2$.
- [`adapters/FormalConjecturesVariants.lean#L663-L673`](https://github.com/wcook04/plectis-erdos/blob/c94b23bb94fd29186bece8aea70de195f81fd8ab/adapters/FormalConjecturesVariants.lean#L663-L673), the link target `erdos_257_variants_summable_reciprocal_support`.

All three files are sorry-free. The adapter statement is token-identical to the statement added here, so the link target can be compared against the upstream text line by line.

Kernel-checked axiom set of the link target:

```
'erdos_257_variants_summable_reciprocal_support' depends on axioms: [propext,
 Classical.choice,
 Quot.sound]
```

`lake build FormalConjectures.ErdosProblems.«257»` on this branch:

```
✔ [8895/8895] Built FormalConjectures.ErdosProblems.«257» (263s)
Build completed successfully (8895 jobs).
```

## Relation to open PR #5044

PR #5044, by the same author, offers `erdos_257.variants.pairwise_coprime_support` among other declarations. The theorem here subsumes that one, since it drops the coprimality hypothesis. #5044 stays open for its other content, and I will rebase it if this pull request lands first.

## AI usage disclosure

The Lean proof and the text of this pull request were produced by AI agents working under Will Cook's direction. Cook reviewed the statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)