### PR TITLE
docs(FormalConjectures): cross-references, a duplicate declaration, and copy fixes

### DIFF
--- a/FormalConjectures/OEIS/2326.lean
+++ b/FormalConjectures/OEIS/2326.lean
@@ -82,6 +82,12 @@ then $a((p^{k+1}-1)/2) = p \cdot a((p^k-1)/2)$.
 Computer testing of this generalized conjecture shows that there is no counterexample for $k$
 and $p$ both up to 1000.
 - [Ahmad J. Masad](https://oeis.org/wiki/User:Ahmad_J._Masad), Oct 17 2020
+
+The two are in fact equivalent. Its $k = 2$ instance is `conjecture1`. Conversely, write
+$d = \operatorname{ord}_{p^2}(2)$. `conjecture1` for $p$ says
+$v_p(2^d - 1) = 2$, and lifting the exponent for the odd prime $p$ then gives
+$v_p(2^{d p^t} - 1) = 2 + t$, hence $\operatorname{ord}_{p^{2+t}}(2) = d p^t$ for every
+$t \ge 0$, which is every instance for that $p$.
 -/
 @[category research open, AMS 11]
 theorem conjecture2 (k : ℕ) (hk : 2 ≤ k) (p : ℕ) (hp : p.Prime) (hp_odd : p ≠ 2) :

--- a/FormalConjectures/OEIS/3162.lean
+++ b/FormalConjectures/OEIS/3162.lean
@@ -26,7 +26,7 @@ with $\binom{n}{-1} = 0$.
 
 *References:*
 - [A003162](https://oeis.org/A003162)
-- H. W. Gould, Problem E2384, Amer. Math. Monthly, 81 (1974), 170-171
+- H. W. Gould, Problem E2384 (proposal), Amer. Math. Monthly, 81 (1974), 170-171
 -/
 
 namespace OeisA3162
@@ -69,7 +69,9 @@ theorem a_4 : a 4 = 6 := by eval_a
 
 /--
 $a(n)$ is an integer for all $n \ge 0$.
-- Solution to Problem E2384 by H. W. Gould, Amer. Math. Monthly, 81 (1974), 170-171
+
+Gould proposed this as Monthly Problem E2384. The 1974 reference in the module docstring
+is that proposal, not a solution to it.
 -/
 @[category textbook, AMS 11]
 theorem a_is_integer (n : ℕ) : (a n).den = 1 := by

--- a/FormalConjectures/OEIS/323557.lean
+++ b/FormalConjectures/OEIS/323557.lean
@@ -79,6 +79,10 @@ Conjecture: Odd terms occur only at positions $n(n+1)$ for $n \ge 0$ (verified f
 
 A formal proof has been found with the methods described in
 [arxiv/2605.22763](https://arxiv.org/abs/2605.22763).
+
+This statement is equivalent to `OeisA325046.odd_a_implies_pronic`. The two sequences differ
+only by the sign $(-1)^j$ on each summand, so they agree modulo $2$ and have the same odd
+indices.
 -/
 @[category research solved, AMS 11, formal_proof using formal_conjectures at
 "https://github.com/mo271/formal-conjectures/blob/a32396489dcb8f86c3549b93aa358ac6a10a3a1f/FormalConjectures/OEIS/323557.wip.lean#L193"]

--- a/FormalConjectures/OEIS/325046.lean
+++ b/FormalConjectures/OEIS/325046.lean
@@ -86,6 +86,10 @@ Conjecture: Odd terms occur only at positions $n(n+1)$ for $n \ge 0$.
 
 A formal proof has been found with the methods described in
 [arxiv/2605.22763](https://arxiv.org/abs/2605.22763).
+
+This statement is equivalent to `OeisA323557.odd_a_implies_pronic`. The two sequences differ
+only by the sign $(-1)^j$ on each summand, so they agree modulo $2$ and have the same odd
+indices.
 -/
 @[category research solved, AMS 11, formal_proof using formal_conjectures at
 "https://github.com/mo271/formal-conjectures/blob/a32396489dcb8f86c3549b93aa358ac6a10a3a1f/FormalConjectures/OEIS/325046.wip.lean#L166"]

--- a/FormalConjectures/OEIS/51903.lean
+++ b/FormalConjectures/OEIS/51903.lean
@@ -51,6 +51,16 @@ theorem a_5 : a 5 = 1 := by
 /--
 Are there composite numbers $n > 4$ such that $n \equiv a(n) \pmod{\phi(n)}$?
 - Thomas Ordowski, Dec 02 2019
+
+This question is equivalent to Lehmer's totient problem `LehmerTotient.lehmer_totient`; a
+positive answer here falsifies the universal statement asked about in
+`Erdos828.erdos_828.variants.lehmer_conjecture`. Any composite
+$n$ with $\phi(n) \mid n - 1$ is squarefree, so $a(n) = 1$ and the condition here holds.
+Conversely, let $n > 4$ be composite with $\phi(n) \mid n - a(n)$ and $e = a(n) \ge 2$, and
+pick $p$ with $p^e \mid n$. Then $p^{e-1} \mid \phi(n) \mid n - e$ and $p^{e-1} \mid n$, so
+$p^{e-1} \mid e$, which forces $p = 2$ and $e = 2$. Now $n = 4m$ with $m$ odd and squarefree,
+and $2\phi(m) \mid 4m - 2$ makes $\phi(m)$ odd, so $m = 1$ and $n = 4$. Hence $e = 1$ and the
+condition is $\phi(n) \mid n - 1$.
 -/
 @[category research open, AMS 11]
 theorem conjecture1 :

--- a/FormalConjectures/Wikipedia/EulerBrick.lean
+++ b/FormalConjectures/Wikipedia/EulerBrick.lean
@@ -21,7 +21,7 @@ import FormalConjecturesUtil
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Euler_brick)
 - [stackexchange](https://math.stackexchange.com/questions/2264401/euler-bricks-and-the-4th-dimension)
-- [Sh12] Shapirov, Ruslan. Perfect cuboids and irreducible polynomials. https://arxiv.org/abs/1108.5348
+- [Sh12] Sharipov, Ruslan. Perfect cuboids and irreducible polynomials. https://arxiv.org/abs/1108.5348
 -/
 
 namespace EulerBrick

--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -19,7 +19,7 @@ import FormalConjecturesUtil
 /-!
 # Modularity conjecture
 
-The **Modularity conjecture** (also know as the Shimura-Taniyama-Weil conjecture) states that
+The **Modularity conjecture** (also known as the Shimura-Taniyama-Weil conjecture) states that
 every rational elliptic curve is modular, meaning that it can be
 associated with a modular form. We state the `a_p` version of the conjecture, which relates the
 coefficients of the modular form to the number of points on the elliptic curve over finite fields.
@@ -39,7 +39,7 @@ namespace ModularityConjecture
 open Complex CongruenceSubgroup ModularFormClass ModularityConjecture UpperHalfPlane
 open scoped Real ModularForm CongruenceSubgroup
 
-/-- The `n`-th Fourier coefficient of a modular forms (around the cusp at infinity). -/
+/-- The `n`-th Fourier coefficient of a modular form (around the cusp at infinity). -/
 noncomputable def modularFormAn (n : ℕ) {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : ℂ :=
   (qExpansion N f).coeff n
 

--- a/FormalConjectures/Wikipedia/RegularPrimes.lean
+++ b/FormalConjectures/Wikipedia/RegularPrimes.lean
@@ -39,7 +39,7 @@ noncomputable def IsRegularPrime [Fact p.Prime] : Prop :=
 
 /-- The prime 37 is not a regular prime. -/
 @[category textbook, AMS 11]
-theorem not_isRegularPrime_37_first : ¬ @IsRegularPrime 37 (by decide) := by
+theorem not_isRegularPrime_37 : ¬ @IsRegularPrime 37 (by decide) := by
   sorry
 
 /-- The set of regular primes. -/
@@ -52,11 +52,6 @@ def irregularPrimes : Set ℕ := { p | ∃ (hp : Nat.Prime p), ¬ @IsRegularPrim
 @[category textbook, AMS 11]
 lemma small_regular_primes :
     { 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31 } ⊆ regularPrimes := by
-  sorry
-
-/-- The prime 37 is not a regular prime. -/
-@[category textbook, AMS 11]
-theorem not_isRegularPrime_37_second : ¬ @IsRegularPrime 37 (by decide) := by
   sorry
 
 /-- An equivalent definition of a regular prime `p` is that it does not divide the numerator of the


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

Documentation-only changes to eight problem files. No statement, hypothesis or `category`
attribute changes, except that `Wikipedia/RegularPrimes` loses one of two identical declarations.

- `OEIS/51903`: `conjecture1` is equivalent to Lehmer's totient problem; the docstring now says so
  and gives the argument, cross-referencing `LehmerTotient.lehmer_totient` and
  `Erdos828.erdos_828.variants.lehmer_conjecture`.
- `OEIS/3162`: the 1974 Monthly item is Gould's **proposal** of Problem E2384, not a solution to
  it — A003162 itself says "Gould (1974) proposed the problem". Relabelled. The audit that raised
  this suggested citing Gould & Clary 1976 as the solution instead; I could not reach that item in
  any accessible source, so I did not add it on faith.
- `OEIS/323557`, `OEIS/325046`: the two sequences differ only by the sign `(−1)^j` on each
  summand, so they agree modulo 2 and the two `odd_a_implies_pronic` theorems are equivalent.
  Cross-referenced in both. A shared lemma would need a common import and problem files import
  only `FormalConjecturesUtil`, so this is a cross-reference only.
- `OEIS/2326`: `conjecture2` is equivalent to `conjecture1`, not strictly stronger; the
  lifting-the-exponent argument is recorded.
- `Wikipedia/RegularPrimes`: `not_isRegularPrime_37_first` and `_second` were the same declaration
  with the same docstring. One is kept, renamed `not_isRegularPrime_37`.
- `Wikipedia/EulerBrick`: "Shapirov" → "Sharipov" (arXiv:1108.5348 is by Ruslan Sharipov).
- `Wikipedia/ModularityConjecture`: "also know as" → "also known as"; "of a modular forms" → "of a
  modular form".

### How this was checked

`lake --wfail build` over the whole repository and `lake --wfail test`, on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends on
the other eight.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
