### PR TITLE
ci: reuse queue-built websites while preserving Lean cache refresh

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -72,9 +72,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # A main push may promote a fully validated merge-queue build. The helper
-      # treats lookup, download, or integrity failures as a normal build.
-      - name: Reuse validated merge-queue artifact
+      # Reuse only the website. Lean validation and cache refresh still run.
+      # Lookup, download, or integrity failures leave the full site build enabled.
+      - name: Reuse validated merge-queue website
         id: reuse
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         timeout-minutes: 5
@@ -99,11 +99,11 @@ jobs:
       # it, so the author sees the failure before the queue does.
       - name: Detect build mode
         id: mode
-        if: steps.reuse.outputs.reused != 'true'
         env:
           WEBSITE_ONLY: ${{ inputs.website_only }}
           REF_NAME: ${{ github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
+          REUSED_SITE: ${{ steps.reuse.outputs.reused }}
         run: |
           if [[ "$WEBSITE_ONLY" == "true" ]] || \
              [[ "$REF_NAME" == *-webtest ]]; then
@@ -127,10 +127,16 @@ jobs:
               echo "::notice::Pull request touches the site, building it."
             fi
           fi
+          # Reuse changes only the site half. Keep Lean validation and its
+          # cache writes enabled, including when #5435 separates the caches.
+          if [[ "$REUSED_SITE" == "true" ]]; then
+            site=false
+            echo "::notice::Reusing the validated website; Lean validation and cache refresh remain enabled."
+          fi
           echo "site=$site" >> "$GITHUB_OUTPUT"
 
       - name: Install elan
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           set -o pipefail
           curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
@@ -138,7 +144,7 @@ jobs:
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - name: Restore ~/.cache/mathlib
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache/mathlib
@@ -147,13 +153,13 @@ jobs:
             oleans-${{ hashFiles('lean-toolchain') }}-
 
       - name: Get olean cache
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           lake exe cache unpack
           lake exe cache get
 
       - name: Restore local lake build
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -165,14 +171,14 @@ jobs:
             lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-
 
       - name: Generate FormalConjecturesForMathlib.lean
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           ./scripts/mk_all_formathlib.sh
 
       # Generating All.lean aggregates all problem files into a single module to detect
       # clashing declaration names across problem modules during compilation.
       - name: Generate All.lean
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           rm -f FormalConjectures/All.lean
           lake exe mk_all --lib FormalConjectures || true
@@ -180,26 +186,26 @@ jobs:
           echo "set_option linter.style.moduleDocstring false" >> FormalConjectures/All.lean
 
       - name: Begin Lean problem matcher
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         uses: leanprover-community/gh-problem-matcher-wrap@65a654fcdf7b64ff7633bc7a558f7b46d59a27bf # master
         with:
           action: add
           linters: lean
 
       - name: Build ForMathlib, utilities, and test
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           python3 scripts/lake-build-wrapper.py /tmp/build_summary_formathlib.json lake --wfail build FormalConjecturesForMathlib FormalConjecturesUtil
           lake --wfail test
 
       - name: Build problems
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           python3 scripts/lake-build-wrapper.py /tmp/build_summary_problems.json lake --wfail build
           rm -f FormalConjectures/All.lean
 
       - name: End Lean problem matcher
-        if: always() && steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: always() && steps.mode.outputs.website_only != 'true'
         uses: leanprover-community/gh-problem-matcher-wrap@65a654fcdf7b64ff7633bc7a558f7b46d59a27bf # master
         with:
           action: remove
@@ -210,7 +216,7 @@ jobs:
       # in `FormalConjecturesForMathlib` or `FormalConjecturesUtil` instead of
       # dead-ending. The test library is left out: it documents nothing.
       - name: Build literate source pages
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           cd docbuild
           lake build FormalConjectures:literate \
@@ -219,12 +225,12 @@ jobs:
           lake exe verso-html .lake/build/literate ../_literate_html
 
       - name: Post-process literate HTML
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           python3 site/fix_literate_html.py _literate_html
 
       - name: Save local lake build
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -242,20 +248,20 @@ jobs:
       # as soon as the batch merges, so the entry is unreachable the moment it
       # is written.
       - name: Pack olean cache
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
         run: |
           lake exe cache pack
           ls ~/.cache/mathlib
 
       - name: Save ~/.cache/mathlib
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
         uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache/mathlib
           key: oleans-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
 
       - name: Set up Python
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12.9'
@@ -263,25 +269,25 @@ jobs:
       # Only the plotting and Verso-fragment scripts need these; the category
       # check below is standard library only.
       - name: Install Python dependencies
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install pandas==2.2.3 numpy==2.2.3 plotly==5.20.0 beautifulsoup4 lxml
 
       - name: Run plotting script
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           mkdir -p site/data
           python site/plot_growth.py
 
       - name: Set up Node.js
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.site == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18'
 
       - name: Generate conjectures data for website
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: |
           mkdir -p site/data
           lake exe extract_names --exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified \
@@ -292,11 +298,11 @@ jobs:
       # written. The first is a contradiction and fails; the other two are counted
       # in the run summary without blocking.
       - name: Check category warnings
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
+        if: steps.mode.outputs.website_only != 'true'
         run: python3 scripts/check_category_warnings.py site/data/conjectures.json
 
       - name: Extract Verso fragments for website
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           python3 site/extract_verso_fragments.py _literate_html site/data/verso-fragments.json
 
@@ -305,7 +311,7 @@ jobs:
       # format ({ conjectures, versoFragments, ... }), so we convert it back to
       # the raw extract_names format ({ problems }) that build.js expects.
       - name: Download live site data
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only == 'true'
+        if: steps.mode.outputs.website_only == 'true'
         run: |
           LIVE_URL="https://google-deepmind.github.io/formal-conjectures"
           mkdir -p site/data _literate_html
@@ -345,7 +351,7 @@ jobs:
           "
 
       - name: Build website
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.site == 'true'
         run: |
           cd site
           node build.js
@@ -353,7 +359,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Assemble deploy artifact
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.site == 'true'
         run: |
           mkdir -p _deploy
           # Website goes at root
@@ -365,7 +371,7 @@ jobs:
 
       - name: Upload deploy artifact
         id: deployment
-        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.mode.outputs.site == 'true'
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: _deploy

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -59,6 +59,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build project
+    permissions:
+      contents: read
+      actions: read
+    env:
+      BASE_PATH: /formal-conjectures
     steps:
 
       - name: Checkout project
@@ -66,6 +71,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # A main push may promote a fully validated merge-queue build. The helper
+      # treats lookup, download, or integrity failures as a normal build.
+      - name: Reuse validated merge-queue artifact
+        id: reuse
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        timeout-minutes: 5
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/queue_artifact.py reuse "$RUNNER_TEMP/queue-pages"
 
       # Two independent halves of this job, each with its own switch.
       #
@@ -83,6 +99,7 @@ jobs:
       # it, so the author sees the failure before the queue does.
       - name: Detect build mode
         id: mode
+        if: steps.reuse.outputs.reused != 'true'
         env:
           WEBSITE_ONLY: ${{ inputs.website_only }}
           REF_NAME: ${{ github.ref_name }}
@@ -113,7 +130,7 @@ jobs:
           echo "site=$site" >> "$GITHUB_OUTPUT"
 
       - name: Install elan
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           set -o pipefail
           curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
@@ -121,7 +138,7 @@ jobs:
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - name: Restore ~/.cache/mathlib
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache/mathlib
@@ -130,13 +147,13 @@ jobs:
             oleans-${{ hashFiles('lean-toolchain') }}-
 
       - name: Get olean cache
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           lake exe cache unpack
           lake exe cache get
 
       - name: Restore local lake build
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -148,14 +165,14 @@ jobs:
             lake-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'docbuild/lake-manifest.json', 'docbuild/lakefile.toml') }}-
 
       - name: Generate FormalConjecturesForMathlib.lean
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           ./scripts/mk_all_formathlib.sh
 
       # Generating All.lean aggregates all problem files into a single module to detect
       # clashing declaration names across problem modules during compilation.
       - name: Generate All.lean
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           rm -f FormalConjectures/All.lean
           lake exe mk_all --lib FormalConjectures || true
