### PR TITLE
fix: answer slots that cannot depend on the inputs they must depend on

### DIFF
--- a/FormalConjectures/ErdosProblems/1047.lean
+++ b/FormalConjectures/ErdosProblems/1047.lean
@@ -124,7 +124,8 @@ a function of the degree of $f$.
 theorem erdos_1047.variants.max_non_convex_components (n : ℕ) :
     IsGreatest {k : ℕ | ∃ (f : ℂ[X]) (c : ℝ), f.Monic ∧ f.natDegree = n ∧ 0 < c ∧
       (componentsIn (sublevelSet f c)).ncard = (f.rootSet ℂ).ncard ∧
-      {t ∈ componentsIn (sublevelSet f c) | ¬ Convex ℝ t}.ncard = k} answer(sorry) := by
+      {t ∈ componentsIn (sublevelSet f c) | ¬ Convex ℝ t}.ncard = k}
+      ((answer(sorry) : ℕ → ℕ) n) := by
   sorry
 
 end Erdos1047

--- a/FormalConjectures/ErdosProblems/321.lean
+++ b/FormalConjectures/ErdosProblems/321.lean
@@ -42,7 +42,7 @@ $\sum_{n\in S} \frac{1}{n}$ are distinct for $S\subseteq A$. What is $R(N)$?
 -/
 @[category research open, AMS 11]
 theorem erdos_321 (N : ℕ) :
-    R N = answer(sorry) := by
+    R N = (answer(sorry) : ℕ → ℕ) N := by
   sorry
 
 /-

--- a/FormalConjectures/ErdosProblems/361.lean
+++ b/FormalConjectures/ErdosProblems/361.lean
@@ -65,7 +65,7 @@ Does this depend on $n$ in an irregular way?
 -/
 @[category research open, AMS 11]
 theorem erdos_361 (c : ℝ) (hc : 0 < c) :
-    subsetSumAvoidanceNumber c = answer(sorry) := by
+    subsetSumAvoidanceNumber c = (answer(sorry) : ℝ → ℕ → ℕ) c := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -35,7 +35,7 @@ How many iterations of $n\mapsto\phi(n) + 1$ are needed before a prime is reache
 -- it becomes static. See also https://oeis.org/A39651
 @[category research open, AMS 11]
 theorem erdos_409.parts.i (n : ℕ) (hn : 0 < n) :
-    IsLeast { i | (φ · + 1)^[i] n |>.Prime } answer(sorry) := by
+    IsLeast { i | (φ · + 1)^[i] n |>.Prime } ((answer(sorry) : ℕ → ℕ) n) := by
   sorry
 
 /-- If $n > 0$, then the iteration $n\mapsto\phi(n) + 1$ necessarily
@@ -123,7 +123,7 @@ How many iterations of $n\mapsto\sigma(n) - 1$ are needed before a prime is reac
 -- it is strictly increasing except at primes.
 @[category research open, AMS 11]
 theorem erdos_409.variants.sigma (n : ℕ) (hn : n > 1) :
-    IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } answer(sorry) := by
+    IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } ((answer(sorry) : ℕ → ℕ) n) := by
   sorry
 
 /-- If $n > 1$ then the iteration $n\mapsto\sigma(n) - 1$ necessarily reaches a prime.

