### PR TITLE
feat: formalize the largest small polygon problem

### DIFF
--- a/FormalConjectures/Paper/LargestSmallPolygon.lean
+++ b/FormalConjectures/Paper/LargestSmallPolygon.lean
@@ -1,0 +1,158 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Maximum-area small polygons
+
+Determine the largest area of a simple planar polygon with exactly $n \geq 3$
+genuine vertices and diameter at most $1$, and characterize the maximizing
+polygons up to Euclidean congruence, including reflection.
+
+The value problem, the reduction to convex hulls, and uniqueness of the
+maximizing shape are stated separately. Quadrilaterals have infinitely many
+noncongruent maximizers. The proposed even-order uniqueness statement starts
+at $n = 8$.
+
+References:
+* C. Bingane and M. J. Mossinghoff, *Small polygons with large area*,
+  Journal of Global Optimization 88 (2024), 1035–1050.
+  https://doi.org/10.1007/s10898-023-01329-1
+* D. Trela, *Maximum-Area Small Polygons of Even Order* (2026),
+  Theorem 1.1 and Section 2. https://arxiv.org/abs/2608.15666
+* https://github.com/google-deepmind/formal-conjectures/issues/5303
+-/
+
+open scoped EuclideanGeometry
+
+namespace LargestSmallPolygon
+
+/-- A simple small $n$-gon with exactly $n$ distinct genuine corners. -/
+def IsAdmissible {n : ℕ} (p : Polygon ℝ² n) : Prop :=
+  p.IsSimple ∧ p.diameter ≤ 1
+
+/-- An admissible polygon whose vertices are in convex boundary order. -/
+def IsConvexAdmissible {n : ℕ} (p : Polygon ℝ² n) : Prop :=
+  IsAdmissible p ∧ EuclideanGeometry.IsConvexPolygon p.vertices
+
+/-- The set of areas attained by simple small $n$-gons. -/
+def feasibleAreas (n : ℕ) : Set ℝ :=
+  {a | ∃ p : Polygon ℝ² n, IsAdmissible p ∧ p.area = a}
+
+/-- The supremum of the areas of simple small $n$-gons. Statements use $n \geq 3$. -/
+noncomputable def maximalArea (n : ℕ) : ℝ := sSup (feasibleAreas n)
+
+/-- The supremum restricted to simple small polygons in convex boundary order. -/
+noncomputable def convexMaximalArea (n : ℕ) : ℝ :=
+  sSup {a | ∃ p : Polygon ℝ² n, IsConvexAdmissible p ∧ p.area = a}
+
+/-- An $n$-tuple feasible for the convex-hull problem. Its entries need not be
+distinct or extreme points; it is not required to trace a simple boundary. -/
+def IsHullFeasible {n : ℕ} (p : Polygon ℝ² n) : Prop :=
+  ∀ i j, dist (p i) (p j) ≤ 1
+
+/-- The supremum of the convex-hull areas of feasible $n$-tuples. -/
+noncomputable def hullMaximalArea (n : ℕ) : ℝ :=
+  sSup {a | ∃ p : Polygon ℝ² n, IsHullFeasible p ∧ p.hullArea = a}
+
+/-- A global maximizer among all simple small $n$-gons, including nonconvex competitors. -/
+def IsMaximizer {n : ℕ} (p : Polygon ℝ² n) : Prop :=
+  IsAdmissible p ∧ ∀ q : Polygon ℝ² n, IsAdmissible q → q.area ≤ p.area
+
+/-- There exists a maximizer and all maximizers are congruent to it.
+Existence is included, so this cannot hold vacuously. -/
+def HasUniqueMaximizer (n : ℕ) : Prop :=
+  ∃ p : Polygon ℝ² n, IsMaximizer p ∧
+    ∀ q : Polygon ℝ² n, IsMaximizer q → p.Congruent q
+
+/-- Admissibility implies the pairwise Euclidean distance bound. -/
+@[category API, AMS 52]
+theorem IsAdmissible.dist_le_one {n : ℕ} {p : Polygon ℝ² n} (hp : IsAdmissible p) :
+    ∀ i j, dist (p i) (p j) ≤ 1 :=
+  p.diameter_le_one_iff.mp hp.2
+
+/-- For $n \geq 3$, the area set is nonempty and bounded above. -/
+@[category textbook, AMS 52]
+theorem feasibleAreas_nonempty_bddAbove (n : ℕ) (hn : 3 ≤ n) :
+    (feasibleAreas n).Nonempty ∧ BddAbove (feasibleAreas n) := by
+  sorry
+
+/-- For $n \geq 3$, the maximum is attained by a polygon in convex boundary order. -/
+@[category textbook, AMS 52]
+theorem exists_convex_maximizer (n : ℕ) (hn : 3 ≤ n) :
+    ∃ p : Polygon ℝ² n, IsConvexAdmissible p ∧ IsMaximizer p ∧
+      p.area = maximalArea n := by
+  sorry
+
+/-- For $n \geq 3$, the simple-polygon, convex-polygon and finite-hull values agree.
+The finite-hull problem allows repeated and nonextreme entries. -/
+@[category textbook, AMS 52]
+theorem maximalArea_eq_convex_eq_hull (n : ℕ) (hn : 3 ≤ n) :
+    maximalArea n = convexMaximalArea n ∧ maximalArea n = hullMaximalArea n := by
+  sorry
+
+/-- At a hull maximum with $n \geq 3$, all $n$ entries are distinct extreme points
+and the diameter is $1$; see Proposition 2.3 in Trela's preprint. -/
+@[category textbook, AMS 52]
+theorem hull_maximizer_has_genuine_vertices (n : ℕ) (hn : 3 ≤ n)
+    (p : Polygon ℝ² n) (hp : IsHullFeasible p) (ha : p.hullArea = hullMaximalArea n) :
+    Function.Injective p.vertices ∧ EuclideanGeometry.ConvexIndep (Set.range p.vertices) ∧
+      p.diameter = 1 := by
+  sorry
+
+/-- For $n \geq 3$, global maximality is equivalent to attaining the area supremum. -/
+@[category textbook, AMS 52]
+theorem isMaximizer_iff_area_eq (n : ℕ) (hn : 3 ≤ n) (p : Polygon ℝ² n) :
+    IsMaximizer p ↔ IsAdmissible p ∧ p.area = maximalArea n := by
+  sorry
+
+/-- Determine the maximal area $A_n$ for every $n \geq 3$.
+The answer is a function of the order; its values below $3$ are unconstrained. -/
+@[category research open, AMS 52 90]
+theorem determine_maximalArea :
+    let a : ℕ → ℝ := answer(sorry)
+    ∀ n : ℕ, 3 ≤ n → maximalArea n = a n := by
+  sorry
+
+/-- For odd $n \geq 3$, Reinhardt's maximal area is
+$n\sin(2\pi/n)/(8\cos^2(\pi/(2n)))$; see the review by Bingane and Mossinghoff. -/
+@[category research solved, AMS 52]
+theorem maximalArea_odd (n : ℕ) (hn : 3 ≤ n) (hodd : Odd n) :
+    maximalArea n = (n : ℝ) * Real.sin (2 * Real.pi / (n : ℝ)) /
+      (8 * Real.cos (Real.pi / (2 * (n : ℝ))) ^ 2) := by
+  sorry
+
+/-- The maximal area of a small quadrilateral is $1/2$. -/
+@[category textbook, AMS 52]
+theorem maximalArea_four : maximalArea 4 = 1 / 2 := by
+  sorry
+
+/-- There are infinitely many pairwise noncongruent maximum-area small quadrilaterals. -/
+@[category textbook, AMS 52]
+theorem quadrilateral_infinitely_many_maximizers :
+    ∃ p : ℕ → Polygon ℝ² 4, (∀ i, IsMaximizer (p i)) ∧
+      ∀ i j, i ≠ j → ¬ (p i).Congruent (p j) := by
+  sorry
+
+/-- The proposed even-order theorem in Trela's preprint: for every even
+$n \geq 8$, there is exactly one congruence class of global maximizers. -/
+@[category research open, AMS 52 90]
+theorem unique_maximizer_even (n : ℕ) (hn : 8 ≤ n) (heven : Even n) :
+    HasUniqueMaximizer n := by
+  sorry
+
+end LargestSmallPolygon

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -129,6 +129,7 @@ public import FormalConjecturesForMathlib.Data.ZMod.PerfectDifferenceSet
 public import FormalConjecturesForMathlib.FieldTheory.MvRatFunc.Defs
 public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.Metric
