### PR TITLE
Erdős 295: fix off-by-one in the definition of k(N)

### DIFF
--- a/FormalConjectures/ErdosProblems/295.lean
+++ b/FormalConjectures/ErdosProblems/295.lean
@@ -31,7 +31,7 @@ Helper lemma: for each $N$, there exists $k$ and $n_1 < ... < n_k$ such that
 $N ≤ n_1 < ⋯ < n_k$ with $\frac 1 {n_1} + ... + \frac 1 {n_k} = 1$.
 -/
 @[category textbook, AMS 5 11]
-lemma exists_k (N : ℕ) : ∃ (k : ℕ) (n : Fin k.succ → ℕ),
+lemma exists_k (N : ℕ) : ∃ (k : ℕ) (n : Fin k → ℕ),
     (∀ i, N ≤ n i) ∧ StrictMono n ∧ ∑ i, (1 / n i : ℝ) = 1 := by
   sorry
 


### PR DESCRIPTION
`exists_k` quantified over families indexed by `Fin k.succ`, so `Nat.find (exists_k N)` returned the minimal number of summands minus one (e.g. `k 1 = 0` and `k 2 = 2`, whereas the source has k(1) = 1 and k(2) = 3). Index by `Fin k` instead so that `k N` is the actual minimal number of unit fractions, matching the docstring and erdosproblems.com.

The two asymptotic statements are unaffected up to a constant shift, but the definition now means what it says.

identified by @tadamcz 