### PR TITLE
WOWII 291: record the refutation

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture291.lean
@@ -47,6 +47,10 @@ $\gamma_t(G) \le k + \mathrm{frequency}(t_{\min}(v))$
 where $\gamma_t(G)$ is the total domination number, $k$ is the Havel-Hakimi zero
 step, and $\mathrm{frequency}(t_{\min}(v))$ is the number of vertices achieving
 the minimum triangle count.
+
+The conjecture is **false**: on July 23, 2026, Zyad Tamimi sent a 12-vertex
+counterexample with $\gamma_t(G) = 4$, $\mathrm{frequency}(t_{\min}(v)) = 1$ and $k = 2$,
+and the source now lists Conjecture 291 as refuted.
 -/
 
 namespace WrittenOnTheWallII.GraphConjecture291
@@ -104,12 +108,19 @@ where:
 - $k$ is the first step in which a zero appears in the Havel-Hakimi process,
 - $\mathrm{frequency}(t_{\min}(v))$ is the number of vertices achieving the
   minimum triangle count.
+
+This is false: the source records a 12-vertex counterexample by Zyad Tamimi (July 23, 2026)
+with $\gamma_t(G) = 4 > 2 + 1 = k + \mathrm{frequency}(t_{\min}(v))$.
+
+The hypothesis $n > 2$ is stated in the source's full list of conjectures (as for the
+neighbouring Conjectures 290, 292 and 293) but omitted on its list of open conjectures;
+the counterexample has $12$ vertices, so it refutes both readings.
 -/
-@[category research open, AMS 5]
-theorem conjecture291 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected)
-    (hn : 2 < Fintype.card α) :
-    G.totalDominationNumber ≤
-    havelHakimiZeroStep G + freqMinTriangles G := by
+@[category research solved, AMS 5]
+theorem conjecture291 : answer(False) ↔
+    ∀ (α : Type) [Fintype α] [DecidableEq α] [Nontrivial α]
+      (G : SimpleGraph α) [DecidableRel G.Adj] (_h : G.Connected) (_hn : 2 < Fintype.card α),
+      G.totalDominationNumber ≤ havelHakimiZeroStep G + freqMinTriangles G := by
   sorry
 
 -- Sanity checks


### PR DESCRIPTION
The source (Written on the Wall II, full list of conjectures) now marks Conjecture 291 as false: on July 23, 2026 Zyad Tamimi sent a 12-vertex counterexample with γ_t(G) = 4, frequency(t_min(v)) = 1 and k = 2, so 4 > 2 + 1. The statement is restated as `answer(False) ↔ ∀ ...`, in the form used for the other refuted WOWII conjectures, and tagged `research solved`.

The hypothesis n > 2 is kept: the source's full list states it (as for Conjectures 290, 292 and 293), while its list of open conjectures omits it; the docstring records the discrepancy. The counterexample has 12 vertices and refutes both readings (see also #4510).

See #4562 for a counterexample