### PR TITLE
fix(util): decide proof status from transitive dependencies, and keep the answer marker on a Prop-valued answer(sorry)

### DIFF
--- a/FormalConjecturesTest/Util/Answer.lean
+++ b/FormalConjecturesTest/Util/Answer.lean
@@ -73,6 +73,29 @@ set_option google.answer "always_true"
 theorem this_works : (answer(sorry) : Prop) := by
   trivial
 
+/-- A `Prop`-valued `answer(sorry)` elaborates to `True` in this mode but keeps its answer
+annotation, so metadata extracted here can still tell it apart from a statement that has no
+answer at all. -/
+theorem prop_sorry_keeps_its_marker : answer(sorry) ↔ 1 + 1 = 2 := by
+  sorry
+
+theorem no_answer_has_no_marker : 1 + 1 = 2 := by
+  rfl
+
+/-- info: 1 -/
+#guard_msgs in
+#eval show Lean.CoreM Nat from do
+  let env ← Lean.getEnv
+  let some ci := env.find? ``prop_sorry_keeps_its_marker | return 0
+  return (Google.findAnswerExprs ci.type).size
+
+/-- info: 0 -/
+#guard_msgs in
+#eval show Lean.CoreM Nat from do
+  let env ← Lean.getEnv
+  let some ci := env.find? ``no_answer_has_no_marker | return 0
+  return (Google.findAnswerExprs ci.type).size
+
 end AlwaysTrue
 
 section FindAnswerExprTests

--- a/FormalConjecturesTest/Util/Attributes/Basic.lean
+++ b/FormalConjecturesTest/Util/Attributes/Basic.lean
@@ -202,3 +202,38 @@ info: 0 General and overarching topics
 -/
 #guard_msgs in
 #AMS
+
+section HasSorryFreeProof
+
+/-! `ProblemAttributes.hasSorryFreeProof` follows the declarations that a statement and a proof
+use, and reports a declaration with no proof term at all as not proved. The declarations used
+here are Lean's own axioms; the repository does not add any of its own. -/
+
+private theorem an_admitted_thm : 1 + 1 = 3 := by sorry
+private theorem a_wrapper_over_an_admitted_thm : 1 + 1 = 3 := an_admitted_thm
+private theorem a_real_proof : 1 + 1 = 2 := rfl
+
+/-- info: true -/
+#guard_msgs in
+#eval ProblemAttributes.hasSorryFreeProof (m := Lean.CoreM) ``a_real_proof
+
+-- An `axiom` has no proof term, so it is not proved even though `sorryAx` is absent.
+/-- info: false -/
+#guard_msgs in
+#eval ProblemAttributes.hasSorryFreeProof (m := Lean.CoreM) ``Classical.choice
+
+/-- info: false -/
+#guard_msgs in
+#eval ProblemAttributes.hasSorryFreeProof (m := Lean.CoreM) ``an_admitted_thm
+
+-- A wrapper whose own proof term carries no `sorry` is still not proved.
+/-- info: false -/
+#guard_msgs in
+#eval ProblemAttributes.hasSorryFreeProof (m := Lean.CoreM) ``a_wrapper_over_an_admitted_thm
+
+-- A declaration that does not exist is not proved.
+/-- info: false -/
+#guard_msgs in
+#eval ProblemAttributes.hasSorryFreeProof (m := Lean.CoreM) `no_such_declaration
+
+end HasSorryFreeProof

--- a/FormalConjecturesTest/Util/Linters/CategoryLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/CategoryLinter.lean
@@ -155,4 +155,17 @@ Note: This linter can be disabled with `set_option linter.style.category_attribu
 theorem test_duplicate_category : 1 + 1 = 2 := by
   rfl
 
+-- The check follows the declarations that the statement and the proof use. A wrapper whose own
+-- proof term carries no `sorry` but whose helper is admitted is not proved, so the linter stays
+-- silent.
+#guard_msgs in
+@[category research open]
+theorem test_admitted_helper : 1 + 1 = 3 := by
+  sorry
+
+#guard_msgs in
+@[category research open]
+theorem test_wrapper_over_admitted_helper : 1 + 1 = 3 :=
+  test_admitted_helper
+
 end CategoryLinter

--- a/FormalConjecturesTest/Util/Linters/FormalProofLinter.lean
+++ b/FormalConjecturesTest/Util/Linters/FormalProofLinter.lean
@@ -52,6 +52,23 @@ Note: This linter can be disabled with `set_option linter.style.conditional_form
 theorem conditional_on_a_proved_assumption : 6 + 6 = 12 := by
   rfl
 