+public import FormalConjecturesForMathlib.Geometry.Polygon
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util

--- a/FormalConjecturesForMathlib/Geometry/Polygon.lean
+++ b/FormalConjecturesForMathlib/Geometry/Polygon.lean
@@ -1,0 +1,101 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Geometry.Polygon.Basic
+public import Mathlib.Analysis.Convex.Topology
+public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
+public import Mathlib.Topology.MetricSpace.Bounded
+public import Mathlib.Topology.MetricSpace.Isometry
+
+/-!
+# Simple planar polygons and area
+
+The area is the absolute value of the shoelace sum. For a simple polygon it is
+the ordinary area of the bounded polygonal region. The convex-hull area is a
+separate definition; no equality with the shoelace area is built into either one.
+
+`IsSimple` requires genuine corners and excludes self-intersections.
+`Congruent` compares boundaries under arbitrary Euclidean isometries, including
+reflections, and does not depend on a choice of vertex labels.
+-/
+
+@[expose] public section
+
+open Set
+open scoped BigOperators
+
+namespace Polygon
+
+local notation "ℝ²" => EuclideanSpace ℝ (Fin 2)
+
+variable {n : ℕ}
+
+/-- A simple polygon with at least three distinct genuine vertices.
+Distinct edges meet only at endpoints that they share. Three consecutive
+vertices are affinely independent, so straight angles are excluded. -/
+def IsSimple (p : Polygon ℝ² n) : Prop :=
+  3 ≤ n ∧ Function.Injective p.vertices ∧
+    (∀ i, AffineIndependent ℝ
+      ![p i, p (finRotate n i), p (finRotate n (finRotate n i))]) ∧
+    ∀ i j, i ≠ j →
+      p.edgeSet ℝ i ∩ p.edgeSet ℝ j ⊆
+        ({p i, p (finRotate n i)} ∩ {p j, p (finRotate n j)})
+
+/-- The oriented area given by the shoelace formula in standard orthonormal coordinates. -/
+noncomputable def signedArea (p : Polygon ℝ² n) : ℝ :=
+  (∑ i : Fin n, (p i 0 * p (finRotate n i) 1 - p i 1 * p (finRotate n i) 0)) / 2
+
+/-- The unoriented shoelace area. It is the usual area when the polygon is simple. -/
+noncomputable def area (p : Polygon ℝ² n) : ℝ := |p.signedArea|
+
+/-- The diameter of the vertex set in the Euclidean metric. -/
+noncomputable def diameter (p : Polygon ℝ² n) : ℝ :=
+  Metric.diam (Set.range p.vertices)
+
+/-- The convex hull of all vertices; repeated or nonextreme vertices are allowed. -/
+def hull (p : Polygon ℝ² n) : Set ℝ² := convexHull ℝ (Set.range p.vertices)
+
+/-- Lebesgue area of the convex hull. A finite planar hull is compact and has finite measure. -/
+noncomputable def hullArea (p : Polygon ℝ² n) : ℝ :=
+  (MeasureTheory.volume p.hull).toReal
+
+/-- Congruence of polygonal boundaries, allowing translations, rotations and reflections. -/
+def Congruent {m : ℕ} (p : Polygon ℝ² n) (q : Polygon ℝ² m) : Prop :=
+  ∃ e : ℝ² ≃ᵢ ℝ², e '' p.boundary ℝ = q.boundary ℝ
+
+theorem area_nonneg (p : Polygon ℝ² n) : 0 ≤ p.area := abs_nonneg _
+
+/-- A finite hull has finite volume, so taking its real-valued area loses no information. -/
+theorem hull_volume_lt_top (p : Polygon ℝ² n) : MeasureTheory.volume p.hull < ⊤ :=
+  ((Set.finite_range p.vertices).isCompact_convexHull ℝ).measure_lt_top
+
+/-- For a finite vertex set, the diameter bound is equivalent to the pairwise distance bound. -/
+theorem diameter_le_one_iff (p : Polygon ℝ² n) :
+    p.diameter ≤ 1 ↔ ∀ i j, dist (p i) (p j) ≤ 1 := by
+  constructor
+  · intro h i j
+    exact (Metric.dist_le_diam_of_mem (Set.finite_range p.vertices).isBounded
+      (Set.mem_range_self i) (Set.mem_range_self j)).trans h
+  · intro h
+    apply Metric.diam_le_of_forall_dist_le zero_le_one
+    rintro _ ⟨i, rfl⟩ _ ⟨j, rfl⟩
+    exact h i j
+
+theorem Congruent.refl (p : Polygon ℝ² n) : p.Congruent p := by
+  exact ⟨IsometryEquiv.refl _, Set.image_id _⟩
+
+end Polygon

