### PR TITLE
ci: save Lean build cache before documentation rebuilds

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -135,17 +135,15 @@ jobs:
           lake exe cache unpack
           lake exe cache get
 
-      - name: Restore local lake build
+      - name: Restore Lean build
         if: steps.mode.outputs.website_only != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             .lake/build
-            docbuild/.lake/build
-            _literate_html
-          key: lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-${{ github.sha }}
+          key: lean-build-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}
           restore-keys: |
-            lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-
+            lean-build-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-
 
       - name: Generate FormalConjecturesForMathlib.lean
         if: steps.mode.outputs.website_only != 'true'
@@ -188,10 +186,48 @@ jobs:
           action: remove
           linters: lean
 
+      # Documentation can rebuild problem modules with different traces in
+      # .lake/build. Save the Lean cache before entering that build context.
+      - name: Save Lean build
+        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            .lake/build
+          key: lean-build-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}
+
       # Every library that the problem files build on gets a literate page, so
       # that hovers and constant links from a problem resolve to the definition
       # in `FormalConjecturesForMathlib` or `FormalConjecturesUtil` instead of
       # dead-ending. The test library is left out: it documents nothing.
+      # Fetch pinned dependency sources before restoring their build files.
+      - name: Initialize documentation workspace
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        working-directory: docbuild
+        run: lake env lean --version
+
+      - name: Restore documentation tools
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            .lake/packages/verso/.lake/build
+            .lake/packages/subverso/.lake/build
+            .lake/packages/MD4Lean/.lake/build
+            .lake/packages/illuminate/.lake/build
+            .lake/packages/plausible/.lake/build
+          key: doc-tools-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}
+
+      - name: Restore literate data
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            docbuild/.lake/build
+          key: literate-build-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-${{ github.sha }}
+          restore-keys: |
+            literate-build-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-
+
       - name: Build literate source pages
         if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
@@ -206,15 +242,25 @@ jobs:
         run: |
           python3 site/fix_literate_html.py _literate_html
 
-      - name: Save local lake build
-        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+      - name: Save documentation tools
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            .lake/build
+            .lake/packages/verso/.lake/build
+            .lake/packages/subverso/.lake/build
+            .lake/packages/MD4Lean/.lake/build
+            .lake/packages/illuminate/.lake/build
+            .lake/packages/plausible/.lake/build
+          key: doc-tools-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}
+
+      - name: Save literate data
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true' && github.event_name == 'push'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
             docbuild/.lake/build
-            _literate_html
-          key: lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-${{ github.sha }}
+          key: literate-build-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-${{ github.sha }}
 
       # Only a push writes to the shared cache. An entry saved from anywhere
       # else is scoped to a ref nothing later restores from, while it takes


### PR DESCRIPTION
Documentation rebuilds some problem modules with different build traces in `.lake/build`. Saving that directory after documentation makes later Lean-only runs rebuild unchanged modules. In the benchmark, documentation changed 69 module traces, and a one-file edit rebuilt those 69 modules as well as the edited module and `All`.

Save the Lean cache immediately after Lean validation, before documentation runs. Cache documentation tools and literate data separately, and initialize documentation dependencies before restoring their build files. Use new cache keys to avoid restoring the old mixed cache.

Validation: actionlint and `git diff --check` passed. A full seed workflow passed, followed by two matched warm-cache comparisons using the same docstring edit to Erdős problem 566. All four runs passed with exact cache hits.

| Measurement | Original, run 1 | Fixed, run 1 | Original, run 2 | Fixed, run 2 |
| --- | ---: | ---: | ---: | ---: |
| Build job, excluding queue | 7m 21s | 4m 51s | 6m 54s | 7m 05s |
| Lean problem build | 3m 40s | 43s | 3m 14s | 2m 41s |
| Problem modules plus `All` rebuilt | 71 | 2 | 71 | 2 |

[Seed](https://github.com/danielchin/formal-conjectures/actions/runs/34378191276), [original 1](https://github.com/danielchin/formal-conjectures/actions/runs/34381150794), [fixed 1](https://github.com/danielchin/formal-conjectures/actions/runs/34381154096), [original 2](https://github.com/danielchin/formal-conjectures/actions/runs/34382131357), [fixed 2](https://github.com/danielchin/formal-conjectures/actions/runs/34382138735).

Both comparisons eliminated all 69 unrelated rebuilds. Overall time averaged 16% lower, but the second fixed run was 11 seconds slower overall: its edited module took 150 seconds versus 34 seconds in the first fixed run. Two samples do not establish a reliable wall-clock speedup. These were manual same-branch simulations; cross-branch PR cache restoration was not tested. The new cache keys require a main-branch run to populate them after merge.

TL;DR: 
Saves the Lean cache before documentation runs.
Caches documentation tools and output separately.
Uses new cache keys so old, mixed caches aren’t restored.