@@ -163,26 +180,26 @@ jobs:
           echo "set_option linter.style.moduleDocstring false" >> FormalConjectures/All.lean
 
       - name: Begin Lean problem matcher
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         uses: leanprover-community/gh-problem-matcher-wrap@65a654fcdf7b64ff7633bc7a558f7b46d59a27bf # master
         with:
           action: add
           linters: lean
 
       - name: Build ForMathlib, utilities, and test
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           python3 scripts/lake-build-wrapper.py /tmp/build_summary_formathlib.json lake --wfail build FormalConjecturesForMathlib FormalConjecturesUtil
           lake --wfail test
 
       - name: Build problems
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           python3 scripts/lake-build-wrapper.py /tmp/build_summary_problems.json lake --wfail build
           rm -f FormalConjectures/All.lean
 
       - name: End Lean problem matcher
-        if: always() && steps.mode.outputs.website_only != 'true'
+        if: always() && steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         uses: leanprover-community/gh-problem-matcher-wrap@65a654fcdf7b64ff7633bc7a558f7b46d59a27bf # master
         with:
           action: remove
@@ -193,7 +210,7 @@ jobs:
       # in `FormalConjecturesForMathlib` or `FormalConjecturesUtil` instead of
       # dead-ending. The test library is left out: it documents nothing.
       - name: Build literate source pages
-        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           cd docbuild
           lake build FormalConjectures:literate \
@@ -202,12 +219,12 @@ jobs:
           lake exe verso-html .lake/build/literate ../_literate_html
 
       - name: Post-process literate HTML
-        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           python3 site/fix_literate_html.py _literate_html
 
       - name: Save local lake build
-        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -225,20 +242,20 @@ jobs:
       # as soon as the batch merges, so the entry is unreachable the moment it
       # is written.
       - name: Pack olean cache
-        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
         run: |
           lake exe cache pack
           ls ~/.cache/mathlib
 
       - name: Save ~/.cache/mathlib
-        if: steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && github.event_name == 'push'
         uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.cache/mathlib
           key: oleans-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}
 
       - name: Set up Python
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12.9'
@@ -246,25 +263,25 @@ jobs:
       # Only the plotting and Verso-fragment scripts need these; the category
       # check below is standard library only.
       - name: Install Python dependencies
-        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install pandas==2.2.3 numpy==2.2.3 plotly==5.20.0 beautifulsoup4 lxml
 
       - name: Run plotting script
-        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           mkdir -p site/data
           python site/plot_growth.py
 
       - name: Set up Node.js
-        if: steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18'
 
       - name: Generate conjectures data for website
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           mkdir -p site/data
           lake exe extract_names --exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified \
@@ -275,11 +292,11 @@ jobs:
       # written. The first is a contradiction and fails; the other two are counted
       # in the run summary without blocking.
       - name: Check category warnings
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true'
         run: python3 scripts/check_category_warnings.py site/data/conjectures.json
 
       - name: Extract Verso fragments for website
-        if: steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only != 'true' && steps.mode.outputs.site == 'true'
         run: |
           python3 site/extract_verso_fragments.py _literate_html site/data/verso-fragments.json
 
@@ -288,7 +305,7 @@ jobs:
       # format ({ conjectures, versoFragments, ... }), so we convert it back to
       # the raw extract_names format ({ problems }) that build.js expects.
       - name: Download live site data
