### PR TITLE
solve(ErdosProblems): link formal refutation of 786(i)

### DIFF
--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -32,7 +32,7 @@ open Erdos786
 
 -- TODO : add variants that allow repetition.
 -- According to the updated website, Erdos likely intended repetitions to be allowed here
--- however, the analogous questions without repetition are also open.
+-- Part (i) without repetition has an external formal refutation; part (ii) remains open.
 /--
 `Nat.IsMulCardSet A` means that `A` is a set of natural numbers that
 satisfies the property that $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$
@@ -47,8 +47,10 @@ Let $\epsilon > 0$. Is there some set $A\subset\mathbb{N}$ of density $> 1 - \ep
 such that $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold when
 $r = s$?
 -/
-@[category research open, AMS 11]
-theorem erdos_786.parts.i : answer(sorry) ↔ ∀ ε > 0, ε ≤ 1 →
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/WoshuaJolk/jig-verifier/blob/f8b1f084d62fcfa81ae9c26000cd04da51a865a4/Submissions/Erdos786DistinctDensityRefuted/BadPrimes.lean"]
+theorem erdos_786.parts.i : answer(False) ↔ ∀ ε > 0, ε ≤ 1 →
     ∃ (A : Set ℕ) (δ : ℝ), 0 ∉ A ∧ 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet := by
   sorry
 


### PR DESCRIPTION
Set `answer(False)` for `erdos_786.parts.i`, mark that theorem `research solved`, and link its external Lean proof. Part (ii) remains open.

The proof establishes natural density at most 7/8 for sets whose finite subsets with equal products have equal cardinalities. Its definitions of natural density and the distinct-factor property match this module. The full proof stays outside this statement repository.

Human-readable [research note](https://gist.github.com/declangessel/f807fd0a11bea766cd1d2e7ae717b7a3/5c39c80c3e68b334b39ae24c1807eefc14ea68ed#file-manuscript-md).

Pinned source: https://github.com/WoshuaJolk/jig-verifier/blob/f8b1f084d62fcfa81ae9c26000cd04da51a865a4/Submissions/Erdos786DistinctDensityRefuted/BadPrimes.lean
Jig verification: https://github.com/WoshuaJolk/jig-verifier/actions/runs/34000438623
Result: https://jig.so/p/172?s=3

Historical qualification: Erdős (1980), p. 114, attributes a stronger unpublished negative result to Ruzsa. This is an independently derived formal proof, with no priority claim over Ruzsa and no claim about part (ii) or upper natural density.

Validation: Jig's local and server verifiers passed the exact refutation under Lean 4.33.0, with only propext, Classical.choice, and Quot.sound. The full proof plus the exact collection proposition (using verbatim collection definitions) also compiles with only those three standard axioms. The changed collection module passes `lake --wfail build 'FormalConjectures.ErdosProblems.«786»'` under Lean 4.33.1; `git diff --check` passes.

AI disclosure: proof and contribution prepared using GPT-6 Astra in Codex, directed by Declan Gessel.
