### PR TITLE
ErdosProblems/450: sublinear-scale statement is false as formalised (proof inlined), add far-window variant

### DIFF
--- a/FormalConjectures/ErdosProblems/450.lean
+++ b/FormalConjectures/ErdosProblems/450.lean
@@ -49,12 +49,67 @@ How large must $y=y(\epsilon,n)$ be such that the number of integers in
 $(x,x+y)$ with a divisor in $(n,2n)$ is at most $\epsilon y$?
 
 A **linear** scale is known to suffice (see `erdos_450.linear_scale_suffices`).
-Whether the optimal scale is *sublinear* — a sufficient `Y` with `Y ε n = o(n)` —
-is open.
+
+With `UniformlySparse` quantifying over *every* window start `x`, a **sublinear** scale
+cannot suffice, for a trivial reason: the window `(n, n + y)` with `y ≤ n` is full, since each of
+its integers lies in `(n, 2n)` and divides itself. So `Y ε n = o(n)` fails already at `ε = 1/2`,
+and this statement holds with `answer(False)`. This settles the formal statement only; the
+question Erdős asked is unaffected (erdosproblems.com notes the intended quantifier on `x` is
+unclear). See `erdos_450.variants.far_windows` for the version with windows beyond `2n`.
+-/
+@[category research solved, AMS 11]
+theorem erdos_450 : answer(False) ↔
+    ∃ Y : ℝ → ℕ → ℕ, IsSufficientScale Y ∧
+      ∀ ε : ℝ, 0 < ε → Tendsto (fun n : ℕ => (Y ε n : ℝ) / n) atTop (𝓝 0) := by
+  refine iff_of_false not_false ?_
+  rintro ⟨Y, hY, hlim⟩
+  obtain ⟨N, hN⟩ := hY (1 / 2) (by norm_num)
+  obtain ⟨M, hM⟩ := eventually_atTop.1
+    ((tendsto_order.1 (hlim (1 / 2) (by norm_num))).2 (1 / 2) (by norm_num))
+  set n := max (max N M) 3 with hn
+  have hnN : N ≤ n := le_trans (le_max_left _ _) (le_max_left _ _)
+  have hnM : M ≤ n := le_trans (le_max_right _ _) (le_max_left _ _)
+  have hn3 : 3 ≤ n := le_max_right _ _
+  have hYn : Y (1 / 2) n ≤ n := by
+    have h := hM n hnM
+    have hnpos : (0 : ℝ) < n := by exact_mod_cast (show 0 < n by omega)
+    rw [div_lt_iff₀ hnpos] at h
+    exact_mod_cast (show (Y (1 / 2) n : ℝ) < n by linarith).le
+  set y := max (Y (1 / 2) n) 3 with hy
+  have hy3 : 3 ≤ y := le_max_right _ _
+  have hyn : y ≤ n := max_le hYn hn3
+  -- The window `(n, n + y)` is full: every element is its own divisor in `(n, 2n)`.
+  have hfull : localCount n n y = y - 1 := by
+    classical
+    unfold localCount
+    rw [Finset.filter_true_of_mem, Nat.card_Ioo]
+    · omega
+    · intro m hm
+      rw [Finset.mem_Ioo] at hm
+      exact ⟨m, hm.1, by omega, dvd_rfl⟩
+  have hsp := hN n hnN y (le_max_left _ _) n
+  rw [hfull, Nat.cast_sub (by omega), Nat.cast_one] at hsp
+  have : (3 : ℝ) ≤ y := by exact_mod_cast hy3
+  linarith
+
+/-- Every window `(x, x+y)` starting at or beyond `2n` has at most `ε y` integers with a
+divisor in `(n, 2n)`. Such windows contain no element of `(n, 2n)` itself, which removes the
+trivial obstruction to `erdos_450`. -/
+def UniformlySparseFar (ε : ℝ) (n y : ℕ) : Prop :=
+  ∀ x : ℕ, 2 * n ≤ x → (localCount n x y : ℝ) ≤ ε * (y : ℝ)
+
+/-- `Y ε n` is a sufficient window length for windows beyond `2n`. -/
+def IsSufficientFarScale (Y : ℝ → ℕ → ℕ) : Prop :=
+  ∀ ε : ℝ, 0 < ε → ∃ N : ℕ, ∀ n : ℕ, N ≤ n → ∀ y : ℕ, Y ε n ≤ y → UniformlySparseFar ε n y
+
+/--
+The sublinear-scale question for windows that lie beyond `(n, 2n)`: is there a sufficient
+`Y` with `Y ε n = o(n)` once windows starting inside `(n, 2n)` are excluded? This is the
+reading of `erdos_450` that is not settled by the trivial full window.
 -/
 @[category research open, AMS 11]
-theorem erdos_450 : answer(sorry) ↔
-    ∃ Y : ℝ → ℕ → ℕ, IsSufficientScale Y ∧
+theorem erdos_450.variants.far_windows : answer(sorry) ↔
+    ∃ Y : ℝ → ℕ → ℕ, IsSufficientFarScale Y ∧
       ∀ ε : ℝ, 0 < ε → Tendsto (fun n : ℕ => (Y ε n : ℝ) / n) atTop (𝓝 0) := by
   sorry
 


### PR DESCRIPTION
## What

`erdos_450` asks whether a sufficient window scale `Y` with `Y ε n = o(n)` exists. As formalised it is false for a trivial reason, unrelated to the arithmetic of divisors:

`UniformlySparse ε n y` requires *every* window `(x, x + y)` to be `ε`-sparse. The window starting at `x = n` with `y ≤ n` is full: each integer `m` with `n < m < n + y ≤ 2n` lies in `(n, 2n)` and divides itself, so `localCount n n y = y - 1`. If `Y (1/2) n / n → 0` then for large `n` we can take `y = max (Y (1/2) n) 3 ≤ n`, and sparsity at `x = n` gives `y - 1 ≤ y / 2`, contradicting `y ≥ 3`.

This PR:
- fills `answer(False)` in `erdos_450`, marks it `category research solved`, and inlines the proof (about 35 lines, within the short-proof guideline);
- adds `erdos_450.variants.far_windows` as the new `research open` statement: the same question with windows restricted to `2n ≤ x`, which removes the trivial obstruction. Whether this is the right reading is for reviewers; erdosproblems.com/450 records that the intended quantifier on `x` is unclear;
- leaves `erdos_450.linear_scale_suffices` (externally proved, #4588) untouched. The two results are consistent: under the all-`x` reading the full window forces `y ≥ (n - 1) / ε`, a linear lower bound.

## Verification

Compiled inside this repository at `b82b08f` (Lean 4.33.1, pinned mathlib). `#print axioms Erdos450.erdos_450` gives `[propext, Classical.choice, Quot.sound]`. Supporting definitions, imports and namespace are byte-identical to the current file. The only `sorry`s in the file are the two intended stubs (`far_windows`, `linear_scale_suffices`).

This settles the formal statement only. It does not resolve Erdős's question.