-        if: steps.mode.outputs.website_only == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.website_only == 'true'
         run: |
           LIVE_URL="https://google-deepmind.github.io/formal-conjectures"
           mkdir -p site/data _literate_html
@@ -328,16 +345,15 @@ jobs:
           "
 
       - name: Build website
-        if: steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
         run: |
           cd site
           node build.js
         env:
-          BASE_PATH: /formal-conjectures
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Assemble deploy artifact
-        if: steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
         run: |
           mkdir -p _deploy
           # Website goes at root
@@ -349,10 +365,39 @@ jobs:
 
       - name: Upload deploy artifact
         id: deployment
-        if: steps.mode.outputs.site == 'true'
+        if: steps.reuse.outputs.reused != 'true' && steps.mode.outputs.site == 'true'
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: _deploy
+
+      # upload-pages-artifact has already created artifact.tar. Re-upload that
+      # file unchanged; running upload-pages-artifact again would double-wrap it.
+      - name: Upload reused deploy artifact
+        if: steps.reuse.outputs.reused == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/queue-pages/artifact.tar
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
+      # The receipt is usable only after this entire workflow (including the
+      # parallel script tests) succeeds. Bind the exact immutable Pages artifact.
+      - name: Record merge-queue build inputs
+        if: github.event_name == 'merge_group'
+        env:
+          PAGES_ARTIFACT_ID: ${{ steps.deployment.outputs.artifact_id }}
+        run: python3 scripts/queue_artifact.py record "$RUNNER_TEMP/queue-receipt"
+
+      - name: Upload merge-queue receipt
+        if: github.event_name == 'merge_group'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: queue-build-receipt
+          path: ${{ runner.temp }}/queue-receipt/receipt.json
+          retention-days: 1
+          if-no-files-found: error
 
   # Deployment job
   deploy:
@@ -364,7 +409,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, scripts]
     # Only the deployment job needs write access to Pages and the OIDC token.
     permissions:
       contents: read

--- a/scripts/queue-artifact.md
+++ b/scripts/queue-artifact.md
@@ -1,0 +1,49 @@
+# Reusing merge-queue validation
+
+A push to `main` first looks for a successful merge-queue run from the same
+repository and workflow at the exact same commit. If its receipt and Pages
+archive match, the build job uploads those same tar bytes into the current run.
+The existing deployment job consumes the current run's artifact as usual.
+
+```text
+merge queue: script tests + full Lean/site build → Pages archive + receipt
+                                                    ↓ exact match
+main:        script tests + validate receipt → upload archive → deploy
+                              ↓ no match
+                         ordinary full build → deploy
+```
+
+The receipt binds the artifact ID and tar digest to the repository, source
+commit, workflow, run attempt, runner image/version, base path, and full build
+mode. The source commit binds the checked-in build recipes and dependency pins.
+The entire source workflow must succeed, including its parallel script tests.
+A receipt from an earlier rerun attempt cannot validate a later one.
+
+Only `merge_group` runs targeting `main` can supply artifacts. PR artifacts,
+website-only builds, other repositories, other workflows, different commits,
+and failed or unfinished runs cannot qualify. Downloads copy only the named
+archive member; they do not execute or extract the site contents. The tar digest
+is checked before upload. Deployment also waits for the current script tests.
+
+No new repository setting, secret, or required check is needed. The build job
+uses `actions: read` on its existing `GITHUB_TOKEN`. Artifacts expire after one
+day. Missing, expired, ambiguous, mismatched, or unavailable artifacts result in
+an ordinary build. A manual full run on `main` always rebuilds, which also permits
+refreshing external contributor metadata used by the site.
+
+Reused builds preserve the validated snapshot, including external metadata;
+they do not refresh that data or write a new Lean cache. Cache separation in
+#5435 remains independent. If configurable site feeds or other environment
+inputs are added, include them in the receipt comparison before allowing reuse.
+
+## Qualification before adoption
+
+Local tests cover promotion, wrong source runs, changed inputs, expired/missing
+artifacts, old attempts, download failures, digest mismatches, and a source rerun
+during download. Run `python3 -m unittest discover -s scripts -p 'test_*.py'`.
+
+Live acceptance still requires a successful queue run followed by a `main` push
+at the same SHA: confirm compilation is skipped, the archive is unchanged, the
+source run is linked in the summary, and Pages deploys it. Also confirm a push
+without a qualifying receipt builds normally. Do not infer this acceptance from
+mocked API tests or from a successful PR check, which cannot take the reuse path.

--- a/scripts/queue-artifact.md
+++ b/scripts/queue-artifact.md
@@ -1,17 +1,21 @@
-# Reusing merge-queue validation
+# Reusing the merge-queue website
 
-A push to `main` first looks for a successful merge-queue run from the same
-repository and workflow at the exact same commit. If its receipt and Pages
-archive match, the build job uploads those same tar bytes into the current run.
-The existing deployment job consumes the current run's artifact as usual.
+A push to `main` always validates Lean and refreshes its shared build cache.
+It also looks for a successful merge-queue run from the same repository and
+workflow at the exact same commit. If its receipt and Pages archive match,
+it uploads those same tar bytes instead of rebuilding the website.
 
 ```text
 merge queue: script tests + full Lean/site build → Pages archive + receipt
                                                     ↓ exact match
-main:        script tests + validate receipt → upload archive → deploy
-                              ↓ no match
-                         ordinary full build → deploy
+main:        script tests + Lean validation + Lean cache refresh
+               → reuse website OR render/build website → deploy
 ```
+
+Reuse skips Verso rendering, HTML processing, plotting, fragment extraction,
+and website assembly. Lean library/problem builds, utility tests, metadata
+extraction, category checks, and Lean cache saves still run. A failed current
+check blocks deployment even when the website artifact is valid.
 
 The receipt binds the artifact ID and tar digest to the repository, source
 commit, workflow, run attempt, runner image/version, base path, and full build
