### PR TITLE
fix(MovingSofa): apply translation before rotation

### DIFF
--- a/FormalConjectures/Wikipedia/MovingSofa.lean
+++ b/FormalConjectures/Wikipedia/MovingSofa.lean
@@ -115,8 +115,13 @@ The rigid motion that translates by $p$ and then rotates counterclockwise by $\a
 Note that [Ge92] used this definition while [Ro18] used rotation first and then translation.
 -/
 def rotateTranslate (α : Real.Angle) (p : ℝ²) : E(2) :=
-  (EuclideanGeometry.o.rotation α).toAffineIsometryEquiv
-    |>.trans (AffineIsometryEquiv.vaddConst ℝ p)
+  (AffineIsometryEquiv.vaddConst ℝ p).trans
+    (EuclideanGeometry.o.rotation α).toAffineIsometryEquiv
+
+/-- The translation is applied before the rotation. -/
+@[category test, AMS 49]
+theorem rotateTranslate_apply (α : Real.Angle) (p q : ℝ²) :
+    rotateTranslate α p q = EuclideanGeometry.o.rotation α (q + p) := rfl
 
 /--
 The sofa according to a rotation path $p : [0, \pi/2] \to \mathbb{R}^2$ as in [Ge92] is the


### PR DESCRIPTION
Refs #5270.

This is a **draft**, pending confirmation of the intended composition order.
It proposes following the existing docstring: translate first, then rotate.
If rotation before translation is intended instead, this code change should
not be merged; the documentation and path conventions need to be considered
instead.

Changes (one file only):

- Reverse the composition in `MovingSofa.rotateTranslate`.
- Add `MovingSofa.rotateTranslate_apply`, a pointwise regression theorem for
  `rotateTranslate alpha p q = rotation alpha (q + p)`, proved by `rfl` and
  tagged `@[category test, AMS 49]`.

The integral path formulas and existing conjecture placeholders are unchanged.
This is not a formal proof of Gerver sofa optimality or of the full
representation/motion bridge in this repository.

Validation already performed locally on commit
`8323e878b83fcd7f4a448256069352a265460d75` with this exact patched file:

- Lean 4.33.1 (`leanprover/lean4:v4.33.1`).
- `lake --wfail build FormalConjectures.Wikipedia.MovingSofa`: exit 0.
- `#print axioms MovingSofa.rotateTranslate_apply`: only `propext`,
  `Classical.choice`, and `Quot.sound`; no `sorryAx` for this theorem.

The submission branch starts at `2c817e975be7a95478b72a8429155ca568e1a3de`. Before applying the change,
the launcher verified that `MovingSofa.lean` there was byte-identical to the
tested original. The full build was not rerun for this submission base; CI still
needs to validate the submitted branch. The axiom check above concerns the
new regression theorem, not all existing declarations in the file.

Prepared with AI assistance; the build and axiom-check results above come
from local Lean runs.
