### PR TITLE
fix(ForMathlib/SimpleGraph): graphSquare joined vertices in different components

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture146.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture146.lean
@@ -81,13 +81,13 @@ theorem conjecture146 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected
 -- Sanity checks
 
 /-- In `graphSquare G`, adjacent vertices in $G$ are also adjacent
-($\mathrm{dist} \le 1 \le 2$). -/
+(`edist` is at most $1 \le 2$). -/
 @[category test, AMS 5]
 example (G : SimpleGraph (Fin 4)) (u v : Fin 4) (h : G.Adj u v) :
     (graphSquare G).Adj u v := by
   refine ⟨G.ne_of_adj h, ?_⟩
-  -- dist u v ≤ length of the 1-step walk ≤ 2
-  exact (G.dist_le (Walk.cons h Walk.nil)).trans (by norm_num)
+  -- edist u v ≤ length of the 1-step walk ≤ 2
+  exact (G.edist_le (Walk.cons h Walk.nil)).trans (by norm_num)
 
 /-- `graphSquare` is loopless: no vertex is adjacent to itself. -/
 @[category test, AMS 5]
@@ -102,5 +102,15 @@ example (G : SimpleGraph (Fin 3)) : 0 ≤ graphSquareRadius G := Nat.zero_le _
 @[category test, AMS 5]
 example (G : SimpleGraph (Fin 4)) (u v : Fin 4) (h : (graphSquare G).Adj u v) :
     (graphSquare G).Adj v u := h.symm
+
+/-- `graphSquare` does not join different connected components: the square of the edgeless
+graph on two vertices is still edgeless. -/
+@[category test, AMS 5]
+example : graphSquare (⊥ : SimpleGraph (Fin 2)) = ⊥ := by
+  ext u v
+  simp only [graphSquare, bot_adj, iff_false, not_and]
+  intro huv
+  rw [SimpleGraph.edist_bot_of_ne huv]
+  simp
 
 end WrittenOnTheWallII.GraphConjecture146

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
@@ -103,10 +103,15 @@ noncomputable def distavg (G : SimpleGraph α) (S : Set α) : ℝ :=
     0
 
 /-- The **square** of a graph `G`, denoted `G²`: two distinct vertices are adjacent
-iff their distance in `G` is at most 2. -/
+iff their distance in `G` is at most 2.
+
+The bound uses the extended distance `SimpleGraph.edist`, which is `⊤` for unreachable
+vertices. The natural-valued `SimpleGraph.dist` is `0` there, so it would make distinct
+vertices in different components adjacent: the square of the edgeless graph on two vertices
+would be the complete graph. -/
 def graphSquare (G : SimpleGraph α) : SimpleGraph α where
-  Adj u v := u ≠ v ∧ G.dist u v ≤ 2
-  symm.symm _ _ := fun ⟨hne, hd⟩ => ⟨hne.symm, by rwa [dist_comm]⟩
+  Adj u v := u ≠ v ∧ G.edist u v ≤ 2
+  symm.symm _ _ := fun ⟨hne, hd⟩ => ⟨hne.symm, by rwa [edist_comm]⟩
   loopless.irrefl v := by simp
 
 /-- Check whether four distinct vertices form an induced 4-cycle in `G`.


### PR DESCRIPTION
*One of nine related pull requests from the same review pass. They touch pairwise disjoint
files and can be reviewed and merged in any order.*

`graphSquare` used `G.dist u v ≤ 2`, and Mathlib's natural-valued `SimpleGraph.dist` is `0` for
unreachable pairs, so distinct vertices in different components became adjacent: the square of the
edgeless graph on two vertices was the complete graph. Adjacency now uses `G.edist`, which is `⊤`
there. The one downstream sanity check in `WrittenOnTheWallII/GraphConjecture146.lean` moves from
`dist_le` to `edist_le`, and a regression test proving
`graphSquare (⊥ : SimpleGraph (Fin 2)) = ⊥` is added. `conjecture146` assumes connectedness and is
unaffected.

**Not in this PR.** The other distance definitions in the same file — `distToSet`, `ecc`,
`distMin`, `eccSet`, `distMaxSet`, `distavg`, `averageDistance`, `distEven` and the even-distance
family — share the `dist`-is-0-when-unreachable pattern. Every current consumer hypothesises `G.Connected`, so no
conjecture in the repository is presently wrong because of them, and only `graphSquare` is changed
here. Happy to convert the rest in a follow-up if you would like them consistent.

### How this was checked

`lake --wfail build` over the whole repository and `lake --wfail test`, on the combined tree
holding all nine of these pull requests; they change disjoint files, so nothing here depends
on the other eight.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFB53GPMrBBwtsq2RyS4W7
