### PR TITLE
feat: add Kaplansky's problem on the values of the u-invariant

### DIFF
--- a/FormalConjectures/Paper/KaplanskyUInvariant.lean
+++ b/FormalConjectures/Paper/KaplanskyUInvariant.lean
@@ -1,0 +1,226 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Kaplansky's problem on the values of the $u$-invariant
+
+The $u$-invariant $u(F)$ of a field $F$ is the largest dimension of an anisotropic quadratic form
+over $F$, or $\infty$ if there is no largest one; that is, $u(F) = n$ exactly when
+`IsGreatest (QuadraticForm.anisotropicDims F) n`. Following [Kaplansky1953] and
+[MerkurjevParimala2025, §5.1], all fields are of characteristic not $2$.
+
+Kaplansky introduced the invariant (his $C(F)$) in [Kaplansky1953, p. 201], proved that $u(F) \ne 3$
+(his Theorem 2), observed that every power of $2$ occurs (his Theorem 3 gives
+$u(F((t))) = 2u(F)$), and conjectured that $u(F)$ is a power of $2$ whenever it is finite
+[Kaplansky1953, p. 202]. It is classical that $u(F) \notin \{3, 5, 7\}$
+[Lam2005, Proposition XI.6.8], [EKM2008, Corollary 36.4]. Merkurjev disproved Kaplansky's
+conjecture with a field of $u$-invariant $6$ [Merkurjev1989] and then showed that every positive
+even integer is a $u$-invariant [Merkurjev1991]. Izhboldin constructed a field of $u$-invariant
+$9$ [Izhboldin2001], and Vishik fields of $u$-invariant $2^r + 1$ for every $r \ge 3$
+[Vishik2009]. A 2026 preprint of Karpenko constructs fields of $u$-invariant $n$ for every $n$
+that is neither of the form $2^r - 1$ nor of the form $2^r - 3$ [Karpenko2026]; as of September
+2026 it is not yet peer-reviewed.
+
+The problem (`u_invariant_values`) is to determine which integers are $u$-invariants of fields.
+The survey [MerkurjevParimala2025, §5.1] records the expectation that every odd integer $\ge 9$
+is a $u$-invariant (`u_invariant_values.variants.odd`). Given the results above, the problem is
+open exactly for the integers $2^r - 1$ and $2^r - 3$ with $r \ge 4$, the smallest of which are
+$13$ and $15$.
+
+*References:*
+- [Kaplansky1953] I. Kaplansky, *Quadratic forms*, J. Math. Soc. Japan 5 (1953), 200–207,
+  [doi:10.2969/jmsj/00520200](https://doi.org/10.2969/jmsj/00520200).
+- [Lam2005] T. Y. Lam, *Introduction to quadratic forms over fields*, Grad. Stud. Math. 67,
+  Amer. Math. Soc., 2005, [doi:10.1090/gsm/067](https://doi.org/10.1090/gsm/067).
+- [EKM2008] R. Elman, N. Karpenko, A. Merkurjev, *The algebraic and geometric theory of quadratic
+  forms*, Amer. Math. Soc. Colloq. Publ. 56, Amer. Math. Soc., 2008,
+  [doi:10.1090/coll/056](https://doi.org/10.1090/coll/056).
+- [Merkurjev1989] A. S. Merkurjev, *Kaplansky's conjecture in the theory of quadratic forms*
+  (Russian), Zap. Nauchn. Sem. LOMI 175 (1989), 75–89; English transl. J. Soviet Math. 57
+  (1991), no. 6, 3489–3497, [doi:10.1007/BF01100118](https://doi.org/10.1007/BF01100118).
+- [Merkurjev1991] A. S. Merkurjev, *Simple algebras and quadratic forms* (Russian), Izv. Akad.
+  Nauk SSSR Ser. Mat. 55 (1991), no. 1, 218–224; English transl. Math. USSR-Izv. 38 (1992),
+  no. 1, 215–221,
+  [doi:10.1070/IM1992v038n01ABEH002195](https://doi.org/10.1070/IM1992v038n01ABEH002195).
+- [Izhboldin2001] O. T. Izhboldin, *Fields of $u$-invariant $9$*, Ann. of Math. (2) 154 (2001),
+  no. 3, 529–587, [doi:10.2307/3062141](https://doi.org/10.2307/3062141).
+- [Vishik2009] A. Vishik, *Fields of $u$-invariant $2^r + 1$*, pp. 661–685 in Algebra,
+  arithmetic, and geometry: in honor of Yu. I. Manin, Vol. II, Progr. Math. 270, Birkhäuser,
+  2009, [doi:10.1007/978-0-8176-4747-6_22](https://doi.org/10.1007/978-0-8176-4747-6_22).
+- [Karpenko2026] N. A. Karpenko, *Fields of any $u$-invariant but a 2-power minus 1 or 3*,
+  preprint, 5 August 2026,
+  [author's web page](https://sites.ualberta.ca/~karpenko/publ/u1or3-02.pdf).
+- [MerkurjevParimala2025] A. Merkurjev, R. Parimala, *Quadratic forms beyond arithmetic*, Notices
+  Amer. Math. Soc. 72 (2025), no. 7, 711–718,
+  [doi:10.1090/noti3192](https://doi.org/10.1090/noti3192).
+-/
+
+namespace KaplanskyUInvariant
+
+open QuadraticForm
+
+/-- `IsUInvariant n` means that some field of characteristic not `2` has $u$-invariant $n$, i.e.
+$n$ is the largest dimension of an anisotropic quadratic form over that field. -/
+def IsUInvariant (n : ℕ) : Prop :=
+  ∃ (F : Type) (_ : Field F) (_ : NeZero (2 : F)), IsGreatest (anisotropicDims F) n
+
+/-- $u(\mathbb{C}) = 1$ [MerkurjevParimala2025, §5.1]: the form $x^2$ is anisotropic, and every
+quadratic form in two or more variables over an algebraically closed field is isotropic. -/
+@[category test, AMS 11 12]
+theorem isGreatest_anisotropicDims_complex : IsGreatest (anisotropicDims ℂ) 1 := by
+  refine ⟨one_mem_anisotropicDims ℂ, fun n ⟨Q, hQ, _⟩ ↦ ?_⟩
+  by_contra! h
+  have hsep : (QuadraticMap.associated (R := ℂ) Q).SeparatingLeft := fun x hx ↦
+    hQ x (by simpa [QuadraticMap.associated_eq_self_apply] using hx x)
+  obtain ⟨e⟩ := Q.equivalent_weightedSumSquares_of_isAlgClosed hsep
+  have hm : 2 ≤ Module.finrank ℂ (Fin n → ℂ) := by
+    rw [Module.finrank_fintype_fun_eq_card, Fintype.card_fin]
+    exact h
+  generalize Module.finrank ℂ (Fin n → ℂ) = m at e hm
+  obtain ⟨k, rfl⟩ : ∃ k, m = k + 2 := ⟨m - 2, by omega⟩
+  set v : Fin (k + 2) → ℂ := Fin.cons 1 (Fin.cons Complex.I 0) with hv
+  have hv0 : QuadraticMap.weightedSumSquares ℂ (1 : Fin (k + 2) → ℂ) v = 0 := by
+    simp [hv, Fin.sum_univ_succ, Complex.I_mul_I]
+  have h0 : e.symm v = 0 := hQ _ (by rw [e.symm.map_app, hv0])
+  have : v = 0 := e.symm.toLinearEquiv.map_eq_zero_iff.mp h0
+  simpa [hv] using congr_fun this 0
+
+/-- $u(\mathbb{R}) = \infty$ [MerkurjevParimala2025, §5.1]: the sum of $n$ squares is anisotropic
+for every $n$, so there is no largest dimension of an anisotropic form. -/
+@[category test, AMS 11 12]
+theorem not_bddAbove_anisotropicDims_real : ¬ BddAbove (anisotropicDims ℝ) := by
+  rw [anisotropicDims_eq_univ]
+  exact not_bddAbove_univ
+
+/--
+**The values of the $u$-invariant**, stated as in [MerkurjevParimala2025, §5.1]: which integers
+are $u$-invariants of fields (of characteristic not $2$)? The question goes back to
+[Kaplansky1953], who conjectured that only powers of $2$ occur
+(`u_invariant_values.variants.kaplansky_conjecture`). Every positive even integer is a
+$u$-invariant (`u_invariant_values.variants.even`), $3$, $5$ and $7$ are not
+(`u_invariant_values.variants.not_three`, `u_invariant_values.variants.not_five`,
+`u_invariant_values.variants.not_seven`), and it is expected that every odd integer $\ge 9$ is
+(`u_invariant_values.variants.odd`). Granting the preprint [Karpenko2026]
+(`u_invariant_values.variants.karpenko`), the answer is known for every $n$ except $n = 2^r - 1$
+and $n = 2^r - 3$ with $r \ge 4$.
+-/
+@[category research open, AMS 11 12]
+theorem u_invariant_values :
+    let S : Set ℕ := answer(sorry)
+    ∀ n, n ∈ S ↔ IsUInvariant n := by
+  sorry
+
+/--
+**Kaplansky's conjecture** [Kaplansky1953, p. 202]: the $u$-invariant of a field is a power of
+$2$ whenever it is finite. Disproved by Merkurjev, who constructed a field of $u$-invariant $6$
+[Merkurjev1989] (`u_invariant_values.variants.even`).
+-/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.kaplansky_conjecture :
+    answer(False) ↔ ∀ n, IsUInvariant n → ∃ k, n = 2 ^ k := by
+  sorry
+
+/-- The $u$-invariant is never $3$ [Kaplansky1953, Theorem 2]; see also
+[Lam2005, Proposition XI.6.8] and [EKM2008, Corollary 36.4]. -/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.not_three : ¬ IsUInvariant 3 := by
+  sorry
+
+/-- The $u$-invariant is never $5$ [Lam2005, Proposition XI.6.8], [EKM2008, Corollary 36.4]. -/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.not_five : ¬ IsUInvariant 5 := by
+  sorry
+
+/-- The $u$-invariant is never $7$ [Lam2005, Proposition XI.6.8], [EKM2008, Corollary 36.4]. -/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.not_seven : ¬ IsUInvariant 7 := by
+  sorry
+
+/--
+Every power of $2$ is a $u$-invariant [Kaplansky1953, p. 202]: Theorem 3 of [Kaplansky1953]
+gives $u(F((t))) = 2u(F)$, so $u(\mathbb{C}((t_1)) \cdots ((t_k))) = 2^k$; see also
+[EKM2008, §38].
+-/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.two_pow (k : ℕ) : IsUInvariant (2 ^ k) := by
+  sorry
+
+/--
+**Merkurjev's theorem** [Merkurjev1991], see also [EKM2008, Theorem 38.4]: every positive even
+integer is a $u$-invariant. The case $6$, the first counterexample to Kaplansky's conjecture, is
+[Merkurjev1989].
+-/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.even (n : ℕ) (hn : Even n) (hn₀ : n ≠ 0) :
+    IsUInvariant n := by
+  sorry
+
+/-- **Izhboldin's theorem** [Izhboldin2001]: there is a field of $u$-invariant $9$,
+the first example of an odd $u$-invariant greater than $1$. -/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.nine : IsUInvariant 9 := by
+  sorry
+
+/-- **Vishik's theorem** [Vishik2009, Corollary 5.2]: for every $r \ge 3$ there is a field of
+$u$-invariant $2^r + 1$. -/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.two_pow_add_one (r : ℕ) (hr : 3 ≤ r) :
+    IsUInvariant (2 ^ r + 1) := by
+  sorry
+
+/--
+**Karpenko's theorem** [Karpenko2026, Theorem 1.1]: if neither $n + 1$ nor $n + 3$ is a power
+of $2$, then there is a field of $u$-invariant $n$. This covers every positive integer except
+$1$, $3$, $5$, $7$ and the integers $2^r - 1$, $2^r - 3$ with $r \ge 4$. As of September 2026
+the result is a preprint and not yet peer-reviewed.
+-/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.karpenko (n : ℕ) (h₁ : ∀ r, 2 ^ r ≠ n + 1)
+    (h₃ : ∀ r, 2 ^ r ≠ n + 3) : IsUInvariant n := by
+  sorry
+
+/--
+The special case $n = 11$ of `u_invariant_values.variants.karpenko`, the first odd value not of
+the form $2^r + 1$ shown to be a $u$-invariant; it was announced in the preprint
+*Fields of $u$-invariant 11* (21 April 2026) that [Karpenko2026] absorbs.
+-/
+@[category research solved, AMS 11 12]
+theorem u_invariant_values.variants.eleven : IsUInvariant 11 := by
+  sorry
+
+/--
+The expectation recorded in [MerkurjevParimala2025, §5.1]: every odd integer $\ge 9$ is a
+$u$-invariant. By `u_invariant_values.variants.karpenko` this is open exactly for the integers
+$2^r - 1$ and $2^r - 3$ with $r \ge 4$.
+-/
+@[category research open, AMS 11 12]
+theorem u_invariant_values.variants.odd :
+    answer(sorry) ↔ ∀ n, Odd n → 9 ≤ n → IsUInvariant n := by
+  sorry
+
+/-- The smallest open case of the form $2^r - 3$: is there a field of $u$-invariant $13$? -/
+@[category research open, AMS 11 12]
+theorem u_invariant_values.variants.thirteen : answer(sorry) ↔ IsUInvariant 13 := by
+  sorry
+
+/-- The smallest open case of the form $2^r - 1$: is there a field of $u$-invariant $15$? -/
+@[category research open, AMS 11 12]
+theorem u_invariant_values.variants.fifteen : answer(sorry) ↔ IsUInvariant 15 := by
+  sorry
+
+end KaplanskyUInvariant

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -135,6 +135,7 @@ public import FormalConjecturesForMathlib.Geometry.«3d»
 public import FormalConjecturesForMathlib.Lean.Elab.InfoTree.Util
 public import FormalConjecturesForMathlib.LinearAlgebra.AffineSpace.Simplex.Basic
 public import FormalConjecturesForMathlib.LinearAlgebra.GeneralLinearGroup
+public import FormalConjecturesForMathlib.LinearAlgebra.QuadraticForm.UInvariant
 public import FormalConjecturesForMathlib.LinearAlgebra.SpecialLinearGroup
 public import FormalConjecturesForMathlib.Logic.Equiv.Fin.Rotate
 public import FormalConjecturesForMathlib.NumberTheory.AdditionChain

--- a/FormalConjecturesForMathlib/LinearAlgebra/QuadraticForm/UInvariant.lean
+++ b/FormalConjecturesForMathlib/LinearAlgebra/QuadraticForm/UInvariant.lean
@@ -1,0 +1,110 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+
+@[expose] public section
+
+/-!
+# Dimensions of anisotropic quadratic forms
+
+The *$u$-invariant* $u(F)$ of a field $F$ is the largest dimension of an anisotropic quadratic
+form over $F$, or $\infty$ if there is no largest one [Kaplansky1953, p. 201]; in characteristic $2$
+the forms are required to be nondegenerate [EKM2008, §36]. This file defines
+
+* `QuadraticForm.anisotropicDims F`: the set of `n` such that there is a nondegenerate anisotropic
+  quadratic form on `Fin n → F`.
+
+The $u$-invariant of `F` is `n` exactly when `IsGreatest (QuadraticForm.anisotropicDims F) n`, and
+it is infinite exactly when `¬ BddAbove (QuadraticForm.anisotropicDims F)`. No numeric invariant
+is defined, so that no convention for the infinite case is needed.
+
+The set contains `0` and `1` for every field. In characteristic not `2` every anisotropic form is
+nondegenerate (`QuadraticMap.Anisotropic.nondegenerate`), so the nondegeneracy condition can be
+dropped (`QuadraticForm.mem_anisotropicDims_iff`). Over a linearly ordered field the sum of `n`
+squares is anisotropic for every `n`, so the set is all of `ℕ`
+(`QuadraticForm.anisotropicDims_eq_univ`).
+
+## References
+
+* [Kaplansky1953] I. Kaplansky, *Quadratic forms*, J. Math. Soc. Japan 5 (1953), 200–207.
+* [EKM2008] R. Elman, N. Karpenko, A. Merkurjev, *The algebraic and geometric theory of
+  quadratic forms*, Amer. Math. Soc. Colloq. Publ. 56, 2008.
+-/
+
+open Finset QuadraticMap
+
+namespace QuadraticMap
+
+variable {F M : Type*} [Field F] [AddCommGroup M] [Module F M] {Q : QuadraticForm F M}
+
+/-- The radical of an anisotropic quadratic form is trivial. -/
+theorem Anisotropic.radical_eq_bot (hQ : Q.Anisotropic) : Q.radical = ⊥ :=
+  (Submodule.eq_bot_iff _).mpr fun m hm ↦ hQ m (mem_radical_iff'.mp hm).1
+
+/-- An anisotropic quadratic form on a module of rank at most `1` is nondegenerate. -/
+theorem Anisotropic.nondegenerate_of_rank_le_one (hQ : Q.Anisotropic)
+    (hM : Module.rank F M ≤ 1) : Q.Nondegenerate where
+  radical_eq_bot := hQ.radical_eq_bot
+  rank_rad_polar_le := (Submodule.rank_le _).trans hM
+
+/-- In characteristic not `2`, an anisotropic quadratic form is nondegenerate. -/
+theorem Anisotropic.nondegenerate [NeZero (2 : F)] (hQ : Q.Anisotropic) : Q.Nondegenerate := by
+  have := invertibleOfNonzero (two_ne_zero : (2 : F) ≠ 0)
+  exact nondegenerate_iff_radical_eq_bot.mpr hQ.radical_eq_bot
+
+end QuadraticMap
+
+namespace QuadraticForm
+
+variable (F : Type*) [Field F]
+
+/-- The set of `n` such that there is a nondegenerate anisotropic quadratic form on `Fin n → F`.
+Its greatest element, when it exists, is the $u$-invariant of `F`; the set is not bounded above
+exactly when the $u$-invariant of `F` is infinite. -/
+def anisotropicDims : Set ℕ :=
+  {n | ∃ Q : QuadraticForm F (Fin n → F), Q.Anisotropic ∧ Q.Nondegenerate}
+
+theorem zero_mem_anisotropicDims : 0 ∈ anisotropicDims F :=
+  have h : (0 : QuadraticForm F (Fin 0 → F)).Anisotropic := fun x _ ↦ Subsingleton.elim x 0
+  ⟨0, h, h.nondegenerate_of_rank_le_one (by simp)⟩
+
+theorem one_mem_anisotropicDims : 1 ∈ anisotropicDims F :=
+  have h : (weightedSumSquares F (1 : Fin 1 → F)).Anisotropic := fun v hv ↦ by
+    simp only [weightedSumSquares_apply, Pi.one_apply, one_smul, Fin.sum_univ_one,
+      mul_self_eq_zero] at hv
+    exact funext fun i ↦ by rw [Fin.fin_one_eq_zero i]; exact hv
+  ⟨_, h, h.nondegenerate_of_rank_le_one (by simp)⟩
+
+variable {F}
+
+/-- In characteristic not `2`, the nondegeneracy condition in `anisotropicDims` is automatic. -/
+theorem mem_anisotropicDims_iff [NeZero (2 : F)] {n : ℕ} :
+    n ∈ anisotropicDims F ↔ ∃ Q : QuadraticForm F (Fin n → F), Q.Anisotropic :=
+  ⟨fun ⟨Q, hQ, _⟩ ↦ ⟨Q, hQ⟩, fun ⟨Q, hQ⟩ ↦ ⟨Q, hQ, hQ.nondegenerate⟩⟩
+
+/-- Over a linearly ordered field, the sum of `n` squares is anisotropic for every `n`, so every
+`n` is the dimension of an anisotropic quadratic form. -/
+theorem anisotropicDims_eq_univ [LinearOrder F] [IsStrictOrderedRing F] :
+    anisotropicDims F = Set.univ :=
+  Set.eq_univ_of_forall fun n ↦ mem_anisotropicDims_iff.mpr
+    ⟨weightedSumSquares F (1 : Fin n → F), fun v hv ↦ by
+      simp only [weightedSumSquares_apply, Pi.one_apply, one_smul] at hv
+      rw [sum_eq_zero_iff_of_nonneg fun i _ ↦ mul_self_nonneg (v i)] at hv
+      exact funext fun i ↦ mul_self_eq_zero.mp (hv i (mem_univ i))⟩
+
+end QuadraticForm


### PR DESCRIPTION
Fixes #5392

**What changed**

The $u$-invariant $u(F)$ of a field is the largest dimension of an anisotropic quadratic form
over $F$. Kaplansky (1953) conjectured that every finite value is a power of $2$; Merkurjev
refuted that and showed every positive even integer occurs. Which odd values occur is open, and
this adds the problem as posed in Merkurjev-Parimala, *Quadratic forms beyond arithmetic*
(Notices AMS 72 (2025), no. 7, §5.1).

- `FormalConjecturesForMathlib/LinearAlgebra/QuadraticForm/UInvariant.lean` (new, all proved):
  `QuadraticForm.anisotropicDims F`, the set of dimensions of nondegenerate anisotropic forms
  over `F`. "$u(F) = n$" is `IsGreatest (anisotropicDims F) n` and "$u(F) = \infty$" is
  `¬ BddAbove (anisotropicDims F)`, so no numeric invariant and no convention for the infinite
  case are needed (the design used for `pythagorasBounds` in #5343). With it:
  `Anisotropic.nondegenerate` in characteristic $\ne 2$, `mem_anisotropicDims_iff` dropping the
  nondegeneracy condition there, and `anisotropicDims_eq_univ` over an ordered field.
- `FormalConjectures/Paper/KaplanskyUInvariant.lean` (new): `IsUInvariant n`, the open problem
  `u_invariant_values` of determining which integers occur, and as `research solved` variants
  Kaplansky's conjecture (disproved), the classical exclusion of $3$, $5$, $7$, every power of
  $2$, every positive even integer (Merkurjev), $9$ (Izhboldin), $2^r + 1$ for $r \ge 3$
  (Vishik), and Karpenko's $n$ with neither $n + 1$ nor $n + 3$ a power of $2$. Open: the
  survey's expectation that every odd $n \ge 9$ occurs, and its two smallest untouched
  instances $13$ and $15$. Two proved `test`s: $u(\mathbb{C}) = 1$ and $u(\mathbb{R}) = \infty$. `variants.eleven` is
  derived from `variants.karpenko`.

Three things a reviewer may want to weigh:

- Karpenko's result is a **preprint of 5 August 2026 and not yet peer-reviewed**; the docstring
  says so, and `variants.karpenko` and `variants.eleven` are nonetheless marked `research
  solved`. Happy to downgrade them if you would rather wait for refereeing.
- His hypothesis is stated as `∀ r, 2 ^ r ≠ n + 1` and `∀ r, 2 ^ r ≠ n + 3` rather than with
  subtraction, which avoids truncation and also excludes $n = 0$ (never a $u$-invariant).
- All problem statements assume characteristic $\ne 2$ (`NeZero (2 : F)`), following Kaplansky
  and the survey, but `anisotropicDims` itself keeps the nondegeneracy condition so that it is
  the Elman-Karpenko-Merkurjev definition in characteristic $2$ as well.

**How I checked**

- `lake --wfail build FormalConjecturesForMathlib FormalConjectures.Paper.KaplanskyUInvariant`
  passes, `scripts/mk_all_formathlib.sh` reports no change beyond the one index line, and
  `scripts/check_category_warnings.py` gives `research_open_with_proof: 0`,
  `test_without_proof: 0`, `api_without_proof: 0`.
- Every lemma in the library file and both `test`s depend only on `propext`, `Classical.choice`,
  `Quot.sound`.
- Sources read directly: Kaplansky 1953 (definition p. 201, conjecture pp. 201-202, Theorem 2),
  EKM §36 and §38, Izhboldin 2001, Vishik 2009 (Corollary 5.2), Karpenko's preprint
  (Theorem 1.1), and the Notices survey §5.1. All DOIs resolve.

AI disclosure: this formalization was drafted with Claude Code, and reviewed by Codex and by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014D4nxaGt9eJTEjG5nwdbHb

