### PR TITLE
feat: add Pfister's problem on the Pythagoras number of ℝ(X₁, …, Xₙ)

### DIFF
--- a/FormalConjectures/Paper/PfisterPythagorasNumber.lean
+++ b/FormalConjectures/Paper/PfisterPythagorasNumber.lean
@@ -1,0 +1,177 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Pfister's problem on the Pythagoras number of $\mathbb{R}(X_1, \dots, X_n)$
+
+The Pythagoras number $p(K)$ of a field $K$ is the least $p$ such that every sum of squares in
+$K$ is a sum of $p$ squares, i.e. the least element of `pythagorasBounds K`.
+
+Artin's solution of Hilbert's 17th problem shows that a positive semidefinite rational function
+in $\mathbb{R}(X_1, \dots, X_n)$ is a sum of squares, and Pfister showed that $2^n$ squares
+suffice ([Pfister1967, Theorem 1]; for the field, Corollary 1 of Theorem 2 in [Pfister1971]).
+Since sums of squares are positive semidefinite, $p(\mathbb{R}(X_1, \dots, X_n)) \le 2^n$
+[Pfister1995, p. 95].
+
+Problem 1 of [Pfister1971, §4] asks for the true value of $p(\mathbb{R}(X_1, \dots, X_n))$.
+The question is often posed as: is $p(\mathbb{R}(X_1, \dots, X_n)) = 2^n$, i.e. is Pfister's
+bound optimal? See e.g. [Benoist2017, Question 0.2].
+
+Problem 1 itself quotes the lower bound $n + 1 \le p(\mathbb{R}(X_1, \dots, X_n))$ from Cassels'
+theorem [Cassels1964]. For $n \ge 2$ the best known bounds are
+$n + 2 \le p(\mathbb{R}(X_1, \dots, X_n)) \le 2^n$ [Pfister1995, p. 97], where the lower bound
+follows from the Cassels–Ellison–Pfister theorem [CEP1971]. The bounds agree for $n = 2$, so the
+value is known for $n \le 2$ and open for every $n \ge 3$. The survey
+[MerkurjevParimala2025, §5.2] records the question as open even for $\mathbb{R}(X_1, X_2, X_3)$
+(Question 5.7).
+
+*References:*
+- [Pfister1971] A. Pfister, *Sums of squares in real function fields*, pp. 297–300 in Actes du
+  Congrès International des Mathématiciens, Tome 1 (Nice, 1970), Gauthier-Villars, 1971,
+  [IMU scan](https://www.mathunion.org/fileadmin/ICM/Proceedings/ICM1970.1/ICM1970.1.ocr.pdf).
+- [Pfister1967] A. Pfister, *Zur Darstellung definiter Funktionen als Summe von Quadraten*,
+  Invent. Math. 4 (1967), 229–237, [doi:10.1007/BF01425382](https://doi.org/10.1007/BF01425382).
+- [Cassels1964] J. W. S. Cassels, *On the representation of rational functions as sums of squares*,
+  Acta Arith. 9 (1964), 79–82, [doi:10.4064/aa-9-1-79-82](https://doi.org/10.4064/aa-9-1-79-82).
+- [Pfister1995] A. Pfister, *Quadratic forms with applications to algebraic geometry and
+  topology*, London Math. Soc. Lecture Note Ser. 217, Cambridge University Press, 1995.
+- [CEP1971] J. W. S. Cassels, W. J. Ellison, A. Pfister, *On sums of squares and on elliptic
+  curves over function fields*, J. Number Theory 3 (1971), 125–149,
+  [doi:10.1016/0022-314X(71)90030-8](https://doi.org/10.1016/0022-314X(71)90030-8).
+- [Benoist2017] O. Benoist, *On Hilbert's 17th problem in low degree*, Algebra Number Theory 11
+  (2017), 929–959, [doi:10.2140/ant.2017.11.929](https://doi.org/10.2140/ant.2017.11.929),
+  [arXiv:1602.07330](https://arxiv.org/abs/1602.07330).
+- [MerkurjevParimala2025] A. Merkurjev, R. Parimala, *Quadratic forms beyond arithmetic*, Notices
+  Amer. Math. Soc. 72 (2025), no. 7, 711–718,
+  [doi:10.1090/noti3192](https://doi.org/10.1090/noti3192).
+-/
+
+namespace PfisterPythagorasNumber
+
+/-- Every sum of squares in $\mathbb{R}$ is a square and $1$ is not a sum of zero squares, so
+$p(\mathbb{R}) = 1$. -/
+@[category test, AMS 11]
+theorem isLeast_pythagorasBounds_real : IsLeast (pythagorasBounds ℝ) 1 := by
+  refine ⟨fun a ha ↦ ⟨fun _ ↦ √a, ?_⟩, fun p hp ↦ ?_⟩
+  · simp [Real.mul_self_sqrt ha.nonneg]
+  · rcases Nat.eq_zero_or_pos p with rfl | h
+    · obtain ⟨f, hf⟩ := hp 1 IsSumSq.one
+      simp at hf
+    · exact h
+
+/--
+**Pfister's problem** (Problem 1 of [Pfister1971, §4]): what is the true value of
+$p(\mathbb{R}(X_1, \dots, X_n))$, as a function of $n$? It is $1$, $2$, $4$ for $n = 0, 1, 2$
+(`pfister_problem.variants.zero`, `pfister_problem.variants.one`, `pfister_problem.variants.two`)
+and open for every $n \ge 3$, where only the bounds
+$n + 2 \le p(\mathbb{R}(X_1, \dots, X_n)) \le 2^n$ are known.
+-/
+@[category research open, AMS 11 12 14]
+theorem pfister_problem :
+    let p : ℕ → ℕ := answer(sorry)
+    ∀ n, IsLeast (pythagorasBounds (MvRatFunc (Fin n) ℝ)) (p n) := by
+  sorry
+
+/--
+Pfister's problem in its common yes/no form (e.g. Question 0.2 of [Benoist2017]): is
+$p(\mathbb{R}(X_1, \dots, X_n)) = 2^n$ for every $n$, i.e. is Pfister's bound optimal? This
+holds for $n \le 2$ and is open for every $n \ge 3$.
+-/
+@[category research open, AMS 11 12 14]
+theorem pfister_problem.variants.eq_two_pow :
+    answer(sorry) ↔ ∀ n : ℕ, IsLeast (pythagorasBounds (MvRatFunc (Fin n) ℝ)) (2 ^ n) := by
+  sorry
+
+/--
+**Pfister's theorem**: every sum of squares in $\mathbb{R}(X_1, \dots, X_n)$ is a sum of $2^n$
+squares [Pfister1995, p. 95]; this is Corollary 1 of Theorem 2 in [Pfister1971]. For positive
+semidefinite polynomials it is [Pfister1967, Theorem 1], the quantitative refinement of Artin's
+theorem `Hilbert17.hilbert_17th_problem` in `FormalConjectures/HilbertProblems/17.lean`.
+-/
+@[category research solved, AMS 11 12 14]
+theorem pfister_problem.variants.upper_bound (n : ℕ) :
+    2 ^ n ∈ pythagorasBounds (MvRatFunc (Fin n) ℝ) := by
+  sorry
+
+/--
+**Cassels' theorem** [Cassels1964], as quoted in Problem 1 of [Pfister1971, §4]:
+$1 + X_1^2 + \dots + X_n^2$ is not a sum of $n$ squares in $\mathbb{R}(X_1, \dots, X_n)$.
+-/
+@[category research solved, AMS 11 12 14]
+theorem pfister_problem.variants.cassels (n : ℕ) :
+    ¬IsSumSqOfLength n (algebraMap (MvPolynomial (Fin n) ℝ) (MvRatFunc (Fin n) ℝ)
+      (1 + ∑ i, MvPolynomial.X i * MvPolynomial.X i)) := by
+  sorry
+
+/--
+The lower bound $n + 1 \le p(\mathbb{R}(X_1, \dots, X_n))$ quoted in Problem 1 of
+[Pfister1971, §4]: $1 + X_1^2 + \dots + X_n^2$ is a sum of $n + 1$ squares but, by Cassels'
+theorem `pfister_problem.variants.cassels`, not of $n$ squares. It is superseded by
+`pfister_problem.variants.lower_bound` for $n \ge 2$.
+-/
+@[category research solved, AMS 11 12 14]
+theorem pfister_problem.variants.add_one_le (n : ℕ) {p : ℕ}
+    (hp : p ∈ pythagorasBounds (MvRatFunc (Fin n) ℝ)) : n + 1 ≤ p := by
+  by_contra h
+  have hsq : IsSumSqOfLength (n + 1) (algebraMap (MvPolynomial (Fin n) ℝ) (MvRatFunc (Fin n) ℝ)
+      (1 + ∑ i, MvPolynomial.X i * MvPolynomial.X i)) :=
+    ⟨Fin.cons 1 fun i ↦ algebraMap (MvPolynomial (Fin n) ℝ) (MvRatFunc (Fin n) ℝ)
+      (MvPolynomial.X i), by simp [Fin.sum_univ_succ, map_sum]⟩
+  exact pfister_problem.variants.cassels n ((hp _ hsq.isSumSq).of_le (by omega))
+
+/--
+The lower bound $n + 2 \le p(\mathbb{R}(X_1, \dots, X_n))$ for $n \ge 2$ [Pfister1995, p. 97],
+a consequence of the Cassels–Ellison–Pfister theorem [CEP1971]. The hypothesis $n \ge 2$ is
+needed: $p(\mathbb{R}(X)) = 2 < 3$.
+-/
+@[category research solved, AMS 11 12 14]
+theorem pfister_problem.variants.lower_bound (n : ℕ) (hn : 2 ≤ n) {p : ℕ}
+    (hp : p ∈ pythagorasBounds (MvRatFunc (Fin n) ℝ)) : n + 2 ≤ p := by
+  sorry
+
+/--
+$p(\mathbb{R}(X_1, \dots, X_n)) = 1$ for $n = 0$, i.e. $p(\mathbb{R}) = 1$: here the bounds $n + 1$
+and $2^n$ of `pfister_problem.variants.add_one_le` and `pfister_problem.variants.upper_bound`
+agree. Compare `isLeast_pythagorasBounds_real`, the same value for `ℝ` itself.
+-/
+@[category textbook, AMS 11 12 14]
+theorem pfister_problem.variants.zero : IsLeast (pythagorasBounds (MvRatFunc (Fin 0) ℝ)) 1 :=
+  ⟨pfister_problem.variants.upper_bound 0,
+    fun _ hp ↦ pfister_problem.variants.add_one_le 0 hp⟩
+
+/--
+$p(\mathbb{R}(X)) = 2$ [Pfister1995, p. 96]: Pfister's bound gives $p \le 2$, and Cassels'
+theorem `pfister_problem.variants.cassels` gives $p \ge 2$ through
+`pfister_problem.variants.add_one_le`, since $1 + X^2$ is a sum of two squares that is not a
+square in $\mathbb{R}(X)$.
+-/
+@[category textbook, AMS 11 12 14]
+theorem pfister_problem.variants.one : IsLeast (pythagorasBounds (MvRatFunc (Fin 1) ℝ)) 2 :=
+  ⟨pfister_problem.variants.upper_bound 1,
+    fun _ hp ↦ pfister_problem.variants.add_one_le 1 hp⟩
+
+/--
+$p(\mathbb{R}(X_1, X_2)) = 4$ [CEP1971], as recorded in [Pfister1971, §4] and [Pfister1995, p. 96]:
+the bounds $n + 2$ and $2^n$ agree when $n = 2$.
+-/
+@[category research solved, AMS 11 12 14]
+theorem pfister_problem.variants.two : IsLeast (pythagorasBounds (MvRatFunc (Fin 2) ℝ)) 4 :=
+  ⟨pfister_problem.variants.upper_bound 2,
+    fun _ hp ↦ pfister_problem.variants.lower_bound 2 le_rfl hp⟩
+
+end PfisterPythagorasNumber

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -27,6 +27,7 @@ public import FormalConjecturesForMathlib.Algebra.Polynomial.Basic
 public import FormalConjecturesForMathlib.Algebra.Polynomial.HasseDeriv
 public import FormalConjecturesForMathlib.Algebra.Powerfree
 public import FormalConjecturesForMathlib.Algebra.QuadraticAlgebra.Instances
+public import FormalConjecturesForMathlib.Algebra.Ring.PythagorasNumber
 public import FormalConjecturesForMathlib.AlgebraicGeometry.ProjectiveSpace
 public import FormalConjecturesForMathlib.AlgebraicGeometry.VectorBundle
 public import FormalConjecturesForMathlib.Analysis.Asymptotics.Basic

--- a/FormalConjecturesForMathlib/Algebra/Ring/PythagorasNumber.lean
+++ b/FormalConjecturesForMathlib/Algebra/Ring/PythagorasNumber.lean
@@ -1,0 +1,105 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Algebra.Ring.SumsOfSquares
+
+@[expose] public section
+
+/-!
+# Pythagoras numbers
+
+The *Pythagoras number* $p(R)$ of $R$ is the least $p$ such that every sum of squares in $R$ is a
+sum of $p$ squares; see [Pfister1995] for fields and [CDLR1982] for rings. This file defines:
+
+* `IsSumSqOfLength n a`: `a` is a sum of `n` squares, a counted refinement of Mathlib's `IsSumSq`;
+* `pythagorasBounds R`: the set of `p` such that every sum of squares in `R` is a sum of `p`
+  squares.
+
+The Pythagoras number of `R` is `p` exactly when `IsLeast (pythagorasBounds R) p`. The set
+`pythagorasBounds R` can be empty, in which case the Pythagoras number is infinite; by [CDLR1982]
+this happens for $\mathbb{R}[X, Y]$. No numeric invariant is defined here, so that no convention
+for the infinite case is needed.
+
+The definitions and the correspondence with `IsSumSq` need only `[AddCommMonoid R] [Mul R]`; the
+`AddCommMonoid` is what the sum `∑ i : Fin n` requires, since `IsSumSq` itself assumes only
+`[Mul R] [Add R] [Zero R]`. Padding a sum of squares with zeros needs `0 * 0 = 0`, so
+`IsSumSqOfLength.of_le` and `mem_pythagorasBounds_of_le` are stated for a
+`NonUnitalNonAssocSemiring`.
+
+## References
+
+* [CDLR1982] M. D. Choi, Z. D. Dai, T. Y. Lam, B. Reznick, *The Pythagoras number of some
+  affine algebras and local algebras*, J. reine angew. Math. 336 (1982), 45–82.
+* [Pfister1995] A. Pfister, *Quadratic forms with applications to algebraic geometry and
+  topology*, London Math. Soc. Lecture Note Ser. 217, Cambridge University Press, 1995.
+-/
+
+variable {R : Type*}
+
+section AddCommMonoid
+
+variable [AddCommMonoid R] [Mul R]
+
+/-- `IsSumSqOfLength n a` means that `a` is a sum of `n` squares. -/
+def IsSumSqOfLength (n : ℕ) (a : R) : Prop :=
+  ∃ f : Fin n → R, a = ∑ i, f i * f i
+
+variable (R) in
+/-- The set of `p` such that every sum of squares in `R` is a sum of `p` squares. Its least
+element, when it exists, is the Pythagoras number of `R`. -/
+def pythagorasBounds : Set ℕ :=
+  {p | ∀ a : R, IsSumSq a → IsSumSqOfLength p a}
+
+theorem IsSumSqOfLength.isSumSq {n : ℕ} {a : R} (h : IsSumSqOfLength n a) : IsSumSq a := by
+  obtain ⟨f, rfl⟩ := h
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Fin.sum_univ_succ]
+    exact IsSumSq.sq_add (f 0) (ih fun i ↦ f i.succ)
+
+theorem IsSumSq.exists_isSumSqOfLength {a : R} (h : IsSumSq a) : ∃ n, IsSumSqOfLength n a := by
+  induction h with
+  | zero => exact ⟨0, fun _ ↦ 0, by simp⟩
+  | sq_add b _ ih =>
+    obtain ⟨n, f, hf⟩ := ih
+    refine ⟨n + 1, Fin.cons b f, ?_⟩
+    rw [Fin.sum_univ_succ]
+    simp [hf]
+
+theorem isSumSq_iff_exists_isSumSqOfLength {a : R} : IsSumSq a ↔ ∃ n, IsSumSqOfLength n a :=
+  ⟨IsSumSq.exists_isSumSqOfLength, fun ⟨_, h⟩ ↦ h.isSumSq⟩
+
+end AddCommMonoid
+
+section NonUnitalNonAssocSemiring
+
+variable [NonUnitalNonAssocSemiring R]
+
+/-- Padding with zeros: a sum of `p` squares is a sum of `q` squares for every `q ≥ p`. -/
+theorem IsSumSqOfLength.of_le {p q : ℕ} (hpq : p ≤ q) {a : R} (h : IsSumSqOfLength p a) :
+    IsSumSqOfLength q a := by
+  obtain ⟨f, rfl⟩ := h
+  obtain ⟨r, rfl⟩ := Nat.exists_eq_add_of_le hpq
+  exact ⟨Fin.append f 0, by simp [Fin.sum_univ_add]⟩
+
+theorem mem_pythagorasBounds_of_le {p q : ℕ} (hpq : p ≤ q) (hp : p ∈ pythagorasBounds R) :
+    q ∈ pythagorasBounds R :=
+  fun a ha ↦ (hp a ha).of_le hpq
+
+end NonUnitalNonAssocSemiring


### PR DESCRIPTION

Adds the open question of whether Pfister's bound $p(\mathbb{R}(X_1, \dots, X_n)) \le 2^n$ is
optimal. Problem 1 of Pfister's 1970 ICM address asks for the true value of
$p(\mathbb{R}(X_1, \dots, X_n))$; it is often posed as whether the bound $2^n$ is optimal (e.g.
Question 0.2 of Benoist, *On Hilbert's 17th problem in low degree*, Algebra Number Theory 11, 2017).

For $n \ge 2$ the known bounds are $n + 2 \le p(\mathbb{R}(X_1, \dots, X_n)) \le 2^n$. They
coincide for $n = 2$, so the value is known for $n \le 2$ and open for every $n \ge 3$.

**New in `FormalConjecturesForMathlib/Algebra/Ring/PythagorasNumber.lean`** (all proved, no
`sorry`): `IsSumSqOfLength n a` (a counted refinement of Mathlib's `IsSumSq`, stated with
`f i * f i` under `[AddCommMonoid R] [Mul R]` — the `AddCommMonoid` only for the `Finset` sum, since
`IsSumSq` itself needs just `[Mul R] [Add R] [Zero R]`), `pythagorasBounds R`
(the set of admissible lengths; the Pythagoras number is its least element, expressed as
`IsLeast (pythagorasBounds R) p`), and basic API (`isSumSq_iff_exists_isSumSqOfLength`, padding
lemma `IsSumSqOfLength.of_le`, `mem_pythagorasBounds_of_le`). No numeric invariant is defined, so
no convention for infinite Pythagoras number is needed. Mathlib has `IsSumSq` but nothing
counted.

**New in `FormalConjectures/Paper/PfisterPythagorasNumber.lean`:**
- `pfister_problem` (open): `let p : ℕ → ℕ := answer(sorry); ∀ n, IsLeast (pythagorasBounds ℝ(X₁..Xₙ)) (p n)`
  — Pfister's Problem 1 as he stated it ("what is the true value", for every `n`); the answer is
  hoisted as a closed function, following the repo's `let … := answer(sorry)` idiom, so no
  quantifier precedes `answer(sorry)`
- `.variants.eq_two_pow` (open): `answer(sorry) ↔ ∀ n, IsLeast (pythagorasBounds ℝ(X₁..Xₙ)) (2^n)`
  — the common yes/no form (e.g. Benoist's Question 0.2)
- `.variants.upper_bound` — Pfister's theorem (solved)
- `.variants.cassels` — Cassels' theorem: $1 + X_1^2 + \dots + X_n^2$ is not a sum of $n$ squares
  (solved; the bound quoted in Problem 1 itself)
- `.variants.add_one_le` — $n + 1 \le p$, proved from `.variants.cassels`
- `.variants.lower_bound` — $n + 2 \le p$ for $n \ge 2$, from Cassels–Ellison–Pfister (solved)
- `.variants.zero`, `.variants.one` — $p(\mathbb{R}(X_1, \dots, X_n)) = 1, 2$ for $n = 0, 1$
  (textbook), each proved from `.variants.upper_bound` and `.variants.add_one_le`
- `.variants.two` — $p(\mathbb{R}(X_1, X_2)) = 4$, proved from `.variants.upper_bound` and
  `.variants.lower_bound`
- a `test` computing `IsLeast (pythagorasBounds ℝ) 1` for `ℝ` itself — a different type from
  `MvRatFunc (Fin 0) ℝ` in `.variants.zero`, hence both

## Formalisation notes for reviewers

- Values are stated as `IsLeast (pythagorasBounds R) p` rather than through a numeric
  `pythagorasNumber`, so no `sInf ∅ = 0`-style convention is needed for rings of infinite
  Pythagoras number (e.g. `ℝ[X, Y]`, by Choi–Dai–Lam–Reznick).
- Both open statements range over all `n`, as Pfister and Benoist posed them; the values for
  `n ≤ 2` are known (and recorded as variants), so the open content is exactly `n ≥ 3`. In
  `pfister_problem` the unknown is a function `ℕ → ℕ`; in `.variants.eq_two_pow` it is a single
  yes/no, so both readings of the problem are present.
- `.variants.two` is proved from `.variants.upper_bound` and `.variants.lower_bound` rather than
  left as `sorry`, to record that it is a formal consequence of the two bounds.
- Filed under `Paper/` because the source of the problem is Pfister's 1971 ICM article (not on
  arXiv), read directly in the IMU's scan of the proceedings. Benoist (2017) and the 2025 Notices
  survey (vol. 72, no. 7) are cited as modern references for the standard formulation and the
  known bounds.

## How I checked it

- `lake --wfail build FormalConjecturesForMathlib FormalConjectures.Paper.PfisterPythagorasNumber`
  and `lake --wfail test` pass on current `main`; so does the full-project build. The problem
  file also elaborates under the `FormalConjecturesAnswerPostpone` target's
  `google.answer = postpone` setting (the mode `extract_names` uses for Prop-valued answer
  metadata). `extract_names` → `check_category_warnings.py` passes with
  `research_open_with_proof: 0`.
- `#print axioms` on every declaration: all `FormalConjecturesForMathlib` lemmas and the `test`
  depend only on `propext`, `Classical.choice`, `Quot.sound`; the research statements carry
  `sorryAx` as intended.
- Citation content was checked against primary sources: Pfister's §4 Problem 1 read verbatim in
  the IMU scan of the ICM proceedings; Benoist's Question 0.2; Pfister 1995 pp. 95–97 as cited by
  both Benoist and the Notices survey; Question 5.7 in §5.2 of that survey. Bibliographic
  metadata (volumes, pages, DOIs) was checked against Crossref/zbMATH.
- `scripts/mk_all_formathlib.sh` regenerates `FormalConjecturesForMathlib.lean` with exactly this
  one-line change.
- Both files are clean under Mathlib's style linters, and the `FormalConjecturesForMathlib`
  file's imports are minimal (each is needed).

## AI use

This formalization was produced using Claude Code; I also used Codex to review it.

Fixes #5342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
