### PR TITLE
Add a proof link for Sawin’s totally real tower

### DIFF
--- a/FormalConjectures/ErdosProblems/90.lean
+++ b/FormalConjectures/ErdosProblems/90.lean
@@ -190,7 +190,7 @@ A "completely split" rational prime $q$ in $F$ is one for which $(q)$ is the pro
 $[F:\mathbb{Q}]$ distinct maximal ideals.
 -/
 @[category research solved, AMS 11,
-  formal_proof using lean4 at "https://github.com/n-yamaguchi-0729/SawinTotallyRealTowers/blob/1c848b887a72b27d5f791186c40c49f8559f94de/Lean4/SawinTotallyRealTowers/SawinTotallyRealTower.lean#L31"]
+  formal_proof using lean4 at "https://github.com/n-yamaguchi-0729/SawinTotallyRealTowers/blob/3a455e1aa9140dbbe7b7d68f508392a69c86d0f4/Lean4/SawinTotallyRealTowers/SawinTotallyRealTower.lean#L31"]
 theorem sawin_totally_real_tower :
     ∃ (rdBound : ℝ) (Q : Set ℕ), Q.Infinite ∧ (∀ q ∈ Q, q.Prime ∧ q % 4 = 1) ∧
       ∀ N : ℕ, ∃ (F : Type) (_ : Field F) (_ : CharZero F) (_ : NumberField F)

--- a/FormalConjectures/ErdosProblems/90.lean
+++ b/FormalConjectures/ErdosProblems/90.lean
@@ -189,7 +189,8 @@ tower construction.
 A "completely split" rational prime $q$ in $F$ is one for which $(q)$ is the product of exactly
 $[F:\mathbb{Q}]$ distinct maximal ideals.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/n-yamaguchi-0729/SawinTotallyRealTowers/blob/1c848b887a72b27d5f791186c40c49f8559f94de/Lean4/SawinTotallyRealTowers/SawinTotallyRealTower.lean#L31"]
 theorem sawin_totally_real_tower :
     ∃ (rdBound : ℝ) (Q : Set ℕ), Q.Infinite ∧ (∀ q ∈ Q, q.Prime ∧ q % 4 = 1) ∧
       ∀ N : ℕ, ∃ (F : Type) (_ : Field F) (_ : CharZero F) (_ : NumberField F)


### PR DESCRIPTION
Adds a fixed-commit proof link for `Erdos90.sawin_totally_real_tower`. The statement is unchanged, and the linked theorem has no additional hypotheses.

[Proof](https://github.com/n-yamaguchi-0729/SawinTotallyRealTowers/blob/3a455e1aa9140dbbe7b7d68f508392a69c86d0f4/Lean4/SawinTotallyRealTowers/SawinTotallyRealTower.lean#L31) · [CI](https://github.com/n-yamaguchi-0729/SawinTotallyRealTowers/actions/runs/34114797233)

The proof uses Lean 4.33.0 and pinned dependencies. Fresh build, exact-statement check, all-declaration axiom audit and official kernel replay passed. The main theorem uses only `propext`, `Classical.choice` and `Quot.sound`. The modified FC file builds with Lean 4.33.1.

AI assistance: OpenAI Codex for implementation and verification; GPT-5.6 Sol for earlier shared-library work.
