### PR TITLE
solve(ErdosProblems): link formal refutation of 488

### DIFF
--- a/FormalConjectures/ErdosProblems/488.lean
+++ b/FormalConjectures/ErdosProblems/488.lean
@@ -31,8 +31,10 @@ $$B=\{ n \geq 1 : a\mid n\textrm{ for some }a\in A\}.$$
 Is it true that, for every $m>n\geq \max(A)$,
 $$\frac{\lvert B\cap [1,m]\rvert }{m}< 2\frac{\lvert B\cap [1,n]\rvert}{n}?$$
 -/
-@[category research open, AMS 5 11]
-theorem erdos_488 : answer(sorry) ↔ ∀ (A : Finset ℕ), A.Nonempty →
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at
+    "https://gist.github.com/declangessel/d8e15e5ff1b6c7e99e3d86d7c66f1d08/034be67a5c958e55505bb357f9e4ef3015788465#file-erdos488-lean"]
+theorem erdos_488 : answer(False) ↔ ∀ (A : Finset ℕ), A.Nonempty →
     -- These are needed for the reasons outlined here: https://github.com/google-deepmind/formal-conjectures/pull/256
     0 ∉ A → 1 ∉ A →
     letI B := {n ≥ 1 | ∃ a ∈ A, a ∣ n}


### PR DESCRIPTION
Erdős #488 has a Lean-checked finite counterexample to the corrected multiples formulation. Set `answer(False)`, change the category to `research solved`, and link the external proof, preserving all existing hypotheses.

The [pinned proof package](https://gist.github.com/declangessel/d8e15e5ff1b6c7e99e3d86d7c66f1d08/034be67a5c958e55505bb357f9e4ef3015788465#file-erdos488-lean) includes an adapter `Erdos488ExactAdapter.refutation` to this file’s exact proposition: exclusions of 0 and 1, `Finset.max`, and rational densities. The adapter rules out 1 from the strict reverse inequality and clears the positive denominators. It compiled locally with the full proof under Lean 4.33.0/mathlib `db584cd6d46c92f209a44c0f1c829460d327499d`; its axioms are only `propext`, `Classical.choice`, and `Quot.sound`.

The original counterexample also passed [Jig’s independent server verification](https://github.com/WoshuaJolk/jig-verifier/actions/runs/33990129375), including the literal-negation check: [result](https://jig.so/p/398?s=40). Its finite construction proves existence of a scale k<4096 without enumerating k.

Validation: the full external proof and exact adapter compile under Lean 4.33.0 with only standard axioms. The submitted collection module also passes `lake --wfail build 'FormalConjectures.ErdosProblems.«488»'` under the repository’s Lean 4.33.1 toolchain; `git diff --check` passes. The long proof stays outside this statement repository.

AI disclosure: the proof, adapter, and contribution preparation were produced using GPT-6 Astra in Codex, directed by Declan Gessel. Independent specialist review and priority checking are being sought; this does not claim human review or exhaustive novelty certification.

Related statement history: #47, #1534, #3529.