@@ -23,27 +27,39 @@ Only `merge_group` runs targeting `main` can supply artifacts. PR artifacts,
 website-only builds, other repositories, other workflows, different commits,
 and failed or unfinished runs cannot qualify. Downloads copy only the named
 archive member; they do not execute or extract the site contents. The tar digest
-is checked before upload. Deployment also waits for the current script tests.
+is checked before upload. Deployment waits for the current build and script tests.
 
 No new repository setting, secret, or required check is needed. The build job
 uses `actions: read` on its existing `GITHUB_TOKEN`. Artifacts expire after one
 day. Missing, expired, ambiguous, mismatched, or unavailable artifacts result in
-an ordinary build. A manual full run on `main` always rebuilds, which also permits
-refreshing external contributor metadata used by the site.
+an ordinary website build. A manual full run on `main` always rebuilds the site,
+which also permits refreshing its external contributor metadata.
 
-Reused builds preserve the validated snapshot, including external metadata;
-they do not refresh that data or write a new Lean cache. Cache separation in
-#5435 remains independent. If configurable site feeds or other environment
-inputs are added, include them in the receipt comparison before allowing reuse.
+## Dependency and qualification
 
-## Qualification before adoption
+Merge #5435 first. Its cache separation saves the Lean build before documentation
+can change its traces. This PR keeps that save enabled on reuse hits and uses
+the existing `site` switch to skip documentation cache restores and saves.
+It does not copy #5435's implementation into this branch.
 
-Local tests cover promotion, wrong source runs, changed inputs, expired/missing
-artifacts, old attempts, download failures, digest mismatches, and a source rerun
-during download. Run `python3 -m unittest discover -s scripts -p 'test_*.py'`.
+The documentation cache is not refreshed on reuse hits. Later queue builds may
+therefore spend longer rebuilding documentation even though the shared Lean
+cache stays current. Measure consecutive queue/main cycles after #5435, including
+cache restores, rendering, artifact transfer, and total runtime, before adoption.
+A single faster deployment is insufficient evidence of an overall improvement.
+
+Run `python3 -m unittest discover -s scripts -p 'test_*.py'`. Tests cover artifact
+provenance/integrity, old attempts, unavailable downloads, source reruns, and the
+workflow conditions that preserve Lean work while skipping website work. Set
+`FC_BUILD_WORKFLOW` to a combined workflow file to run the same condition tests
+with #5435 applied.
 
 Live acceptance still requires a successful queue run followed by a `main` push
-at the same SHA: confirm compilation is skipped, the archive is unchanged, the
-source run is linked in the summary, and Pages deploys it. Also confirm a push
-without a qualifying receipt builds normally. Do not infer this acceptance from
-mocked API tests or from a successful PR check, which cannot take the reuse path.
+at the same SHA. Confirm Lean validation and cache refresh run, site construction
+is skipped, the archive is unchanged, and Pages deploys it. Check that a failed
+current Lean build blocks deployment and that a push without a qualifying receipt
+builds the site normally. A successful PR check cannot exercise the reuse path.
+
+Reused sites preserve the queue's external metadata snapshot. If configurable
+feeds or other environment inputs are added, include them in the receipt
+comparison before allowing reuse.

--- a/scripts/queue_artifact.py
+++ b/scripts/queue_artifact.py
@@ -2,7 +2,8 @@
 """Retain and reuse the Pages artifact from an exact-commit merge-queue build.
 
 Only this workflow's successful merge_group runs can supply artifacts. A cache
-miss (including API or integrity failures) leaves the ordinary build enabled.
+miss (including API or integrity failures) leaves the website build enabled.
+Lean validation and cache refresh run whether or not the website is reused.
 """
 
 import argparse
@@ -171,9 +172,10 @@ def main():
             run_id = reuse(api, expected, current, args.directory)
         except (KeyError, TypeError, ValueError, OSError, zipfile.BadZipFile,
                 subprocess.SubprocessError):
-            print("Merge-queue artifact lookup unavailable; running the normal build.")
-    message = (f"Reusing validated merge-queue run {run_id} for {expected['sha']}."
-               if run_id else "No matching validated merge-queue artifact; running the normal build.")
+            print("Merge-queue artifact lookup unavailable; building the website normally.")
+    message = (f"Reusing the website from validated merge-queue run {run_id} for {expected['sha']}. "
+               "Lean validation and cache refresh remain enabled."
+               if run_id else "No matching validated merge-queue artifact; building the website normally.")
     print(message)
     with open(os.environ["GITHUB_OUTPUT"], "a") as output:
         output.write(f"reused={'true' if run_id else 'false'}\n")

