### PR TITLE
Green 14: the AKS14 lower bounds are proved, the exact values are conjectured

### DIFF
--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -212,86 +212,132 @@ theorem W_3_18 : W 3 18 = 312 := by sorry
 @[category research solved, AMS 5 11]
 theorem W_3_19 : W 3 19 = 349 := by sorry
 
--- Conjectured lower bounds for W(3,r) from [AKS14, Table 2].
-/-- $W(3, 20) \ge 389$ from [AKS14, Table 2]. -/
-@[category research open, AMS 5 11]
-theorem W_3_20_lower : answer(sorry) ↔ W 3 20 ≥ 389 := sorry
+-- Lower bounds for W(3,r) from [AKS14, Table 2], established by the good partitions
+-- (certificates) in [AKS14, Appendix A]; [AKS14] conjectures these bounds to be exact.
+/-- $W(3, 20) \ge 389$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_20_lower : answer(True) ↔ W 3 20 ≥ 389 := sorry
 
-/-- $W(3, 21) \ge 416$ from [AKS14, Table 2]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 20) = 389$. -/
 @[category research open, AMS 5 11]
-theorem W_3_21_lower : answer(sorry) ↔ W 3 21 ≥ 416 := sorry
+theorem W_3_20_eq : answer(sorry) ↔ W 3 20 = 389 := sorry
 
-/-- $W(3, 22) \ge 464$ from [AKS14, Table 2]. -/
-@[category research open, AMS 5 11]
-theorem W_3_22_lower : answer(sorry) ↔ W 3 22 ≥ 464 := sorry
+/-- $W(3, 21) \ge 416$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_21_lower : answer(True) ↔ W 3 21 ≥ 416 := sorry
 
-/-- $W(3, 23) \ge 516$ from [AKS14, Table 2]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 21) = 416$. -/
 @[category research open, AMS 5 11]
-theorem W_3_23_lower : answer(sorry) ↔ W 3 23 ≥ 516 := sorry
+theorem W_3_21_eq : answer(sorry) ↔ W 3 21 = 416 := sorry
 
-/-- $W(3, 24) \ge 593$ from [AKS14, Table 2]. -/
-@[category research open, AMS 5 11]
-theorem W_3_24_lower : answer(sorry) ↔ W 3 24 ≥ 593 := sorry
+/-- $W(3, 22) \ge 464$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_22_lower : answer(True) ↔ W 3 22 ≥ 464 := sorry
 
-/-- $W(3, 25) \ge 656$ from [AKS14, Table 2]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 22) = 464$. -/
 @[category research open, AMS 5 11]
-theorem W_3_25_lower : answer(sorry) ↔ W 3 25 ≥ 656 := sorry
+theorem W_3_22_eq : answer(sorry) ↔ W 3 22 = 464 := sorry
 
-/-- $W(3, 26) \ge 727$ from [AKS14, Table 2]. -/
-@[category research open, AMS 5 11]
-theorem W_3_26_lower : answer(sorry) ↔ W 3 26 ≥ 727 := sorry
+/-- $W(3, 23) \ge 516$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_23_lower : answer(True) ↔ W 3 23 ≥ 516 := sorry
 
-/-- $W(3, 27) \ge 770$ from [AKS14, Table 2]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 23) = 516$. -/
 @[category research open, AMS 5 11]
-theorem W_3_27_lower : answer(sorry) ↔ W 3 27 ≥ 770 := sorry
+theorem W_3_23_eq : answer(sorry) ↔ W 3 23 = 516 := sorry
 
-/-- $W(3, 28) \ge 827$ from [AKS14, Table 2]. -/
-@[category research open, AMS 5 11]
-theorem W_3_28_lower : answer(sorry) ↔ W 3 28 ≥ 827 := sorry
+/-- $W(3, 24) \ge 593$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_24_lower : answer(True) ↔ W 3 24 ≥ 593 := sorry
 
-/-- $W(3, 29) \ge 868$ from [AKS14, Table 2]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 24) = 593$. -/
 @[category research open, AMS 5 11]
-theorem W_3_29_lower : answer(sorry) ↔ W 3 29 ≥ 868 := sorry
+theorem W_3_24_eq : answer(sorry) ↔ W 3 24 = 593 := sorry
 
-/-- $W(3, 30) \ge 903$ from [AKS14, Table 2]. -/
-@[category research open, AMS 5 11]
-theorem W_3_30_lower : answer(sorry) ↔ W 3 30 ≥ 903 := sorry
+/-- $W(3, 25) \ge 656$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_25_lower : answer(True) ↔ W 3 25 ≥ 656 := sorry
 
