### PR TITLE
Add structured 3-CNF reference semantics

### DIFF
--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -101,6 +101,7 @@ public import FormalConjecturesForMathlib.Combinatorics.YoungDiagram
 public import FormalConjecturesForMathlib.Computability.BitstringEncoding
 public import FormalConjecturesForMathlib.Computability.Complexity
 public import FormalConjecturesForMathlib.Computability.DFA
+public import FormalConjecturesForMathlib.Computability.ThreeSAT
 public import FormalConjecturesForMathlib.Computability.TuringMachine.BusyBeavers
 public import FormalConjecturesForMathlib.Computability.TuringMachine.Notation
 public import FormalConjecturesForMathlib.Computability.TuringMachine.PostTuringMachine

--- a/FormalConjecturesForMathlib/Computability/ThreeSAT.lean
+++ b/FormalConjecturesForMathlib/Computability/ThreeSAT.lean
@@ -1,0 +1,98 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Data.Fintype.Pi
+public import Mathlib.Data.Finset.BooleanAlgebra
+
+/-!
+# Structured 3-CNF reference semantics
+
+Variables are explicitly indexed by `Fin n`; each clause has at most three literals.
+The empty conjunction is true and an empty clause is false. The reference checker exhausts
+all assignments, including those of unused or sparsely occurring variable indices.
+
+This module supplies reference semantics for structured formulas. A bitstring parser and
+polynomial reductions to the existing complexity classes are separate developments.
+For the surrounding SAT decision/search distinction, see Aaronson, *P =? NP*, §2.2.1,
+https://www.scottaaronson.com/papers/pnp.pdf.
+-/
+
+@[expose] public section
+
+namespace Computability.ThreeSAT
+
+/-- A signed variable; `positive = false` denotes a negated variable. -/
+structure Literal (n : ℕ) where
+  index : Fin n
+  positive : Bool
+  deriving DecidableEq
+
+/-- Clauses have at most three literals, including empty clauses. -/
+structure Clause (n : ℕ) where
+  literals : List (Literal n)
+  length_le : literals.length ≤ 3
+  deriving DecidableEq
+
+abbrev Formula (n : ℕ) := List (Clause n)
+
+variable {n : ℕ}
+
+/-- Mathematical satisfiability, expressed using assignments and clause witnesses. -/
+def Satisfiable (formula : Formula n) : Prop :=
+  ∃ assignment : Fin n → Bool, ∀ clause ∈ formula,
+    ∃ literal ∈ clause.literals, assignment literal.index = literal.positive
+
+def eval (formula : Formula n) (assignment : Fin n → Bool) : Bool :=
+  formula.all fun clause ↦ clause.literals.any fun literal ↦
+    assignment literal.index == literal.positive
+
+theorem eval_eq_true (formula : Formula n) (assignment : Fin n → Bool) :
+    eval formula assignment = true ↔ ∀ clause ∈ formula,
+      ∃ literal ∈ clause.literals, assignment literal.index = literal.positive := by
+  simp [eval]
+
+/-- Exhaustive reference evaluation over all $2^n$ assignments; no polynomial bound is claimed. -/
+def referenceCheck (formula : Formula n) : Bool :=
+  decide (∃ assignment : Fin n → Bool, eval formula assignment = true)
+
+@[simp]
+theorem referenceCheck_eq_true (formula : Formula n) :
+    referenceCheck formula = true ↔ Satisfiable formula := by
+  simp [referenceCheck, Satisfiable, eval_eq_true]
+
+/-- Renaming variables transports assignments by composition. -/
+def rename {m : ℕ} (f : Fin n → Fin m) (formula : Formula n) : Formula m :=
+  formula.map fun clause ↦
+    ⟨clause.literals.map (fun literal ↦ ⟨f literal.index, literal.positive⟩), by
+      simpa using clause.length_le⟩
+
+theorem eval_rename {m : ℕ} (f : Fin n → Fin m) (formula : Formula n)
+    (assignment : Fin m → Bool) :
+    eval (rename f formula) assignment = eval formula (assignment ∘ f) := by
+  simp [rename, eval, Function.comp_def]
+
+theorem satisfiable_rename_equiv {m : ℕ} (e : Fin n ≃ Fin m) (formula : Formula n) :
+    Satisfiable (rename e formula) ↔ Satisfiable formula := by
+  simp only [← referenceCheck_eq_true, referenceCheck, decide_eq_true_eq, eval_rename]
+  constructor
+  · rintro ⟨assignment, h⟩
+    exact ⟨assignment ∘ e, h⟩
+  · rintro ⟨assignment, h⟩
+    refine ⟨assignment ∘ e.symm, ?_⟩
+    simpa [Function.comp_def] using h
+
+end Computability.ThreeSAT

