### PR TITLE
fix: Ramsey size linear

### DIFF
--- a/FormalConjectures/ErdosProblems/566.lean
+++ b/FormalConjectures/ErdosProblems/566.lean
@@ -31,7 +31,7 @@ open SimpleGraph
 
 /--
 Let $G$ be such that any subgraph on $k$ vertices has at most $2k-3$ edges.
-Is it true that, if $H$ has $m$ edges and no isolated vertices, then $\hat{r}(G,H) \ll m$?
+Is it true that, if $H$ has $m$ edges and no isolated vertices, then $R(G,H) \ll m$?
 
 In other words: if $G$ is sparse (every induced subgraph on $k$ vertices has $≤ 2k-3$ edges),
 is $G$ Ramsey size linear?
@@ -41,12 +41,7 @@ theorem erdos_566 : answer(sorry) ↔
     ∀ (p : ℕ) (G : SimpleGraph (Fin p)),
       -- G is sparse: every induced subgraph on k ≥ 2 vertices has ≤ 2k - 3 edges
       (∀ S : Finset (Fin p), 2 ≤ S.card → (G.induce S).edgeSet.ncard ≤ 2 * S.card - 3) →
-      -- Then G is Ramsey size linear
-      ∃ c > (0 : ℝ), ∀ (n : ℕ) (H : SimpleGraph (Fin n)) [DecidableRel H.Adj],
-        -- H has no isolated vertices
-        (∀ v, 0 < H.degree v) →
-        -- r̂(G,H) ≤ c · m
-        (sizeRamsey G H : ℝ) ≤ c * H.edgeSet.ncard := by
+      IsRamseySizeLinear G := by
   sorry
 
 end Erdos566

--- a/FormalConjectures/ErdosProblems/567.lean
+++ b/FormalConjectures/ErdosProblems/567.lean
@@ -21,7 +21,7 @@ import FormalConjecturesUtil
 
 Let $G$ be either $Q_3$ or $K_{3,3}$ or $H_5$ (the last formed by adding two vertex-disjoint chords
 to $C_5$). Is it true that, if $H$ has $m$ edges and no isolated vertices, then
-$$ \hat{r}(G,H) \ll m? $$
+$$ R(G,H) \ll m? $$
 
 In other words, is $G$ Ramsey size linear? A special case of Problem 566.
 

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Ramsey.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Ramsey.lean
@@ -17,6 +17,9 @@ module
 
 public import Mathlib.Combinatorics.SimpleGraph.Basic
 public import Mathlib.Combinatorics.SimpleGraph.Copy
+public import Mathlib.Data.Real.Basic
+public import Mathlib.Data.Set.Card
+public import Mathlib.Order.Lattice.Nat
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.EdgeColouring
 
 @[expose] public section
@@ -34,6 +37,14 @@ The Erdős–Hajnal "exceptional pair" trio of predicates:
 
 These were introduced for Erdős Problem 596 but are reusable for Problem 595 and other
 Ramsey-type questions; we factor them out per mo271's review.
+
+It also defines the two-colour graph Ramsey number `graphRamsey G H` and the notion of a
+**Ramsey size linear** graph `IsRamseySizeLinear G` of Erdős, Faudree, Rousseau and Schelp.
+
+## References
+
+* Erdős, Faudree, Rousseau and Schelp, *Ramsey size linear graphs*,
+  Combin. Probab. Comput. 2 (1993), 389–399.
 -/
 
 namespace SimpleGraph
@@ -64,5 +75,30 @@ property and the countable Ramsey escape property. -/
 def IsErdosHajnalExceptional {U₁ U₂ : Type*}
     (G₁ : SimpleGraph U₁) (G₂ : SimpleGraph U₂) : Prop :=
   HasFiniteRamseyProperty G₁ G₂ ∧ HasCountableRamseyEscape G₁ G₂
+
+/--
+The two-color Ramsey number `graphRamsey G H` is the minimum number of vertices `n`
+such that every 2-coloring of the edges of the complete graph on `n` vertices contains
+a copy of `G` in the first color or a copy of `H` in the second color.
+
+A 2-coloring of the complete graph on `Fin n` is represented by a graph `C` (the edges of the
+first color) and its complement `Cᶜ` (the edges of the second color).
+-/
+noncomputable def graphRamsey {α β : Type*} [Fintype α] [Fintype β]
+    (G : SimpleGraph α) (H : SimpleGraph β) : ℕ :=
+  sInf { n : ℕ | ∀ (C : SimpleGraph (Fin n)), G.IsContained C ∨ H.IsContained Cᶜ }
+
+/--
+A graph `G` is **Ramsey size linear** if there exists a constant `c > 0` such that
+for all graphs `H` with `m` edges and no isolated vertices, the Ramsey number satisfies
+`R(G, H) ≤ c · m`.
+
+Note that this is about the (vertex) Ramsey number `graphRamsey G H`, not the size Ramsey
+number `sizeRamsey G H`.
+-/
+def IsRamseySizeLinear {α : Type*} [Fintype α] (G : SimpleGraph α) : Prop :=
+  ∃ c > (0 : ℝ), ∀ (n : ℕ) (H : SimpleGraph (Fin n)) [DecidableRel H.Adj],
+    (∀ v, 0 < H.degree v) →
+    (graphRamsey G H : ℝ) ≤ c * H.edgeSet.ncard
 
 end SimpleGraph

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SizeRamsey.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/SizeRamsey.lean
@@ -16,7 +16,6 @@ limitations under the License.
 module
 
 public import Mathlib.Combinatorics.SimpleGraph.Copy
-public import Mathlib.Data.Real.Basic
 public import Mathlib.Data.Set.Card
 public import Mathlib.Order.Lattice.Nat
 
@@ -47,14 +46,5 @@ noncomputable def sizeRamsey {α β : Type*} [Fintype α] [Fintype β]
     F.edgeSet.ncard = m ∧
     ∀ (R : SimpleGraph (Fin n)), R ≤ F →
       G.IsContained R ∨ H.IsContained (F \ R) }
-
-/--
-A graph `G` is **Ramsey size linear** if there exists a constant `c > 0` such that
-for all graphs `H` with `m` edges and no isolated vertices, `r̂(G, H) ≤ c · m`.
--/
-def IsRamseySizeLinear {α : Type*} [Fintype α] (G : SimpleGraph α) : Prop :=
-  ∃ c > (0 : ℝ), ∀ (n : ℕ) (H : SimpleGraph (Fin n)) [DecidableRel H.Adj],
-    (∀ v, 0 < H.degree v) →
-    (sizeRamsey G H : ℝ) ≤ c * H.edgeSet.ncard
 
 end SimpleGraph


### PR DESCRIPTION
Ramsey size linear: use the Ramsey number, not the size Ramsey number
`IsRamseySizeLinear G` bounded the size Ramsey number r̂(G, H) (minimum
number of edges of a host graph) linearly in e(H). The notion of Erdős,
Faudree, Rousseau and Schelp, and the statements of Erdős problems 566
and 567 on erdosproblems.com, bound the ordinary Ramsey number R(G, H)
(minimum number of vertices of the host). The two are not equivalent:
K₃ is Ramsey size linear, but r̂(K₃, K_{1,t}) grows quadratically in t.

identified by @tadamcz running an AI pipeline: https://tadamcz.com/fc-review-results/#/f/ForMathlib/Combinatorics/SimpleGraph/SizeRamsey
