### PR TITLE
Erdős 257: add the half-value membership question and its finite exclusion

### DIFF
--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -37,6 +37,34 @@ theorem erdos_257 : answer(sorry) ↔ ∀ (A : Set ℕ), A.Infinite →
   sorry
 
 /--
+Let $b \ge 2$ be an integer and let $A \subseteq \mathbb{N}$ be an infinite set with
+$\sum_{a \in A} \frac{1}{a} < \infty$. Then
+$$
+\sum_{a \in A} \frac{1}{b^a - 1}
+$$
+is irrational.
+
+[Er68] proves this on p. 222 for pairwise coprime $A$, at every integer base $b \ge 2$.
+The next sentence of that paper states that pairwise coprimality can be removed by a more
+complicated argument, which is not printed there. The linked proof establishes the
+coprimality-free statement.
+
+Consequently, any infinite $A$ for which $\sum_{a \in A} \frac{1}{2^a - 1}$ is rational has
+$\sum_{a \in A} \frac{1}{a} = \infty$. This does not decide `erdos_257`.
+
+As in `erdos_257`, the term at $a = 0$ contributes $0$ under Lean's division convention.
+
+[Er68] Erdős, P., _On the irrationality of certain series_. Math. Student 36 (1968), 222-226.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-erdos/blob/c94b23bb94fd29186bece8aea70de195f81fd8ab/adapters/FormalConjecturesVariants.lean#L663-L673"]
+theorem erdos_257.variants.summable_reciprocal_support
+    (b : ℕ) (A : Set ℕ) (hb : 2 ≤ b) (hA : A.Infinite)
+    (hsum : Summable fun a : A => (1 : ℝ) / (a : ℕ)) :
+    Irrational (∑' n : A, (1 : ℝ) / ((b : ℝ) ^ (n : ℕ) - 1)) := by
+  sorry
+
+/--
 Show that
 $$
 \sum_{n} \frac{1}{2^n - 1} = \sum_{n} \frac{d(n)}{2^n},

--- a/FormalConjectures/ErdosProblems/257.lean
+++ b/FormalConjectures/ErdosProblems/257.lean
@@ -65,6 +65,54 @@ theorem erdos_257.variants.summable_reciprocal_support
   sorry
 
 /--
+Is there an infinite set $A \subseteq \mathbb{N}$ with
+$$
+\sum_{n \in A} \frac{1}{2^n - 1} = \frac{1}{2}?
+$$
+
+A positive answer refutes the universal statement in `erdos_257`. The restriction to
+infinite $A$ costs nothing, because no finite set has this value
+(`erdos_257.variants.half_not_finite_support`), so the question is equivalent to asking
+whether $\tfrac12$ lies in the set of all subseries values.
+
+The linked corpus reduces a positive answer to a single inequality holding for infinitely
+many rows of an explicit greedy remainder sequence, and records that the inequality holds
+at about half of the rows checked. That record is numerical evidence and proves nothing
+about the question. See
+[`half_mem_of_remainderReachesHalfPointCofinally`](https://github.com/wcook04/plectis-erdos/blob/fd53947f32d9146629be163521d3d5c7cb87a1a8/ErdosProblems/Bit/R2.lean#L306)
+for the reduction and
+[`frontier.json`](https://github.com/wcook04/plectis-erdos/blob/fd53947f32d9146629be163521d3d5c7cb87a1a8/docs/semantic/frontier.json)
+for the record. The question remains open.
+
+As in `erdos_257`, the term at $n = 0$ contributes $0$ under Lean's division convention.
+-/
+@[category research open, AMS 11]
+theorem erdos_257.variants.half_infinite_support :
+    answer(sorry) ↔ ∃ A : Set ℕ, A.Infinite ∧
+      ∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1) = 1 / 2 := by
+  sorry
+
+/--
+No finite set $A \subseteq \mathbb{N}$ satisfies
+$$
+\sum_{n \in A} \frac{1}{2^n - 1} = \frac{1}{2}.
+$$
+
+Every finite subsum has odd reduced denominator, since each $2^n - 1$ with $n \ge 1$ is
+odd, while $\tfrac12$ has denominator $2$. The term at $n = 0$ contributes $0$ under
+Lean's division convention.
+
+This is the finite half of `erdos_257.variants.half_infinite_support`: any set with
+value $\tfrac12$ is infinite.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/wcook04/plectis-erdos/blob/e0b476742edd0937b0f50da566803b669f197b72/adapters/FormalConjecturesVariants.lean#L377-L396"]
+theorem erdos_257.variants.half_not_finite_support
+    (A : Set ℕ) (hA : A.Finite) :
+    ∑' n : A, (1 : ℝ) / (2 ^ n.1 - 1) ≠ 1 / 2 := by
+  sorry
+
+/--
 Show that
 $$
 \sum_{n} \frac{1}{2^n - 1} = \sum_{n} \frac{d(n)}{2^n},


### PR DESCRIPTION
Closes #5295.

Stacked on #5290: only commit `adf4129f936ba1d46a3707f0fc8812e4ba6d48ca` is new here. If #5290 lands first this rebases cleanly; if this is reviewed first, the first commit is exactly #5290.

## The open question

$$
\exists\, A \subseteq \mathbb{N} \text{ infinite with } \sum_{n \in A} \frac{1}{2^n - 1} = \frac12 \;?
$$

`erdos_257.variants.half_infinite_support`, `research open`. A positive answer refutes the universal statement in `erdos_257`, since $\tfrac12$ is rational.

## The finite exclusion

`erdos_257.variants.half_not_finite_support`, `research solved`, with a `formal_proof` link: for every finite `A : Set ℕ`, `∑' n : A, 1/(2^n - 1) ≠ 1/2`. Every finite subsum has odd reduced denominator because each $2^n - 1$ with $n \ge 1$ is odd, and the $n = 0$ term is $0$ under Lean's convention. This is what makes the open variant a clean one-sided test: any set with value $\tfrac12$ is infinite.

## Reduction and numerical evidence, labelled as such

The linked corpus proves (Lean, standard axioms) that $\tfrac12$ is a subseries value if and only if an explicit greedy skip condition holds at arbitrarily late rows, and that this follows from the inequality `seamIntegerGreedyRemainder s ≤ 2^s` holding for infinitely many `s`. It records that this inequality holds at about half of the rows checked up to `s = 6000`. That record is numerical evidence and proves nothing about the question; the docstring says so. Pointers: [`half_mem_of_remainderReachesHalfPointCofinally`](https://github.com/wcook04/plectis-erdos/blob/fd53947f32d9146629be163521d3d5c7cb87a1a8/ErdosProblems/Bit/R2.lean#L306), [`half_mem_iff_unboundedLargestSkipLate`](https://github.com/wcook04/plectis-erdos/blob/fd53947f32d9146629be163521d3d5c7cb87a1a8/ErdosProblems/Skip/D2.lean#L307), [`frontier.json`](https://github.com/wcook04/plectis-erdos/blob/fd53947f32d9146629be163521d3d5c7cb87a1a8/docs/semantic/frontier.json). These use the corpus's own vocabulary, so they are cited from the docstring rather than added as declarations.

## Verification

- Permalink pinned to commit `e0b476742edd0937b0f50da566803b669f197b72` of `wcook04/plectis-erdos` (branch `release/erdos257-half-membership-adapter`, PR wcook04/plectis-erdos#114); the adapter theorem at L377–L396 is token-identical to the upstream statement.
- `#print axioms` on the adapter theorem: `[propext, Classical.choice, Quot.sound]`.
- `lake build FormalConjectures.ErdosProblems.«257»` on this branch: `Build completed successfully (8895 jobs)`.
- The open variant carries `answer(sorry)`; the solved variant keeps `sorry` in the file per the external-proof convention.

## Relation to other open PRs by the same author

#5044 (support families and value-space geometry) touches the same file with disjoint declarations; whichever lands second gets a one-line rebase. No other PR is affected.

## AI Usage Disclosure

The Lean and the prose in this pull request were produced by AI agents working under my direction. I reviewed the statement, the hypotheses, the index conventions, and the prior-art attribution, and I take responsibility for the submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
