### PR TITLE
fix(Arxiv/math.0608009): the rank-two Poisson conjecture is false

### DIFF
--- a/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
+++ b/FormalConjectures/Arxiv/math.0608009/PoissonConjecture.lean
@@ -29,6 +29,8 @@ import FormalConjecturesUtil
   by *Hyman Bass, Edwin H. Connell, David Wright*, Bull. Amer. Math. Soc. 7 (1982), 287–330.
 - [Alp26] [Counterexample to the Jacobian conjecture](https://x.com/__alpoge__/status/2079028340955197566)
   by *Levent Alpöge* (2026), disproving the Jacobian conjecture in dimension $3$
+- [Lon26] [An Explicit Counterexample to the Rank-Two Poisson Conjecture](https://arxiv.org/abs/2608.23777)
+  by *Christopher D. Long* (2026), disproving $PC_2$
 
 The Poisson Conjecture $PC_n$ ([AvdE07], Notations 5) asserts that, over a field of
 characteristic zero, every endomorphism of the `n`-th canonical Poisson algebra
@@ -45,7 +47,8 @@ dimension $n ≥ 3$ by padding with identity coordinates — $PC_n$ is false for
 composing the counterexample's failure of $JC_3$ through $PC_3 \Longrightarrow DC_3 \Longrightarrow JC_3$ refutes
 $PC_3$, and directly, the cotangent (symplectic) lift of the counterexample map
 ([AvdE07], Theorem 1 in reverse) is a non-invertible Poisson endomorphism of $P_3(K)$.
-The cases $n = 1$ and $n = 2$ remain open.
+$PC_2$ is false as well, by the explicit rank-two counterexample of [Lon26]. Only $n = 1$
+remains open.
 
 Indexing note: we index the $2n$ variables of $P_n(K)$ by `Fin n ⊕ Fin n`, with
 `Sum.inl i` playing the role of $X_i$ and `Sum.inr i` the role of $X_{i+n}$ of [AvdE07],
@@ -99,13 +102,22 @@ theorem poisson_conjecture.variants.dimension_one : PoissonConjectureFor K 1 := 
   sorry
 
 /--
-The Poisson Conjecture in dimension $2$ ($PC_2$) is open. Since the Jacobian conjecture is
-false in every dimension $n ≥ 3$ [Alp26], no known implication bounds $PC_2$ from above
-any more; the chain of [AvdE07], Theorem 7 places it as the strongest of the remaining
-open conjectures $PC_2 \Longrightarrow DC_2 \Longrightarrow JC_2 \Longrightarrow PC_1 \Longrightarrow DC_1$.
+The Poisson Conjecture is false in dimension $2$ ($PC_2$). [Lon26] gives four explicit
+polynomials $R, T, D, S \in \mathbb{Q}[x, q, p, z]$ with
+$\{R, D\} = \{T, S\} = 1$ and $\{R, T\} = \{R, S\} = \{D, T\} = \{D, S\} = 0$, so that
+$X_1 \mapsto R$, $X_2 \mapsto T$, $X_3 \mapsto D$, $X_4 \mapsto S$ is a Poisson endomorphism of
+$P_2(K)$. It is not surjective: in the coordinates $(X_1, X_2, X_3, X_4)$ the two rational
+points $(0, 0, 1/24, -1/8)$ and $(1, 2/3, 247/96, -89/64)$ have the same image under
+$(R, T, D, S)$, so every polynomial in the image of the endomorphism takes equal values at
+them, while $X_1$ does not. The formulas have rational coefficients and the two points are
+rational, so the argument applies over every field of characteristic zero.
+
+This does not settle any conjecture further down the chain of [AvdE07], Theorem 7, which only
+propagates falsity upwards: $\lnot PC_2$ gives $\lnot JC_4$, already known from [Alp26].
+$DC_2$, $JC_2$ (Keller's problem), $PC_1$ and $DC_1$ all remain open.
 -/
-@[category research open, AMS 14 17]
-theorem poisson_conjecture.variants.dimension_two : PoissonConjectureFor K 2 := by
+@[category research solved, AMS 14 17]
+theorem poisson_conjecture.variants.dimension_two : ¬ PoissonConjectureFor K 2 := by
   sorry
 
 /--
@@ -122,11 +134,11 @@ theorem poisson_conjecture.variants.dimension_three : ¬ PoissonConjectureFor K 
   sorry
 
 /--
-The Poisson Conjecture is false in every dimension $n ≥ 3$, by padding the dimension $3$
-counterexample with identity coordinates.
+The Poisson Conjecture is false in every dimension $n ≥ 2$, by padding the dimension $2$
+counterexample of [Lon26] with identity canonical pairs.
 -/
 @[category research solved, AMS 14 17]
-theorem poisson_conjecture.variants.dimension_ge_three (n : ℕ) (hn : 3 ≤ n) :
+theorem poisson_conjecture.variants.dimension_ge_two (n : ℕ) (hn : 2 ≤ n) :
     ¬ PoissonConjectureFor K n := by
   sorry
 


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

`poisson_conjecture.variants.dimension_two` positively asserted `PoissonConjectureFor K 2` for
every characteristic-zero field. It is false. Long,
[arXiv:2608.23777](https://arxiv.org/abs/2608.23777) (July 2026), gives explicit
`R, T, D, S ∈ ℚ[x, q, p, z]` with `{R, D} = {T, S} = 1` and the other four generator brackets
zero, so `(x, q, p, z) ↦ (R, T, D, S)` is a Poisson endomorphism of `P₂(K)`. It is not
surjective: `(0, 0, 1/24, −1/8)` and `(1, 2/3, 247/96, −89/64)` have the same image, so every
polynomial in the image agrees at those two points, while `X₁` does not. Coefficients and points
are rational, so this descends to every field of characteristic zero.

I re-derived the six bracket identities and the point collision in exact rational arithmetic
against this repository's own `poissonBracket` convention, and separately checked a Lean proof of
`¬ PoissonConjectureFor ℚ 2` built from those polynomials: it typechecks against this module and
`#print axioms` gives `[propext, Classical.choice, Quot.sound]`.

One convention note, since it inverts the reading of the paper. Long's bracket is the negative of
this repository's — his `H_F = F_p ∂_x + F_z ∂_q − F_x ∂_p − F_q ∂_z`, against
`poissonBracket f g = ∑ᵢ (∂_{inl i} f · ∂_{inr i} g − ∂_{inr i} f · ∂_{inl i} g)` here — so his
Theorem 5.2 `{D, R} = {S, T} = 1` is `{R, D} = {T, S} = 1` in this file, which is how the
docstring states it. His Φ sends `x ↦ R, q ↦ T, p ↦ D, z ↦ S`, matching `X₁ … X₄` under the
file's own `Sum.inl i = Xᵢ`, `Sum.inr i = X_{i+n}` indexing note.

The declaration is negated and marked `research solved`. `variants.dimension_ge_three` becomes
`variants.dimension_ge_two` with hypothesis `2 ≤ n`, and the module docstring and reference list
are updated. The docstring states explicitly that this settles nothing lower in the `[AvdE07]`
chain, which propagates falsity only upwards: `¬PC₂` gives `¬JC₄`, already known, and leaves
`DC₂`, `JC₂`, `PC₁` and `DC₁` open.

### How this was checked

`lake --wfail build` over the whole repository and `lake --wfail test`, on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends
on the other eight.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
