### PR TITLE
ErdosProblems/548: sync solved status and link formal proof

### DIFF
--- a/FormalConjectures/ErdosProblems/548.lean
+++ b/FormalConjectures/ErdosProblems/548.lean
@@ -43,7 +43,8 @@ namespace Erdos548
 /--
 Let $n\geq k+1$. Every graph on $n$ vertices with at least $\frac{k-1}{2}n+1$ edges contains every tree on $k+1$ vertices.
 -/
-@[category research open, AMS 5]
+@[category research solved, AMS 5,
+  formal_proof using lean4 at "https://github.com/Jayyhk/erdos-lean/blob/4c355efbf8e90c2572aa8d0c8d6f3b4b43f011f4/problems/548/Erdos548.lean"]
 theorem erdos_548 (n k : ℕ) (hk : k + 1 ≤ n) (G : SimpleGraph (Fin n))
     (H : ((k : ℚ) - 1) / 2 * n + 1 ≤ (G.edgeSet.ncard : ℚ))
     (T : SimpleGraph (Fin (k + 1))) (hT : T.IsTree) : T.IsContained G := by


### PR DESCRIPTION
Fixes #5328.

## Summary

- mark Erdős Problem 548 as `research solved`
- link the complete Lean proof in `Jayyhk/erdos-lean` at a pinned commit
- leave the theorem statement and in-repo `sorry` unchanged

The linked proof establishes the same Erdős 548 statement used in this repository. Its `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.

The change is limited to the category attribute and pinned `formal_proof` metadata.