### PR TITLE
antiRamseyNum: colour only edges of Kₙ, and forbid rainbow copies

### DIFF
--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Coloring/Vertex.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/Coloring/Vertex.lean
@@ -18,7 +18,9 @@ module
 public import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.Clique
 public import Mathlib.Data.NNRat.Floor
 public import Mathlib.Combinatorics.Enumerative.DoubleCounting
+public import Mathlib.Combinatorics.SimpleGraph.Coloring.EdgeLabeling
 public import Mathlib.Combinatorics.SimpleGraph.Coloring.Vertex
+public import Mathlib.Combinatorics.SimpleGraph.Copy
 public import Mathlib.Data.Set.Card
 
 @[expose] public section
@@ -142,13 +144,21 @@ def CDSColorable [Fintype α] (G : SimpleGraph α) : Prop :=
     ∃ (C : G.Coloring Nat), ∀ k : Nat,
    ∑ i < k, (C.colorClass i).ncard = indepNumK G k
 
-/-- A homomorphism is rainbow if it maps distinct edges to distinct colors. -/
-def IsRainbow {α V : Type*} {H : SimpleGraph α} {G : SimpleGraph V} (f : H →g G) {C : Type*}
-    (c : Sym2 V → C) : Prop :=
-  Function.Injective fun e : H.edgeSet => c (Sym2.map f e)
+/-- A homomorphism `f : H →g G` is *rainbow* with respect to an edge labelling `c` of `G` if it
+maps distinct edges of `H` to edges with distinct labels, i.e. the pullback labelling
+`c.pullback f` of `H` is injective. -/
+def IsRainbow {α V : Type*} {H : SimpleGraph α} {G : SimpleGraph V} (f : H →g G) {K : Type*}
+    (c : G.EdgeLabeling K) : Prop :=
+  Function.Injective (c.pullback f)
 
 /--
-The anti-Ramsey number $\mathrm{AR}(n, H)$: maximum colors to edge-color $K_n$ without rainbow $H$.
+The anti-Ramsey number $\mathrm{AR}(n, H)$: the maximum number of colours in an edge colouring of
+$K_n$ without a rainbow copy of $H$, that is, without an injective homomorphism `H →g K_n` mapping
+distinct edges of `H` to distinct colours.
+
+Only the edges of $K_n$ are coloured (so the colouring is a `TopEdgeLabeling`), and only copies of
+$H$ (injective homomorphisms, `H.Copy ⊤`) are forbidden from being rainbow.
 -/
 noncomputable def antiRamseyNum {α : Type*} [Fintype α] (H : SimpleGraph α) (n : ℕ) : ℕ :=
-  sSup {k | ∃ c : Sym2 (Fin n) → Fin k, Function.Surjective c ∧ ∀ f : H →g ⊤, ¬IsRainbow f c}
+  sSup {k | ∃ c : TopEdgeLabeling (Fin n) (Fin k), Function.Surjective c ∧
+    ∀ f : H.Copy (⊤ : SimpleGraph (Fin n)), ¬IsRainbow f.toHom c}


### PR DESCRIPTION
`antiRamseyNum H n` had two defects, both in the shared definition:

- The colouring was `c : Sym2 (Fin n) → Fin k`, so the n diagonal pairs `s(v, v)`, which are not edges of Kₙ, carried colours that counted towards surjectivity but could never appear on an edge of a copy of H. This inflates the value, e.g. AR(3, K₃) became ≥ 5 instead of 2, and makes both Erdős 1105 statements false (already at k = 3 for the cycles, and at n = k = 5 for the paths).
- It forbade rainbow homomorphisms `H →g ⊤` rather than rainbow copies. A non-injective homomorphism can be rainbow (P₄ → K₃ folding an end vertex onto the first), so the definition rejected extremal colourings such as the star colouring for P₅.

Now the colouring is a `TopEdgeLabeling (Fin n) (Fin k)` (Mathlib's labelling of the edges of Kₙ), `IsRainbow f c` is injectivity of the pullback `c.pullback f`, and only copies `H.Copy ⊤` (injective homomorphisms) are required not to be rainbow. Erdős 1105 is unchanged and builds; a scratch proof checks that every surjective 3-colouring of K₃ now has a rainbow copy of K₃.

identified by @tadamcz running an AI pipeline: https://tadamcz.com/fc-review-results/#/f/ForMathlib/Combinatorics/SimpleGraph/Coloring/Vertex