### PR TITLE
chore: status corrections across seven problem files

### DIFF
--- a/FormalConjectures/ErdosProblems/306.lean
+++ b/FormalConjectures/ErdosProblems/306.lean
@@ -20,7 +20,12 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 306
 
-*Reference:* [erdosproblems.com/306](https://www.erdosproblems.com/306)
+*References:*
+- [erdosproblems.com/306](https://www.erdosproblems.com/306)
+- [Ta26] [Tang, Yuren, *A Lean 4 formalisation of Erdős Problem
+  306*](https://github.com/Yuren-Tang/erdos-306), which derives the statement below from two
+  results of Rosser and Schoenfeld, *Approximate formulas for some functions of prime numbers*,
+  Illinois J. Math. **6** (1962), 64-94, declared there as axioms
 -/
 
 open ArithmeticFunction

--- a/FormalConjectures/OEIS/237271.lean
+++ b/FormalConjectures/OEIS/237271.lean
@@ -185,8 +185,17 @@ That is, $a(k) \ge 3$ for every Carmichael number $k$.
 A002997 is the sequence of Carmichael numbers: the composite numbers $k$ such that
 $b^{k-1} \equiv 1 \pmod k$ for every $b$ coprime to $k$. This is `IsCarmichael`,
 which also forces $k$ to be composite.
+
+The observation holds for every odd composite $k$, so in particular for every Carmichael
+number. Write $p$ for the least prime factor of $k$ and $q = k/p$. The two smallest divisors
+of $k$ are $1$ and $p$, and the two largest are $q$ and $k$, so $(1, p)$ and $(q, k)$ are both
+consecutive pairs in the sorted divisor list, and they are distinct because $1 < q$. Both
+qualify: $p$ and $k$ are odd, $p \ge 2 \cdot 1$, and $k = pq \ge 3q > 2q$. Hence the count is
+at least $2$ and $a(k) \ge 3$. A Carmichael number is odd: it is composite by the $b = 1$ case
+of `IsCarmichael`, so $k > 2$, and if $k$ were even then the coprime base $k - 1 \equiv -1$
+would give $k \mid (-1)^{k-1} - 1 = -2$.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11]
 theorem observation_carmichael (k : ℕ) (hk : IsCarmichael k) :
     3 ≤ a k := by
   sorry

--- a/FormalConjectures/OEIS/2454.lean
+++ b/FormalConjectures/OEIS/2454.lean
@@ -22,7 +22,9 @@ import FormalConjecturesUtil
 Central factorial numbers: $a(n) = 4^n (n!)^2 = ((2n)!!)^2$.
 
 *References:*
-- [A002454](https://oeis.org/A002454)-/
+- [A002454](https://oeis.org/A002454)
+- [SSX22] [She, Y.-F., Sun, Z.-W., Xia, W., *A novel permanent identity with applications*,
+  arXiv:2208.12167 (2022)](https://arxiv.org/abs/2208.12167)-/
 
 namespace OeisA2454
 
@@ -54,8 +56,13 @@ theorem a_4 : a 4 = 147456 := by rfl
 Let $\zeta$ be a primitive $(2n+1)$-th root of unity. Then the permanent of the
 $2n \times 2n$ matrix $[m(j,k)]_{j,k=1..2n}$ is $a(n)/(2n+1) = ((2n)!!)^2/(2n+1)$,
 where $m(j,k)$ is $1$ or $(1+\zeta^{j-k})/(1-\zeta^{j-k})$ according as $j = k$ or not.
-- Zhi-Wei Sun, Dec 21 2021-/
-@[category research open, AMS 11 15]
+- Zhi-Wei Sun, Jun 26 2022
+
+Proved by [SSX22], Theorem 1.3(ii): for odd $m > 1$ and $\zeta$ a primitive $m$-th root of
+unity, the permanent of $[c_{j,k}]_{1 \le j,k \le m-1}$ is $((m-1)!!)^2/m$. Take $m = 2n+1$;
+translating both matrix indices by one leaves $j - k$ unchanged. For $n = 0$ the matrix is
+empty and both sides are $1$.-/
+@[category research solved, AMS 11 15]
 theorem conjecture (n : ℕ) :
     let N : ℕ := 2 * n
     let K : ℕ := N + 1

--- a/FormalConjectures/OEIS/53175.lean
+++ b/FormalConjectures/OEIS/53175.lean
@@ -23,7 +23,9 @@ The Catalan-Larcombe-French sequence defined by $a(0)=1$, $a(1)=8$, and
 $$n^2 a(n) = 8(3n^2 - 3n + 1) a(n-1) - 128(n-1)^2 a(n-2)$$ for $n \ge 2$.
 
 *References:*
-- [A053175](https://oeis.org/A053175)-/
+- [A053175](https://oeis.org/A053175)
+- [ZS18] [Zhu, B.-X., Sun, Z.-W., *Hankel-type determinants for some combinatorial sequences*,
+  Int. J. Number Theory **14** (2018), 1265-1277](https://arxiv.org/abs/1609.06810)-/
 
 namespace OeisA53175
 
@@ -71,8 +73,11 @@ def hankelMatrix (n : ℕ) : Matrix (Fin (n + 1)) (Fin (n + 1)) ℤ :=
 Conjecture: let $P(n)$ be the $(n+1) \times (n+1)$ Hankel-type determinant with $(i,j)$-entry
 equal to $a(i+j)$ for all $i,j = 0, \ldots, n$. Then $P(n)/2^{n(n+3)}$ is a positive odd integer.
 - Zhi-Wei Sun, Aug 14 2013
+
+Proved by [ZS18], Theorem 1.2: $2^{-n(n+3)} |P_{i+j}|_{0 \le i,j \le n}$ is a positive odd
+integer for every $n \in \mathbb{N}$, where $P_n$ are the Catalan-Larcombe-French numbers.
 -/
-@[category research open, AMS 11 15]
+@[category research solved, AMS 11 15]
 theorem conjecture (n : ℕ) :
     let detP := (hankelMatrix n).det
     let pow2 := (2 : ℤ) ^ (n * (n + 3))

--- a/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
+++ b/FormalConjectures/Paper/MonochromaticQuantumGraph.lean
@@ -70,6 +70,10 @@ coefficient domains (e.g. `ℂ`, `ℝ`, `ℤ`, and restricted integer weights).
 
 * [Chandran2024] [Krenn–Gu conjecture for sparse graphs](https://arxiv.org/abs/2407.00303)
   by *N. Chandran, S. Gajjala, S. Illickan, M. Krenn*, MFCS 2024.
+
+* [Ki26] [A solver-free Lean 4 proof of the sharp bound $D \le N - 2$ for monochromatic quantum
+  graph equation systems over integral domains](https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/tree/6c5340384479dbb36129b2e0084449be2458cce2),
+  commit `6c534038`.
 -/
 
 open scoped Matrix
@@ -418,10 +422,13 @@ theorem eqSystem6_no_solution_d4 :
 
 
 /-- For $N = 6$ and $D = 5$, does there exist no solution to the monochromatic quantum graph
-equation system over $\mathbb{C}$? -/
-@[category research open, AMS 5 14 81]
+equation system over $\mathbb{C}$?
+
+The sharp bound $D \le N - 2$ over an integral domain [Ki26] settles this: here $D = N - 1$. -/
+@[category research solved, AMS 5 14 81, formal_proof using lean4 at
+"https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c5340384479dbb36129b2e0084449be2458cce2/lean/QuantumCR/FormalConjecturesWrappers.lean#L55-L62"]
 theorem eqSystem6_no_solution_d5 :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 6 5 ℂ, EqSystemN 6 5 W := by
   sorry
 
@@ -515,10 +522,13 @@ theorem eqSystem10_no_solution_d8 :
   sorry
 
 /-- For $N = 10$ and $D = 9$, does there exist no solution to the monochromatic quantum graph
-equation system over $\mathbb{C}$? -/
-@[category research open, AMS 5 14 81]
+equation system over $\mathbb{C}$?
+
+The sharp bound $D \le N - 2$ over an integral domain [Ki26] settles this: here $D = N - 1$. -/
+@[category research solved, AMS 5 14 81, formal_proof using lean4 at
+"https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c5340384479dbb36129b2e0084449be2458cce2/lean/QuantumCR/FormalConjecturesWrappers.lean#L73-L80"]
 theorem eqSystem10_no_solution_d9 :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 10 9 ℂ, EqSystemN 10 9 W := by
   sorry
 
@@ -594,10 +604,13 @@ theorem eqSystem6_no_solution_d3_real :
   sorry
 
 /-- For $N = 6$ and $D = 5$, does there exist no solution to the monochromatic quantum graph
-equation system over $\mathbb{R}$? -/
-@[category research open, AMS 5 14 81]
+equation system over $\mathbb{R}$?
+
+The sharp bound $D \le N - 2$ over an integral domain [Ki26] settles this: here $D = N - 1$. -/
+@[category research solved, AMS 5 14 81, formal_proof using lean4 at
+"https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/blob/6c5340384479dbb36129b2e0084449be2458cce2/lean/QuantumCR/FormalConjecturesWrappers.lean#L64-L71"]
 theorem eqSystem6_no_solution_d5_real :
-    answer(sorry) ↔
+    answer(True) ↔
       ¬ ∃ W : WeightsN 6 5 ℝ, EqSystemN 6 5 W := by
   sorry
 

--- a/FormalConjectures/Paper/TuDengConjecture.lean
+++ b/FormalConjectures/Paper/TuDengConjecture.lean
@@ -23,6 +23,12 @@ import FormalConjecturesUtil
   Boolean functions with optimal algebraic immunity*, Des. Codes Cryptogr. **60** (2011),
   1–14](https://doi.org/10.1007/s10623-010-9413-9)
 * [IACR ePrint 2009/272](https://eprint.iacr.org/2009/272)
+* [LLX26] [Liu, R., Luo, H., Xie, T., *A Complete Proof for Tu-Deng Conjecture*, arXiv:2608.05187v2
+  (2026)](https://arxiv.org/abs/2608.05187v2)
+* [Cu26] [Cusick, T. W., *Proof of the TuDeng Conjecture*, arXiv:2608.14821
+  (2026)](https://arxiv.org/abs/2608.14821)
+* [Lean26] [A Lean 4 proof of the count form of the conjecture](https://github.com/ifeelok92/tu-deng-conjecture-lean-formal-proof/blob/3c00561415deedcdc56b9e803042c1d0f15f5d5b/TuDengFormal/FirstExitNat.lean#L529-L535),
+  commit `3c005614`, theorem `TuDeng.FirstExit.tu_deng_conjecture_full`
 
 For an integer $k \ge 2$, identify the residues modulo $2^k - 1$ with the integers
 $0, 1, \dots, 2^k - 2$, and let $w(a)$ denote the binary weight of $a$ (the number of ones in
@@ -34,6 +40,10 @@ Tu and Deng showed that this combinatorial statement implies that their construc
 Boolean functions (a bent class and a balanced class) achieve optimal algebraic immunity,
 which is the motivation for the conjecture. They verified the conjecture numerically for
 $k \le 29$ (Remark 3.1 of the ePrint version).
+
+The conjecture is no longer open: [LLX26] and, independently, [Cu26] give complete proofs.
+[Lean26] is a Lean 4 development of the same bound, stated for the count of natural-number
+representatives $x < 2^k - 1$ rather than for the set of residue pairs used below.
 -/
 
 namespace TuDengConjecture
@@ -45,8 +55,10 @@ def binaryWeight (n : ℕ) : ℕ := (Nat.digits 2 n).sum
 **The Tu-Deng conjecture.** For $k \ge 2$ and a nonzero residue $t$ modulo $2^k - 1$, there
 are at most $2^{k-1}$ pairs of residues $(a, b)$ with $a + b = t$ whose binary weights
 (of their representatives in $0, \dots, 2^k - 2$) sum to at most $k - 1$.
+
+Proved in [LLX26] and independently in [Cu26]; see also the Lean development [Lean26].
 -/
-@[category research open, AMS 5 11 94]
+@[category research solved, AMS 5 11 94]
 theorem tu_deng_conjecture (k : ℕ) (hk : 2 ≤ k) (t : ZMod (2 ^ k - 1)) (ht : t ≠ 0) :
     {p : ZMod (2 ^ k - 1) × ZMod (2 ^ k - 1) |
         p.1 + p.2 = t ∧ binaryWeight p.1.val + binaryWeight p.2.val ≤ k - 1}.ncard

--- a/FormalConjectures/Wikipedia/Fuglede.lean
+++ b/FormalConjectures/Wikipedia/Fuglede.lean
@@ -21,6 +21,8 @@ import FormalConjecturesUtil
 
 *References:*
 - [Fuglede's conjecture](https://en.wikipedia.org/wiki/Fuglede%27s_conjecture)
+- [Zh26] [Zhang, Tao, *Both directions of Fuglede's conjecture fail in dimension two*,
+  arXiv:2607.15632 (2026)](https://arxiv.org/abs/2607.15632)
 -/
 
 namespace Fuglede
@@ -45,6 +47,10 @@ theorem FugledeConjecture.variants.dim_1 :
 
 /--
 **Fuglede's conjecture** in two dimensions: A bounded subset of ℝ^2 with positive Lebesgue measure is spectral iff it tiles ℝ^2 by translation.
+
+[Zh26], a July 2026 preprint, announces a negative answer in both directions, from two
+explicit $60$-point subsets of $\mathbb{Z}_{60} \times \mathbb{Z}_{12}$ lifted to finite
+unions of unit squares in $\mathbb{R}^2$. It is not yet published.
 -/
 @[category research open, AMS 42 46 47]
 theorem FugledeConjecture.variants.dim_2 :


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

Seven declarations whose answers are in the literature or in a public proof artifact, plus two
developments recorded as references without a status change.

### `Paper/MonochromaticQuantumGraph` — three declarations

The sharp bound `D ≤ N − 2` over an integral domain, proved in
[`KitaKen1/monochromatic-quantum-graph-sharp-bound-lean@6c534038`](https://github.com/KitaKen1/monochromatic-quantum-graph-sharp-bound-lean/tree/6c5340384479dbb36129b2e0084449be2458cce2),
settles the three open `D = N − 1` declarations. `eqSystem6_no_solution_d5`,
`eqSystem6_no_solution_d5_real` and `eqSystem10_no_solution_d9` become `answer(True)`,
`research solved`, each with a `formal_proof using lean4` link to its own wrapper in that
project's `lean/QuantumCR/FormalConjecturesWrappers.lean`.

What I checked about the artifact:

- It does not paraphrase these propositions. Its `lean/QuantumCR/Vertices.lean` does
  `import FormalConjectures.Paper.MonochromaticQuantumGraph`, and its `lakefile.toml` pins this
  repository at `f7349f32`, whose copy of this file is byte-identical to current `main`
  (SHA-256 `a04ac0b1…`). The wrappers are therefore stated in terms of this file's own `WeightsN`
  and `EqSystemN`.
- Its three wrapper statements are `answer(True) ↔ ¬ ∃ W : WeightsN N D K, EqSystemN N D W` for
  `(6, 5, ℂ)`, `(6, 5, ℝ)` and `(10, 9, ℂ)`, matching the three declarations here, and each is
  discharged from `no_eqSystem_of_vertices_sub_two_lt_colors_domain`.
- No `sorry`, no `axiom`, no `native_decide` in any of the project's 25 Lean files.
- The project also ships a self-contained `lean4web/` variant that inlines the definitions. Its
  copies of `V`, `EdgeN`, `WeightsN`, `mkEdge`, `vertices`, `allEqual`, `pmSumList`, `pmSumN` and
  `EqSystemN` are byte-identical to the ones in this file, so it proves the same three
  propositions. I ran that variant with `lake env lean` against this repository's own toolchain
  and Mathlib (Lean 4.33.1). It elaborates with no errors, the three wrapper statements print as
  `True ↔ ¬∃ W, EqSystemN 6 5 W`, `True ↔ ¬∃ W, EqSystemN 6 5 W` (over `ℝ`) and
  `True ↔ ¬∃ W, EqSystemN 10 9 W`, and each depends on axioms
  `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

One caveat. The `lean/` project the `formal_proof` links point at is pinned to Lean 4.27.0 and
Mathlib v4.27.0, so the run above was of the standalone variant on 4.33.1, not of the linked files
on their own toolchain. Separately, the same bound would settle `eqSystem6_no_solution_d5_int` and
`eqSystem6_no_solution_d5_trinary_int` too, since `ℤ` is an integral domain, but those have no
wrapper in the artifact, so they are left open.

### `Paper/TuDengConjecture`

Complete proofs appeared in August 2026: Liu–Luo–Xie,
[arXiv:2608.05187](https://arxiv.org/abs/2608.05187) (v1 30 July, v2 12 August), and
independently Cusick, [arXiv:2608.14821](https://arxiv.org/abs/2608.14821) (14 August). There is
also a Lean development,
[`ifeelok92/tu-deng-conjecture-lean-formal-proof@3c005614`](https://github.com/ifeelok92/tu-deng-conjecture-lean-formal-proof/blob/3c00561415deedcdc56b9e803042c1d0f15f5d5b/TuDengFormal/FirstExitNat.lean#L529-L535),
which proves the same bound in a count form over natural-number representatives rather than the
residue-pair form used here.

The two forms are the same count, by a direct bijection rather than by coincidence. That
development's `tuDengCount k t` filters `x ∈ [0, 2^k − 1)` by
`hammingWeight k x + hammingWeight k (partner k t x) ≤ k − 1`, with
`partner k t x = (t + (2^k − 1) − x) % (2^k − 1)`. Here each `a : ZMod (2^k − 1)` determines
`b = t − a` uniquely, `b.val` is exactly that `partner`, and `binaryWeight v = (Nat.digits 2 v).sum`
agrees with `hammingWeight k v` for every `v < 2^k − 1`, since such a `v` has no bit at index `≥ k`.
I also evaluated this file's own residue-pair count directly for `k = 2 … 14` and every non-zero
`t`: the maximum is exactly `2^(k−1)` at each `k`, so the bound holds and is tight throughout that
range. The development declares no `axiom` and contains no `sorry` or `native_decide` in any of its
9 Lean files.

`research open → research solved`, with all three references recorded. **No `formal_proof`
attribute**: the correspondence above is a short argument rather than something the development
states about this file's declaration, so the link is recorded as a plain reference.

### `OEIS/237271`

`observation_carmichael` holds for every odd composite `k`, not just Carmichael numbers. With
`p = minFac k` and `q = k/p`, the sorted divisor list begins `1, p` and ends `q, k`, so `(1, p)`
and `(q, k)` are distinct consecutive pairs — distinct because `1 < q` — and both satisfy the
predicate, since `p` and `k` are odd, `p ≥ 2·1` and `k = pq ≥ 3q > 2q`. So the `countP` is at
least 2 and `a k ≥ 3`. Carmichael numbers are odd: `IsCarmichael` at `b = 1` forces
compositeness, so `k > 2`, and if `k` were even the coprime base `k − 1 ≡ −1` would give
`k ∣ (−1)^{k−1} − 1 = −2`. Marked `research solved`, with the argument in the docstring. I also
checked computationally that no odd composite `k < 20000` has `a(k) < 3`. There is no public
formal proof, so no `formal_proof` attribute; a Lean proof would be a natural follow-up.

### `OEIS/53175` and `OEIS/2454`

Zhu–Sun, *Hankel-type determinants for some combinatorial sequences*,
[arXiv:1609.06810](https://arxiv.org/abs/1609.06810) = Int. J. Number Theory **14** (2018)
1265–1277, **Theorem 1.2**, proves that `2^{−n(n+3)}|P_{i+j}|` is a positive odd integer for the
Catalan–Larcombe–French numbers. (The abstract names only Franel, Domb and Apéry; the
Catalan–Larcombe–French half is in the body.) I checked that this file's ℕ-valued recurrence
agrees with `P_n` for `n = 0 … 30` and that the quotients are `1, 1, 5, 95, 7771, 2461771`.

She–Sun–Xia, [arXiv:2208.12167](https://arxiv.org/abs/2208.12167), **Theorem 1.3(ii)**, evaluates
the odd-order root-of-unity permanent as `((m−1)!!)²/m`. Taking `m = 2n+1` and shifting both
indices by one leaves `j − k` unchanged and gives this statement; the paper needs `m > 1`, so the
`n = 0` endpoint (empty matrix, both sides 1) is checked separately. The A002454 attribution date
is also corrected from "Dec 21 2021" to "Jun 26 2022" to match OEIS.

Both are marked `research solved` and cited.

### Recorded, but left `research open`

- `Wikipedia/Fuglede`: [arXiv:2607.15632](https://arxiv.org/abs/2607.15632) (Zhang, July 2026)
  announces that both directions fail in dimension two. `variants.dim_2` **stays
  `research open`**: the preprint is unrefereed with no independent write-up, so it does not yet
  meet the `research solved` bar of a solution widely accepted by experts. The reference and the
  announcement are recorded. Say the word and I will flip it.
- `ErdosProblems/306`: [`Yuren-Tang/erdos-306`](https://github.com/Yuren-Tang/erdos-306) states
  this file's proposition character-for-character and derives it from two Rosser–Schoenfeld 1962
  results declared there as axioms, which I checked transcribe the source faithfully. But
  `erdosproblems.com/306` still reads "OPEN … cannot be resolved with a finite computation",
  records "Proof claims (0)", and lists that development's author under *Working on formalising*
  rather than as a solver. The declaration **stays `research open`** and only a factual reference
  is added.

I am aware these two decisions and the Tu–Deng one pull in different directions on preprint
evidence, and I would rather be told which way you want the bar set than guess silently. The
distinction I drew is not preprint age: Long's Poisson preprint in PR A carries a finite
self-contained certificate that can be re-derived without trusting the paper, and these do not.

### How this was checked

`lake --wfail build` over the whole repository and `lake --wfail test`, on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends on
the other eight. Every citation was read in the body of the paper rather than the abstract.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