--- a/FormalConjecturesTest/LargestSmallPolygon.lean
+++ b/FormalConjecturesTest/LargestSmallPolygon.lean
@@ -1,0 +1,75 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjectures.Paper.LargestSmallPolygon
+
+/-!
+# Boundary checks for maximum-area small polygons
+
+These checks use complete proofs and do not use the unproved problem statements.
+-/
+
+open scoped EuclideanGeometry
+
+namespace LargestSmallPolygonTest
+
+open LargestSmallPolygon WithLp
+
+/-- The domain restriction excludes every order below three. -/
+theorem no_admissible_below_three {n : ℕ} (hn : n < 3) (p : Polygon ℝ² n) :
+    ¬ IsAdmissible p := by
+  intro hp
+  exact (Nat.not_le_of_lt hn) hp.1.1
+
+/-- A repeated vertex cannot be counted as a second genuine corner. -/
+theorem no_repeated_vertex {n : ℕ} (p : Polygon ℝ² n) (i j : Fin n)
+    (hij : i ≠ j) (hp : p i = p j) : ¬ IsAdmissible p := by
+  intro h
+  exact hij (h.1.2.1 hp)
+
+/-- A unit diagonal has squared Euclidean length two, ruling out the sup-norm metric. -/
+theorem diagonal_dist_sq :
+    dist (toLp 2 ![(0 : ℝ), 0]) (toLp 2 ![(1 : ℝ), 1]) ^ 2 = 2 := by
+  norm_num [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two, Real.dist_eq]
+
+/-- Reversing a triangle's orientation preserves its unoriented area. -/
+theorem triangle_area_both_orientations :
+    let p : Polygon ℝ² 3 :=
+      ⟨![toLp 2 ![0, 0], toLp 2 ![1 / 2, 0], toLp 2 ![0, 1 / 2]]⟩
+    let q : Polygon ℝ² 3 :=
+      ⟨![toLp 2 ![0, 0], toLp 2 ![0, 1 / 2], toLp 2 ![1 / 2, 0]]⟩
+    p.area = 1 / 8 ∧ q.area = 1 / 8 := by
+  norm_num [Polygon.area, Polygon.signedArea, Fin.sum_univ_succ, Fin.add_def]
+
+/-- Distinct vertices alone do not define a simple polygon: changing the boundary
+order of the square to a bow tie changes its shoelace area. -/
+theorem square_and_crossed_order_areas :
+    let p : Polygon ℝ² 4 :=
+      ⟨![toLp 2 ![0, 0], toLp 2 ![1 / 2, 0],
+        toLp 2 ![1 / 2, 1 / 2], toLp 2 ![0, 1 / 2]]⟩
+    let q : Polygon ℝ² 4 :=
+      ⟨![toLp 2 ![0, 0], toLp 2 ![1 / 2, 1 / 2],
+        toLp 2 ![0, 1 / 2], toLp 2 ![1 / 2, 0]]⟩
+    p.area = 1 / 4 ∧ q.area = 0 := by
+  norm_num [Polygon.area, Polygon.signedArea, Fin.sum_univ_succ, Fin.add_def]
+
+/-- A uniqueness assertion supplies an actual admissible maximizer. -/
+theorem uniqueness_implies_existence {n : ℕ} (h : HasUniqueMaximizer n) :
+    ∃ p : Polygon ℝ² n, IsAdmissible p := by
+  obtain ⟨p, hp, _⟩ := h
+  exact ⟨p, hp.1⟩
+
+end LargestSmallPolygonTest