--- a/FormalConjectures/ErdosProblems/434.lean
+++ b/FormalConjectures/ErdosProblems/434.lean
@@ -60,7 +60,8 @@ theorem erdos_434.parts.i (n k : ℕ) (hn : 1 ≤ n) (hk : 2 ≤ k) (h : k ≤ n
     IsGreatest
       { Nat.NcardUnrepresentable S | (S : Finset ℕ) (_ : S ⊆ Finset.Icc 1 n)
         (_ : #S = k) (_ : S.gcd id = 1) }
-      (Nat.NcardUnrepresentable <| answer(Set.Icc (n - k + 1 : ℕ) n)) := by
+      (Nat.NcardUnrepresentable <|
+        (answer(fun m j => Set.Icc (m - j + 1 : ℕ) m) : ℕ → ℕ → Set ℕ) n k) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/503.lean
+++ b/FormalConjectures/ErdosProblems/503.lean
@@ -33,7 +33,7 @@ of the distances $|x - y|$, $|y - z|$, $|x - z|$ are equal.
 -/
 @[category research open, AMS 51]
 theorem erdos_503 (n : ℕ) :
-    IsGreatest {(A.ncard) | (A : Set (ℝ^n)) (hA : A.IsIsosceles)} answer(sorry) := by
+    IsGreatest {(A.ncard) | (A : Set (ℝ^n)) (hA : A.IsIsosceles)} ((answer(sorry) : ℕ → ℕ) n) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/506.lean
+++ b/FormalConjectures/ErdosProblems/506.lean
@@ -62,7 +62,7 @@ theorem erdos_506 (n : ℕ) (hn : 4 ≤ n) :
     IsLeast { k : ℕ | ∃ P : Finset ℝ²,
         P.card = n ∧ ¬ Collinear ℝ (P : Set ℝ²) ∧ ¬ Cospherical (P : Set ℝ²) ∧
         numCircles (P : Set ℝ²) = k }
-      answer(sorry) := by
+      ((answer(sorry) : ℕ → ℕ) n) := by
   sorry
 
 /--
@@ -76,7 +76,7 @@ theorem erdos_506.variants.large_n (n : ℕ) (hn : 393 < n) :
     IsLeast { k : ℕ | ∃ P : Finset ℝ²,
         P.card = n ∧ ¬ Collinear ℝ (P : Set ℝ²) ∧ ¬ Cospherical (P : Set ℝ²) ∧
         numCircles (P : Set ℝ²) = k }
-      answer((n - 1).choose 2 + 1 - (n - 1) / 2) := by
+      ((answer(fun m => (m - 1).choose 2 + 1 - (m - 1) / 2) : ℕ → ℕ) n) := by
   sorry
 
 /--
@@ -89,7 +89,7 @@ theorem erdos_506.variants.small_n (n : ℕ) (hn : 4 ≤ n) (hn' : n ≤ 393) :
     IsLeast { k : ℕ | ∃ P : Finset ℝ²,
         P.card = n ∧ ¬ Collinear ℝ (P : Set ℝ²) ∧ ¬ Cospherical (P : Set ℝ²) ∧
         numCircles (P : Set ℝ²) = k }
-      answer(sorry) := by
+      ((answer(sorry) : ℕ → ℕ) n) := by
   sorry
 
 /--

--- a/FormalConjectures/ErdosProblems/596.lean
+++ b/FormalConjectures/ErdosProblems/596.lean
@@ -50,7 +50,7 @@ See Problem 595 for the specific case $(G_1, G_2) = (K_4, K_3)$.
 theorem erdos_596 :
     ∀ {U₁ U₂ : Type} (G₁ : SimpleGraph U₁) (G₂ : SimpleGraph U₂),
       IsErdosHajnalExceptional G₁ G₂ ↔
-      (answer(sorry) : ∀ {U₁ U₂ : Type}, SimpleGraph U₁ → SimpleGraph U₂ → Prop) G₁ G₂ := by
+      (answer(sorry) : ∀ V₁ V₂ : Type, SimpleGraph V₁ → SimpleGraph V₂ → Prop) U₁ U₂ G₁ G₂ := by
   sorry
 
 /-- Erdős–Hajnal exceptional pairs exist — recorded as a known direction of `erdos_596`. -/

--- a/FormalConjectures/GreensOpenProblems/5.lean
+++ b/FormalConjectures/GreensOpenProblems/5.lean
@@ -75,7 +75,7 @@ $\mathrm{SL}_2(\mathbb{F}_p)$.
 -/
 @[category research open, AMS 5 20]
 theorem green_5.variants.sl_two (p : ℕ) [Fact p.Prime] :
-    let S : Finset (SL₂ p) := answer(sorry)
+    let S : Finset (SL₂ p) := (answer(sorry) : (q : ℕ) → Finset (SL₂ q)) p
     MaximalFor (IsProductFree (M := SL₂ p)) Set.ncard (S : Set (SL₂ p)) := by
   sorry
 

--- a/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
+++ b/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
@@ -129,7 +129,7 @@ theorem voronovskaja_theorem.bezier_bernstein_operators
     (f : ℝ → ℝ) (x : ℝ) (hx : x ∈ I)
     (hf : ContDiffOn ℝ 2 f I) :
     Tendsto (fun n : ℕ => Real.sqrt n * (bezierBernstein n α f x - f x)) atTop
-      (𝓝 answer(sorry)) := by
+      (𝓝 ((answer(sorry) : ℝ → (ℝ → ℝ) → ℝ → ℝ) α f x)) := by
   sorry
 
 /--
@@ -140,7 +140,7 @@ $C^m$ function on $[0,1]$ should have the asserted asymptotic formula.
 @[category research open, AMS 26 40 47]
 theorem voronovskaja_theorem.bezier_bernstein_operators.variants.eventually_smooth
     (α : ℝ) (hα_pos : 0 < α) (hα : α ≠ 1) :
-    let limitFormula : (ℝ → ℝ) → ℝ → ℝ := answer(sorry)
+    let limitFormula := (answer(sorry) : ℝ → (ℝ → ℝ) → ℝ → ℝ) α
     ∀ᶠ m : ℕ in atTop,
       ∀ (f : ℝ → ℝ) (x : ℝ), x ∈ I → ContDiffOn ℝ m f I →
         Tendsto (fun n : ℕ => Real.sqrt n * (bezierBernstein n α f x - f x)) atTop
@@ -164,13 +164,13 @@ theorem voronovskaja_theorem.bezier_bernstein_operators.variants.eventually_smoo
 
 /--
 Variant of the Bézier-Bernstein Voronovskaja problem with the required smoothness order itself
-left as an answer. Replacing `(answer(sorry) : ℕ × ((ℝ → ℝ) → ℝ → ℝ))` by a concrete value lets one
-state the conjecture for a chosen regularity threshold.
+left as an answer. Replacing `(answer(sorry) : ℝ → ℕ × ((ℝ → ℝ) → ℝ → ℝ))` by a concrete value
+lets one state the conjecture for a chosen regularity threshold.
 -/
 @[category research open, AMS 26 40 47]
 theorem voronovskaja_theorem.bezier_bernstein_operators.variants.answer_smoothness
     (α : ℝ) (hα_pos : 0 < α) (hα : α ≠ 1) :
-    let p : ℕ × ((ℝ → ℝ) → ℝ → ℝ) := answer(sorry)
+    let p := (answer(sorry) : ℝ → ℕ × ((ℝ → ℝ) → ℝ → ℝ)) α
     let m := p.1
     let limitFormula := p.2
     ∀ (f : ℝ → ℝ) (x : ℝ), x ∈ I → ContDiffOn ℝ m f I →


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

In the `with_auxiliary` answer-extraction mode the answer term is lifted to a closed top-level
definition, so an answer that mentions a theorem binder is a kernel error, and a slot typed
without that binder can never be filled in correctly.

Sweeping every problem file with `lake env lean -Dgoogle.answer=with_auxiliary` finds four
declarations that fail outright today: `erdos_506.variants.large_n` and `erdos_434.parts.i`, whose
answers are filled in and mention a theorem binder, and `erdos_596` and `green_5.variants.sl_two`,
whose answer *type* mentions one.

Each affected slot now applies a closed function to the binders, the idiom already used at
`OpenQuantumProblems/13.lean:562`. Besides the four above this covers `VoronovskajaTypeFormula`
(three slots, all missing the shape parameter `α`), Erdős 409 (`parts.i`, `variants.sigma`), 361,
321, 503, 506 (`erdos_506`, `variants.small_n`) and 1047. After the change a `with_auxiliary`
sweep over all 1268 problem files reports no free-variable error anywhere.

`erdos_361.asymptotic` is deliberately left alone: its answer is a `Θ`-class in `n` and may
legitimately not depend on `c`.

**Scope.** A slot still holding `answer(sorry)` does not fail to compile, because `sorry` is
closed — so the sweep sees only the subset of the defect where an answer has been filled in. A
subsequent exhaustive read of every `answer(` site found **twelve more slots with the same
defect**, which are *not* fixed here: `ErdosProblems/142.lean:37,56`, `319.lean:46`,
`692.lean:71`, `700.lean:72`, `975.lean:88`, `GreensOpenProblems/16.lean:47`, `24.lean:53`,
`37.lean:49,58,64,70,76`, `41.lean:69`. One of them, `erdos_700.parts.i`, looks **unsatisfiable as
written**: with a closed `Prop` answer, `f n = n / P n ↔ answer(sorry)` asserts that the left side
has the same truth value for every composite `n > 1`, and it does not — it holds at `n = 4`
(`f(4) = 2 = 4/P(4)`) and fails at `n = 8` (`f(8) = 2 ≠ 4 = 8/P(8)`). They are held back because
they were found after this change set was verified and deserve their own review. Tell me which you
prefer: I can fold them in here, or open a separate issue and PR for them.

### How this was checked

Every changed file elaborates under `lake env lean` and under
`lake env lean -Dgoogle.answer=with_auxiliary`. Sweeping all 1268 problem files in
`with_auxiliary` mode reports no free-variable error. That sweep does surface four *unrelated*
failures — `ErdosProblems/501`, `593`, `686` and `Wikipedia/JacobianConjecture` fail on `simp` or
`rw` in that mode because the answer term becomes an opaque top-level constant. None of those
files is touched here and all four fail identically on `main`, which I checked by running the
base versions; I mention them only so the sweep output is not mistaken for a regression.

`lake --wfail build` over the whole repository and `lake --wfail test` pass on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends on
the other eight.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
