### PR TITLE
Erdős 243: add the bounded-negative-error solved variant

### DIFF
--- a/FormalConjectures/ErdosProblems/243.lean
+++ b/FormalConjectures/ErdosProblems/243.lean
@@ -41,4 +41,73 @@ theorem erdos_243 (a : ℕ → ℕ) (ha₀ : StrictMono a)
       ∀ᶠ n in atTop, a n = a (n - 1) ^ 2 - a (n - 1) + 1 := by
   sorry
 
+/--
+The denominator state of the cleared reciprocal tail: $D_0 = q$ and
+$D_{n+1} = a_n D_n$.
+-/
+def denState (q : ℕ) (a : ℕ → ℕ) : ℕ → ℕ
+  | 0 => q
+  | n + 1 => a n * denState q a n
+
+/--
+The tail state of the cleared reciprocal tail: $C_0 = p$ and
+$C_{n+1} = a_n C_n - D_n$. When $\sum_n 1/a_n = p/q$ this is the integer
+$C_n = D_n \sum_{k \ge n} 1/a_k$.
+-/
+def tailState (p q : ℕ) (a : ℕ → ℕ) : ℕ → ℤ
+  | 0 => (p : ℤ)
+  | n + 1 => (a n : ℤ) * tailState p q a n - (denState q a n : ℤ)
+
+/--
+The centred state $E_n = D_n - (a_n - 1) C_n$. It measures the deviation of the
+tail from the Sylvester identity $\sum_{k \ge n} 1/a_k = 1/(a_n - 1)$, and it
+vanishes at every index of Sylvester's sequence $2, 3, 7, 43, 1807, \dots$.
+-/
+def centredState (p q : ℕ) (a : ℕ → ℕ) (n : ℕ) : ℤ :=
+  (denState q a n : ℤ) - ((a n : ℤ) - 1) * tailState p q a n
+
+/--
+Let $a_n > 1$ be integers with $\sum_n 1/a_n = p/q$ rational, and let $C_n$ and
+$E_n$ be the tail state and the centred state of the cleared reciprocal tail.
+Assume the tail state at most doubles, $C_{n+1} < 2 C_n$; assume the negative
+part of the centred state is bounded, $-B \le E_n$ for a fixed $B$; and assume
+normalised vanishing, that for every $K$ one has $K |E_n| < C_n$ for all large
+$n$. Then $a_n = a_{n-1}^2 - a_{n-1} + 1$ for all sufficiently large $n$.
+
+The rationality hypotheses are used: they force $C_n = D_n \sum_{k \ge n} 1/a_k$
+to be a positive integer at every index, and positivity of $C$ turns the
+doubling hypothesis into the strict centring $|E_n| < C_n$ that drives the
+argument.
+
+Erdős and Straus [ES64] settle the case $E_n \ge 0$ of the problem. The theorem
+here reaches the same conclusion from a bounded negative part, with no
+periodicity assumption on the sign pattern of $E$. Normalised vanishing remains
+a hypothesis; Koizumi [Ko25] supplies it for the canonical pseudo-greedy orbit.
+
+This does not decide `erdos_243`. The remaining obstruction there is a centred
+state with cofinally unbounded negative excursions, which the hypotheses above
+exclude.
+
+[ES64] Erdős, P. and Straus, E. G., On the irrationality of certain series,
+Pacific J. Math. 14 (1964), 128-137, Theorem 3, p. 132.
+
+[Ko25] Koizumi, J., Irrationality of the reciprocal sum of doubly exponential
+sequences, [arXiv:2504.05933](https://arxiv.org/abs/2504.05933) (2025),
+Lemma 15, p. 9.
+-/
+@[category research solved, AMS 40, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-erdos/blob/263335d19c7eff0b41b67dabbcc706f037876587/adapters/FormalConjecturesVariants.lean#L735-L870"]
+theorem erdos_243.variants.bounded_negative_error
+    (a : ℕ → ℕ) (p q B : ℕ)
+    (ha : ∀ n, 1 < a n)
+    (hq : 0 < q)
+    (ha₂ : Summable ((1 : ℚ) / a ·))
+    (hpq : ∑' n, (1 : ℚ) / a n = (p : ℚ) / (q : ℚ))
+    (hgrow : ∀ n, tailState p q a (n + 1) < 2 * tailState p q a n)
+    (hbound : ∀ n, -(B : ℤ) ≤ centredState p q a n)
+    (hvanish : ∀ K : ℕ, ∃ N, ∀ n, N ≤ n →
+      (K : ℤ) * |centredState p q a n| < tailState p q a n) :
+    ∀ᶠ n in atTop, a n = a (n - 1) ^ 2 - a (n - 1) + 1 := by
+  sorry
+
 end Erdos243


### PR DESCRIPTION
Closes #5291.

`243.lean` currently holds only the open statement. This adds one solved variant
beside it, with an external Lean proof linked through `formal_proof`.

## The statement

Fix integers $a_n > 1$ with $\sum_n 1/a_n = p/q$ rational. Clearing denominators
along the sequence gives $D_0 = q$, $D_{n+1} = a_n D_n$, $C_0 = p$,
$C_{n+1} = a_n C_n - D_n$, and then $C_n = D_n \sum_{k \ge n} 1/a_k$ at every
index. The centred state is $E_n = D_n - (a_n - 1) C_n$; it vanishes identically
on Sylvester's sequence $2, 3, 7, 43, 1807, \dots$, and $E_n = C_n - C_{n+1}$.

**`erdos_243.variants.bounded_negative_error`**: if the tail state at most
doubles, $C_{n+1} < 2 C_n$; if the negative part of the centred state is bounded,
$-B \le E_n$ for a fixed $B$; and if normalised vanishing holds, $K|E_n| < C_n$
for every $K$ and all large $n$; then $a_n = a_{n-1}^2 - a_{n-1} + 1$ for all
sufficiently large $n$.

Three one-off definitions carry the state. They are small and specific to this
problem, so they stay in `243.lean` rather than in
`FormalConjecturesForMathlib`.

The rationality hypotheses are consumed. They force $C_n$ to be a positive
integer at every index, and positivity of $C$ is what turns the doubling
hypothesis into the strict centring $|E_n| < C_n$ the argument runs on.

## Prior art

- Erdős and Straus, *On the irrationality of certain series*, Pacific J. Math.
  14 (1964), 128-137, Theorem 3, p. 132, settle the case $E_n \ge 0$. This
  variant reaches the same conclusion from a bounded negative part, with no
  periodicity assumption on the sign pattern of $E$.
- Duverney, *Irrationality of fast converging series of rational numbers*,
  J. Math. Sci. Univ. Tokyo 8 (2001), Corollary 3.2, p. 287, proves a
  conditional signed form of the problem under convergence of
  $\sum (a_{n+1}/a_n^2 - 1)$. That hypothesis is not comparable with the state
  hypotheses used here.
- Koizumi, [arXiv:2504.05933](https://arxiv.org/abs/2504.05933) (2025),
  Lemma 15, p. 9, supplies the integer coordinates $(c_n, d_n, e_n)$ used above,
  and supplies normalised vanishing for the canonical pseudo-greedy orbit. He
  does not supply boundedness of the negative part, which is the hypothesis this
  variant carries.

## Verification

- The proof is `Erdos243.bounded_negative_error` in
  [`adapters/FormalConjecturesVariants.lean#L735-L870`](https://github.com/wcook04/plectis-erdos/blob/263335d19c7eff0b41b67dabbcc706f037876587/adapters/FormalConjecturesVariants.lean#L735-L870).
  It is sorry-free.
- `#print axioms Erdos243.bounded_negative_error` reports
  `[propext, Classical.choice, Quot.sound]`.
- Everything after the binder list in the linked theorem is character-identical
  to the statement added here, and the three definitions are declared there in
  the same `Erdos243` namespace with the same bodies, so the link resolves to
  this proposition rather than a nearby one.
- `lake build FormalConjectures.ErdosProblems.«243»` is clean on this branch.
  Tail: `✔ [8895/8895] Built FormalConjectures.ErdosProblems.«243» (63s)`, `Build completed successfully (8895 jobs).`

## Relation to the other open 243 pull request

#5059 and issue #5058 are mine and also touch 243. They are independent of this
one and add different declarations:
`erdos_243.variants.sylvester_of_tsum_eq_one`,
`erdos_243.variants.fib_of_tsum_eq_millin` and
`erdos_243.sylvester_satisfies_recurrence`, plus a Sylvester definition in
`FormalConjecturesForMathlib`. There is no overlap in declaration names or in
supporting definitions. Whichever lands second needs a one-line rebase.

## AI Usage Disclosure

The Lean and the prose in this pull request were produced by AI agents working
under my direction. I reviewed the statement, the hypotheses, the index
conventions, and the prior-art attribution, and I take responsibility for the
submission.

> [!NOTE]
> `erdos_243` remains open and is untouched. The remaining obstruction there is
> a centred state with cofinally unbounded negative excursions, which the
> hypotheses of this variant exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
