### PR TITLE
feat(OptimizationConstants): irrationality exp of pi and $Gamma 1/4$

### DIFF
--- a/FormalConjectures/OptimizationConstants/7a.lean
+++ b/FormalConjectures/OptimizationConstants/7a.lean
@@ -1,0 +1,137 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjecturesUtil
+
+/-!
+# Tao's Optimization Constant 7a / The Irrationality Measure of $\pi$
+
+*References:*
+- [Tao's Optimization Constant 7a](https://teorth.github.io/optimizationproblems/constants/7a.html)
+- [D1842] Dirichlet, L. G. P., *Verallgemeinerung eines Satzes aus der Lehre von den
+  Kettenbrüchen nebst einigen Anwendungen auf die Theorie der Zahlen*. Sitzungsberichte der
+  Preussischen Akademie der Wissenschaften (1842), 93–95.
+- [M1953] Mahler, K., *On the approximation of $\pi$*. Nederl. Akad. Wetensch. Proc. Ser. A
+  **56** = Indag. Math. **15** (1953), 30–42.
+- [R1955] Roth, K. F., [*Rational approximations to algebraic
+  numbers*](https://doi.org/10.1112/S0025579300000644). Mathematika **2** (1955), 1–20.
+- [RV1993] Rhin, G. and Viola, C., [*On the irrationality measure of
+  $\zeta(2)$*](https://doi.org/10.5802/aif.1322). Ann. Inst. Fourier **43** (1993), 85–109.
+- [ZZ2020] Zeilberger, D. and Zudilin, W., *The irrationality measure of $\pi$ is at most
+  $7.103205334137\ldots$*. Moscow J. Comb. Number Theory **9** (2020), 407–419.
+  [arXiv:1912.06345](https://arxiv.org/abs/1912.06345)
+-/
+
+namespace Constant7a
+
+open Real ENNReal Set NNReal
+
+/-- The irrationality exponent of a real number. -/
+noncomputable def irrationalityExponent : ℝ → ℝ≥0∞ :=
+  fun x ↦ sSup ((↑) '' {p : ℝ≥0 | LiouvilleWith p x})
+
+/-- The irrationality exponent of a rational number is one. -/
+@[category textbook, AMS 11]
+theorem irrationalityExponent_of_rational (x : ℚ) : irrationalityExponent x = 1 := by
+  unfold irrationalityExponent
+  apply le_antisymm
+  · simp only [sSup_le_iff, mem_image, mem_ofPred_eq, forall_exists_index, and_imp,
+      forall_apply_eq_imp_iff₂, coe_le_one_iff]
+    intro _ h
+    simpa using (LiouvilleWith.irrational h).mt
+  · apply le_sSup
+    simp only [mem_image, mem_ofPred_eq, ENNReal.coe_eq_one, exists_eq_right, NNReal.coe_one]
+    exact liouvilleWith_one x
+
+@[category API, AMS 11]
+theorem le_irrationalityExponent_iff (x : ℝ) (y : ℝ≥0∞) :
+    y ≤ irrationalityExponent x ↔ ∀ z : ℝ≥0, z < y → LiouvilleWith z x := by
+  rw [irrationalityExponent, le_sSup_iff_forall_lt]
+  refine ⟨fun h z zy ↦ ?_, fun h z zy ↦ ?_⟩
+  · obtain ⟨a, ha, za⟩ := h z zy
+    simp only [mem_image, mem_ofPred_eq] at ha
+    obtain ⟨r, hr, ra⟩ := ha
+    apply LiouvilleWith.mono hr
+    simp only [NNReal.coe_le_coe]
+    suffices (z : ℝ≥0∞) ≤ r by simpa
+    grind
+  · simp only [mem_image, mem_ofPred_eq, exists_exists_and_eq_and]
+    rcases eq_or_ne y ⊤ with rfl | hy
+    · simp_all only [coe_lt_top, forall_const, true_and]
+      refine ⟨z.toNNReal + 1, ?_⟩
+      rw [coe_add, ENNReal.coe_one, coe_toNNReal zy.ne]
+      exact lt_add_right zy.ne one_ne_zero
+    obtain ⟨a, za, ay⟩ := DenselyOrdered.dense z y zy
+    refine ⟨a.toNNReal, ?_, ?_⟩
+    · apply h
+      rwa [ENNReal.coe_toNNReal (by grind)]
+    · rwa [ENNReal.coe_toNNReal (by grind)]
+
+@[category API, AMS 11]
+theorem irrationalityExponent_top_iff (x : ℝ) : irrationalityExponent x  = ⊤ ↔ Liouville x := by
+  simp_rw [← ENNReal.not_lt_top, not_lt, le_irrationalityExponent_iff, ← forall_liouvilleWith_iff,
+    coe_lt_top, forall_const]
+  exact ⟨fun h p ↦ (h p.toNNReal).mono <| le_coe_toNNReal p, fun h z ↦ h z⟩
+
+/-- Every irrational real number has irrationality exponent at least two by Dirichlet's
+approximation theorem [D1842]. -/
+@[category textbook, AMS 11]
+theorem two_le_irrationalityExponent {x : ℝ} (hx : Irrational x) :
+    2 ≤ irrationalityExponent x := by
+  sorry
+
+/-- Every algebraic real number has irrationality exponent at most two. For irrational algebraic
+numbers, this is Roth's theorem [R1955]. -/
+@[category research solved, AMS 11]
+theorem irrationalityExponent_of_algebraic {x : ℝ} (hx : IsAlgebraic ℚ x) :
+    irrationalityExponent x ≤ 2 := by
+  sorry
+
+/-- **Tao's Optimization Constant 7a / The irrationality measure of $\pi$**. -/
+noncomputable def C7a : ℝ≥0∞ := irrationalityExponent π
+
+/-- The first and current best known lower bound, given by Dirichlet's theorem [D1842]. This bound
+holds for every irrational real number. -/
+@[category textbook, AMS 11]
+theorem c7a_lower_bound : 2 ≤ C7a := two_le_irrationalityExponent irrational_pi
+
+/-- Can the current best lower bound be improved? -/
+@[category research open, AMS 11]
+theorem c7a_lower_bound_improved : answer(sorry) ↔ 2 < C7a := by
+  sorry
+
+/-- The first known upper bound, proved by Mahler in [M1953]. This was the first proof that
+$C_{7a}$ is finite, or equivalently that $\pi$ is not a Liouville number. -/
+@[category research solved, AMS 11]
+theorem c7a_le_42 : C7a ≤ 42 := by
+  sorry
+
+/-- An intermediate upper bound proved by Rhin and Viola in [RV1993]. It follows from an effective
+irrationality measure for $\zeta(2) = \pi^2 / 6$. -/
+@[category research solved, AMS 11]
+theorem c7a_lt_14_797075 : C7a < 14.797075 := by
+  sorry
+
+/-- The current best known upper bound, proved by Zeilberger and Zudilin in [ZZ2020]. -/
+@[category research solved, AMS 11]
+theorem c7a_upper_bound : C7a < 7.103205334138 := by
+  sorry
+
+/-- Can the current best upper bound be improved? -/
+@[category research open, AMS 11]
+theorem c7a_upper_bound_improved : answer(sorry) ↔ C7a < 7.103205334136 := by
+  sorry
+
+end Constant7a

--- a/FormalConjectures/OptimizationConstants/7a.lean
+++ b/FormalConjectures/OptimizationConstants/7a.lean
@@ -39,12 +39,12 @@ namespace Constant7a
 open Real ENNReal Set NNReal
 
 /-- The irrationality exponent of a real number. -/
-noncomputable def irrationalityExponent : ℝ → ℝ≥0∞ :=
-  fun x ↦ sSup ((↑) '' {p : ℝ≥0 | LiouvilleWith p x})
+noncomputable def irrationalityExponent (x : ℝ) : ℝ≥0∞ :=
+  sSup ((↑) '' {p : ℝ≥0 | LiouvilleWith p x})
 
 /-- The irrationality exponent of a rational number is one. -/
-@[category textbook, AMS 11]
-theorem irrationalityExponent_of_rational (x : ℚ) : irrationalityExponent x = 1 := by
+@[category API, AMS 11]
+theorem irrationalityExponent_ratCast (x : ℚ) : irrationalityExponent x = 1 := by
   unfold irrationalityExponent
   apply le_antisymm
   · simp only [sSup_le_iff, mem_image, mem_ofPred_eq, forall_exists_index, and_imp,
@@ -80,7 +80,7 @@ theorem le_irrationalityExponent_iff (x : ℝ) (y : ℝ≥0∞) :
     · rwa [ENNReal.coe_toNNReal (by grind)]
 
 @[category API, AMS 11]
-theorem irrationalityExponent_top_iff (x : ℝ) : irrationalityExponent x  = ⊤ ↔ Liouville x := by
+theorem irrationalityExponent_eq_top_iff (x : ℝ) : irrationalityExponent x = ⊤ ↔ Liouville x := by
   simp_rw [← ENNReal.not_lt_top, not_lt, le_irrationalityExponent_iff, ← forall_liouvilleWith_iff,
     coe_lt_top, forall_const]
   exact ⟨fun h p ↦ (h p.toNNReal).mono <| le_coe_toNNReal p, fun h z ↦ h z⟩
@@ -131,7 +131,7 @@ theorem c7a_upper_bound : C7a < 7.103205334138 := by
 
 /-- Can the current best upper bound be improved? -/
 @[category research open, AMS 11]
-theorem c7a_upper_bound_improved : answer(sorry) ↔ C7a < 7.103205334136 := by
+theorem c7a_upper_bound_improved : answer(sorry) ↔ C7a < 7.103205334137 := by
   sorry
 
 end Constant7a

--- a/FormalConjectures/OptimizationConstants/7a.lean
+++ b/FormalConjectures/OptimizationConstants/7a.lean
@@ -131,7 +131,7 @@ theorem c7a_upper_bound : C7a < 7.103205334138 := by
 
 /-- Can the current best upper bound be improved? -/
 @[category research open, AMS 11]
-theorem c7a_upper_bound_improved : answer(sorry) ↔ C7a < 7.103205334137 := by
+theorem c7a_upper_bound_improved : answer(sorry) ↔ C7a < 7.103205334136 := by
   sorry
 
 end Constant7a

--- a/FormalConjectures/OptimizationConstants/7b.lean
+++ b/FormalConjectures/OptimizationConstants/7b.lean
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 import FormalConjectures.OptimizationConstants.«7a»
+import FormalConjecturesUtil
 
 /-!
 # Tao's Optimization Constant 7b / The Irrationality Measure of $\Gamma(1/4)$

--- a/FormalConjectures/OptimizationConstants/7b.lean
+++ b/FormalConjectures/OptimizationConstants/7b.lean
@@ -24,6 +24,8 @@ import FormalConjecturesUtil
 - [D1842] Dirichlet, L. G. P., *Verallgemeinerung eines Satzes aus der Lehre von den
   Kettenbrüchen nebst einigen Anwendungen auf die Theorie der Zahlen*. Sitzungsberichte der
   Preussischen Akademie der Wissenschaften (1842), 93–95.
+- [C1976] Chudnovsky, G. V., *Algebraic independence of constants connected with the exponential
+  and the elliptic functions*. Dokl. Akad. Nauk Ukrain. SSR Ser. A 1976, no. 8, 698–701.
 - [Bru2002] Bruiltet, S., [*D'une mesure d'approximation simultanée à une mesure
   d'irrationalité :
   le cas de $\Gamma(1/4)$ et $\Gamma(1/3)$*](https://doi.org/10.4064/aa104-3-3).
@@ -38,11 +40,16 @@ open ENNReal
 noncomputable def C7b : ℝ≥0∞ :=
   Constant7a.irrationalityExponent (Real.Gamma (1 / 4))
 
-/-- The first and current best known lower bound, given by Dirichlet's theorem [D1842]. It applies
-because $\Gamma(1/4)$ is irrational. -/
-@[category textbook, AMS 11 33]
-theorem c7b_lower_bound : 2 ≤ C7b := by
+/-- $\Gamma(1/4)$ is irrational, as proven in [C1976]. -/
+@[category research solved, AMS 11 33]
+theorem irrational_gamma_one_div_four : Irrational (Real.Gamma (1 / 4)) := by
   sorry
+
+/-- The first and current best known lower bound, given by Dirichlet's theorem [D1842]. It applies
+because $\Gamma(1/4)$ is irrational by Chudnovsky's theorem [C1976]. -/
+@[category research solved, AMS 11 33]
+theorem c7b_lower_bound : 2 ≤ C7b :=
+  Constant7a.two_le_irrationalityExponent irrational_gamma_one_div_four
 
 /-- Can the current best lower bound be improved? -/
 @[category research open, AMS 11 33]

--- a/FormalConjectures/OptimizationConstants/7b.lean
+++ b/FormalConjectures/OptimizationConstants/7b.lean
@@ -1,0 +1,62 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjectures.OptimizationConstants.«7a»
+
+/-!
+# Tao's Optimization Constant 7b / The Irrationality Measure of $\Gamma(1/4)$
+
+*References:*
+- [Tao's Optimization Constant 7b](https://teorth.github.io/optimizationproblems/constants/7b.html)
+- [D1842] Dirichlet, L. G. P., *Verallgemeinerung eines Satzes aus der Lehre von den
+  Kettenbrüchen nebst einigen Anwendungen auf die Theorie der Zahlen*. Sitzungsberichte der
+  Preussischen Akademie der Wissenschaften (1842), 93–95.
+- [Bru2002] Bruiltet, S., [*D'une mesure d'approximation simultanée à une mesure
+  d'irrationalité :
+  le cas de $\Gamma(1/4)$ et $\Gamma(1/3)$*](https://doi.org/10.4064/aa104-3-3).
+  Acta Arith. **104** (2002), 243–281.
+-/
+
+namespace Constant7b
+
+open ENNReal
+
+/-- **Tao's Optimization Constant 7b / The irrationality measure of $\Gamma(1/4)$**. -/
+noncomputable def C7b : ℝ≥0∞ :=
+  Constant7a.irrationalityExponent (Real.Gamma (1 / 4))
+
+/-- The first and current best known lower bound, given by Dirichlet's theorem [D1842]. It applies
+because $\Gamma(1/4)$ is irrational. -/
+@[category textbook, AMS 11 33]
+theorem c7b_lower_bound : 2 ≤ C7b := by
+  sorry
+
+/-- Can the current best lower bound be improved? -/
+@[category research open, AMS 11 33]
+theorem c7b_lower_bound_improved : answer(sorry) ↔ 2 < C7b := by
+  sorry
+
+/-- The first and current best known upper bound, proved by Bruiltet in [Bru2002]. It follows from
+an explicit lower bound on $|\Gamma(1/4) - p/q|$ for rational $p/q$ of sufficiently large height. -/
+@[category research solved, AMS 11 33]
+theorem c7b_upper_bound : C7b ≤ 10 ^ 143 := by
+  sorry
+
+/-- Can the current best upper bound be improved? -/
+@[category research open, AMS 11 33]
+theorem c7b_upper_bound_improved : answer(sorry) ↔ C7b < 10 ^ 143 := by
+  sorry
+
+end Constant7b


### PR DESCRIPTION
from https://teorth.github.io/optimizationproblems/constants/7a.html and https://teorth.github.io/optimizationproblems/constants/7b.html

I am quite happy with this format. When this gets merged, I can quickly add many constants (I believe) and then probably make the OptimizationProblems link to formal conjectures (this was discussed on zulip months ago, but not worked on since)

About the format I have decided on:

- Each file should have the title same as those in PR #5340
- Each constant CXY, again like in #5340. If existence of constant unclear; we can occassionally cheat with ENNReal, ENat etc, but let's not have a general rule for this.
- Naming of bounds again as in #5340 and #5537
- We include both upper and lower bounds and follow the following system: Add the first known upper/lower bound; at most two intermediate bounds (espp ones introducing new methods etc) (though exceptions are poossible) as well as the best known upper/lower bound. As well as a research open for upper/lower if it can improved, by taking the best known bound and increasing it slightly (see more next bullet point). If there are separate conjectures (like for C14), they ought to be included as well
- One major problem is the question of rounding. Any proving of as research open sorry should translate to a genuine mathematical improvement  and not just "calculating more digits". Similarly, no proving of sorry of a research solved, should require mathematical optimizitation. Thus we apply following rules:
1. If the domain is "discrete" in some way (in particular, Nat and Int), there are no big issues and we can proceed as in #5537. I.e. simply state the known bounds exactly, and make research open one "the next best one", preferably with < (esp if the best known bound is of form \le)$. This applies if the optimization constant is real or whatever, but best known bounds are integers. In this case, if the best known lower bound is say \sqrt2, the research open question should ask if the constant is > \sqrt 2 etc.
2. "Explicit short forms" which are (reasonably) computable if available are always prefered. I.e. \sqrt(5), e, \Gamma(1/2) or combinations there of are always better than digit expansion.
3. Known bounds are to be rounded in a way that *does not strengthen* the mathematical statement. I.e. if the constant is listed as \le 2.434564245 (and there is no reason why the digits should stop here), we write it in Lean as 2.434564245. This makes the statement very slightly weaker but ensures the formalisation can stay consistent with the known math. Generally, round up/down "late", usually at the last known digit. If there are more than 10 digits (behind the comma) are listed, round at the 10th decimal digit (unless the distance to the other known bound is less than that). Since the cited bounds themselves could be rounded, if there are significantly many digits (say >3 or better >5 digits behind the comma and improvements are historically bigger than 10^-5), in some cases one can round up / down "one more", like in #5340 for the upper bound of 7b. This is not always a good idea, but sometimes a bit safer
4. For research open improvements (again, that are not discrete in some way or another), we do rounding in the opposite direction. I.e. if the best known lower bound is listed as  2.434564245, the research open bound should ask if it it is greater than  2.434564246 (mirrored for upper bounds). 