### PR TITLE
ci: cancel superseded PR builds and lint workflows

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -33,6 +33,12 @@ on:
 permissions:
   contents: read
 
+# Replace older checks for the same PR, including PRs from forks. Every other
+# event gets its own group so pending merge-queue and main runs are preserved.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # The category check is a policy gate, so it has tests of its own. They need
   # no Lean build, so they run alongside it rather than after it.

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -51,6 +51,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check GitHub Actions workflows
+        # Pin the checker and archive digest; optional shell/Python linters are
+        # excluded so validation does not depend on the runner's installed tools.
+        run: |
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
+            -o "$RUNNER_TEMP/actionlint.tar.gz"
+          echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  $RUNNER_TEMP/actionlint.tar.gz" | sha256sum --check
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" -shellcheck= -pyflakes=
+
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:


### PR DESCRIPTION
Cancel an older PR build when a newer run starts. Also add workflow linting to the fast test job.

**Why: obsolete builds kept running**

Audit: 100 recent PRs, September 8–10, 2026 (#5344–#5467). Of these, 88 had executed builds.

| What we observed | Amount |
| --- | ---: |
| Total build time across 162 jobs | 77.7 hours |
| Older builds still running after a newer revision started building | 40 builds across 20 PRs |
| Time those older builds consumed **after that point** | **~16 hours (21% of total build time)** |

The 16 hours measures past overlap. **We have not yet measured how much this PR saves.**

**What changes**

| Situation | Before | With this PR |
| --- | --- | --- |
| New build starts for the same PR | Older build keeps running | Older build is cancelled |
| Merge queue, `main`, manual and preview runs | Run normally | Run normally; never cancelled by this rule |
| Fast test job | No `actionlint` check | Lint all workflows with checksum-verified `actionlint` 1.7.7 |

**Checks**

| Check | Result |
| --- | --- |
| Local workflow lint + 32 script/website tests | Passed |
| Hosted Test scripts | Passed |
| Full hosted build | Running |
| Live cancellation and time saved | Not yet measured |

No new settings or credentials; existing permissions and required check names stay unchanged. Consolidates #5469; independent of #5435.