--- Conjectured strict bounds for W(3,r) from [AKS14, Table 3].
-/-- $W(3, 31) > 930$ from [AKS14, Table 3]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 25) = 656$. -/
 @[category research open, AMS 5 11]
-theorem W_3_31_lower : answer(sorry) ↔ W 3 31 > 930 := sorry
+theorem W_3_25_eq : answer(sorry) ↔ W 3 25 = 656 := sorry
 
-/-- $W(3, 32) > 1006$ from [AKS14, Table 3]. -/
-@[category research open, AMS 5 11]
-theorem W_3_32_lower : answer(sorry) ↔ W 3 32 > 1006 := sorry
+/-- $W(3, 26) \ge 727$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_26_lower : answer(True) ↔ W 3 26 ≥ 727 := sorry
 
-/-- $W(3, 33) > 1063$ from [AKS14, Table 3]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 26) = 727$. -/
 @[category research open, AMS 5 11]
-theorem W_3_33_lower : answer(sorry) ↔ W 3 33 > 1063 := sorry
+theorem W_3_26_eq : answer(sorry) ↔ W 3 26 = 727 := sorry
 
-/-- $W(3, 34) > 1143$ from [AKS14, Table 3]. -/
-@[category research open, AMS 5 11]
-theorem W_3_34_lower : answer(sorry) ↔ W 3 34 > 1143 := sorry
+/-- $W(3, 27) \ge 770$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_27_lower : answer(True) ↔ W 3 27 ≥ 770 := sorry
 
-/-- $W(3, 35) > 1204$ from [AKS14, Table 3]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 27) = 770$. -/
 @[category research open, AMS 5 11]
-theorem W_3_35_lower : answer(sorry) ↔ W 3 35 > 1204 := sorry
+theorem W_3_27_eq : answer(sorry) ↔ W 3 27 = 770 := sorry
 
-/-- $W(3, 36) > 1257$ from [AKS14, Table 3]. -/
-@[category research open, AMS 5 11]
-theorem W_3_36_lower : answer(sorry) ↔ W 3 36 > 1257 := sorry
+/-- $W(3, 28) \ge 827$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_28_lower : answer(True) ↔ W 3 28 ≥ 827 := sorry
 
-/-- $W(3, 37) > 1338$ from [AKS14, Table 3]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 28) = 827$. -/
 @[category research open, AMS 5 11]
-theorem W_3_37_lower : answer(sorry) ↔ W 3 37 > 1338 := sorry
+theorem W_3_28_eq : answer(sorry) ↔ W 3 28 = 827 := sorry
 
-/-- $W(3, 38) > 1378$ from [AKS14, Table 3]. -/
-@[category research open, AMS 5 11]
-theorem W_3_38_lower : answer(sorry) ↔ W 3 38 > 1378 := sorry
+/-- $W(3, 29) \ge 868$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_29_lower : answer(True) ↔ W 3 29 ≥ 868 := sorry
 
-/-- $W(3, 39) > 1418$ from [AKS14, Table 3]. -/
+/-- [AKS14, Table 2] conjectures that $W(3, 29) = 868$. -/
 @[category research open, AMS 5 11]
-theorem W_3_39_lower : answer(sorry) ↔ W 3 39 > 1418 := sorry
+theorem W_3_29_eq : answer(sorry) ↔ W 3 29 = 868 := sorry
+
+/-- $W(3, 30) \ge 903$ from [AKS14, Table 2], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_30_lower : answer(True) ↔ W 3 30 ≥ 903 := sorry
+
+/-- [AKS14, Table 2] conjectures that $W(3, 30) = 903$. -/
+@[category research open, AMS 5 11]
+theorem W_3_30_eq : answer(sorry) ↔ W 3 30 = 903 := sorry
+
+-- Further lower bounds for W(3,r) from [AKS14, Table 3], established by the good partitions
+-- (certificates) in [AKS14, Appendix A]; [AKS14] expects these can be improved.
+/-- $W(3, 31) > 930$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_31_lower : answer(True) ↔ W 3 31 > 930 := sorry
+
+/-- $W(3, 32) > 1006$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_32_lower : answer(True) ↔ W 3 32 > 1006 := sorry
+
+/-- $W(3, 33) > 1063$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_33_lower : answer(True) ↔ W 3 33 > 1063 := sorry
+
+/-- $W(3, 34) > 1143$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_34_lower : answer(True) ↔ W 3 34 > 1143 := sorry
+
+/-- $W(3, 35) > 1204$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_35_lower : answer(True) ↔ W 3 35 > 1204 := sorry
+
+/-- $W(3, 36) > 1257$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_36_lower : answer(True) ↔ W 3 36 > 1257 := sorry
+
+/-- $W(3, 37) > 1338$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_37_lower : answer(True) ↔ W 3 37 > 1338 := sorry
+
+/-- $W(3, 38) > 1378$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_38_lower : answer(True) ↔ W 3 38 > 1378 := sorry
+
+/-- $W(3, 39) > 1418$ from [AKS14, Table 3], proved by an explicit good partition. -/
+@[category research solved, AMS 5 11]
+theorem W_3_39_lower : answer(True) ↔ W 3 39 > 1418 := sorry
 
 end Green14

