### PR TITLE
feat(ErdosProblems): link unconditional proofs of 427, 750, 1141

### DIFF
--- a/FormalConjectures/ErdosProblems/1141.lean
+++ b/FormalConjectures/ErdosProblems/1141.lean
@@ -103,14 +103,10 @@ is $1722$.
 
 The answer is negative: [APSSV26b] proves a stronger finiteness theorem, deducing it from
 Pollack [Po17]. Oriike [Or26] formalised the deduction in Lean.
-
-The linked proof is the deduction and not the whole result. It declares Theorem 1.3 of [Po17] and
-Mertens' third theorem as axioms, so it is marked `conditional` and names both.
 -/
 @[category research solved, AMS 11,
-  conditional formal_proof using lean4 at
-    "https://github.com/yuta0x89/ErdosProblems/blob/a1319f732cdee5140faf47d984e2c451c1184803/Erdos1141.lean"
-  assuming erdos_1141.variants.pollack_1_3 erdos_1141.variants.mertens_third]
+  formal_proof using lean4 at
+    "https://github.com/Jayyhk/erdos-lean/blob/main/problems/1141/Erdos1141.lean"]
 theorem erdos_1141 :
     answer(False) ↔ Infinite { n | Erdos1141Prop n } := by
   sorry

--- a/FormalConjectures/ErdosProblems/427.lean
+++ b/FormalConjectures/ErdosProblems/427.lean
@@ -68,13 +68,10 @@ $$
   d \mid p_{n + 1} + \cdots + p_{n + k},
 $$
 where $p_r$ denotes the $r$th prime?
-
-The linked proof is not complete on its own. It declares Shiu's theorem as an axiom and derives
-the result from it, so it is marked `conditional` and names `erdos_427.variants.shiu`.
 -/
 @[category research solved, AMS 11,
-  conditional formal_proof using lean4 at "https://gist.githubusercontent.com/JohnEdwardJennings/e2c6ef0daab55857b7cc9d340de7af84/raw/8ff97800e38582c71246a238e7541a9d69488cbd/Erdos427.lean"
-  assuming erdos_427.variants.shiu]
+  formal_proof using lean4 at
+    "https://github.com/Jayyhk/erdos-lean/blob/main/problems/427/Erdos427.lean"]
 theorem erdos_427 : answer(True) ↔ erdos427 := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/750.lean
+++ b/FormalConjectures/ErdosProblems/750.lean
@@ -125,17 +125,10 @@ where $\epsilon > 0$. Hence we should assume it is non-negative valued.
 The existence of such a graph was proved [UlamErdos750] by GPT 5.5 Pro (prompted by Chojecki).
 Indeed, this constructs a graph with infinite chromatic number such that every subgraph on $m$
 vertices can be made bipartite after deleting at most $f(m)$ many vertices.
-
-This was formalized in Lean by Ammanamanchi using Claude Code 4.7 and GPT-5.5 Pro.
-
-The linked proof is not complete on its own. It declares Stiebitz's theorem as an axiom and
-derives the result from it, so it is marked `conditional` and names
-`erdos_750.variants.stiebitz`.
 -/
 @[category research solved, AMS 5,
-  conditional formal_proof using lean4 at
-    "https://github.com/Shashi456/erdos-formalizations/blob/main/Erdos/P750/Proof.lean"
-  assuming erdos_750.variants.stiebitz]
+  formal_proof using lean4 at
+    "https://github.com/Jayyhk/erdos-lean/blob/main/problems/750/Erdos750.lean"]
 theorem erdos_750 :
     answer(True) ↔ ∀ (f : ℕ → ℝ≥0) (hf : atTop.Tendsto f atTop),
       ∃ (V : Type*) (G : SimpleGraph V), G.chromaticNumber = ⊤ ∧


### PR DESCRIPTION
The `formal_proof` links for Erdős problems 427, 750, and 1141 are conditional (#4884, #4885, #4886) on results declared as axioms. Unconditional proofs of the same statements, compiling with only `propext`, `Classical.choice`, and `Quot.sound`, can be found in [https://github.com/Jayyhk/erdos-lean](https://github.com/Jayyhk/erdos-lean).