### PR TITLE
Link formal proof of random-colouring bound

### DIFF
--- a/FormalConjectures/Wikipedia/SixStandardDeviations.lean
+++ b/FormalConjectures/Wikipedia/SixStandardDeviations.lean
@@ -75,7 +75,9 @@ the benchmark that Spencer's theorem improves upon by removing the logarithmic
 factor. (The shift $n + 2$ inside the logarithm is a harmless normalization keeping
 it positive for $n \in \{0, 1\}$.)
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at
+    "https://github.com/Lemmy00/spencer-random-coloring-lean/blob/a691214a7263c1010fdd10560091e9f8cfce903a/SpencerRandomColoring/RandomBound.lean#L37"]
 theorem six_standard_deviations.variants.random_bound :
     ∃ K : ℝ, 0 < K ∧ ∀ (n : ℕ) (S : Fin n → Finset (Fin n)),
       ∃ χ : Fin n → ℝ, (∀ j, χ j = 1 ∨ χ j = -1) ∧


### PR DESCRIPTION
In this PR, I add the `formal_proof` for Random-colouring discrepancy bound in Lean. The proof is at https://github.com/Lemmy00/spencer-random-coloring-lean. [LeanFlow](https://github.com/epfl-lara/LeanFlow), an LLM harness for theorem proving and formalization, produced and verified the Lean proof using `GPT-6-astra` with `xhigh` reasoning effort. Both the proof package and Formal Conjectures target passed `lake --wfail build`.