### PR TITLE
fix(Wikipedia/Falconer): falconer_conjecture is false at d = 1

### DIFF
--- a/FormalConjectures/Wikipedia/Falconer.lean
+++ b/FormalConjectures/Wikipedia/Falconer.lean
@@ -20,9 +20,10 @@ public import FormalConjecturesUtil
 /-!
 # Falconer's distance set conjecture
 
-If $E \subseteq \mathbb{R}^d$ is compact with $\dim_H E > \frac{d}{2}$, then the distance set
+If $d \ge 2$ and $E \subseteq \mathbb{R}^d$ is compact with $\dim_H E > \frac{d}{2}$, then the
+distance set
 $$\{ |x - y| \mid x, y \in E \}$$
-has positive Lebesgue measure.
+has positive Lebesgue measure. The restriction $d \ge 2$ is needed; see `falconer_conjecture`.
 
 ## References
 
@@ -39,7 +40,14 @@ open scoped ENNReal EuclideanGeometry
 lemma falconer_conjecture_two (E : Set <| ℝ²) (hc : IsCompact E) (hd : 2 < 2 * dimH E ) :
     0 < volume (image2 dist E E) := sorry
 
-/-- Falconer's distance set conjecture. -/
+/-- Falconer's distance set conjecture in dimension $d \ge 2$.
+
+The hypothesis $2 \le d$ excludes a degenerate case: the conclusion is false for $d = 1$.
+The base-$7$ Cantor set $E = \{\sum_{n \ge 1} a_n 7^{-n} : a_n \in \{0, 1, 2\}\}$ is compact
+with $\dim_H E = \log 3 / \log 7 > 1/2$, but $E - E$ has digits in $\{-2, \dots, 2\}$, so
+after fixing $n$ digits it is covered by $5^n$ intervals of length $\frac{2}{3} 7^{-n}$ and is
+therefore null; its distance set is the image of $E - E$ under $|\cdot|$ and is null too. -/
 @[category research open, AMS 28 42]
-lemma falconer_conjecture (d : ℕ) (E : Set <| ℝ^d) (hc : IsCompact E) (hd : d < 2 * dimH E ) :
+lemma falconer_conjecture (d : ℕ) (h2d : 2 ≤ d) (E : Set <| ℝ^d) (hc : IsCompact E)
+    (hd : d < 2 * dimH E) :
     0 < volume (image2 dist E E) := sorry


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

`falconer_conjecture` quantified over every `d : ℕ`. At `d = 1` it asserts that a compact
`E ⊆ ℝ` with `dim_H E > 1/2` has a distance set of positive measure, which is false. Take the
base-7 Cantor set on digits `{0, 1, 2}`: three similarities of ratio `1/7` with strong separation
give `dim_H E = log 3 / log 7 ≈ 0.5646 > 1/2`, while `E − E` has digits in `{−2, …, 2}`, so fixing
`n` digits leaves a tail in an interval of length `4 · Σ_{k>n} 7⁻ᵏ = (2/3)·7⁻ⁿ` over `5ⁿ`
prefixes, and `|E − E| ≤ (2/3)(5/7)ⁿ → 0`. `d = 0` is already vacuous, so `2 ≤ d` excludes exactly
one genuine counterexample. The hypothesis is added and the degenerate case explained in the
declaration docstring; the module docstring, which stated the falsified form, is corrected too.
`falconer_conjecture_two` is unaffected.

### How this was checked

`lake --wfail build` over the whole repository and `lake --wfail test`, on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends
on the other eight.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