--- a/FormalConjecturesTest/ForMathlib/Computability/ThreeSAT.lean
+++ b/FormalConjecturesTest/ForMathlib/Computability/ThreeSAT.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public meta import FormalConjecturesForMathlib.Computability.ThreeSAT
+public import FormalConjecturesForMathlib.Computability.ThreeSAT
+
+/-! # Regression proofs for structured 3-CNF semantics -/
+
+@[expose] public section
+
+namespace Computability.ThreeSAT.Test
+
+def positiveClause : Clause 1 := ⟨[⟨0, true⟩], by decide⟩
+def negativeClause : Clause 1 := ⟨[⟨0, false⟩], by decide⟩
+def sparseFormula : Formula 5 := [⟨[⟨4, true⟩, ⟨1, false⟩], by decide⟩]
+
+example : referenceCheck ([] : Formula 0) = true := by decide
+example : referenceCheck ([⟨[], by decide⟩] : Formula 0) = false := by decide
+example : referenceCheck [positiveClause] = true := by decide
+example : referenceCheck [positiveClause, negativeClause] = false := by decide
+example : referenceCheck sparseFormula = true := by decide
+example : eval sparseFormula (fun _ ↦ false) = true := by decide
+example : eval sparseFormula (fun i ↦ decide (i.val = 1)) = false := by decide
+/-- info: (true, false) -/
+#guard_msgs in
+#eval (referenceCheck [positiveClause], referenceCheck [positiveClause, negativeClause])
+
+end Computability.ThreeSAT.Test

--- a/scripts/axiom_audits/ThreeSAT.lean
+++ b/scripts/axiom_audits/ThreeSAT.lean
@@ -1,0 +1,32 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjecturesTest.ForMathlib.Computability.ThreeSAT
+
+-- Transitive audit of the completed named definitions, theorems, and regression results.
+#print axioms Computability.ThreeSAT.Literal
+#print axioms Computability.ThreeSAT.Clause
+#print axioms Computability.ThreeSAT.Formula
+#print axioms Computability.ThreeSAT.Satisfiable
+#print axioms Computability.ThreeSAT.eval
+#print axioms Computability.ThreeSAT.eval_eq_true
+#print axioms Computability.ThreeSAT.referenceCheck
+#print axioms Computability.ThreeSAT.referenceCheck_eq_true
+#print axioms Computability.ThreeSAT.rename
+#print axioms Computability.ThreeSAT.eval_rename
+#print axioms Computability.ThreeSAT.satisfiable_rename_equiv
+#print axioms Computability.ThreeSAT.Test.positiveClause
+#print axioms Computability.ThreeSAT.Test.negativeClause
+#print axioms Computability.ThreeSAT.Test.sparseFormula


### PR DESCRIPTION
Part of #5409.

Add structured 3-CNF syntax, an executable exhaustive reference checker, and proofs of its semantics. This small PR is independent of the finite-candidate infrastructure and adds no dependency.

## Definitions and results

| Declaration in `Computability.ThreeSAT` | Meaning |
| --- | --- |
| `Literal n`, `Clause n`, `Formula n` | Signed variables in `Fin n`; clauses of length at most three; finite conjunctions |
| `Satisfiable`, `eval_eq_true` | Assignment-based mathematical semantics and Boolean evaluation correctness |
| `referenceCheck_eq_true` | Exhaustive reference checking returns true iff the formula is satisfiable |
| `eval_rename`, `satisfiable_rename_equiv` | Assignment transport under renaming; satisfiability invariance under bijective renaming |

The empty formula is true, an empty clause is false, and unused/sparse variable indices are allowed. Clauses may contain repeated literals. Reference checking exhausts all `2^n` assignments; no polynomial-time claim is made.

## Literature and formalization choices

- Scott Aaronson, [P =? NP (2017 survey)](https://www.scottaaronson.com/papers/pnp.pdf), §2.1 and §2.2.1, especially p. 16: SAT background and the distinction between deciding existence and finding an assignment. This PR formalizes reference decision semantics, not a search-to-decision reduction or the Cook–Levin theorem. At-most-three clauses, empty clauses, and an explicit ambient variable count are our stated representation choices.
- Igor C. Oliveira, [Meta-Mathematics of Computational Complexity Theory, ECCC TR25-041 (2025)](https://eccc.weizmann.ac.il/report/2025/041/), §5.1.2, equation (4), Open Problem 5.3, pp. 17–18: later motivation from SAT-search guarantees in PV₁. The source quantifies over a formula and a satisfying witness and asks for a candidate's satisfying output. Our Boolean decision checker is not that arithmetic guarantee; no PV₁ statement is introduced.
- Implementation context: the repository already has [`BitstringEncoding` and complexity infrastructure](https://github.com/google-deepmind/formal-conjectures/tree/b82b08faa9006484021c12005ab41287fb2ffb69/FormalConjecturesForMathlib/Computability). This PR deliberately supplies the structured semantics first. A canonical bitstring parser, machine-code interpretation, complexity bounds, and arithmetic representation remain subsequent obligations.

The correctness and renaming proofs are elementary finite-evaluation arguments written here. This PR establishes no NP-completeness theorem, polynomial SAT solver, or independence result.

## Validation

On Lean 4.33.1 and the repository's unchanged dependency pins:

```sh
bash scripts/mk_all_formathlib.sh
lake --wfail build FormalConjecturesForMathlib FormalConjecturesTest.ForMathlib.Computability.ThreeSAT
lake --wfail test
lake env lean scripts/axiom_audits/ThreeSAT.lean
```

All passed on this branch (build: 8883 jobs). Seven kernel-checked examples cover empty formulas/clauses, SAT and UNSAT instances, sparse indices, and concrete assignments; a guarded runtime check covers SAT/UNSAT answers. The audit checks 14 named declarations and finds only subsets of `propext`, `Classical.choice`, and `Quot.sound`. No `sorry`, `native_decide`, or new mathematical axiom is introduced.

Codex drafted the Lean definitions, proofs, tests, and this description, checked source correspondence, and ran the reported validation. Uploaded as a draft pending the author's personal review of the code and formalization choices.
