### PR TITLE
Kaplansky: use ordinary torsion-freeness, not IsMulTorsionFree

### DIFF
--- a/FormalConjectures/Wikipedia/Kaplansky.lean
+++ b/FormalConjectures/Wikipedia/Kaplansky.lean
@@ -20,10 +20,14 @@ import FormalConjecturesUtil
 # Kaplansky's Conjectures
 
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Kaplansky%27s_conjectures)
+
+Throughout, "torsion-free" means that the identity is the only element of finite order
+(`Monoid.IsTorsionFree`). This is weaker than Mathlib's `IsMulTorsionFree`, which asks for
+uniqueness of roots and fails for the Promislow group below.
 -/
 
 variable (K : Type*) [Field K]
-variable (G : Type*) [Group G] (hG : IsMulTorsionFree G)
+variable (G : Type*) [Group G] (hG : Monoid.IsTorsionFree G)
 include hG
 
 namespace Kaplansky
@@ -78,7 +82,7 @@ The Promislow group is torsion-free.
 -/
 @[category API, AMS 20]
 lemma promislow_group_is_torsionfree :
-    IsMulTorsionFree PromislowGroup := by
+    Monoid.IsTorsionFree PromislowGroup := by
   sorry
 
 /--
@@ -107,7 +111,7 @@ At least there is a counterexample for any prime and zero characteristic:
 -/
 @[category research solved, AMS 16 20]
 theorem counter_unit_conjecture :
-    ∃ (G : Type) (_ : Group G) (_ : IsMulTorsionFree G),
+    ∃ (G : Type) (_ : Group G) (_ : Monoid.IsTorsionFree G),
     ∀ (p : ℕ) (_ : p = 0 ∨ p.Prime),
     ∃ (K : Type) (_ : Field K) (_ :  CharP K p) (u : (MonoidAlgebra K G)ˣ), ¬IsTrivialUnit u.val :=
   ⟨PromislowGroup, _, promislow_group_is_torsionfree, fun p hp ↦
@@ -119,7 +123,7 @@ There is a counterexample to **Unit Conjecture** in any characteristic.
 -/
 @[category research solved, AMS 16 20]
 theorem counter_unit_conjecture_weak (p : ℕ) (hp : p = 0 ∨ p.Prime) :
-    ∃ (G : Type) (_ : Group G) (_ : IsMulTorsionFree G)
+    ∃ (G : Type) (_ : Group G) (_ : Monoid.IsTorsionFree G)
       (K : Type) (_ : Field K) (_ :  CharP K p) (u : (MonoidAlgebra K G)ˣ), ¬IsTrivialUnit u.val :=
   have ⟨G, _, _, hG⟩ := counter_unit_conjecture
   ⟨G, _, ‹_›, hG p hp⟩

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -132,6 +132,7 @@ public import FormalConjecturesForMathlib.Geometry.Euclidean
 public import FormalConjecturesForMathlib.Geometry.Metric
 public import FormalConjecturesForMathlib.Geometry.«2d»
 public import FormalConjecturesForMathlib.Geometry.«3d»
+public import FormalConjecturesForMathlib.GroupTheory.Torsion
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util
 public import FormalConjecturesForMathlib.LinearAlgebra.AffineSpace.Simplex.Basic
 public import FormalConjecturesForMathlib.LinearAlgebra.GeneralLinearGroup

