### PR TITLE
Erdős 897: fix growth hypothesis, log-growth conclusion and additive …

### DIFF
--- a/FormalConjectures/ErdosProblems/897.lean
+++ b/FormalConjectures/ErdosProblems/897.lean
@@ -28,25 +28,38 @@ import FormalConjecturesUtil
 - [Wi81] E. Wirsing, Additive and completely additive functions with restricted growth.
   Recent progress in analytic number theory, Vol. 2 (Durham, 1979), 231--280 (1981).
 -/
--- TODO(lezeau): add `ArithmeticFunction.IsAdditive` to `ForMathlib`
+
+open Filter ArithmeticFunction
 
 namespace Erdos897
 
 /--
+The growth hypothesis $\limsup_{p,k} f(p^k)/\log(p^k) = \infty$ of [erdosproblems.com/897]:
+the normalised values $f(q)/\log q$ of $f$ are unbounded above as $q$ ranges over prime powers.
+
+The $\limsup$ is taken along prime powers $q = p^k \to \infty$, which allows a fixed prime with
+unbounded exponent (e.g. $q = 2^k$, as in [Ar25, Lemma 1]). It is *not* the joint limit
+$p, k \to \infty$, which would be a strictly stronger assumption.
+-/
+def LimsupPrimePowEqTop (f : ArithmeticFunction ℝ) : Prop :=
+  (atTop ⊓ 𝓟 {q : ℕ | IsPrimePow q}).limsup (fun q => (f q / Real.log q : EReal)) = ⊤
+
+/--
 Let $f(n)$ be an additive function (so that $f(ab)=f(a)+f(b)$
-if $(a,b)=1$ such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$.
+if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$.
 Is it true that $\limsup_n (f(n+1)−f(n))/ \log n = ∞$?
 
 The answer is no; this follows from a construction of Wirsing [Wi81], rediscovered by
-Archivara [Ar25] and formalised in Lean by Aristotle [ArWu25].
+Archivara [Ar25] and formalised in Lean by Aristotle [ArWu25]. The linked formalisation
+proves an earlier phrasing of this statement (with the growth hypothesis taken along
+$p, k \to \infty$ jointly); its counterexample satisfies the hypothesis as stated here as well,
+since $f(q)/\log q = \log^*(q)$ for every prime power $q$ [ArWu25, Lemma 1].
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at
   "https://github.com/plby/lean-proofs/blob/main/src/v4.24.0/ErdosProblems/Erdos897.lean"]
-theorem erdos_897.parts.i : answer(False) ↔ ∀ (f : ℕ → ℝ),
-    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
-    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
-      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
+theorem erdos_897.parts.i : answer(False) ↔ ∀ (f : ArithmeticFunction ℝ),
+    f.IsAdditive → LimsupPrimePowEqTop f →
+    atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
   sorry
 
 /--