+/-- An assumption discharged by an admitted helper, so still assumed. -/
+theorem an_admitted_helper : 3 = 3 := by
+  sorry
+
+/-- An assumption whose proof term carries no `sorry` of its own. -/
+theorem an_assumption_over_an_admitted_helper : 3 = 3 :=
+  an_admitted_helper
+
+-- Following the declarations the proof uses keeps this silent: the assumption is not proved.
+#guard_msgs in
+/-- A proof conditional on an assumption that only looks proved. -/
+@[category research solved,
+  conditional formal_proof using lean4 at "https://github.com/example/still-conditional"
+    assuming an_assumption_over_an_admitted_helper]
+theorem conditional_on_an_assumption_over_an_admitted_helper : 8 + 8 = 16 := by
+  rfl
+
 end FormalProofLinter
 
 #guard_msgs in

--- a/FormalConjecturesUtil/Answer.lean
+++ b/FormalConjecturesUtil/Answer.lean
@@ -134,9 +134,13 @@ def answerElab : TermElab := fun stx expectedType? => do
       addDecl (.defnDecl answerAuxiliaryDecl) true
       return mkAnswerAnnotation (.const answerName <| levelParamNames.map Level.param)
     | .alwaysTrue =>
-      -- If the answer is a `sorry` of type `Prop` then default to `True` in this setting
+      -- If the answer is a `sorry` of type `Prop` then default to `True` in this setting.
+      -- The annotation is kept, as it is for a non-`Prop` `answer(sorry)` just below: without
+      -- it the elaborated statement carries no record that it has an answer at all, and
+      -- `findAnswerExprs` reports none, so `extract_names` cannot tell a `Prop`-valued answer
+      -- from an omitted one unless it is run against `FormalConjecturesAnswerPostpone`.
       if expectedType? == some (Expr.sort .zero) && a == (← `(term| sorry)) then
-        return .const `True []
+        return mkAnswerAnnotation (.const `True [])
       else if a == (← `(term| sorry)) then
         -- For `answer(sorry)` with a non-Prop expected type, construct a canonical
         -- `sorryAx` call directly. This avoids embedding the current module name

--- a/FormalConjecturesUtil/Attributes/Basic.lean
+++ b/FormalConjecturesUtil/Attributes/Basic.lean
@@ -508,6 +508,27 @@ def getProofConditions (declName : Name) : m (List Name) := do
   let tag ← getFormalProofTag declName
   return (tag.map (·.conditions)).getD []
 
+/-- Whether `declName` is established without `sorry`, following the declarations that its
+statement and its proof use.
+
+Testing `value?.any (!·.hasSorry)` on the proof term alone is not enough: it reports
+`theorem wrapper : P := admitted_helper` as proved even when `admitted_helper` is admitted, so
+reorganising an unproved conjecture through a helper looks like a proof. `Lean.collectAxioms`
+walks the transitive dependencies instead, so `sorryAx` in any of them is caught here. It walks
+the statement as well as the proof, so a theorem whose statement mentions a definition built from
+an admitted lemma also counts as not established. It reads
+pre-computed axiom sets for imported declarations, so the walk stays inside the current module,
+and it takes its constants from the kernel environment, which is what waits on a proof that is
+still elaborating; the `findAsync?` test below only rules out a declaration that does not
+exist. -/
+def hasSorryFreeProof (declName : Name) : m Bool := do
+  let some info := (← MonadEnv.getEnv).findAsync? declName | return false
+  -- A declaration with no proof term at all, such as an `axiom`, is not proved, but
+  -- `collectAxioms` would report it as such because `sorryAx` is not among the axioms it
+  -- depends on. (An `opaque` does have a value and is judged on it, like any definition.)
+  if (info.toConstantInfo.value? (allowOpaque := true)).isNone then return false
+  return !(← collectAxioms declName).contains ``sorryAx
+
 end Helper
 
 /-- Verify that the list of problems contains the expected number of problems

--- a/FormalConjecturesUtil/Linters/CategoryAnswerLinter.lean
+++ b/FormalConjecturesUtil/Linters/CategoryAnswerLinter.lean
@@ -26,8 +26,8 @@ do not leave `answer(sorry)` in their statement: once a problem is solved, the a
 be filled in explicitly, e.g. `answer(True)`.
 
 The check is syntactic. Under the default `google.answer` setting, `answer(sorry)` at `Prop`
-elaborates to a bare `True` carrying no annotation, so the placeholder is no longer visible
-in the elaborated term.
+elaborates to `True`, which is what `answer(True)` elaborates to as well, so the elaborated
+term does not say which one was written.
 
 A statement that deliberately keeps `answer(sorry)` (for instance because the problem is
 independent of ZFC, or because the answer is a constant that is not known explicitly) can opt

--- a/FormalConjecturesUtil/Linters/CategoryLinter.lean
+++ b/FormalConjecturesUtil/Linters/CategoryLinter.lean
@@ -80,8 +80,10 @@ def checkNotOpenIfSorryFree (mods : TSyntax ``Lean.Parser.Command.declModifiers)
   unless ← hasConst declName do return
   unless (← ProblemAttributes.getTags).any
       (fun t => t.declName == declName && t.category == .research .open) do return
-  let some asyncInfo := (← getEnv).findAsync? declName | return
-  if asyncInfo.toConstantInfo.value? (allowOpaque := true) |>.any (!·.hasSorry) then
+  -- `ProblemAttributes.hasSorryFreeProof` follows the declarations that the statement and the
+  -- proof use. Testing the proof term alone would report `theorem wrapper : P :=
+  -- admitted_helper` as proved.
+  if ← ProblemAttributes.hasSorryFreeProof declName then
     logLintIf linter.style.category_attribute declId
       "If a problem has a sorry-free proof, it should not be categorised as `open`."
 

--- a/FormalConjecturesUtil/Linters/FormalProofLinter.lean
+++ b/FormalConjecturesUtil/Linters/FormalProofLinter.lean
@@ -43,11 +43,15 @@ register_option linter.style.conditional_formal_proof : Bool := {
 
 namespace FormalProofLinter
 
-/-- Whether `declName` has a proof term with no `sorry` in it, waiting on the
-declaration to finish elaborating. -/
-def isProved (declName : Name) : CommandElabM Bool := do
-  let some info := (← getEnv).findAsync? declName | return false
-  return info.toConstantInfo.value? (allowOpaque := true) |>.any (!·.hasSorry)
+/-- Whether `declName` is established without `sorry`, following the declarations that its
+statement and its proof use, and waiting on the declaration to finish elaborating.
+
+The transitive test matters here: an assumed hypothesis discharged by an admitted helper is
+still assumed, and testing its proof term alone would report it as proved. Because the walk
+covers the statement too, a declaration whose type mentions an admitted definition is reported
+as not established even when its own proof is complete. -/
+def isProved (declName : Name) : CommandElabM Bool :=
+  ProblemAttributes.hasSorryFreeProof declName
 
 /-- Return every formal-proof tag attached to `declName`.
 

--- a/scripts/extract_names.lean
+++ b/scripts/extract_names.lean
@@ -301,9 +301,11 @@ unsafe def main (args : List String) : IO Unit := do
                     link := tag.proofLink,
                     conditions := tag.conditions.map Name.toString : FormalProofInfo })
                 |>.toArray.qsort (fun a b => a.sortKey < b.sortKey) |>.toList