--- a/FormalConjecturesForMathlib/GroupTheory/Torsion.lean
+++ b/FormalConjecturesForMathlib/GroupTheory/Torsion.lean
@@ -1,0 +1,75 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.GroupTheory.OrderOfElement
+
+@[expose] public section
+
+/-!
+# Torsion-free monoids
+
+This file defines `Monoid.IsTorsionFree G`, the predicate saying that `1` is the only element of
+finite order in `G`.
+
+Mathlib's `IsMulTorsionFree G` asks instead that `a ↦ a ^ n` be injective for every `n ≠ 0`
+(uniqueness of roots). The two notions agree for commutative groups
+(`isMulTorsionFree_iff_not_isOfFinOrder`), but for noncommutative groups `IsMulTorsionFree` is
+strictly stronger: the Klein bottle group `⟨a, b | b⁻¹ab = a⁻¹⟩` is torsion-free, yet
+`(ab)² = b²` with `ab ≠ b`. Statements about torsion-free groups in the literature, such as
+Kaplansky's conjectures on group rings, use the weaker notion defined here.
+-/
+
+variable {G : Type*}
+
+/-- A predicate on a monoid saying that only `1` has finite order. -/
+@[to_additive /-- A predicate on an additive monoid saying that only `0` has finite order. -/]
+def Monoid.IsTorsionFree (G : Type*) [Monoid G] : Prop :=
+  ∀ g : G, g ≠ 1 → ¬IsOfFinOrder g
+
+namespace Monoid.IsTorsionFree
+
+variable [Monoid G]
+
+@[to_additive]
+theorem eq_one_of_isOfFinOrder (hG : Monoid.IsTorsionFree G) {g : G} (hg : IsOfFinOrder g) :
+    g = 1 :=
+  by_contra fun h ↦ hG g h hg
+
+@[to_additive]
+theorem isOfFinOrder_iff_eq_one (hG : Monoid.IsTorsionFree G) {g : G} :
+    IsOfFinOrder g ↔ g = 1 :=
+  ⟨hG.eq_one_of_isOfFinOrder, fun h ↦ h ▸ IsOfFinOrder.one⟩
+
+end Monoid.IsTorsionFree
+
+@[to_additive]
+theorem Monoid.isTorsionFree_iff_forall_isOfFinOrder_imp_eq_one [Monoid G] :
+    Monoid.IsTorsionFree G ↔ ∀ g : G, IsOfFinOrder g → g = 1 :=
+  ⟨fun hG _ ↦ hG.eq_one_of_isOfFinOrder, fun h g hg hfin ↦ hg (h g hfin)⟩
+
+/-- Uniqueness of roots implies torsion-freeness. -/
+@[to_additive /-- Uniqueness of roots implies torsion-freeness. -/]
+theorem Monoid.IsTorsionFree.of_isMulTorsionFree [Monoid G] [IsMulTorsionFree G] :
+    Monoid.IsTorsionFree G :=
+  fun _ hg ↦ not_isOfFinOrder_of_isMulTorsionFree hg
+
+/-- For commutative groups, torsion-freeness is equivalent to uniqueness of roots. -/
+@[to_additive /-- For additive commutative groups, torsion-freeness is equivalent to uniqueness
+of roots. -/]
+theorem Monoid.isTorsionFree_iff_isMulTorsionFree [CommGroup G] :
+    Monoid.IsTorsionFree G ↔ IsMulTorsionFree G :=
+  isMulTorsionFree_iff_not_isOfFinOrder.symm

--- a/FormalConjecturesForMathlib/GroupTheory/Torsion.lean
+++ b/FormalConjecturesForMathlib/GroupTheory/Torsion.lean
@@ -31,6 +31,8 @@ Mathlib's `IsMulTorsionFree G` asks instead that `a ↦ a ^ n` be injective for 
 strictly stronger: the Klein bottle group `⟨a, b | b⁻¹ab = a⁻¹⟩` is torsion-free, yet
 `(ab)² = b²` with `ab ≠ b`. Statements about torsion-free groups in the literature, such as
 Kaplansky's conjectures on group rings, use the weaker notion defined here.
+
+TODO(mo271): refactor after https://github.com/leanprover-community/mathlib4/pull/43727 lands
 -/
 
 variable {G : Type*}


### PR DESCRIPTION
Kaplansky's conjectures concern torsion-free groups: the identity is the only element of finite order. The file used Mathlib's `IsMulTorsionFree`, which requires `a ↦ a ^ n` to be injective for all `n ≠ 0` (uniqueness of roots). The two agree for commutative groups but `IsMulTorsionFree` is strictly stronger in general, and the Promislow group P fails it: `(a²b)² = b²` with `a²b ≠ b`. So `promislow_group_is_torsionfree` was false, the two `counter_unit_conjecture` statements asserted more than the cited results, and the two open conjectures were stated only for a subclass of the intended groups.

The file originally used `Monoid.IsTorsionFree`, which Mathlib later deprecated in favour of `IsMulTorsionFree` (#24311) and removed; the toolchain bump silently strengthened the hypothesis. Mathlib currently has no predicate for ordinary torsion-freeness of noncommutative groups, so this reintroduces `Monoid.IsTorsionFree` (with `to_additive`) in ForMathlib, following the former Mathlib definition, together with the implication from `IsMulTorsionFree` and the equivalence for commutative groups.

identified by @tadamcz running an AI pipeline: https://tadamcz.com/fc-review-results/#/f/Wikipedia/Kaplansky