@@ -54,15 +67,14 @@ Let $f(n)$ be an additive function (so that $f(ab)=f(a)+f(b)$
 if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$.
 Is it true that $\limsup_n f(n+1)/ f(n) = ∞$?
 
-The answer is no; the same counterexample is formalised in Lean by Aristotle [ArWu25].
+The answer is no; the same counterexample is formalised in Lean by Aristotle [ArWu25]
+(see the remark in `erdos_897.parts.i` about the phrasing of the growth hypothesis).
 -/
 @[category research solved, AMS 11, formal_proof using lean4 at
   "https://github.com/plby/lean-proofs/blob/main/src/v4.24.0/ErdosProblems/Erdos897.lean"]
-theorem erdos_897.parts.ii : answer(False) ↔ ∀ (f : ℕ → ℝ),
-    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
-    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
-      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
+theorem erdos_897.parts.ii : answer(False) ↔ ∀ (f : ArithmeticFunction ℝ),
+    f.IsAdditive → LimsupPrimePowEqTop f →
+    atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
   sorry
 
 /--
@@ -71,48 +83,44 @@ $c$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_897.variants.log_growth
-    (f : ℕ → ℝ)
-    (hf : ∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b)
+    (f : ArithmeticFunction ℝ) (hf : f.IsAdditive)
     (C : ℝ) (hf' : ∀ n, |f (n+1) - f n| ≤ C) :
-    ∃ c, ∃ (O : ℕ → ℝ), O =O[Filter.atTop] (1 : ℕ → ℝ) ∧
-      ∀ n, f n ≤ c*Real.log n + O n := by
+    ∃ c, ∃ (O : ℕ → ℝ), O =O[atTop] (1 : ℕ → ℝ) ∧
+      ∀ n, f n = c*Real.log n + O n := by
   sorry
-
 
 /--
 Let $f(n)$ be an additive function (so that $f(ab)=f(a)+f(b)$
-if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$ and $f(p^k) = f(p)$
-or $f(p^k) = kf(p)$.
+if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$.
+Assume moreover that $f(p^k) = f(p)$ for all primes $p$ and $k \geq 1$ (i.e. $f$ is strongly
+additive), or that $f(p^k) = kf(p)$ for all primes $p$ and $k$ (i.e. $f$ is completely additive).
 Is it true that $\limsup_n (f(n+1)−f(n))/ \log n = ∞$?
 
 The known counterexample does not satisfy either of these extra hypotheses, so this variant remains
 open.
 -/
 @[category research open, AMS 11]
-theorem erdos_897.variants.parts.i : answer(sorry) ↔ ∀ (f : ℕ → ℝ),
-    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
-    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
-      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
-    (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
-    Filter.atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
+theorem erdos_897.variants.parts.i : answer(sorry) ↔ ∀ (f : ArithmeticFunction ℝ),
+    f.IsAdditive → LimsupPrimePowEqTop f →
+    (f.IsStronglyAdditive ∨ f.IsCompletelyAdditive) →
+    atTop.limsup (fun (n : ℕ) => ((f (n+1) - f n) / (n : ℝ).log : EReal)) = ⊤ := by
   sorry
 
 /--
 Let $f(n)$ be an additive function (so that $f(ab)=f(a)+f(b)$
-if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$ and $f(p^k) = f(p)$
-or $f(p^k) = kf(p)$.
+if $(a,b)=1$) such that $\limsup_{p,k} f(p^k) / \log(p^k) = ∞$.
+Assume moreover that $f(p^k) = f(p)$ for all primes $p$ and $k \geq 1$ (i.e. $f$ is strongly
+additive), or that $f(p^k) = kf(p)$ for all primes $p$ and $k$ (i.e. $f$ is completely additive).
 Is it true that $\limsup_n f(n+1)/f(n) = ∞$?
 
 The known counterexample does not satisfy either of these extra hypotheses, so this variant remains
 open.
 -/
 @[category research open, AMS 11]
-theorem erdos_897.variants.parts.ii : answer(sorry) ↔ ∀ (f : ℕ → ℝ),
-    (∀ᵉ (a > 0) (b > 0), a.Coprime b → f (a * b) = f a + f b) →
-    ((Filter.atTop ⊓ Filter.principal {(p, k) : ℕ × ℕ | p.Prime}).limsup
-      (fun (p, k) => (f (p^k) / (p^k : ℝ).log : EReal)) = ⊤) →
-    (∀ k p, p.Prime → f (p^k) = f p) ∨ (∀ (k p : ℕ), p.Prime → f (p^k) = k*f p) →
-    Filter.atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
+theorem erdos_897.variants.parts.ii : answer(sorry) ↔ ∀ (f : ArithmeticFunction ℝ),
+    f.IsAdditive → LimsupPrimePowEqTop f →
+    (f.IsStronglyAdditive ∨ f.IsCompletelyAdditive) →
+    atTop.limsup (fun (n : ℕ) => (f (n+1) / f n : EReal)) = ⊤ := by
   sorry
 
 end Erdos897

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -142,6 +142,7 @@ public import FormalConjecturesForMathlib.NumberTheory.AdditiveComplement
 public import FormalConjecturesForMathlib.NumberTheory.AdditivelyComplete
 public import FormalConjecturesForMathlib.NumberTheory.AlmostPrime
 public import FormalConjecturesForMathlib.NumberTheory.Amicable
+public import FormalConjecturesForMathlib.NumberTheory.ArithmeticFunction.Additive
 public import FormalConjecturesForMathlib.NumberTheory.BeurlingPrimes
 public import FormalConjecturesForMathlib.NumberTheory.Carmichael
 public import FormalConjecturesForMathlib.NumberTheory.CoveringSystem

--- a/FormalConjecturesForMathlib/NumberTheory/ArithmeticFunction/Additive.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/ArithmeticFunction/Additive.lean
@@ -1,0 +1,112 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.NumberTheory.ArithmeticFunction.Defs
+
+@[expose] public section
+
+/-!
+# Additive arithmetic functions
+
+An arithmetic function `f` is *additive* if `f 1 = 0` and `f (m * n) = f m + f n` whenever `m`
+and `n` are coprime, *completely additive* if the latter holds for all nonzero `m` and `n`, and
+*strongly additive* if it is additive and `f (p ^ k) = f p` for every prime `p` and every `k ≠ 0`.
+
+These are the additive counterparts of `ArithmeticFunction.IsMultiplicative`, and follow the
+same conventions: as there, the value at `1` is part of the definition.
+-/
+
+namespace ArithmeticFunction
+
+variable {R : Type*} [AddMonoid R]
+
+/-- Additive functions -/
+def IsAdditive (f : ArithmeticFunction R) : Prop :=
+  f 1 = 0 ∧ ∀ {m n : ℕ}, m.Coprime n → f (m * n) = f m + f n
+
+/-- Completely additive functions -/
+def IsCompletelyAdditive (f : ArithmeticFunction R) : Prop :=
+  f 1 = 0 ∧ ∀ {m n : ℕ}, m ≠ 0 → n ≠ 0 → f (m * n) = f m + f n
+
+/-- Strongly additive functions: additive functions with `f (p ^ k) = f p` for every prime `p`
+and every `k ≠ 0`. -/
+def IsStronglyAdditive (f : ArithmeticFunction R) : Prop :=
+  f.IsAdditive ∧ ∀ {p k : ℕ}, p.Prime → k ≠ 0 → f (p ^ k) = f p
+
+namespace IsAdditive
+
+variable {f : ArithmeticFunction R}
+
+@[simp]
+theorem map_one (h : f.IsAdditive) : f 1 = 0 :=
+  h.1
+
+@[simp]
+theorem map_mul_of_coprime (hf : f.IsAdditive) {m n : ℕ} (h : m.Coprime n) :
+    f (m * n) = f m + f n :=
+  hf.2 h
+
+end IsAdditive
+
+namespace IsCompletelyAdditive
+
+variable {f : ArithmeticFunction R}
+
+@[simp]
+theorem map_one (h : f.IsCompletelyAdditive) : f 1 = 0 :=
+  h.1
+
+theorem map_mul (hf : f.IsCompletelyAdditive) {m n : ℕ} (hm : m ≠ 0) (hn : n ≠ 0) :
+    f (m * n) = f m + f n :=
+  hf.2 hm hn
+
+theorem isAdditive (hf : f.IsCompletelyAdditive) : f.IsAdditive := by
+  refine ⟨hf.map_one, fun {m n} hmn => ?_⟩
+  rcases eq_or_ne m 0 with rfl | hm
+  · rw [Nat.coprime_zero_left] at hmn
+    simp [hmn, hf.map_one]
+  rcases eq_or_ne n 0 with rfl | hn
+  · rw [Nat.coprime_zero_right] at hmn
+    simp [hmn, hf.map_one]
+  exact hf.map_mul hm hn
+
+theorem map_pow (hf : f.IsCompletelyAdditive) {m : ℕ} (hm : m ≠ 0) (k : ℕ) :
+    f (m ^ k) = k • f m := by
+  induction k with
+  | zero => simp [hf.map_one]
+  | succ k ih => rw [pow_succ, hf.map_mul (pow_ne_zero _ hm) hm, ih, succ_nsmul]
+
+theorem map_prime_pow (hf : f.IsCompletelyAdditive) {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    f (p ^ k) = k • f p :=
+  hf.map_pow hp.ne_zero k
+
+end IsCompletelyAdditive
+
+namespace IsStronglyAdditive
+
+variable {f : ArithmeticFunction R}
+
+theorem isAdditive (hf : f.IsStronglyAdditive) : f.IsAdditive :=
+  hf.1
+
+theorem map_prime_pow (hf : f.IsStronglyAdditive) {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
+    f (p ^ k) = f p :=
+  hf.2 hp hk
+
+end IsStronglyAdditive
+
+end ArithmeticFunction


### PR DESCRIPTION
…variants

Add `ArithmeticFunction.IsAdditive`, `IsCompletelyAdditive` and `IsStronglyAdditive` to ForMathlib (resolving the TODO in 897.lean) with basic API, and restate Erdős 897 in terms of them.

Fixes in 897.lean:
- The growth hypothesis limsup f(p^k)/log(p^k) = ∞ was taken along the product filter on (p, k), forcing p and k to grow jointly. The source means the limsup over prime powers q = p^k → ∞ (e.g. along q = 2^k). Now a single local definition `LimsupPrimePowEqTop` used by all four statements.
- `variants.log_growth` concluded f n ≤ c log n + O(1); Wirsing's theorem is an equality with bounded error.
- The "strongly additive" disjunct in both variants quantified over k = 0, so with additivity it forced f p = 0 on all primes and the disjunct was vacuous. Now `IsStronglyAdditive` (k ≥ 1) or `IsCompletelyAdditive`.

identified by @tadamcz running an AI pipeline: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/897