### PR TITLE
Add a local review report pilot with pinned evidence

### DIFF
--- a/scripts/review-report/README.md
+++ b/scripts/review-report/README.md
@@ -1,0 +1,142 @@
+# Local review-report pilot
+
+Prepare pinned inputs, collect an advisory review and existing check evidence, and render
+one local report. The tool runs Git reads only. It does not run Lean, a model, external
+proof code, a network request or a GitHub write.
+
+This is an experimental operational format, not an accepted FC interface or a replacement
+for the older `formal-conjectures.pr-audit.v1` evidence prototype. That prototype's stricter
+validation and independent-review claims are not implemented here. Its records may be retained
+as evidence files, but this tool does not validate their internal schema or import their authority.
+
+## Prepare a review
+
+Use a checkout of the exact PR head and a trusted copy of the review skill, such as #4899.
+Put the cited source excerpts and their URLs/retrieval notes in a dedicated source directory.
+An empty directory is allowed when the source is unavailable; source review must then remain
+incomplete. The tool records the committed head, actual merge base, changed paths, procedure
+files and source bytes. Local uncommitted changes are not the review target. Skill `evals/`
+directories are excluded from reviewer inputs.
+
+```sh
+python3 scripts/review_report.py prepare \
+  --checkout /path/to/pr-checkout --repository google-deepmind/formal-conjectures \
+  --base origin/main --skill /path/to/formal-conjectures-review \
+  --sources /path/to/source-excerpts --require build --out /tmp/review-inputs
+```
+
+Add `--require proof` when a proof claim needs verification. Build is always required.
+The repository locator is supplied by the operator; the tool does not authenticate GitHub
+or establish that the local Git commits belong to that remote.
+
+The output contains `request.json`, copied `procedure/` and `sources/` files, and a
+`review-template.json`. Give the reviewer these inputs and the corresponding source checkout.
+Store the completed template separately as `review.json`; do not edit the pinned request.
+
+## Review input contract
+
+The template has exactly these fields:
+
+- `request_id`: copied from `request.json`; the reviewer cannot supply a verdict for another request.
+- `reviewer`: human identity or actual model/version used. This is recorded, not authenticated.
+- `context_policy`: `fresh` or `rereview`. A rereview must retain its prior review context.
+- `prior_reviews`: evidence paths for prior reports and replies; empty for a fresh review.
+- `coverage`: `source-fidelity`, `statement-soundness`, `metadata-hygiene`, each `complete` or `incomplete`.
+- `findings`: objects with exactly `angle`, `file`, `line`, `severity`, `message`, `suggestion`, `evidence`.
+- `questions`: unresolved material questions as strings. Optional non-material notes do not belong here.
+
+A finding's angle is one of the three coverage keys. Its file must be in the recorded diff;
+line is a nonnegative integer (`0` means file-wide). For deletions, cite the old file's line.
+The tool validates scope membership but does not validate line numbers against source bytes.
+Severity is `semantic` or `nit`. Message and suggestion must be nonempty. Evidence is a
+nonempty list of retained paths, for example `sources/problem.txt` or `evidence/witness.txt`.
+Documentary evidence and checked counterexamples remain different kinds of support; the reviewer
+must explain which supports the finding. The assembler cannot judge that relationship.
+
+## Supplied checks
+
+Create an evidence directory containing `checks.json` and files under `evidence/`:
+
+```json
+{
+  "request_id": "COPY_THE_REQUEST_ID",
+  "artifacts": [
+    {"path": "evidence/build.json", "sha256": "SHA256_OF_THE_EXACT_FILE_BYTES"}
+  ],
+  "checks": [
+    {
+      "kind": "build",
+      "status": "pass",
+      "producer": "the workflow/run or operator that produced this evidence",
+      "policy": "lake --wfail build on the affected modules",
+      "detail": "What ran and the scope it establishes",
+      "evidence": ["evidence/build.json"]
+    }
+  ]
+}
+```
+
+This is a shape example, not a build result. `kind` is `build` or `proof`; each occurs at most
+once. `status` is `pass`, `fail`, `error` or `not_run`. Pass/fail requires retained evidence.
+Missing required checks become `not_run`. An empty `artifacts` and `checks` array records that
+no checks were supplied. The manifest can also retain witness outputs or earlier audit records
+for findings to reference, without inventing a build or proof verdict for them.
+
+For proof evidence, retain the exact statement/proof/bridge pins, dependency and verifier
+versions, configured axiom policy, and the actual result in the referenced artifact. Name the
+policy in the check. **Do not turn an arbitrary log into a passing receipt.** Producers must
+establish the result through their documented verification path. This tool checks supplied
+record shape, identity and file digests, not producer authenticity or proof correctness.
+A nonzero Comparator exit without a documented classification is an error, not a parsed
+mathematical rejection. No policy is inferred from log text or filenames.
+
+## Assemble and check freshness
+
+Run `prepare` again with the current checkout, trusted skill and source excerpts, writing
+another directory. This captures changes since the original review. `--current` is required;
+supplying an old snapshot again cannot establish current freshness.
+
+```sh
+python3 scripts/review_report.py assemble \
+  --request /tmp/review-inputs --current /tmp/current-review-inputs \
+  --review /tmp/review.json --evidence /tmp/review-evidence --out /tmp/review-result
+```
+
+The output directory must not exist. It contains:
+
+- `report.json`: deterministic advisory result with the original request, supplied findings,
+  normalized checks, artifact digests and assembler code hash.
+- `observation.json`: original report digest, current request identity and freshness/completeness.
+  Different current inputs change this observation, not the original result.
+- `summary.md`: escaped human-readable view of both records, with local evidence links.
+- Copied input records, original procedure/source files, and check evidence.
+
+Confirmed semantic findings yield `NEEDS REVISION`, with any incomplete checks still listed.
+Otherwise a missing/failed check, incomplete coverage or material question yields `INCOMPLETE`.
+Only a complete review can yield `CLEAN` or `ACCEPT WITH NITS`. Staleness is a separate prominent
+state: an old clean result does not become current merely because its original checks passed.
+A failed build or rejected proof remains a check outcome, not an invented semantic finding.
+
+Exit `0` means the report was assembled, including when incomplete or stale. Exit `2` means
+invalid input or an I/O/Git failure. Neither exit code approves a PR. Strict readers should use
+the versioned JSON fields, never scrape `summary.md` or treat CLI success as a review pass.
+
+## Evaluation and next integration
+
+Compare review variants only on matching head, merge base, source snapshots, tool access and
+context policy. A fresh run and a rereview with prior findings are different evaluation inputs.
+Keep historical runs separately. Count actual findings, unsupported claims, false positives,
+contradictory suggestions and human effort; a report that parses is not a successful review.
+
+The design adapts Tau Ceti's [case-file approach](https://github.com/TauCetiProject/TauCetiReview/blob/afb424eda89e8ac96d9eb69f6a88972055a4cd1b/runner/casefile.py)
+and [separation of operational state from archived runs](https://github.com/TauCetiProject/TauCetiData#design).
+It handles procedure freshness explicitly, the missing behavior tracked in
+[TauCetiReview #95](https://github.com/TauCetiProject/TauCetiReview/issues/95).
+No upstream implementation is vendored. Isolated evidence execution, authenticated producer
+adapters, model invocation, persistent PR state and publication remain follow-ups under FC #4394.
+
+Run the offline checks with:
+
+```sh
+python3 -m unittest discover -s scripts -p 'test_review_report.py' -v
+```

--- a/scripts/review-report/README.md
+++ b/scripts/review-report/README.md
@@ -45,6 +45,14 @@ The template has exactly these fields:
 - `findings`: objects with exactly `angle`, `file`, `line`, `severity`, `message`, `suggestion`, `evidence`.
 - `questions`: unresolved material questions as strings. Optional non-material notes do not belong here.
 
+The template also includes `reconciliations`, an optional additive v1 field for rereviews.
+Each entry has exactly `prior_evidence`, `status` (`retained`, `corrected` or `withdrawn`),
+`reason`, and nonempty supporting `evidence` paths. The prior reference must occur in
+`prior_reviews`; use a separate retained record per prior finding. Each prior reference can
+be reconciled once. A withdrawn finding is preserved in the report without becoming a current
+finding or unresolved question. An unresolved dispute belongs in `questions`. Producers that
+omit this field remain valid; the assembler does not infer a disposition for them.
+
 A finding's angle is one of the three coverage keys. Its file must be in the recorded diff;
 line is a nonnegative integer (`0` means file-wide). For deletions, cite the old file's line.
 The tool validates scope membership but does not validate line numbers against source bytes.

--- a/scripts/review_report.py
+++ b/scripts/review_report.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare pinned review inputs and render supplied evidence as an advisory report.
+
+This local pilot never executes Lean, models, submitted code or network requests.
+It validates record shape, input identity and retained bytes, not the truth of a
+producer's claims. See scripts/review-report/README.md for the input contracts.
+"""
+
+import argparse
+import hashlib
+import html
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+from urllib.parse import quote
+
+ANGLES = ("source-fidelity", "statement-soundness", "metadata-hygiene")
+KINDS = ("build", "proof")
+REQUEST_VERSION = "fc.review-pilot.request.v1"
+REPORT_VERSION = "fc.review-pilot.report.v1"
+
+
+class InputError(ValueError):
+    """Invalid or inconsistent evidence; not a mathematical rejection."""
+
+
+def require(condition, message):
+    if not condition:
+        raise InputError(message)
+
+
+def obj(value, fields, label):
+    require(type(value) is dict and set(value) == set(fields.split()),
+            f"{label}: expected exactly {fields}")
+
+
+def text(value, label):
+    require(type(value) is str and bool(value.strip()), f"{label}: expected nonempty text")
+    require(not any(ord(c) < 32 and c not in '\n\t' for c in value),
+            f"{label}: control character")
+
+
+def array(value, label):
+    require(type(value) is list, f"{label}: expected array")
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def encode(value):
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2,
+                       allow_nan=False) + "\n").encode("utf-8")
+
+
+def parse(raw):
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            require(key not in result, f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    def invalid(value):
+        raise InputError(f"invalid JSON constant: {value}")
+
+    try:
+        value = json.loads(raw, object_pairs_hook=pairs, parse_constant=invalid)
+        encode(value)  # Reject unpaired surrogates before creating output.
+        return value
+    except (ValueError, UnicodeError) as error:
+        raise InputError(str(error)) from error
+
+
+def read_json(path):
+    return parse(Path(path).read_bytes())
+
+
+def relative(value):
+    text(value, "path")
+    path = PurePosixPath(value)
+    require(not path.is_absolute() and ".." not in path.parts and "\\" not in value
+            and value == path.as_posix() and value != ".", f"unsafe path: {value}")
+    return path
+
+
+def read_artifact(root, name):
+    path = Path(root)
+    require(not path.is_symlink(), f"symlink artifact directory: {root}")
+    for part in relative(name).parts:
+        path = path / part
+        require(not path.is_symlink(), f"symlink artifact: {name}")
+    require(path.is_file(), f"missing artifact: {name}")
+    return path.read_bytes()
+
+
+def collect(root, prefix, exclude_evals=False):
+    root = Path(root)
+    require(root.is_dir() and not root.is_symlink(), f"not a plain directory: {root}")
+    result = {}
+    for path in sorted(root.rglob("*")):
+        rel = path.relative_to(root)
+        if exclude_evals and "evals" in rel.parts:
+            continue
+        require(not path.is_symlink(), f"symlink input: {path}")
+        if path.is_file():
+            name = f"{prefix}/{rel.as_posix()}"
+            relative(name)
+            result[name] = path.read_bytes()
+    return result
+
+
+def descriptors(files):
+    return [{"path": path, "sha256": digest(raw)} for path, raw in sorted(files.items())]
+
+
+def validate_descriptors(items, label):
+    array(items, label)
+    paths = set()
+    for item in items:
+        obj(item, "path sha256", label)
+        relative(item["path"])
+        require(item["path"] not in paths, f"duplicate artifact: {item['path']}")
+        paths.add(item["path"])
+        require(type(item["sha256"]) is str and
+                re.fullmatch(r"[0-9a-f]{64}", item["sha256"]), f"{label}: invalid digest")
+
+
+def request_id(request):
+    return digest(encode({k: v for k, v in request.items() if k != "id"}))
+
+
+def validate_request(request):
+    obj(request, "schema_version repository head_commit merge_base scope procedure sources required_checks id",
+        "request")
+    require(request["schema_version"] == REQUEST_VERSION, "unsupported request version")
+    text(request["repository"], "repository")
+    for key in ("head_commit", "merge_base"):
+        require(type(request[key]) is str and re.fullmatch(r"[0-9a-f]{40}", request[key]),
+                f"invalid {key}")
+    array(request["scope"], "scope")
+    require(bool(request["scope"]), "empty review scope")
+    for path in request["scope"]:
+        relative(path)
+    require(len(request["scope"]) == len(set(request["scope"])), "duplicate scope path")
+    for field in ("procedure", "sources"):
+        validate_descriptors(request[field], field)
+        require(all(d["path"].startswith(field + "/") for d in request[field]),
+                f"{field}: wrong artifact prefix")
+    require(any(d["path"] == "procedure/SKILL.md" for d in request["procedure"]),
+            "procedure must contain SKILL.md")
+    array(request["required_checks"], "required_checks")
+    require(all(type(k) is str and k in KINDS for k in request["required_checks"]),
+            "unsupported required check")
+    require(len(set(request["required_checks"])) == len(request["required_checks"]),
+            "duplicate required check")
+    require("build" in request["required_checks"], "build must be a required check")
+    require(request["id"] == request_id(request), "request digest mismatch")
+
+
+def git(checkout, *args):
+    return subprocess.run(["git", "-C", str(checkout), *args], check=True,
+                          capture_output=True).stdout
+
+
+def prepare(checkout, repository, base, skill, sources, checks):
+    head = git(checkout, "rev-parse", "HEAD").decode().strip()
+    merge_base = git(checkout, "merge-base", "--", base, head).decode().strip()
+    scope = git(checkout, "diff", "--no-ext-diff", "--no-renames", "--name-only", "-z",
+                merge_base, head, "--").decode().rstrip("\0").split("\0")
+    procedure = collect(skill, "procedure", exclude_evals=True)
+    source_files = collect(sources, "sources")
+    request = {"schema_version": REQUEST_VERSION, "repository": repository,
+               "head_commit": head, "merge_base": merge_base, "scope": sorted(scope),
+               "procedure": descriptors(procedure), "sources": descriptors(source_files),
+               "required_checks": sorted({"build", *checks})}
+    request["id"] = request_id(request)
+    validate_request(request)
+    template = {"request_id": request["id"], "reviewer": "REPLACE with reviewer/model identity",
+                "context_policy": "fresh", "prior_reviews": [],
+                "coverage": {angle: "incomplete" for angle in ANGLES},
+                "findings": [], "questions": ["Review has not run."]}
+    files = procedure | source_files | {"request.json": encode(request),
+                                       "review-template.json": encode(template)}
+    return files
+
+
+def load_request(folder):
+    request = read_json(Path(folder) / "request.json")
+    validate_request(request)
+    files = {}
+    for item in request["procedure"] + request["sources"]:
+        raw = read_artifact(folder, item["path"])
+        require(digest(raw) == item["sha256"], f"digest mismatch: {item['path']}")
+        files[item["path"]] = raw
+    return request, files
+
+
+def references(items, available, label):
+    array(items, label)
+    require(bool(items), f"{label}: evidence required")
+    for name in items:
+        require(type(name) is str and name in available, f"unknown evidence: {name}")
+
+
+def validate_review(review, request, available):
+    obj(review, "request_id reviewer context_policy prior_reviews coverage findings questions", "review")
+    require(review["request_id"] == request["id"], "review belongs to another request")
+    text(review["reviewer"], "reviewer")
+    require(review["context_policy"] in ("fresh", "rereview"), "unknown context policy")
+    array(review["prior_reviews"], "prior_reviews")
+    if review["context_policy"] == "fresh":
+        require(not review["prior_reviews"], "fresh review cannot carry prior reviews")
+    else:
+        references(review["prior_reviews"], available, "prior review evidence")
+    obj(review["coverage"], " ".join(ANGLES), "coverage")
+    require(all(v in ("complete", "incomplete") for v in review["coverage"].values()),
+            "invalid coverage state")
+    if review["coverage"]["source-fidelity"] == "complete":
+        require(bool(request["sources"]), "complete source review requires retained sources")
+    array(review["findings"], "findings")
+    for finding in review["findings"]:
+        obj(finding, "angle file line severity message suggestion evidence", "finding")
+        require(finding["angle"] in ANGLES, "unknown finding angle")
+        require(finding["file"] in request["scope"], "finding outside review scope")
+        require(type(finding["line"]) is int and finding["line"] >= 0, "invalid finding line")
+        require(finding["severity"] in ("semantic", "nit"), "unknown severity")
+        text(finding["message"], "finding message")
+        text(finding["suggestion"], "finding suggestion")
+        references(finding["evidence"], available, "finding evidence")
+    array(review["questions"], "questions")
+    for question in review["questions"]:
+        text(question, "question")
+
+
+def load_checks(manifest, request, folder):
+    obj(manifest, "request_id artifacts checks", "evidence manifest")
+    require(manifest["request_id"] == request["id"], "checks belong to another request")
+    validate_descriptors(manifest["artifacts"], "check artifacts")
+    files = {}
+    for item in manifest["artifacts"]:
+        require(item["path"].startswith("evidence/"), "check artifact needs evidence/ prefix")
+        raw = read_artifact(folder, item["path"])
+        require(digest(raw) == item["sha256"], f"digest mismatch: {item['path']}")
+        files[item["path"]] = raw
+    array(manifest["checks"], "checks")
+    kinds = set()
+    for check in manifest["checks"]:
+        obj(check, "kind status producer policy detail evidence", "check")
+        require(type(check["kind"]) is str and check["kind"] in KINDS, "unknown check kind")
+        require(check["kind"] not in kinds, "duplicate check kind")
+        kinds.add(check["kind"])
+        require(check["status"] in ("pass", "fail", "error", "not_run"), "unknown check status")
+        for key in ("producer", "policy", "detail"):
+            text(check[key], key)
+        if check["status"] in ("pass", "fail"):
+            references(check["evidence"], files, "check evidence")
+        else:
+            array(check["evidence"], "check evidence")
+            for name in check["evidence"]:
+                require(type(name) is str and name in files, "unknown check evidence")
+    return files
+
+
+def escape(value):
+    value = html.escape(value, quote=False).replace("\n", " ").replace("\t", " ")
+    return re.sub(r"([\\`*_{}\[\]()#+.!|>~-])", r"\\\1", value).replace("@", "&#64;")
+
+
+def render(report, observation):
+    req, review = report["request"], report["review"]
+    lines = ["# FC review", "", f"**Freshness:** {observation['freshness']}",
+             f"**Semantic review:** {report['semantic_verdict']}",
+             f"**Review completeness:** {observation['completeness']}", "",
+             f"Reviewed commit: `{req['head_commit']}`",
+             f"Request: `{req['id']}`", f"Reviewer: {escape(review['reviewer'])}", "",
+             "Supplied evidence; producer claims are not independently authenticated by this tool.",
+             "This report does not decide acceptance or establish source fidelity or proof correctness.", "",
+             "| Check | Reported result | Policy |", "| --- | --- | --- |"]
+    for check in report["checks"]:
+        lines.append(f"| {check['kind']} | {check['status']} | {escape(check['policy'])} |")
+    for finding in review["findings"]:
+        lines += ["", f"- **{finding['severity']} / {finding['angle']}** — "
+                  f"{escape(finding['file'])}:{finding['line']}: {escape(finding['message'])}",
+                  f"  Suggestion: {escape(finding['suggestion'])}"]
+    gaps = list(report["gaps"])
+    if observation["freshness"] == "STALE":
+        gaps.insert(0, "Review inputs changed; the verdict below applies only to the reviewed request.")
+    if gaps:
+        lines += ["", "Unresolved checks and questions:", ""]
+        lines += [f"- {escape(gap)}" for gap in gaps]
+    lines += ["", "Evidence:", ""]
+    for item in report["artifacts"]:
+        # Percent-encode names instead of interpolating them as Markdown link syntax.
+        lines.append(f"- [{escape(item['path'])}]({quote(item['path'], safe='/')}) "
+                     f"(`{item['sha256']}`)")
+    return "\n".join(lines) + "\n"
+
+
+def assemble(request_dir, current_dir, review_path, evidence_dir):
+    request, retained = load_request(request_dir)
+    current, _ = load_request(current_dir)
+    review = read_json(review_path)
+    manifest = read_json(Path(evidence_dir) / "checks.json")
+    retained |= load_checks(manifest, request, evidence_dir)
+    validate_review(review, request, retained)
+    checks = list(manifest["checks"])
+    for kind in request["required_checks"]:
+        if not any(c["kind"] == kind for c in checks):
+            checks.append({"kind": kind, "status": "not_run", "producer": "none",
+                           "policy": "not supplied", "detail": "Required check missing.", "evidence": []})
+    checks.sort(key=lambda c: c["kind"])
+    gaps = [f"{angle}: incomplete" for angle, state in review["coverage"].items()
+            if state == "incomplete"] + review["questions"]
+    gaps += [f"{c['kind']}: {c['status']} — {c['detail']}" for c in checks if c["status"] != "pass"]
+    semantic = any(f["severity"] == "semantic" for f in review["findings"])
+    verdict = ("NEEDS REVISION" if semantic else "INCOMPLETE" if gaps else
+               "ACCEPT WITH NITS" if review["findings"] else "CLEAN")
+    fresh = request["id"] == current["id"]
+    report = {"schema_version": REPORT_VERSION, "authority_effect": "none",
+              "assembler_sha256": digest(Path(__file__).read_bytes()),
+              "request": request, "review": review,
+              "checks": checks, "artifacts": descriptors(retained),
+              "completeness": "complete" if not gaps else "incomplete",
+              "semantic_verdict": verdict, "gaps": gaps}
+    observation = {"schema_version": "fc.review-pilot.observation.v1",
+                   "report_sha256": digest(encode(report)), "current_request_id": current["id"],
+                   "freshness": "current" if fresh else "STALE",
+                   "completeness": report["completeness"] if fresh else "incomplete"}
+    files = retained | {"request.json": encode(request), "current-request.json": encode(current),
+                        "review.json": encode(review), "checks.json": encode(manifest),
+                        "report.json": encode(report), "observation.json": encode(observation),
+                        "summary.md": render(report, observation).encode()}
+    return files
+
+
+def write_directory(output, files):
+    output = Path(output)
+    output.mkdir(parents=True, exist_ok=False)
+    for name, raw in files.items():
+        path = output / relative(name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(raw)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    prep = sub.add_parser("prepare")
+    prep.add_argument("--checkout", type=Path, required=True)
+    prep.add_argument("--repository", required=True, help="Repository locator supplied by the operator")
+    prep.add_argument("--base", required=True)
+    prep.add_argument("--skill", type=Path, required=True)
+    prep.add_argument("--sources", type=Path, required=True)
+    prep.add_argument("--require", action="append", choices=KINDS, default=[])
+    prep.add_argument("--out", type=Path, required=True)
+    build = sub.add_parser("assemble")
+    for name in ("request", "current", "review", "evidence", "out"):
+        build.add_argument(f"--{name}", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "prepare":
+            files = prepare(args.checkout, args.repository, args.base, args.skill, args.sources,
+                            args.require or ["build"])
+        else:
+            files = assemble(args.request, args.current, args.review, args.evidence)
+        write_directory(args.out, files)
+    except (InputError, OSError, UnicodeError, subprocess.CalledProcessError) as error:
+        print(f"review-report: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review_report.py
+++ b/scripts/review_report.py
@@ -194,7 +194,7 @@ def prepare(checkout, repository, base, skill, sources, checks):
     validate_request(request)
     template = {"request_id": request["id"], "reviewer": "REPLACE with reviewer/model identity",
                 "context_policy": "fresh", "prior_reviews": [],
-                "coverage": {angle: "incomplete" for angle in ANGLES},
+                "reconciliations": [], "coverage": {angle: "incomplete" for angle in ANGLES},
                 "findings": [], "questions": ["Review has not run."]}
     files = procedure | source_files | {"request.json": encode(request),
                                        "review-template.json": encode(template)}
@@ -220,7 +220,11 @@ def references(items, available, label):
 
 
 def validate_review(review, request, available):
-    obj(review, "request_id reviewer context_policy prior_reviews coverage findings questions", "review")
+    fields = "request_id reviewer context_policy prior_reviews coverage findings questions"
+    # Optional additive field: earlier v1 producers remain valid.
+    if type(review) is dict and "reconciliations" in review:
+        fields += " reconciliations"
+    obj(review, fields, "review")
     require(review["request_id"] == request["id"], "review belongs to another request")
     text(review["reviewer"], "reviewer")
     require(review["context_policy"] in ("fresh", "rereview"), "unknown context policy")
@@ -229,6 +233,22 @@ def validate_review(review, request, available):
         require(not review["prior_reviews"], "fresh review cannot carry prior reviews")
     else:
         references(review["prior_reviews"], available, "prior review evidence")
+    reconciliations = review.get("reconciliations", [])
+    array(reconciliations, "reconciliations")
+    require(not reconciliations or review["context_policy"] == "rereview",
+            "reconciliation requires rereview context")
+    seen = set()
+    for item in reconciliations:
+        obj(item, "prior_evidence status reason evidence", "reconciliation")
+        prior = item["prior_evidence"]
+        require(type(prior) is str and prior in review["prior_reviews"],
+                "reconciliation must reference retained prior review")
+        require(prior not in seen, "duplicate reconciliation")
+        seen.add(prior)
+        require(item["status"] in ("retained", "corrected", "withdrawn"),
+                "invalid reconciliation status")
+        text(item["reason"], "reconciliation reason")
+        references(item["evidence"], available, "reconciliation evidence")
     obj(review["coverage"], " ".join(ANGLES), "coverage")
     require(all(v in ("complete", "incomplete") for v in review["coverage"].values()),
             "invalid coverage state")
@@ -299,6 +319,11 @@ def render(report, observation):
         lines += ["", f"- **{finding['severity']} / {finding['angle']}** — "
                   f"{escape(finding['file'])}:{finding['line']}: {escape(finding['message'])}",
                   f"  Suggestion: {escape(finding['suggestion'])}"]
+    if review.get("reconciliations"):
+        lines += ["", "Prior findings:", ""]
+        for item in review["reconciliations"]:
+            lines.append(f"- **{item['status']}** — {escape(item['prior_evidence'])}: "
+                         f"{escape(item['reason'])}")
     gaps = list(report["gaps"])
     if observation["freshness"] == "STALE":
         gaps.insert(0, "Review inputs changed; the verdict below applies only to the reviewed request.")

--- a/scripts/test_review_report.py
+++ b/scripts/test_review_report.py
@@ -109,6 +109,38 @@ class ReportTest(unittest.TestCase):
         self.review["questions"] = ["Which version of the source is intended?"]
         self.assertEqual(self.report()["semantic_verdict"], "INCOMPLETE")
 
+    def reconciliation(self):
+        self.review.update(context_policy="rereview", prior_reviews=["evidence/build.json"])
+        return {"prior_evidence": "evidence/build.json", "status": "withdrawn",
+                "reason": "The prior claim was contradicted by the retained source.",
+                "evidence": ["sources/paper.txt"]}
+
+    def test_withdrawn_finding_is_traceable_without_becoming_a_current_finding(self):
+        self.review["reconciliations"] = [self.reconciliation()]
+        files = self.run_report()
+        report = rr.parse(files["report.json"])
+        self.assertEqual(report["semantic_verdict"], "CLEAN")
+        self.assertEqual(report["review"]["findings"], [])
+        self.assertIn("**withdrawn**", files["summary.md"].decode())
+
+    def test_reconciliation_needs_prior_context_and_support(self):
+        item = self.reconciliation()
+        for field, value in (("prior_evidence", "sources/paper.txt"),
+                             ("status", "unresolved"), ("evidence", []), ("reason", "")):
+            with self.subTest(field=field):
+                self.review["reconciliations"] = [{**item, field: value}]
+                with self.assertRaises(rr.InputError):
+                    self.run_report()
+        self.review["reconciliations"] = [item, item]
+        with self.assertRaises(rr.InputError):
+            self.run_report()
+
+    def test_fresh_review_cannot_reconcile_an_unretained_prior_claim(self):
+        self.review["reconciliations"] = [self.reconciliation()]
+        self.review.update(context_policy="fresh", prior_reviews=[])
+        with self.assertRaises(rr.InputError):
+            self.run_report()
+
     def test_changed_head_procedure_or_source_makes_only_observation_stale(self):
         original = self.run_report()
         for field in ("head_commit", "procedure", "sources", "merge_base", "required_checks"):

--- a/scripts/test_review_report.py
+++ b/scripts/test_review_report.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline review-report contract checks; no Lean, model or GitHub calls."""
+
+import copy
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import review_report as rr
+
+
+class ReportTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.request_dir = self.root / "request"
+        self.evidence_dir = self.root / "checks"
+        self.evidence_dir.mkdir()
+        self.review_path = self.root / "review.json"
+        self.inputs = {"procedure/SKILL.md": b"review procedure\n",
+                       "sources/paper.txt": b"Source: for every positive n.\n"}
+        self.request = {
+            "schema_version": rr.REQUEST_VERSION, "repository": "owner/repo",
+            "head_commit": "a" * 40, "merge_base": "b" * 40,
+            "scope": ["FormalConjectures/Example.lean"],
+            "procedure": rr.descriptors({k: v for k, v in self.inputs.items() if k.startswith("procedure/")}),
+            "sources": rr.descriptors({k: v for k, v in self.inputs.items() if k.startswith("sources/")}),
+            "required_checks": ["build"],
+        }
+        self.request["id"] = rr.request_id(self.request)
+        rr.write_directory(self.request_dir, self.inputs | {"request.json": rr.encode(self.request)})
+        self.review = {"request_id": self.request["id"], "reviewer": "Test reviewer",
+                       "context_policy": "fresh", "prior_reviews": [],
+                       "coverage": {a: "complete" for a in rr.ANGLES},
+                       "findings": [], "questions": []}
+        (self.evidence_dir / "evidence").mkdir()
+        self.raw = b'{"example":"supplied check receipt; not a real Lean run"}\n'
+        (self.evidence_dir / "evidence/build.json").write_bytes(self.raw)
+        self.manifest = {"request_id": self.request["id"],
+                         "artifacts": [{"path": "evidence/build.json", "sha256": rr.digest(self.raw)}],
+                         "checks": [{"kind": "build", "status": "pass", "producer": "test fixture",
+                                     "policy": "example build policy", "detail": "Fixture only.",
+                                     "evidence": ["evidence/build.json"]}]}
+
+    def run_report(self, current=None):
+        self.review_path.write_bytes(rr.encode(self.review))
+        (self.evidence_dir / "checks.json").write_bytes(rr.encode(self.manifest))
+        return rr.assemble(self.request_dir, current or self.request_dir,
+                           self.review_path, self.evidence_dir)
+
+    def report(self):
+        return rr.parse(self.run_report()["report.json"])
+
+    def finding(self, **changes):
+        return {"angle": "source-fidelity", "file": self.request["scope"][0],
+                "line": 7, "severity": "semantic", "message": "A direct source mismatch.",
+                "suggestion": "Match the cited bound.", "evidence": ["sources/paper.txt"], **changes}
+
+    def test_complete_advisory_report_is_deterministic(self):
+        first, second = self.run_report(), self.run_report()
+        self.assertEqual(first, second)
+        report = rr.parse(first["report.json"])
+        self.assertEqual(report["semantic_verdict"], "CLEAN")
+        self.assertEqual(report["authority_effect"], "none")
+        self.assertEqual(rr.parse(first["observation.json"])["report_sha256"], rr.digest(first["report.json"]))
+        self.assertIn("not independently authenticated", first["summary.md"].decode())
+
+    def test_missing_required_check_is_not_a_pass(self):
+        self.manifest["checks"] = []
+        report = self.report()
+        self.assertEqual(report["checks"][0]["status"], "not_run")
+        self.assertEqual(report["semantic_verdict"], "INCOMPLETE")
+
+    def test_fail_and_error_do_not_become_semantic_findings(self):
+        for status in ("fail", "error", "not_run"):
+            with self.subTest(status=status):
+                self.manifest["checks"][0]["status"] = status
+                report = self.report()
+                self.assertEqual(report["semantic_verdict"], "INCOMPLETE")
+                self.assertEqual(report["checks"][0]["status"], status)
+                self.assertEqual(report["review"]["findings"], [])
+
+    def test_confirmed_defect_survives_incomplete_coverage(self):
+        self.review["findings"] = [self.finding()]
+        self.review["coverage"]["statement-soundness"] = "incomplete"
+        report = self.report()
+        self.assertEqual(report["semantic_verdict"], "NEEDS REVISION")
+        self.assertEqual(report["completeness"], "incomplete")
+
+    def test_nit_and_question_precedence(self):
+        self.review["findings"] = [self.finding(severity="nit")]
+        self.assertEqual(self.report()["semantic_verdict"], "ACCEPT WITH NITS")
+        self.review["questions"] = ["Which version of the source is intended?"]
+        self.assertEqual(self.report()["semantic_verdict"], "INCOMPLETE")
+
+    def test_changed_head_procedure_or_source_makes_only_observation_stale(self):
+        original = self.run_report()
+        for field in ("head_commit", "procedure", "sources", "merge_base", "required_checks"):
+            with self.subTest(field=field):
+                current = copy.deepcopy(self.request)
+                inputs = dict(self.inputs)
+                if field in ("head_commit", "merge_base"):
+                    current[field] = "c" * 40
+                elif field == "required_checks":
+                    current[field].append("proof")
+                else:
+                    path = current[field][0]["path"]
+                    inputs[path] += b"changed\n"
+                    current[field] = rr.descriptors({path: inputs[path]})
+                current["id"] = rr.request_id(current)
+                folder = self.root / field
+                rr.write_directory(folder, inputs | {"request.json": rr.encode(current)})
+                changed = self.run_report(folder)
+                self.assertEqual(changed["report.json"], original["report.json"])
+                observation = rr.parse(changed["observation.json"])
+                self.assertEqual(observation["freshness"], "STALE")
+                self.assertEqual(observation["completeness"], "incomplete")
+
+    def test_old_results_cannot_attach_to_new_request(self):
+        self.review["request_id"] = "c" * 64
+        with self.assertRaisesRegex(rr.InputError, "another request"):
+            self.run_report()
+        self.review["request_id"] = self.request["id"]
+        self.manifest["request_id"] = "c" * 64
+        with self.assertRaisesRegex(rr.InputError, "another request"):
+            self.run_report()
+
+    def test_request_and_evidence_tampering_rejected(self):
+        (self.evidence_dir / "evidence/build.json").write_bytes(b"changed")
+        with self.assertRaisesRegex(rr.InputError, "digest mismatch"):
+            self.run_report()
+        (self.evidence_dir / "evidence/build.json").write_bytes(self.raw)
+        (self.request_dir / "procedure/SKILL.md").write_bytes(b"changed")
+        with self.assertRaisesRegex(rr.InputError, "digest mismatch"):
+            self.run_report()
+
+    def test_malformed_findings_and_unknown_fields_rejected(self):
+        baseline = copy.deepcopy(self.review)
+        for field, value in (("findings", "not an array"), ("verdict", "CLEAN"),
+                             ("questions", [True])):
+            with self.subTest(field=field):
+                self.review = copy.deepcopy(baseline)
+                self.review[field] = value
+                with self.assertRaises(rr.InputError):
+                    self.run_report()
+
+    def test_invalid_finding_locations_and_evidence_rejected(self):
+        for change in ({"line": True}, {"file": "outside.lean"}, {"evidence": []},
+                       {"evidence": ["invented.json"]}, {"severity": "approve"}):
+            with self.subTest(change=change):
+                self.review["findings"] = [self.finding(**change)]
+                with self.assertRaises(rr.InputError):
+                    self.run_report()
+
+    def test_duplicate_checks_and_missing_pass_evidence_rejected(self):
+        self.manifest["checks"] *= 2
+        with self.assertRaisesRegex(rr.InputError, "duplicate check"):
+            self.run_report()
+        self.manifest["checks"] = [self.manifest["checks"][0]]
+        self.manifest["checks"][0]["evidence"] = []
+        with self.assertRaisesRegex(rr.InputError, "evidence required"):
+            self.run_report()
+
+    def test_proof_policy_and_outcome_remain_visible(self):
+        self.manifest["checks"].append({"kind": "proof", "status": "pass", "producer": "test verifier",
+                                        "policy": "extra assumption H allowed", "detail": "Conditional fixture.",
+                                        "evidence": ["evidence/build.json"]})
+        files = self.run_report()
+        self.assertIn("extra assumption H allowed", files["summary.md"].decode())
+        self.assertNotIn("unconditional", files["summary.md"].decode())
+
+    def test_rereviews_require_retained_prior_context(self):
+        self.review["context_policy"] = "rereview"
+        with self.assertRaisesRegex(rr.InputError, "evidence required"):
+            self.run_report()
+        self.review["prior_reviews"] = ["evidence/build.json"]
+        self.assertEqual(self.report()["review"]["context_policy"], "rereview")
+        self.review["context_policy"] = "fresh"
+        with self.assertRaisesRegex(rr.InputError, "cannot carry"):
+            self.run_report()
+
+    def test_paths_symlinks_and_duplicate_json_keys_rejected(self):
+        for name in ("../secret", "/secret", "evidence/../secret", "evidence//file", "a\\b"):
+            with self.subTest(name=name), self.assertRaises(rr.InputError):
+                rr.relative(name)
+        path = self.evidence_dir / "evidence/build.json"
+        path.unlink()
+        path.symlink_to(self.request_dir / "sources/paper.txt")
+        with self.assertRaisesRegex(rr.InputError, "symlink"):
+            self.run_report()
+        for raw in ('{"a":1,"a":2}', '{"a":NaN}', '{"a":"\\ud800"}'):
+            with self.subTest(raw=raw), self.assertRaises(rr.InputError):
+                rr.parse(raw)
+
+    def test_render_escapes_findings_and_does_not_overwrite(self):
+        self.review["findings"] = [self.finding(message='<script> @someone [click](https://example.org)')]
+        files = self.run_report()
+        summary = files["summary.md"].decode()
+        self.assertNotIn('<script>', summary)
+        self.assertNotIn('@someone', summary)
+        self.assertNotIn('[click](', summary)
+        output = self.root / "report"
+        rr.write_directory(output, files)
+        with self.assertRaises(FileExistsError):
+            rr.write_directory(output, {"report.json": b"overwrite"})
+        self.assertEqual((output / "report.json").read_bytes(), files["report.json"])
+
+    def test_prepare_uses_committed_git_scope_and_excludes_eval_keys(self):
+        repo = self.root / "repo"
+        repo.mkdir()
+        def git(*args):
+            return subprocess.run(['git', '-C', str(repo), *args], check=True,
+                                  capture_output=True, text=True).stdout.strip()
+        git('init', '-q')
+        git('config', 'user.name', 'Test')
+        git('config', 'user.email', 'test@example.invalid')
+        (repo / 'Example.lean').write_text('base\n')
+        git('add', '.')
+        git('commit', '-qm', 'base')
+        base = git('rev-parse', 'HEAD')
+        (repo / 'Example.lean').write_text('PR\n')
+        git('commit', '-qam', 'PR')
+        (repo / 'untracked.txt').write_text('caller edit\n')
+        skill = self.request_dir / 'procedure'
+        (skill / 'evals').mkdir()
+        (skill / 'evals/key.json').write_text('private answer key')
+        files = rr.prepare(repo, 'owner/repo', base, skill, self.request_dir / 'sources', ['proof'])
+        request = rr.parse(files['request.json'])
+        self.assertEqual(request['scope'], ['Example.lean'])
+        self.assertEqual(request['head_commit'], git('rev-parse', 'HEAD'))
+        self.assertEqual(request['required_checks'], ['build', 'proof'])
+        self.assertNotIn('procedure/evals/key.json', files)
+        self.assertEqual((repo / 'untracked.txt').read_text(), 'caller edit\n')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Consolidated into #4899, **Add a review skill, reports and evaluation harness**. The report implementation and tests are included there; continue review on that PR.

---

Adds a local pilot for combining an FC semantic review with supplied build and proof evidence. Missing checks remain `not_run`; unavailable evidence cannot produce a complete review. This is the first report integration under #4394, alongside the review skill in #4899.

- `prepare` records the Git head, actual merge base, scope, review-procedure files and retained sources, excluding evaluation answer keys.
- `assemble` validates structured findings, input identity and artifact digests, then writes a deterministic advisory result and escaped Markdown summary.
- Current-state observations are separate: changing the head, procedure, source snapshot or required checks marks the summary stale without rewriting the original result.
- Confirmed semantic findings survive incomplete checks. A build/proof failure or execution error remains a check result and does not invent a semantic finding.
- Retains fresh/rereview context and optional dispositions for prior findings: retained, corrected or withdrawn. A withdrawal stays traceable without becoming a current defect or unresolved question.

This pilot validates supplied records, not producer authenticity or mathematical correctness. It does not execute models, Lean or external proof code, contact GitHub, publish reviews or change acceptance policy. It is a separate experimental operational format; it does not replace or claim compatibility with the older `formal-conjectures.pr-audit.v1` prototype. Authenticated producer adapters, isolated evidence execution and publication remain follow-ups.

Validation: all 45 repository script tests pass, including 19 report contract tests for stale inputs, missing checks, malformed findings, altered evidence, unsafe paths, outcome separation and output preservation. The CLI was exercised against current main `d33e35a5` (BSD change): with no semantic review or build supplied, it correctly produced `INCOMPLETE` / `not_run`. No Lean modules changed. This is contract validation, not an independent review-skill evaluation.