### PR DESCRIPTION
The largest small polygon problem asks for the maximum area of a simple planar n-gon of diameter at most one and a characterization of the maximizing shapes.

This PR adds the definitions and problem statements. It separates the area question from uniqueness up to Euclidean congruence, including reflection, and preserves the quadrilateral exception. Simple polygons, convex polygons and convex hulls of finite tuples have separate optimization values, related by explicit theorem statements. Area uses the absolute shoelace formula; congruence compares polygonal boundaries.

The contribution includes the classical odd-order area formula and the proposed uniqueness statement for even n ≥ 8 from [my preprint](https://arxiv.org/abs/2608.15666). The general value question and proposed even-order uniqueness statement are provisionally tagged `research open`. The variational characterization is reserved for a later contribution.

Validation passed with Lean 4.33.1:

```text
lake --wfail build FormalConjecturesForMathlib FormalConjectures.Paper.LargestSmallPolygon FormalConjecturesTest.LargestSmallPolygon
```

All six boundary checks compiled. An axiom audit of 27 definitions, helper proofs and checks found no `sorryAx`. `git diff --check` passed.

This is a statement contribution: problem proofs remain explicit `by sorry`, and the unknown area function uses `answer(sorry)`. The preprint is disclosed as a proposed solution; no `formal_proof` claim is made.

Prepared with AI assistance.

Fixes #5303
