### PR TITLE
Fix(Website): Fix source page breadcrumb links

### DIFF
--- a/site/fix_literate_html.py
+++ b/site/fix_literate_html.py
@@ -8,13 +8,17 @@ Fixes:
 3. Fixes domain-mappers.js module syntax
 4. Installs the shared Verso syntax theme
 5. Adds a root index page that redirects to the website's module index
+6. Links parent breadcrumbs to the filtered module index
 
 Usage: python3 fix_literate_html.py <literate-html-dir>
 """
 
 import os
+import re
 import shutil
 import sys
+from html import escape, unescape
+from urllib.parse import quote, unquote
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 HIGHLIGHT_STYLESHEET = 'lean-syntax.css'
@@ -45,12 +49,33 @@ document.addEventListener("DOMContentLoaded", function() {
 '''
 
 
+def fix_breadcrumbs(html):
+    """Point Verso's parent-folder links to the website's module index."""
+    def fix_list(match):
+        def fix_link(link):
+            href = unescape(link.group(1))
+            if not href.endswith('/') or href.startswith(('../', '/', '#')) or ':' in href:
+                return link.group(0)
+            # The trailing dot keeps similarly named libraries out of the results.
+            prefix = unquote(href).replace('/', '.')
+            target = '../modules/?q=' + quote(prefix, safe='')
+            return f'href="{escape(target, quote=True)}"'
+
+        return re.sub(r'href="([^"]*)"', fix_link, match.group(0))
+
+    # Limit rewriting to navigation; source-code and sidebar links stay intact.
+    return re.sub(r'<ol\b[^>]*class="breadcrumbs"[^>]*>.*?</ol>',
+                  fix_list, html, flags=re.DOTALL)
+
+
 def fix_html_file(path):
     """Install the syntax theme and KaTeX in a Verso HTML file."""
     with open(path, 'r', encoding='utf-8') as f:
         html = f.read()
 
-    modified = False
+    fixed_html = fix_breadcrumbs(html)
+    modified = fixed_html != html
+    html = fixed_html
 
     # Add these independently: cached pages may already contain KaTeX.
     if f'href="{HIGHLIGHT_STYLESHEET}"' not in html and '</head>' in html:

--- a/site/test_fix_literate_html.py
+++ b/site/test_fix_literate_html.py
@@ -4,8 +4,40 @@
 import os
 import tempfile
 import unittest
+from urllib.parse import parse_qs, urljoin, urlsplit
 
 import fix_literate_html as fix
+
+
+class BreadcrumbTest(unittest.TestCase):
+
+    def test_parent_links_resolve_to_filtered_modules_under_any_base_path(self):
+        html = '''<ol class="breadcrumbs" aria-label="Breadcrumb">
+<li><a href="FormalConjectures/">FormalConjectures</a></li>
+<li><a href="FormalConjectures/Wikipedia/">Wikipedia</a></li>
+<li><span class="current">ABC</span></li></ol>'''
+        fixed = fix.fix_breadcrumbs(html)
+        for base in ('https://example.com/', 'https://example.com/formal-conjectures/'):
+            page = urljoin(base, 'src/FormalConjectures/Wikipedia/ABC/')
+            verso_base = urljoin(page, '../../../')
+            for prefix in ('FormalConjectures.', 'FormalConjectures.Wikipedia.'):
+                href = '../modules/?q=' + prefix
+                self.assertIn(f'href="{href}"', fixed)
+                target = urlsplit(urljoin(verso_base, href))
+                self.assertEqual(target.path, urlsplit(urljoin(base, 'modules/')).path)
+                self.assertEqual(parse_qs(target.query), {'q': [prefix]})
+        self.assertIn('<span class="current">ABC</span>', fixed)
+        self.assertEqual(fix.fix_breadcrumbs(fixed), fixed)
+
+    def test_nested_escaped_names_and_non_breadcrumb_links(self):
+        link = '<a href="FormalConjectures/Arxiv/%C2%AB0911.2077%C2%BB/">Paper</a>'
+        html = f'<nav>{link}</nav><ol class="breadcrumbs"><li>{link}</li></ol>'
+        fixed = fix.fix_breadcrumbs(html)
+        self.assertIn(f'<nav>{link}</nav>', fixed)
+        self.assertIn(
+            'href="../modules/?q=FormalConjectures.Arxiv.%C2%AB0911.2077%C2%BB."',
+            fixed,
+        )
 
 
 class FixHtmlFileTest(unittest.TestCase):


### PR DESCRIPTION
Fixes these breadcrumb links at the top. They're currently going to a 404 instead.

<img width="855" height="299" alt="Screenshot 2026-09-09 at 8 29 23 AM" src="https://github.com/user-attachments/assets/c4ea593b-e16b-4f12-8e86-5c4ba4f5300e" />