-              -- Check whether the proof term is sorry-free
-              let hasSorryFreeProof :=
-                info.value? (allowOpaque := true) |>.any (!·.hasSorry)
+              -- Check whether the declaration is established without `sorry`, following the
+              -- declarations that its statement and its proof use. Testing `info.value?` alone
+              -- would report a wrapper whose proof is `exact admitted_helper` as proved, and
+              -- would miss a statement that mentions an admitted definition.
+              let hasSorryFreeProof ← ProblemAttributes.hasSorryFreeProof name
               -- Warn about suspicious category / sorry combinations
               if let some catTag := categoryFullMap.get? name then
                 match catTag.category, hasSorryFreeProof with


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

Two independent corrections to repository utilities. This pull request originally also carried a
set of `FormalConjectures/` documentation fixes; on review those were split out, and nothing here
touches `FormalConjectures/`.

### Proof-status checks followed only the immediate proof term

`scripts/extract_names.lean`, `CategoryLinter` and `FormalProofLinter` all decided whether a
declaration is proved with `info.value? … |>.any (!·.hasSorry)`. That looks only at the proof
body, so `theorem wrapper : P := admitted_helper` counts as proved. `OeisA237271.conjecture_3` is
a live example: its proof is `conjecture_2`, which is `sorry`, and the direct test reports it as
sorry-free. For a `research open` declaration of that shape, `check_category_warnings.py` would
turn the resulting metadata into a blocking `research_open_with_proof` CI failure, and the
conditional-proof linter would report an assumed hypothesis as discharged.

