### PR TITLE
fix(OEIS): disprove the A067857 sign conjecture

### DIFF
--- a/FormalConjectures/OEIS/67857.lean
+++ b/FormalConjectures/OEIS/67857.lean
@@ -25,7 +25,9 @@ $$a(n) = n! \sum_{d \mid n} \mu(n/d) H_d$$
 where $H_d = \sum_{j=1}^d \frac{1}{j}$ is the $d$-th harmonic number.
 
 *References:*
-- [A067857](https://oeis.org/A067857)-/
+- [A067857](https://oeis.org/A067857)
+- [A001221](https://oeis.org/A001221)
+-/
 
 namespace OeisA67857
 
@@ -66,10 +68,19 @@ theorem a_5 : a 5 = 154 := by
 /--
 The terms are not all positive. The first negative one is
 $a(30) = -22690644647302814715858124800000$.
-Conjecture: $a(n) < 0$ if and only if A001221(n) is an odd number $\ge 3$.-/
-@[category research open, AMS 11]
-theorem conjecture (n : ℕ) (hn : 0 < n) :
-    a n < 0 ↔ Odd (cardDistinctFactors n) ∧ 3 ≤ cardDistinctFactors n := by
+Conjecture: $a(n) < 0$ if and only if A001221(n) is an odd number $\ge 3$.
+
+This conjecture is false. A counterexample is the product of all primes at most $1000$,
+which has $168$ distinct prime factors and a negative sequence value.
+
+The counterexample and formal proof were developed by Codex (GPT-6),
+prompted by Samuel Schlesinger.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/SamuelSchlesinger/a067857-counterexample/blob/44317ddb5bd735f7a1f6764c22db10c455e4b584/Counterexample.lean#L89-L92"]
+theorem conjecture :
+    answer(False) ↔ ∀ n : ℕ, 0 < n →
+      (a n < 0 ↔ Odd (cardDistinctFactors n) ∧ 3 ≤ cardDistinctFactors n) := by
   sorry
 
 end OeisA67857


### PR DESCRIPTION
Disprove the A067857 sign conjecture: the product of all primes at most 1000 has 168 distinct prime factors, yet its sequence value is negative. Record `answer(False)` and link the Lean proof.

The counterexample and formal proof were developed by Codex (GPT-6), prompted by Samuel Schlesinger. The proof uses only standard Lean axioms, and the changed module passes `lake --wfail build`.
