### PR TITLE
fix(GreensOpenProblems/14): the exponential lower bounds were contentless, and the polynomial question has a known answer

### DIFF
--- a/FormalConjectures/GreensOpenProblems/14.lean
+++ b/FormalConjectures/GreensOpenProblems/14.lean
@@ -61,11 +61,15 @@ noncomputable def W (k r : ℕ) : ℕ := sInf (mixedMonoAPGuaranteeSet k r)
 Is $W(k, r)$ a polynomial in $r$, for fixed $k$?
 
 We formulate this as asking if $W(k, r)$ has polynomial growth in $r$.
-We know it is not the case for $k = 3$ [Gr21, p.3].
+The answer is no, already for $k = 4$. Every red $k$-term progression with $k \ge 3$ contains a
+red $3$-term progression, so `mixedMonoAPGuaranteeSet k r ⊆ mixedMonoAPGuaranteeSet 3 r`, and
+both sets are nonempty by van der Waerden's theorem, so $W(3, r) \le W(k, r)$. Polynomial
+growth for one $k \ge 4$ would therefore force polynomial growth for $k = 3$, contradicting
+`green_14_polynomial_k_eq_3` [Gr21, p.3].
 -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11]
 theorem green_14_polynomial :
-    answer(sorry) ↔ ∀ k ≥ 4, ∃ d : ℕ, (fun r => (W k r : ℝ)) =O[atTop] fun r => (r : ℝ) ^ d := by
+    answer(False) ↔ ∀ k ≥ 4, ∃ d : ℕ, (fun r => (W k r : ℝ)) =O[atTop] fun r => (r : ℝ) ^ d := by
   sorry
 
 /-- We know $W(3, r)$ does not have polynomial growth in $r$ [Gr21, p.3]. -/
@@ -87,14 +91,14 @@ theorem green_14_quadratic :
 /-- [Gr21] proved a lower bound of shape $W(3, r) \gg \exp(c(\log r)^{4/3-o(1)})$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_lower_bound_green :
-    answer(True) ↔ ∃ c : ℝ, ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+    answer(True) ↔ ∃ c : ℝ, 0 < c ∧ ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
     (fun (r : ℕ) => Real.exp (c * (Real.log r)^(4/3 - o r))) =O[atTop] fun r => (W 3 r : ℝ) := by
   sorry
 
 /-- [Hu22] improved this to $W(3, r) \gg \exp(c(\log r)^{2-o(1)})$. -/
 @[category research solved, AMS 5 11]
 theorem green_14_lower_bound_hunter :
-    answer(True) ↔ ∃ c : ℝ, ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
+    answer(True) ↔ ∃ c : ℝ, 0 < c ∧ ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
     (fun (r : ℕ) => Real.exp (c * (Real.log r)^(2 - o r))) =O[atTop] (fun r => (W 3 r : ℝ)) := by
   sorry
 


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

`green_14_lower_bound_green` and `green_14_lower_bound_hunter` quantify `∃ c : ℝ` with no sign
condition. At `c = 0` the left-hand side is `Real.exp 0 = 1`, and `1 =O[atTop] fun r => (W 3 r : ℝ)`
holds, so neither declaration said anything about superpolynomial growth. Both now require `0 < c`.
`green_14_upper_bound_kelley_meka` is deliberately left alone: for an *upper* bound a small
constant makes the claim harder, not trivially true.

`green_14_polynomial` asked whether `W(k, r)` grows polynomially for fixed `k ≥ 4`, and was
`research open`. Excluding `k = 3` does not avoid the known answer. `Set.IsAPOfLength k` forces
`d ≠ 0` for `k ≥ 2`, so a red `k`-term progression contains a red 3-term one and
`mixedMonoAPGuaranteeSet k r ⊆ mixedMonoAPGuaranteeSet 3 r`; both sets are non-empty by van der
Waerden's theorem, which is what rules out the `sInf ∅ = 0` degeneracy, so `W(3, r) ≤ W(k, r)`. A
polynomial bound at `k = 4` would give one at `k = 3`, contradicting `green_14_polynomial_k_eq_3`
in the same file. The declaration becomes `answer(False)`, `research solved`, with that argument
in its docstring.

### How this was checked

`lake --wfail build` over the whole repository and `lake --wfail test`, on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends
on the other eight.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
