### PR TITLE
feat(Arxiv/math.0703548): add two algebraic consequences of the Farrell–Jones conjecture

### DIFF
--- a/FormalConjectures/Arxiv/math.0703548/FarrellJonesConsequences.lean
+++ b/FormalConjectures/Arxiv/math.0703548/FarrellJonesConsequences.lean
@@ -1,0 +1,79 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Algebraic consequences of the Farrell–Jones conjecture
+
+The assembly map in the Farrell–Jones conjecture is not yet available in Mathlib. This file
+states two of its algebraic consequences using projective modules and matrices over group rings:
+the vanishing of the reduced projective class group and the Bass conjecture for commutative
+integral domains.
+
+*Reference:*
+- [BLR08] [arxiv/math.0703548](https://arxiv.org/abs/math/0703548)
+  **On the Farrell–Jones Conjecture and its applications**
+  by *Arthur Bartels, Wolfgang Lück, Holger Reich*, J. Topol. 1 (2008), 57–86.
+-/
+
+namespace Arxiv.«math.0703548»
+
+open scoped Classical in
+/--
+The value at the conjugacy class of `g` of the universal trace of a matrix over `R[G]`.
+
+For each diagonal entry, this sums the coefficients of the elements conjugate to `g`. If the
+matrix is idempotent, these values give the Hattori–Stallings rank of the projective module
+represented by the matrix.
+-/
+noncomputable def matrixHattoriStallingsTraceAt {R : Type*} [CommRing R] {G : Type*} [Group G]
+    {n : Type*} [Fintype n] (A : Matrix n n (MonoidAlgebra R G)) (g : G) : R :=
+  ∑ i, (A i i).coeff.sum fun h r ↦ if IsConj h g then r else 0
+
+/--
+**Vanishing of the reduced projective class group for integral group rings.**
+
+If `G` is torsion-free, that is, if its only element of finite order is `1`, then every finitely
+generated projective module over `ℤ[G]` is stably free. This is the stable-freeness form of the
+vanishing of $\widetilde K_0(\mathbb{Z}[G])$, which is the conclusion of Theorem 0.2 (ii) of
+[BLR08] for the regular ring $\mathbb{Z}$. That theorem assumes the K-theoretic Farrell–Jones
+conjecture for `G` with coefficients in `ℤ`.
+-/
+@[category research open, AMS 16 19 20]
+theorem projective_module_isStablyFree {G : Type*} [Group G] (hG : ∀ g : G, IsOfFinOrder g → g = 1)
+    (M : Type*) [AddCommGroup M] [Module (MonoidAlgebra ℤ G) M]
+    [Module.Finite (MonoidAlgebra ℤ G) M] [Module.Projective (MonoidAlgebra ℤ G) M] :
+    Module.IsStablyFree (MonoidAlgebra ℤ G) M := by
+  sorry
+
+/--
+**Bass conjecture for commutative integral domains, in idempotent-matrix form.**
+
+Let `A` be an idempotent matrix over `R[G]`. If the order of `g` is not invertible in `R`, then
+the Hattori–Stallings trace of the projective module represented by `A` vanishes at the conjugacy
+class of `g`. This includes every infinite-order `g`, whose `orderOf` is zero. This is
+Conjecture 0.6 of [BLR08]. By Theorems 0.5 (ii) and 0.7 of [BLR08] it follows from the
+Farrell–Jones conjecture with coefficients in every field of prime characteristic.
+-/
+@[category research open, AMS 16 19 20]
+theorem bass_conjecture_integral_domain {R : Type*} [CommRing R] [IsDomain R] {G : Type*}
+    [Group G] {n : Type*} [Fintype n] (A : Matrix n n (MonoidAlgebra R G))
+    (hA : A * A = A) (g : G) (hg : ¬IsUnit (orderOf g : R)) :
+    matrixHattoriStallingsTraceAt A g = 0 := by
+  sorry
+
+end Arxiv.«math.0703548»


### PR DESCRIPTION
Fixes #5455.

Mathlib has no algebraic K-theory of rings, so the assembly map — and with it the Farrell–Jones
conjecture itself, #1792 — is out of reach. This adds two of its algebraic consequences from the
introduction of Bartels–Lück–Reich, both expressible with projective modules and matrices over
group rings.

- `projective_module_isStablyFree`: for a torsionfree `G`, every finitely generated projective
  `ℤ[G]`-module is stably free. This is the stable-freeness form of the vanishing of
  `K̃₀(ℤ[G])`, the conclusion of Theorem 0.2 (ii) for the regular ring `ℤ`.
- `bass_conjecture_integral_domain`: Conjecture 0.6, stated on idempotent matrices.

### Formalisation choices

**The Hattori–Stallings rank.** Mathlib has none, so the local definition
`matrixHattoriStallingsTraceAt` follows (4.1) and (4.2) of the reference: the universal trace
`Σ rg · g ↦ Σ rg · (g)`, extended to matrices by summing the traces of the diagonal entries, read
off at one conjugacy class. Quantifying over idempotent matrices rather than over modules is
equivalent, since every finitely generated projective module is the image of an idempotent matrix
and the rank depends only on the isomorphism class.

**The order hypothesis.** `¬IsUnit (orderOf g : R)` covers both cases of Conjecture 0.6 at once:
`orderOf g` is `0` in the infinite-order case, and `IsDomain` supplies `Nontrivial`, so `(0 : R)`
is not a unit. It also excludes `g = 1` automatically, as the source does, because `IsUnit (1 : R)`
always holds.

**Torsion-freeness** is written out as `∀ g, IsOfFinOrder g → g = 1` rather than as
`IsMulTorsionFree`. That class asks that every power map be injective, which is equivalent to
torsion-freeness only for commutative groups — `isMulTorsionFree_iff_not_isOfFinOrder` is stated in
`section CommGroup`. The Klein bottle group is torsionfree but has `(ab)² = b²` with `ab ≠ b`, so
the class would have excluded groups the conjecture covers.

### How this was checked

`lake --wfail build 'FormalConjectures.Arxiv.«math.0703548».FarrellJonesConsequences'` on `8faf8bcc`.

The trace definition was tested against the source on examples: the identity matrix has trace `1`
at the trivial class; two conjugate transpositions in `S₃` contribute `2`, so the sum really is
over a whole conjugacy class; a class not containing `g` contributes `0`; and over a field of
characteristic zero the hypothesis is unsatisfiable for every element of a finite group, as
Conjecture 0.6 requires — `ℚ[ℤ/2]` has the idempotent `(1 + g)/2`, whose rank at `(g)` is `1/2`.

Disclosure: this formalisation was first drafted with Codex, then audited and edited with Claude
Code, and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq5intN7UGhriwvZzt4axC