--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -35,6 +35,8 @@ import FormalConjecturesUtil
   numbers." Journal of Combinatorial Theory, Series A 115.7 (2008): 1304-1309.
 - [LiSh10] Li, Yusheng, and Jinlong Shu. "A lower bound for off-diagonal van der Waerden numbers."
   Advances in Applied Mathematics 44.3 (2010): 243-247.
+- [Ko15] Kouril, Michal. "Leveraging FPGA clusters for SAT computations." Parallel Computing:
+  On the Road to Exascale (2015): 525-532.
 -/
 
 open Filter Set Topology
@@ -214,13 +216,16 @@ theorem W_3_19 : W 3 19 = 349 := by sorry
 
 -- Lower bounds for W(3,r) from [AKS14, Table 2], established by the good partitions
 -- (certificates) in [AKS14, Appendix A]; [AKS14] conjectures these bounds to be exact.
-/-- $W(3, 20) \ge 389$ from [AKS14, Table 2], proved by an explicit good partition. -/
-@[category research solved, AMS 5 11]
+/-- $W(3, 20) \ge 389$ from [AKS14, Table 2], proved by an explicit good partition.
+A kernel-checked Lean proof from the certificate was given by Dominic Dabish. -/
+@[category research solved, AMS 5 11, formal_proof using lean4 at
+  "https://github.com/DomTheDeveloper/formal-conjectures/blob/013a0f04de0057d2bd1034c7cc4caf10ac8dc2cf/FormalConjectures/GreensOpenProblems/Green14FastKernel20.lean"]
 theorem W_3_20_lower : answer(True) ↔ W 3 20 ≥ 389 := sorry
 
-/-- [AKS14, Table 2] conjectures that $W(3, 20) = 389$. -/
-@[category research open, AMS 5 11]
-theorem W_3_20_eq : answer(sorry) ↔ W 3 20 = 389 := sorry
+/-- $W(3, 20) = 389$, conjectured in [AKS14, Table 2] and established by Kouril [Ko15] using
+FPGA-based SAT solving. -/
+@[category research solved, AMS 5 11]
+theorem W_3_20 : W 3 20 = 389 := by sorry
 
 /-- $W(3, 21) \ge 416$ from [AKS14, Table 2], proved by an explicit good partition. -/
 @[category research solved, AMS 5 11]

--- a/FormalConjectures/Subsets/FC100OpenSet1.lean
+++ b/FormalConjectures/Subsets/FC100OpenSet1.lean
@@ -223,6 +223,6 @@ end Subsets.FC100OpenSet1
 
 open Lean Meta ProblemAttributes in
 #eval verifyCategoryCounts Subsets.FC100OpenSet1.problems [
-  ("research open", 91),
-  ("research solved", 9)
+  ("research open", 89),
+  ("research solved", 11)
 ]


### PR DESCRIPTION


The twenty statements `W_3_t_lower` for 20 ≤ t ≤ 39 were tagged `research open` and described as conjectured. In Ahmed–Kullmann–Snevily (AKS14) every one of them is a proved lower bound, certified by an explicit good partition in Appendix A (Sections "Certificates"). What AKS14 conjectures, for 20 ≤ t ≤ 30 only, is that the Table 2 bounds are the exact values; for 31 ≤ t ≤ 39 they say only that the Table 3 bounds can probably be improved.

Mark all twenty lower bounds `research solved` with `answer(True)`, and add the eleven conjectured exact values W(3, t) = v for 20 ≤ t ≤ 30 as `W_3_t_eq` with `answer(sorry)`, `research open`. Values checked against Tables 2 and 3 of the arXiv source of AKS14.

Fixes #4854 (reported by @KitaKen1).