--- a/scripts/queue_artifact.py
+++ b/scripts/queue_artifact.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Retain and reuse the Pages artifact from an exact-commit merge-queue build.
+
+Only this workflow's successful merge_group runs can supply artifacts. A cache
+miss (including API or integrity failures) leaves the ordinary build enabled.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from urllib.parse import urlencode
+import zipfile
+
+WORKFLOW = ".github/workflows/build-and-docs.yml"
+RECEIPT = "queue-build-receipt"
+MAX_ARCHIVE = 2 * 1024**3
+
+
+def sha256(path):
+    with Path(path).open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def inputs():
+    # The commit binds source, workflow, dependency pins, and build recipes.
+    # Include environment inputs here if the workflow adds configurable feeds.
+    return {
+        "schema": 1,
+        "repository": os.environ["GITHUB_REPOSITORY"],
+        "sha": os.environ["GITHUB_SHA"],
+        "workflow": WORKFLOW,
+        "base_path": os.environ["BASE_PATH"],
+        "runner_os": os.environ["RUNNER_OS"],
+        "runner_image": os.environ["ImageOS"],
+        "runner_image_version": os.environ["ImageVersion"],
+        "build_mode": "full",
+    }
+
+
+class GitHub:
+    def __init__(self, repository):
+        self.root = f"repos/{repository}/actions"
+
+    def get(self, path):
+        result = subprocess.run(
+            ["gh", "api", f"{self.root}/{path}"], check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30,
+        )
+        return json.loads(result.stdout)
+
+    def download(self, artifact_id, destination):
+        with destination.open("wb") as stream:
+            subprocess.run(
+                ["gh", "api", f"{self.root}/artifacts/{artifact_id}/zip"],
+                check=True, stdout=stream, stderr=subprocess.PIPE, timeout=180,
+            )
+
+
+def eligible(run, current, expected):
+    return (
+        run.get("event") == "merge_group"
+        and run.get("status") == "completed"
+        and run.get("conclusion") == "success"
+        and run.get("head_sha") == expected["sha"]
+        and run.get("path") == WORKFLOW
+        and run.get("workflow_id") == current["workflow_id"]
+        and run.get("repository", {}).get("id") == current["repository"]["id"]
+        and run.get("head_repository", {}).get("id") == current["repository"]["id"]
+        and run.get("head_branch", "").startswith("gh-readonly-queue/main/")
+    )
+
+
+def artifact_named(artifacts, name, run, repository_id):
+    matches = [a for a in artifacts if a.get("name") == name]
+    if len(matches) != 1:
+        raise ValueError("missing or ambiguous artifact")
+    artifact = matches[0]
+    origin = artifact.get("workflow_run") or {}
+    if (artifact.get("expired") is not False
+            or not 0 < artifact.get("size_in_bytes", 0) <= MAX_ARCHIVE
+            or origin.get("id") != run["id"]
+            or origin.get("head_sha") != run["head_sha"]
+            or origin.get("repository_id") != repository_id
+            or origin.get("head_repository_id") != repository_id):
+        raise ValueError("artifact provenance or availability mismatch")
+    return artifact
+
+
+def unpack(archive, name, destination, limit):
+    # Copy a single named member. Never extract paths or execute archive content.
+    with zipfile.ZipFile(archive) as bundle:
+        if bundle.namelist() != [name]:
+            raise ValueError("unexpected archive members")
+        if bundle.getinfo(name).file_size > limit:
+            raise ValueError("artifact is too large")
+        with bundle.open(name) as source, destination.open("wb") as target:
+            shutil.copyfileobj(source, target)
+
+
+def reuse(api, expected, current, destination):
+    query = urlencode({"event": "merge_group", "head_sha": expected["sha"],
+                       "status": "success", "per_page": 10})
+    runs = api.get(f"workflows/{current['workflow_id']}/runs?{query}")["workflow_runs"]
+    for candidate in runs:
+        # Refresh: list results can predate a rerun.
+        run = api.get(f"runs/{candidate['id']}")
+        if not eligible(run, current, expected):
+            continue
+        try:
+            artifacts = api.get(f"runs/{run['id']}/artifacts?per_page=100")["artifacts"]
+            repository_id = current["repository"]["id"]
+            receipt_artifact = artifact_named(artifacts, RECEIPT, run, repository_id)
+            pages = artifact_named(artifacts, "github-pages", run, repository_id)
+            with tempfile.TemporaryDirectory() as temporary:
+                work = Path(temporary)
+                api.download(receipt_artifact["id"], work / "receipt.zip")
+                unpack(work / "receipt.zip", "receipt.json", work / "receipt.json", 64 * 1024)
+                receipt = json.loads((work / "receipt.json").read_text())
+                if (receipt["inputs"] != expected or receipt["run_id"] != run["id"]
+                        or receipt["run_attempt"] != run["run_attempt"]
+                        or receipt["artifact_id"] != pages["id"]):
+                    raise ValueError("receipt does not match this build or run attempt")
+                api.download(pages["id"], work / "pages.zip")
+                unpack(work / "pages.zip", "artifact.tar", work / "artifact.tar", MAX_ARCHIVE)
+                if sha256(work / "artifact.tar") != receipt["tar_sha256"]:
+                    raise ValueError("Pages archive digest mismatch")
+                # A source rerun or cancellation during download invalidates reuse.
+                after = api.get(f"runs/{run['id']}")
+                if not eligible(after, current, expected) or after["run_attempt"] != run["run_attempt"]:
+                    raise ValueError("source run changed during download")
+                destination.mkdir(parents=True, exist_ok=True)
+                shutil.move(work / "artifact.tar", destination / "artifact.tar")
+            return run["id"]
+        except (KeyError, TypeError, ValueError, OSError, zipfile.BadZipFile,
+                subprocess.SubprocessError):
+            print(f"Merge-queue run {run['id']} has no usable validated artifact; checking other runs.")
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=["record", "reuse"])
+    parser.add_argument("directory", type=Path)
+    args = parser.parse_args()
+    expected = inputs()
+    if args.operation == "record":
+        if os.environ["GITHUB_EVENT_NAME"] != "merge_group":
+            parser.error("only merge-group builds can record reuse receipts")
+        args.directory.mkdir(parents=True, exist_ok=True)
+        receipt = {
+            "inputs": expected,
+            "run_id": int(os.environ["GITHUB_RUN_ID"]),
+            "run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+            "artifact_id": int(os.environ["PAGES_ARTIFACT_ID"]),
+            "tar_sha256": sha256(Path(os.environ["RUNNER_TEMP"]) / "artifact.tar"),
+        }
+        (args.directory / "receipt.json").write_text(json.dumps(receipt, indent=2) + "\n")
+        return
+
+    run_id = None
+    if (os.environ.get("GITHUB_EVENT_NAME") == "push"
+            and os.environ.get("GITHUB_REF") == "refs/heads/main"):
+        try:
+            api = GitHub(expected["repository"])
+            current = api.get(f"runs/{os.environ['GITHUB_RUN_ID']}")
+            run_id = reuse(api, expected, current, args.directory)
+        except (KeyError, TypeError, ValueError, OSError, zipfile.BadZipFile,
+                subprocess.SubprocessError):
+            print("Merge-queue artifact lookup unavailable; running the normal build.")
+    message = (f"Reusing validated merge-queue run {run_id} for {expected['sha']}."
+               if run_id else "No matching validated merge-queue artifact; running the normal build.")
+    print(message)
+    with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        output.write(f"reused={'true' if run_id else 'false'}\n")
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+        summary.write(message + "\n")
+        if run_id:
+            summary.write(f"[Source validation and logs](https://github.com/{expected['repository']}/actions/runs/{run_id})\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_queue_artifact.py
+++ b/scripts/test_queue_artifact.py
@@ -1,0 +1,170 @@
+"""Exercise artifact promotion and safe misses without a Lean build or network."""
+
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+import zipfile
+
+import queue_artifact as qa
+
+
+class FakeGitHub:
+    def __init__(self):
+        self.expected = {"schema": 1, "repository": "owner/repo", "sha": "a" * 40,
+                         "workflow": qa.WORKFLOW, "base_path": "/formal-conjectures",
+                         "runner_os": "Linux", "build_mode": "full"}
+        self.current = {"workflow_id": 10, "repository": {"id": 20}}
+        self.run = {**self.current, "id": 30, "run_attempt": 1,
+                    "event": "merge_group", "status": "completed", "conclusion": "success",
+                    "head_sha": self.expected["sha"], "path": qa.WORKFLOW,
+                    "head_repository": {"id": 20}, "head_branch": "gh-readonly-queue/main/pr-1-abc"}
+        self.tar = b"exact Pages tar bytes"
+        self.receipt = {"inputs": self.expected.copy(), "run_id": 30, "run_attempt": 1,
+                        "artifact_id": 40, "tar_sha256": hashlib.sha256(self.tar).hexdigest()}
+        origin = {"id": 30, "head_sha": self.expected["sha"],
+                  "repository_id": 20, "head_repository_id": 20}
+        self.artifacts = [{"id": id_, "name": name, "expired": False,
+                           "size_in_bytes": 1000, "workflow_run": origin.copy()}
+                          for id_, name in [(40, "github-pages"), (41, qa.RECEIPT)]]
+        self.fail_download = False
+        self.extra_member = False
+        self.run_reads = 0
+        self.rerun_during_download = False
+
+    def get(self, path):
+        if path.startswith("workflows/"):
+            return {"workflow_runs": [self.run]}
+        if "/artifacts?" in path:
+            return {"artifacts": self.artifacts}
+        self.run_reads += 1
+        run = copy.deepcopy(self.run)
+        if self.rerun_during_download and self.run_reads > 1:
+            run["run_attempt"] += 1
+        return run
+
+    def download(self, artifact_id, destination):
+        if self.fail_download:
+            raise OSError("download failed")
+        with zipfile.ZipFile(destination, "w") as bundle:
+            if artifact_id == 40:
+                bundle.writestr("artifact.tar", self.tar)
+                if self.extra_member:
+                    bundle.writestr("../unexpected", "unsafe")
+            else:
+                bundle.writestr("receipt.json", json.dumps(self.receipt))
+
+
+class ReuseTest(unittest.TestCase):
+    def setUp(self):
+        self.api = FakeGitHub()
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.destination = Path(self.temp.name) / "promoted"
+
+    def reuse(self):
+        return qa.reuse(self.api, self.api.expected, self.api.current, self.destination)
+
+    def assert_miss(self):
+        self.assertIsNone(self.reuse())
+        self.assertFalse((self.destination / "artifact.tar").exists())
+
+    def test_success_copies_exact_tar(self):
+        self.assertEqual(self.reuse(), 30)
+        self.assertEqual((self.destination / "artifact.tar").read_bytes(), self.api.tar)
+
+    def test_only_successful_exact_commit_queue_runs_are_eligible(self):
+        for key, value in [("event", "pull_request"), ("event", "push"),
+                           ("status", "in_progress"), ("conclusion", "failure"),
+                           ("conclusion", "cancelled"), ("head_sha", "b" * 40),
+                           ("workflow_id", 99), ("path", ".github/workflows/other.yml"),
+                           ("repository", {"id": 99}), ("head_repository", {"id": 99}),
+                           ("head_branch", "gh-readonly-queue/other/pr-1")]:
+            with self.subTest(key=key, value=value):
+                self.api = FakeGitHub()
+                self.api.run[key] = value
+                self.assert_miss()
+
+    def test_missing_ambiguous_expired_and_foreign_artifacts(self):
+        for change in [lambda a: a.clear(), lambda a: a.append(a[0].copy()),
+                       lambda a: a[0].update(expired=True),
+                       lambda a: a[0].update(size_in_bytes=qa.MAX_ARCHIVE + 1),
+                       lambda a: a[0]["workflow_run"].update(head_repository_id=99),
+                       lambda a: a[0]["workflow_run"].update(head_sha="b" * 40),
+                       lambda a: a[0]["workflow_run"].update(id=99)]:
+            self.api = FakeGitHub()
+            change(self.api.artifacts)
+            self.assert_miss()
+
+    def test_receipt_binds_build_inputs_and_attempt(self):
+        for key, value in [("inputs", {"schema": 0}), ("run_id", 99),
+                           ("run_attempt", 2), ("artifact_id", 99),
+                           ("tar_sha256", "bad")]:
+            with self.subTest(key=key):
+                self.api = FakeGitHub()
+                self.api.receipt[key] = value
+                self.assert_miss()
+
+    def test_unavailable_or_unsafe_archive_falls_back(self):
+        for flag in ["fail_download", "extra_member", "rerun_during_download"]:
+            self.api = FakeGitHub()
+            setattr(self.api, flag, True)
+            self.assert_miss()
+
+    def test_old_workflows_without_receipts_build_normally(self):
+        self.api.artifacts.pop()
+        self.assert_miss()
+
+    def test_size_checked_before_unzip(self):
+        archive = Path(self.temp.name) / "large.zip"
+        with zipfile.ZipFile(archive, "w") as bundle:
+            bundle.writestr("receipt.json", "x" * 100)
+        with self.assertRaises(ValueError):
+            qa.unpack(archive, "receipt.json", Path(self.temp.name) / "out", 10)
+
+    def test_api_failure_records_miss(self):
+        env = {"GITHUB_REPOSITORY": "owner/repo", "GITHUB_SHA": "a" * 40,
+               "BASE_PATH": "/formal-conjectures", "RUNNER_OS": "Linux",
+               "ImageOS": "ubuntu24", "ImageVersion": "20260907.1",
+               "GITHUB_EVENT_NAME": "push", "GITHUB_REF": "refs/heads/main",
+               "GITHUB_RUN_ID": "100", "GITHUB_OUTPUT": self.temp.name + "/output",
+               "GITHUB_STEP_SUMMARY": self.temp.name + "/summary"}
+        with patch.dict(os.environ, env), patch("sys.argv", ["queue_artifact.py", "reuse", str(self.destination)]), \
+                patch.object(qa.GitHub, "get", side_effect=OSError("unavailable")):
+            qa.main()
+        self.assertEqual(Path(env["GITHUB_OUTPUT"]).read_text(), "reused=false\n")
+        self.assertFalse(self.destination.exists())
+
+    def test_other_events_never_query_artifacts(self):
+        env = {"GITHUB_REPOSITORY": "owner/repo", "GITHUB_SHA": "a" * 40,
+               "BASE_PATH": "/formal-conjectures", "RUNNER_OS": "Linux",
+               "ImageOS": "ubuntu24", "ImageVersion": "20260907.1",
+               "GITHUB_EVENT_NAME": "workflow_dispatch", "GITHUB_REF": "refs/heads/main",
+               "GITHUB_OUTPUT": self.temp.name + "/output", "GITHUB_STEP_SUMMARY": self.temp.name + "/summary"}
+        with patch.dict(os.environ, env), patch("sys.argv", ["queue_artifact.py", "reuse", str(self.destination)]), \
+                patch.object(qa.GitHub, "get") as get:
+            qa.main()
+        get.assert_not_called()
+
+    def test_record_binds_tar_and_runner_image(self):
+        env = {"GITHUB_REPOSITORY": "owner/repo", "GITHUB_SHA": "a" * 40,
+               "BASE_PATH": "/formal-conjectures", "RUNNER_OS": "Linux",
+               "ImageOS": "ubuntu24", "ImageVersion": "20260907.1",
+               "GITHUB_EVENT_NAME": "merge_group", "GITHUB_RUN_ID": "30",
+               "GITHUB_RUN_ATTEMPT": "2", "PAGES_ARTIFACT_ID": "40",
+               "RUNNER_TEMP": self.temp.name}
+        (Path(self.temp.name) / "artifact.tar").write_bytes(self.api.tar)
+        with patch.dict(os.environ, env), patch("sys.argv", ["queue_artifact.py", "record", str(self.destination)]):
+            qa.main()
+        receipt = json.loads((self.destination / "receipt.json").read_text())
+        self.assertEqual(receipt["tar_sha256"], hashlib.sha256(self.api.tar).hexdigest())
+        self.assertEqual(receipt["run_attempt"], 2)
+        self.assertEqual(receipt["inputs"]["runner_image_version"], "20260907.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_queue_artifact.py
+++ b/scripts/test_queue_artifact.py
@@ -4,6 +4,9 @@ import copy
 import hashlib
 import json
 import os
+import re
+import subprocess
+import textwrap
 from pathlib import Path
 import tempfile
 import unittest
@@ -164,6 +167,100 @@ class ReuseTest(unittest.TestCase):
         self.assertEqual(receipt["tar_sha256"], hashlib.sha256(self.api.tar).hexdigest())
         self.assertEqual(receipt["run_attempt"], 2)
         self.assertEqual(receipt["inputs"]["runner_image_version"], "20260907.1")
+
+
+class WorkflowReuseTest(unittest.TestCase):
+    """Run the real mode script and check the workflow's build-step conditions.
+
+    This covers successful-job selection, not a simulation of the Actions runner.
+    actionlint and live qualification cover the rest of the workflow contract.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        default = Path(__file__).resolve().parents[1] / ".github/workflows/build-and-docs.yml"
+        cls.workflow = Path(os.environ.get("FC_BUILD_WORKFLOW", default)).read_text()
+        build = cls.workflow.split("  build:\n", 1)[1].split("  # Deployment job", 1)[0]
+        cls.steps = dict(re.findall(
+            r"^      - name: ([^\n]+)\n(.*?)(?=^      - name: |\Z)", build, re.M | re.S))
+
+    def mode(self, reused, website_only="", event="push", ref="main"):
+        step = self.steps["Detect build mode"]
+        match = re.search(r"        run: \|\n((?:          .*\n|\n)+)", step)
+        self.assertIsNotNone(match)
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            env = {**os.environ, "GITHUB_OUTPUT": str(output), "REUSED_SITE": reused,
+                   "WEBSITE_ONLY": website_only, "EVENT_NAME": event, "REF_NAME": ref}
+            subprocess.run(["bash", "-eu", "-c", textwrap.dedent(match[1])],
+                           env=env, cwd=directory, capture_output=True, check=True)
+            return dict(line.split("=", 1) for line in output.read_text().splitlines())
+
+    def enabled(self, name, mode, reused, event="push"):
+        condition = re.search(r"^        if: (.+)$", self.steps[name], re.M)
+        if condition is None:
+            return True
+        values = {"steps.mode.outputs.website_only": mode["website_only"],
+                  "steps.mode.outputs.site": mode["site"],
+                  "steps.reuse.outputs.reused": reused, "github.event_name": event}
+        expression = condition[1]
+        for key, value in values.items():
+            expression = expression.replace(key, "'" + value + "'")
+        # All tested conditions use the shared ==, !=, && subset of Actions/bash.
+        self.assertNotRegex(expression, r"steps\.|github\.|always\(|failure\(")
+        result = subprocess.run(["bash", "-c", "[[ " + expression + " ]]"], capture_output=True)
+        self.assertIn(result.returncode, (0, 1), result.stderr)
+        return result.returncode == 0
+
+    def test_reuse_preserves_lean_and_cache_but_skips_site(self):
+        mode = self.mode("true")
+        self.assertEqual(mode, {"website_only": "false", "site": "false"})
+        required = ["Install elan", "Get olean cache", "Build ForMathlib, utilities, and test",
+                    "Build problems", "Pack olean cache", "Save ~/.cache/mathlib",
+                    "Generate conjectures data for website", "Check category warnings",
+                    "Upload reused deploy artifact"]
+        required += [name for name in ("Restore local lake build", "Save local lake build",
+                                      "Restore Lean build", "Save Lean build") if name in self.steps]
+        self.assertTrue(any(name.startswith("Save ") and "build" in name for name in required))
+        for name in required:
+            with self.subTest(step=name):
+                self.assertTrue(self.enabled(name, mode, "true"))
+        skipped = ["Build literate source pages", "Post-process literate HTML",
+                   "Install Python dependencies", "Run plotting script", "Set up Node.js",
+                   "Extract Verso fragments for website", "Build website",
+                   "Assemble deploy artifact", "Upload deploy artifact", "Download live site data"]
+        skipped += [name for name in ("Initialize documentation workspace", "Restore documentation tools",
+                                     "Restore literate data", "Save documentation tools", "Save literate data")
+                    if name in self.steps]
+        for name in skipped:
+            with self.subTest(step=name):
+                self.assertFalse(self.enabled(name, mode, "true"))
+
+    def test_missing_or_failed_lookup_builds_site(self):
+        for reused in ("false", ""):
+            mode = self.mode(reused)
+            self.assertEqual(mode, {"website_only": "false", "site": "true"})
+            for name in ("Build problems", "Build literate source pages", "Build website", "Upload deploy artifact"):
+                self.assertTrue(self.enabled(name, mode, reused))
+            self.assertFalse(self.enabled("Upload reused deploy artifact", mode, reused))
+
+    def test_manual_and_website_preview_modes(self):
+        self.assertEqual(self.mode("", event="workflow_dispatch"),
+                         {"website_only": "false", "site": "true"})
+        for options in ({"website_only": "true", "event": "workflow_dispatch"}, {"ref": "example-webtest"}):
+            mode = self.mode("", **options)
+            self.assertEqual(mode, {"website_only": "true", "site": "true"})
+            self.assertFalse(self.enabled("Build problems", mode, ""))
+            self.assertTrue(self.enabled("Download live site data", mode, ""))
+
+    def test_deployment_keeps_current_validation_dependency(self):
+        deploy = self.workflow.split("  deploy:\n", 1)[1]
+        self.assertIn("needs: [build, scripts]", deploy)
+        self.assertNotIn("always()", deploy)
+        for name in ("Build ForMathlib, utilities, and test", "Build problems", "Check category warnings",
+                     "Upload reused deploy artifact"):
+            self.assertNotIn("continue-on-error:", self.steps[name])
+            self.assertNotIn("always()", self.steps[name])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reuse the website from a successful merge-queue run at the exact same commit, while **keeping Lean validation and shared Lean cache refresh on `main`**.

```mermaid
flowchart LR
  M[Push to main] --> L[Validate Lean + refresh Lean cache]
  L --> C{Matching validated website?}
  Q[Successful exact-commit queue run] --> C
  C -->|Yes| R[Reuse Pages archive]
  C -->|No or unavailable| B[Render Verso + build website]
  R --> D[Deploy after current checks pass]
  B --> D
```

| On a reuse hit | Behavior |
| --- | --- |
| Lean libraries, problems, utility tests | Run |
| Metadata extraction and category checks | Run |
| Shared Lean cache refresh | Remains enabled |
| Verso rendering, HTML processing, plotting, fragment extraction, site assembly | Skipped |
| Pages deployment | Uses the unchanged archive after current build and script checks pass |

Reuse requires the same repository/workflow, a successful `merge_group` targeting `main`, exact commit and configured inputs, matching runner image/version, immutable artifact ID, current run attempt, and matching tar digest. Missing, expired, or invalid artifacts trigger the normal website build. Manual full runs also rebuild the site.

**Cache prerequisite satisfied:** #5435 merged on 10 September 2026. Lean cache saves now happen before documentation changes build traces. This PR uses the existing `site` switch and contains none of #5435's commits. Its compatibility tests passed with #5435. #5460 is independent; no dependency on #5375 or the toolkit stack.

**Validation:** 40 script tests and 6 website tests pass. All 14 artifact/workflow tests also pass with #5435's patch applied. `actionlint` 1.7.7 passes on both workflows. Tests check that reuse preserves Lean checks and cache saves while suppressing site work, and that unavailable reuse retains normal builds.

**Still draft:** qualify real queue → `main` reuse, Pages deployment, failure blocking, and cache writes. Measure successive queue/main cycles: the documentation cache is not refreshed on reuse hits, so later rendering may take longer. No net speedup is claimed until those measurements pass. Reused sites retain the queue's external metadata snapshot.

No new repository setting, credential, or required check. Uses `actions: read` on the existing `GITHUB_TOKEN`. Contract and acceptance details: `scripts/queue-artifact.md`.
