### PR TITLE
SpectralSets: require positive measure in spectralPair

### DIFF
--- a/FormalConjectures/Arxiv/2209.04540/SpectralSetsAndWeakTiling.lean
+++ b/FormalConjectures/Arxiv/2209.04540/SpectralSetsAndWeakTiling.lean
@@ -55,9 +55,13 @@ def productSet {n m : ℕ} (A : Set (Fin n → ℝ)) (B : Set (Fin m → ℝ)) :
   {x | (fun i ↦ x (Fin.castAdd m i)) ∈ A ∧ (fun j ↦ x (Fin.natAdd n j)) ∈ B}
 
 /-- Spectrality of a product with an `n`-dimensional convex body forces spectrality of its
-bounded, measurable `m`-dimensional right factor. -/
+bounded, measurable `m`-dimensional right factor.
+
+Following [KLM2023, §1.1], a convex body is a compact convex set with nonempty interior;
+Mathlib's `ConvexBody` does not require the latter, so it is imposed explicitly here. -/
 def spectralProductImpliesRightSpectral (n m : ℕ) : Prop :=
   ∀ (A : ConvexBody (Fin n → ℝ)) (B : Set (Fin m → ℝ)),
+    (interior (A : Set (Fin n → ℝ))).Nonempty →
     Bornology.IsBounded B → MeasurableSet B →
       isSpectral (productSet (A : Set (Fin n → ℝ)) B) → isSpectral B
 

--- a/FormalConjecturesForMathlib/Analysis/Fourier/SpectralSets.lean
+++ b/FormalConjecturesForMathlib/Analysis/Fourier/SpectralSets.lean
@@ -68,11 +68,15 @@ theorem exponentialCharacter_memLp {d : ℕ} {Ω : Set (Fin d → ℝ)}
     (MeasureTheory.integrableOn_const (μ := volume) (s := Ω) (C := (1 : ℝ)) hΩ_finite)
 
 /--
-(Ω, Λ) is called a spectral pair if Λ is a spectrum for Ω, i.e.
-a set Λ of frequencies such that the associated exponential characters
- form an orthogonal basis of L^2(Ω).
+(Ω, Λ) is called a spectral pair if Ω is a (Lebesgue) measurable set of positive finite
+measure and Λ is a spectrum for Ω, i.e. a set Λ of frequencies such that the associated
+exponential characters form an orthogonal basis of L^2(Ω).
+
+The positivity requirement matters: if Ω is a null set then L^2(Ω) is the zero space and
+every Λ would vacuously be a spectrum.
 -/
 def spectralPair {d : ℕ} (Ω Λ : Set (Fin d → ℝ)) : Prop :=
+  NullMeasurableSet Ω volume ∧ 0 < volume Ω ∧
   ∃ hΩ_finite : volume Ω ≠ ⊤,
     let e : (Fin d → ℝ) → MeasureTheory.Lp ℂ 2 (volume.restrict Ω) := fun ξ ↦
       MeasureTheory.MemLp.toLp (exponentialCharacter ξ) (exponentialCharacter_memLp hΩ_finite ξ)


### PR DESCRIPTION
`spectralPair Ω Λ` only required `volume Ω ≠ ⊤`. For a null set Ω the space L²(Ω) is zero, so every Λ (including ∅) is vacuously a spectrum and `isSpectral Ω` holds. The literature (KLM, arXiv:2209.04540 §1.1; Wikipedia) defines spectral sets only for measurable sets of positive finite measure.

This made the product problems in Arxiv/2209.04540 false as stated: Mathlib's `ConvexBody` allows the singleton `{0}`, whose product with any B is null and hence "spectral", so the statements asserted that every bounded measurable set is spectral (see #5228).

Fix: `spectralPair` now requires `NullMeasurableSet Ω volume` and `0 < volume Ω`. Additionally `spectralProductImpliesRightSpectral` requires the convex body to have nonempty interior, matching KLM's definition of a convex body.

Fixes #5228