A new `ProblemAttributes.hasSorryFreeProof` uses `Lean.collectAxioms`, which reads pre-computed
axiom sets for imported declarations, so the walk stays inside the current module, and takes its
constants from the kernel environment, so it waits on a proof that is still elaborating. It
reports a declaration as established only when `sorryAx` is absent from the transitive closure of
its statement and its proof. All three call sites use it, and regression tests are added to both
linter test files and to `FormalConjecturesTest/Util/Attributes/Basic.lean`.

Note that `collectAxioms` walks the *statement* as well as the proof, so two different things make
it return `false`: a proof that depends on an admitted declaration, which is the defect above, and
a statement that mentions an admitted definition even when the proof is complete. Both are
defensible answers to "is this established", but they are different phenomena.

Repository-wide, 30 of the 5265 categorised declarations that `extract_names` exports flip to
"not proved", and none flips the other way: 27 because the proof depends on an admitted
declaration, and 3 (`OeisA87719.a_1` to `a_3`) because the statement mentions a definition built
from an admitted existence proof. By category the 30 are 12 `test`, 11 `research solved`, 4 `API`
and 3 `textbook` — no `research open` declaration changes. Two advisory CI counters move,
`test_without_proof` 53 → 65 and `api_without_proof` 13 → 17, while the blocking
`research_open_with_proof` stays at 0.

**Not done.** The metadata still does not *distinguish* a syntactically complete wrapper from a
proof with no admitted dependencies: `extract_names` exports a single `hasSorryFreeProof` boolean,
so a consumer cannot tell those two states apart. A second field would close that. Left as a
follow-up rather than widened here.

### The answer marker was dropped on a `Prop`-valued `answer(sorry)`

`defaultTargets` omits `FormalConjecturesAnswerPostpone`, and CI extracts metadata after the
ordinary build, so `extract_names` reads artifacts elaborated in `always_true` mode. In that mode
a `Prop`-valued `answer(sorry)` returned a bare `True` carrying no answer annotation, while a
non-`Prop` `answer(sorry)` and an explicit `answer(True)` both kept theirs. So `findAnswerExprs`
saw nothing and `answerKinds` could not distinguish a `Prop`-valued answer from a declaration with
no answer at all.

The `Prop` branch now annotates too, matching the other two. `CategoryAnswerLinter`'s docstring is
corrected: its check does have to stay syntactic, but because `answer(sorry)` and `answer(True)`
elaborate to the same term, not because the annotation is missing.

Checked by elaborating four declarations against the old and the new `Answer.lean`, rebuilding
only `FormalConjecturesUtil` in between: a `Prop`-valued `answer(sorry)` goes from `[]` —
indistinguishable from having no answer — to `["Prop"]`, while `answer(True)`, a non-`Prop`
`answer(sorry)` and a declaration with no answer are all unchanged. The two cases are pinned by
new `#guard_msgs` tests in `FormalConjecturesTest/Util/Answer.lean`.

The alternative would be to build `FormalConjecturesAnswerPostpone` before the extraction step in
`.github/workflows/build-and-docs.yml`. That is behaviour-preserving but roughly doubles the Lean
time in CI, since the two libraries share globs and differ only in a Lean option. Happy to switch
if you would rather not touch `Answer.lean`.

### How this was checked

`lake --wfail build FormalConjecturesForMathlib FormalConjecturesUtil`, `lake --wfail test`, and
`lake --wfail build` over the whole repository, followed by `lake exe extract_names` and
`scripts/check_category_warnings.py`. The repository-wide figures above were measured on a build
with the `FormalConjecturesAnswerPostpone` library disabled: it shares its globs with
`FormalConjectures` and writes to the same olean paths, so an ordinary local build leaves a
mixed-mode cache that `extract_names` then reads. CI is unaffected — it builds only the default
targets — but a local reproduction needs that step.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
