### PR TITLE
fix(Wikipedia/Kaplansky): state torsion-freeness, not `IsMulTorsionFree`

### DIFF
--- a/FormalConjectures/Wikipedia/Kaplansky.lean
+++ b/FormalConjectures/Wikipedia/Kaplansky.lean
@@ -23,7 +23,7 @@ import FormalConjecturesUtil
 -/
 
 variable (K : Type*) [Field K]
-variable (G : Type*) [Group G] (hG : IsMulTorsionFree G)
+variable (G : Type*) [Group G] (hG : ∀ g : G, IsOfFinOrder g → g = 1)
 include hG
 
 namespace Kaplansky
@@ -74,11 +74,11 @@ abbrev PromislowGroup : Type :=
   PresentedGroup {b⁻¹ * a * a * b * a * a, a⁻¹ * b * b * a * b * b}
 
 /--
-The Promislow group is torsion-free.
+The Promislow group is torsion-free: its only element of finite order is `1`.
 -/
 @[category API, AMS 20]
 lemma promislow_group_is_torsionfree :
-    IsMulTorsionFree PromislowGroup := by
+    ∀ g : PromislowGroup, IsOfFinOrder g → g = 1 := by
   sorry
 
 /--
@@ -107,7 +107,7 @@ At least there is a counterexample for any prime and zero characteristic:
 -/
 @[category research solved, AMS 16 20]
 theorem counter_unit_conjecture :
-    ∃ (G : Type) (_ : Group G) (_ : IsMulTorsionFree G),
+    ∃ (G : Type) (_ : Group G) (_ : ∀ g : G, IsOfFinOrder g → g = 1),
     ∀ (p : ℕ) (_ : p = 0 ∨ p.Prime),
     ∃ (K : Type) (_ : Field K) (_ :  CharP K p) (u : (MonoidAlgebra K G)ˣ), ¬IsTrivialUnit u.val :=
   ⟨PromislowGroup, _, promislow_group_is_torsionfree, fun p hp ↦
@@ -119,7 +119,7 @@ There is a counterexample to **Unit Conjecture** in any characteristic.
 -/
 @[category research solved, AMS 16 20]
 theorem counter_unit_conjecture_weak (p : ℕ) (hp : p = 0 ∨ p.Prime) :
-    ∃ (G : Type) (_ : Group G) (_ : IsMulTorsionFree G)
+    ∃ (G : Type) (_ : Group G) (_ : ∀ g : G, IsOfFinOrder g → g = 1)
       (K : Type) (_ : Field K) (_ :  CharP K p) (u : (MonoidAlgebra K G)ˣ), ¬IsTrivialUnit u.val :=
   have ⟨G, _, _, hG⟩ := counter_unit_conjecture
   ⟨G, _, ‹_›, hG p hp⟩


### PR DESCRIPTION
Mathlib's `IsMulTorsionFree` asks that every power map `a ↦ a ^ n` be injective. For commutative
groups that is equivalent to torsion-freeness — `isMulTorsionFree_iff_not_isOfFinOrder` is stated
in `section CommGroup` — but for nonabelian groups it is strictly stronger. The source asks only
that `G` be torsionfree, as does Conjecture 0.11 of [arXiv:math/0703548](https://arxiv.org/abs/math/0703548).

## `promislow_group_is_torsionfree` was false as stated

The `category API` lemma claimed `IsMulTorsionFree PromislowGroup`. In the Promislow group the
second relator `a⁻¹b²ab²` gives `b²ab² = a`, hence

```
(b²a)² = (b²ab²)·a = a·a = a²,
```

while `b² ≠ 1`, because the homomorphism to `ZMod 4` sending `a ↦ 0` and `b ↦ 1` kills both
relators and sends `b²` to `2`. So `b²a` and `a` are distinct elements with the same square, and
squaring is not injective. (Promislow's group is a 3-dimensional Bieberbach group, so this is the
same phenomenon as in the Klein bottle group, which it contains.)

<details>
<summary>Lean proof of <code>¬ IsMulTorsionFree PromislowGroup</code>, sorry-free</summary>

```lean
abbrev A : PromislowGroup := PresentedGroup.of 0
abbrev B : PromislowGroup := PresentedGroup.of 1

lemma sq_eq : (B * B * A) ^ 2 = A ^ 2 := by
  have h : B * B * A * B * B = A := by
    have := congrArg (A * ·) rel₂
    simpa [mul_assoc] using this
  calc (B * B * A) ^ 2 = B * B * A * B * B * A := by rw [sq]; group
    _ = A * A := by rw [h]
    _ = A ^ 2 := (sq A).symm

def φ : PromislowGroup →* Multiplicative (ZMod 4) :=
  PresentedGroup.toGroup (f := fun i : Fin 2 => Multiplicative.ofAdd (if i = 0 then 0 else 1))
    (by rintro r (rfl | rfl) <;> simp <;> decide)

theorem not_isMulTorsionFree : ¬ IsMulTorsionFree PromislowGroup := by
  intro hfree
  have h2 : B * B * A = A := hfree.pow_left_injective two_ne_zero sq_eq
  have h3 : B * B * A = 1 * A := by rw [one_mul]; exact h2
  exact B_sq_ne_one (mul_right_cancel h3)
```

`#print axioms not_isMulTorsionFree` gives `[propext, Classical.choice, Quot.sound]`. The full
file, including `rel₂` and `B_sq_ne_one`, is available on request; it is not included in the diff
because it is about a class this file no longer mentions.
</details>

That lemma was the witness for `counter_unit_conjecture` and, through it,
`counter_unit_conjecture_weak`. Both are tagged `research solved`, but as stated they asserted a
group satisfying the stronger class, which is more than Gardam, Murray and Passman prove.

## The change

`IsMulTorsionFree G` becomes `∀ g : G, IsOfFinOrder g → g = 1` in five places: the file-level
`variable` shared by `zero_divisor_conjecture` and `idempotent_conjecture`, the Promislow lemma,
and the two counterexample statements. All five now say what their sources say, and the
counterexample statements become true. `IsMulTorsionFree` no longer occurs in the repository.

## How this was checked

`lake --wfail build 'FormalConjectures.Wikipedia.Kaplansky'` and
`lake --wfail build 'FormalConjectures.Subsets.FC100SolvedSet1'`, which references
`UnitConjecture.counterexamples.ii`, both on `8faf8bcc`.

Disclosure: found and fixed with Claude Code, and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq5intN7UGhriwvZzt4axC