### PR TITLE
fix(Millenium/Poincare): require Hausdorff in SmoothConjectureFor

### DIFF
--- a/FormalConjectures/Millenium/Poincare.lean
+++ b/FormalConjectures/Millenium/Poincare.lean
@@ -68,10 +68,14 @@ The Generalized Poincaré Conjecture holds in dimension 4.
 theorem poincare_conjecture.variants.dimension_four : ConjectureFor 4 := by
   sorry
 
-/-- The predicate that the smooth Poincaré conjecture holds in dimension $n$. -/
+/-- The predicate that the smooth Poincaré conjecture holds in dimension $n$, i.e. that any
+smooth $n$-dimensional manifold that is homotopy equivalent to the sphere is in fact diffeomorphic
+to the sphere. As in `ConjectureFor`, the manifold must be Hausdorff: `ChartedSpace` and
+`IsManifold` do not imply this, and in every positive dimension there is a non-Hausdorff smooth
+manifold that is homotopy equivalent to the sphere. -/
 def SmoothConjectureFor (n : ℕ) : Prop :=
-  ∀ (M : Type) [TopologicalSpace M] [ChartedSpace (ℝ^n) M] [IsManifold (𝓡 n) ∞ M],
-    M ≃ₕ 𝕊ⁿ → Nonempty (M ≃ₘ⟮𝓡 n, 𝓡 n⟯ 𝕊ⁿ)
+  ∀ (M : Type) [TopologicalSpace M] [T2Space M] [ChartedSpace (ℝ^n) M]
+    [IsManifold (𝓡 n) ∞ M], M ≃ₕ 𝕊ⁿ → Nonempty (M ≃ₘ⟮𝓡 n, 𝓡 n⟯ 𝕊ⁿ)
 
 /-- A reformulation of the Millennium Problem in terms of smooth 3-folds. -/
 @[category textbook, AMS 54 57]


### PR DESCRIPTION
**What changed**

- `SmoothConjectureFor` now assumes `[T2Space M]`, as `ConjectureFor` does. Its docstring says why.

**Why**

`SmoothConjectureFor` quantified over `(M : Type) [TopologicalSpace M] [ChartedSpace (ℝ^n) M] [IsManifold (𝓡 n) ∞ M]` with no Hausdorff hypothesis, and neither `ChartedSpace` nor `IsManifold` implies it. That makes the predicate false for every `n ≥ 1`: let `E = ℝⁿ`, identify `OnePoint E` with `𝕊ⁿ`, take the open halfspaces `B = {x | x₀ < 1}` and `A = {x | x₀ < 0}` in the finite part, and glue a second copy of `B` to `OnePoint E` along `A`. The two copies of the origin cannot be separated, so the glued space `M` is not Hausdorff and admits no homeomorphism to `𝕊ⁿ`. The projection `M → OnePoint E` is a local homeomorphism, so `M` inherits a smooth atlas from the sphere, and translation by `-t • e₀` (which fixes infinity and moves `B` into `A` at `t = 1`) gives a homotopy from `id` to the composite of projection and inclusion, so `M ≃ₕ 𝕊ⁿ`.

Consequently `smooth_for_three`, `smooth_known_cases` and `smooth_dimension_four` were false as stated, `smooth_implication` held only because its premise was false, and `smooth_other_cases` held for every `n > 4` for a reason unrelated to exotic spheres. With `[T2Space M]`, a manifold homotopy equivalent to `𝕊ⁿ` is compact and hence second countable, so no further hypothesis is needed.

The complete Lean proof of `∀ n, ¬ SmoothConjectureFor (n + 1)` for the previous statement is below (one file, about 700 lines). All seven final declarations depend only on `propext`, `Classical.choice`, `Quot.sound`.

<details>
<summary>Lean counterexample (checked with <code>lake env lean</code> against the statement before this PR, no errors)</summary>

```lean
import FormalConjectures.Millenium.Poincare
import Mathlib.Analysis.Normed.Module.Basic
import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
import Mathlib.Geometry.Manifold.IsManifold.Basic
import Mathlib.Topology.Algebra.Module.Basic
import Mathlib.Topology.Compactification.OnePoint.Basic
import Mathlib.Topology.Compactification.OnePoint.Sphere
import Mathlib.Topology.Constructions
import Mathlib.Topology.Homotopy.Equiv
import Mathlib.Topology.IsLocalHomeomorph
import Mathlib.Topology.UnitInterval

/-!
# `PoincareConjecture.SmoothConjectureFor n` is false for every `n ≥ 1` (statement before the fix)

Check with `lake env lean` from a formal-conjectures checkout at commit 8faf8bcc or any earlier commit
with the original `SmoothConjectureFor`. Output: only the `#print axioms` lines, each reporting
`[propext, Classical.choice, Quot.sound]`.

Sections follow the seven modules of the original development: compactness bounds for translation,
open halfspaces in the one-point compactification, gluing along an open subset, pulling a manifold
structure back along a local homeomorphism, the translation homotopy on `OnePoint E`, the homotopy
equivalence of the glued space with the original, and the refutation itself.
-/

section Translation

/- # Compactness bounds for the translating homotopy -/

open Set

namespace FCReview.Poincare

variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]

/-- Translation by a bounded time parameter has uniformly compact inverse images. -/
theorem translation_uniform_compact (v : E) (K : Set E) (hK : IsCompact K) :
    ∃ L : Set E, IsCompact L ∧
      ∀ (t : unitInterval) (x : E), x - (t : ℝ) • v ∈ K → x ∈ L := by
  let L := (fun p : unitInterval × E => p.2 + (p.1 : ℝ) • v) '' (univ ×ˢ K)
  refine ⟨L, ?_, ?_⟩
  · exact (isCompact_univ.prod hK).image
      (continuous_snd.add ((continuous_subtype_val.comp continuous_fst).smul continuous_const))
  · intro t x hx
    exact ⟨(t, x - (t : ℝ) • v), ⟨mem_univ t, hx⟩, sub_add_cancel _ _⟩

/-- The translating family is jointly continuous. -/
theorem continuous_translation (v : E) :
    Continuous (fun p : unitInterval × E => p.2 - (p.1 : ℝ) • v) :=
  continuous_snd.sub ((continuous_subtype_val.comp continuous_fst).smul continuous_const)

end FCReview.Poincare


end Translation

section Halfspace

/- # Open halfspaces in a one-point compactification -/

open Set

namespace FCReview.Poincare

variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]

/-- The strict sublevel set of a coordinate, included in the finite part. -/
def halfspace (ℓ : E →L[ℝ] ℝ) (a : ℝ) : Set (OnePoint E) :=
  OnePoint.some '' {x | ℓ x < a}

theorem isOpen_halfspace (ℓ : E →L[ℝ] ℝ) (a : ℝ) : IsOpen (halfspace ℓ a) :=
  OnePoint.isOpen_image_coe.mpr (isOpen_lt ℓ.continuous continuous_const)

theorem halfspace_mono (ℓ : E →L[ℝ] ℝ) {a b : ℝ} (hab : a ≤ b) :
    halfspace ℓ a ⊆ halfspace ℓ b :=
  image_mono fun _ hx => hx.trans_le hab

@[simp]
theorem some_mem_halfspace (ℓ : E →L[ℝ] ℝ) (a : ℝ) (x : E) :
    OnePoint.some x ∈ halfspace ℓ a ↔ ℓ x < a := by
  simp only [halfspace, mem_image, mem_ofPred_eq, OnePoint.coe_eq_coe, exists_eq_right]

theorem zero_mem_halfspace_one (ℓ : E →L[ℝ] ℝ) :
    OnePoint.some (0 : E) ∈ halfspace ℓ 1 := by simp

theorem zero_notMem_halfspace_zero (ℓ : E →L[ℝ] ℝ) :
    OnePoint.some (0 : E) ∉ halfspace ℓ 0 := by simp

theorem zero_mem_closure_halfspace (ℓ : E →L[ℝ] ℝ) (v : E) (hv : ℓ v = 1) :
    OnePoint.some (0 : E) ∈ closure (halfspace ℓ 0) := by
  have hm : MapsTo (fun t : ℝ => OnePoint.some (t • v)) (Iio 0) (halfspace ℓ 0) := by
    intro t ht
    simp only [some_mem_halfspace, map_smul, hv, smul_eq_mul, mul_one]
    exact ht
  have hc : Continuous (fun t : ℝ => OnePoint.some (t • v)) :=
    OnePoint.continuous_coe.comp (continuous_id.smul continuous_const)
  have h0 : (0 : ℝ) ∈ closure (Iio 0) := by simp [closure_Iio]
  simpa only [zero_smul] using hm.closure hc h0

theorem translation_preserves_halfspace (ℓ : E →L[ℝ] ℝ) (v : E) (hv : ℓ v = 1)
    (t : unitInterval) (a : ℝ) :
    MapsTo (OnePoint.map fun x => x - (t : ℝ) • v) (halfspace ℓ a) (halfspace ℓ a) := by
  rintro _ ⟨x, hx, rfl⟩
  apply (some_mem_halfspace ℓ a _).mpr
  change ℓ (x - (t : ℝ) • v) < a
  simp only [map_sub, map_smul, hv, smul_eq_mul, mul_one]
  exact lt_of_le_of_lt (sub_le_self _ t.2.1) hx

theorem translation_one_halfspace (ℓ : E →L[ℝ] ℝ) (v : E) (hv : ℓ v = 1) :
    MapsTo (OnePoint.map fun x => x - v) (halfspace ℓ 1) (halfspace ℓ 0) := by
  rintro _ ⟨x, hx, rfl⟩
  apply (some_mem_halfspace ℓ 0 _).mpr
  change ℓ (x - v) < 0
  simp only [map_sub, hv]
  exact sub_neg.mpr hx

end FCReview.Poincare


end Halfspace

section Gluing

/-
# Duplicating an open subset along a smaller open subset

This construction is used for the non-Hausdorff counterexample to the audited
smooth Poincaré predicate. The two inclusions are open embeddings, and their
common projection to the original space is a local homeomorphism.
-/

open Set Topology

namespace FCReview.Poincare

variable {X : Type*}

def glueValue (B : Set X) : X ⊕ B → X := Sum.elim id Subtype.val

def glueSetoid (B A : Set X) : Setoid (X ⊕ B) where
  r x y := glueValue B x = glueValue B y ∧ (x.isLeft = y.isLeft ∨ glueValue B x ∈ A)
  iseqv := {
    refl := fun _ => ⟨rfl, Or.inl rfl⟩
    symm := by
      rintro x y ⟨h, ht | ha⟩
      · exact ⟨h.symm, Or.inl ht.symm⟩
      · exact ⟨h.symm, Or.inr (h ▸ ha)⟩
    trans := by
      rintro x y z ⟨hxy, htxy | ha⟩ ⟨hyz, htyz | hb⟩
      · exact ⟨hxy.trans hyz, Or.inl (htxy.trans htyz)⟩
      · exact ⟨hxy.trans hyz, Or.inr (hxy ▸ hb)⟩
      · exact ⟨hxy.trans hyz, Or.inr ha⟩
      · exact ⟨hxy.trans hyz, Or.inr ha⟩ }

abbrev Glued (B A : Set X) := Quotient (glueSetoid B A)

namespace Glued

variable (B A : Set X)

def left (x : X) : Glued B A := Quotient.mk _ (Sum.inl x)
def right (x : B) : Glued B A := Quotient.mk _ (Sum.inr x)

def project : Glued B A → X := Quotient.lift (glueValue B) (fun _ _ h => h.1)

@[simp] theorem project_left (x : X) : project B A (left B A x) = x := rfl
@[simp] theorem project_right (x : B) : project B A (right B A x) = x := rfl

theorem left_injective : Function.Injective (left B A) :=
  fun _ _ h => congrArg (project B A) h

theorem right_injective : Function.Injective (right B A) :=
  fun _ _ h => Subtype.ext (congrArg (project B A) h)

@[simp] theorem left_eq_right (x : X) (y : B) :
    left B A x = right B A y ↔ x = y ∧ x ∈ A := by
  constructor
  · intro h
    have hr := Quotient.exact h
    change x = y.val ∧ (true = false ∨ x ∈ A) at hr
    exact ⟨hr.1, hr.2.resolve_left (by decide)⟩
  · rintro ⟨h, ha⟩
    exact Quotient.sound ⟨h, Or.inr ha⟩

theorem cases {P : Glued B A → Prop}
    (hl : ∀ x, P (left B A x)) (hr : ∀ x, P (right B A x)) : ∀ x, P x := by
  intro x
  induction x using Quotient.inductionOn with
  | h x => cases x with
    | inl x => exact hl x
    | inr x => exact hr x

variable [TopologicalSpace X]

theorem continuous_left : Continuous (left B A) :=
  continuous_quotient_mk'.comp continuous_inl

theorem continuous_right : Continuous (right B A) :=
  continuous_quotient_mk'.comp continuous_inr

theorem continuous_project : Continuous (project B A) := by
  exact (continuous_id.sumElim continuous_subtype_val).quotient_lift _

theorem isOpen_iff (s : Set (Glued B A)) :
    IsOpen s ↔ IsOpen (left B A ⁻¹' s) ∧ IsOpen (right B A ⁻¹' s) := by
  have hq : IsQuotientMap (fun x : X ⊕ B => (Quotient.mk (glueSetoid B A) x : Glued B A)) :=
    isQuotientMap_quotient_mk'
  rw [← hq.isOpen_preimage]
  exact isOpen_sum_iff

theorem isOpenMap_left (hA : IsOpen A) : IsOpenMap (left B A) := by
  intro s hs
  apply (isOpen_iff B A _).mpr
  constructor
  · simpa only [preimage_image_eq s (left_injective B A)] using hs
  · have he : right B A ⁻¹' (left B A '' s) = Subtype.val ⁻¹' (A ∩ s) := by
      ext x
      constructor
      · rintro ⟨y, hy, he⟩
        obtain ⟨rfl, ha⟩ := (left_eq_right B A y x).mp he
        exact ⟨ha, hy⟩
      · rintro ⟨ha, hs⟩
        exact ⟨x.val, hs, (left_eq_right B A _ _).mpr ⟨rfl, ha⟩⟩
    rw [he]
    exact (hA.inter hs).preimage continuous_subtype_val

theorem isOpenMap_right (hB : IsOpen B) (hA : IsOpen A) : IsOpenMap (right B A) := by
  intro s hs
  apply (isOpen_iff B A _).mpr
  constructor
  · have he : left B A ⁻¹' (right B A '' s) = A ∩ (Subtype.val '' s) := by
      ext x
      constructor
      · rintro ⟨y, hy, he⟩
        obtain ⟨hxy, ha⟩ := (left_eq_right B A x y).mp he.symm
        exact ⟨ha, y, hy, hxy.symm⟩
      · rintro ⟨ha, y, hy, rfl⟩
        exact ⟨y, hy, ((left_eq_right B A _ _).mpr ⟨rfl, ha⟩).symm⟩
    rw [he]
    exact hA.inter (hB.isOpenEmbedding_subtypeVal.isOpenMap s hs)
  · simpa only [preimage_image_eq s (right_injective B A)] using hs

theorem isOpenEmbedding_left (hA : IsOpen A) : IsOpenEmbedding (left B A) :=
  .of_continuous_injective_isOpenMap (continuous_left B A)
    (left_injective B A) (isOpenMap_left B A hA)

theorem isOpenEmbedding_right (hB : IsOpen B) (hA : IsOpen A) :
    IsOpenEmbedding (right B A) :=
  .of_continuous_injective_isOpenMap (continuous_right B A)
    (right_injective B A) (isOpenMap_right B A hB hA)

theorem isLocalHomeomorph_project (hB : IsOpen B) (hA : IsOpen A) :
    IsLocalHomeomorph (project B A) := by
  have hl : IsLocalHomeomorphOn (project B A ∘ left B A) univ :=
    (Homeomorph.refl X).isLocalHomeomorph.isLocalHomeomorphOn
  have hr : IsLocalHomeomorphOn (project B A ∘ right B A) univ :=
    hB.isOpenEmbedding_subtypeVal.isLocalHomeomorph.isLocalHomeomorphOn
  have hl' := hl.of_comp_right (isOpenEmbedding_left B A hA).isLocalHomeomorph.isLocalHomeomorphOn
  have hr' := hr.of_comp_right (isOpenEmbedding_right B A hB hA).isLocalHomeomorph.isLocalHomeomorphOn
  intro x
  induction x using Quotient.inductionOn with
  | h x => cases x with
    | inl x => exact hl' _ ⟨x, mem_univ x, rfl⟩
    | inr x => exact hr' _ ⟨x, mem_univ x, rfl⟩

/-- Every point of the smaller open set's boundary inside the duplicated set
gives two distinct points that cannot have disjoint neighborhoods. -/
theorem not_t2Space (hB : IsOpen B) (x : B) (hx : x.val ∈ closure A) (hxa : x.val ∉ A) :
    ¬ T2Space (Glued B A) := by
  intro ht
  let := ht
  have hc : IsClosed {y : B | left B A y.val = right B A y} :=
    isClosed_eq ((continuous_left B A).comp continuous_subtype_val) (continuous_right B A)
  have hs : Subtype.val ⁻¹' A ⊆ {y : B | left B A y.val = right B A y} := by
    intro y hy
    exact (left_eq_right B A _ _).mpr ⟨rfl, hy⟩
  have hx' : x ∈ closure (Subtype.val ⁻¹' A) :=
    hB.isOpenEmbedding_subtypeVal.isOpenMap.preimage_closure_subset_closure_preimage hx
  have he := closure_minimal hs hc hx'
  exact hxa ((left_eq_right B A _ _).mp he).2

theorem isOpenQuotientMap_mk (hB : IsOpen B) (hA : IsOpen A) :
    IsOpenQuotientMap (fun x : X ⊕ B => (Quotient.mk (glueSetoid B A) x : Glued B A)) := by
  refine ⟨?_, continuous_quotient_mk', ?_⟩
  · intro x
    exact Quotient.inductionOn x (fun y => ⟨y, rfl⟩)
  · have he : (fun x : X ⊕ B => (Quotient.mk (glueSetoid B A) x : Glued B A)) =
        Sum.elim (left B A) (right B A) := by
      funext x
      cases x <;> rfl
    rw [he]
    exact (isOpenMap_left B A hA).sumElim (isOpenMap_right B A hB hA)

end Glued
end FCReview.Poincare


end Gluing

section Geometry

/-
# Pulling manifold structures back along local homeomorphisms

This construction allows non-Hausdorff spaces. It applies in particular to the
projection from a space obtained by gluing an additional open chart to a manifold.
-/

noncomputable section

open Set Topology Manifold OpenPartialHomeomorph
open scoped ContDiff

namespace FCReview.Poincare

variable {X Y H : Type*} [TopologicalSpace X] [TopologicalSpace Y]
  [TopologicalSpace H] [ChartedSpace H Y] {f : X → Y}

/-- The atlas pulled back by a local homeomorphism. -/
@[instance_reducible]
def pullbackChartedSpace (hf : IsLocalHomeomorph f) : ChartedSpace H X where
  atlas := Set.range fun x : X ↦
    (hf.localInverseAt x).symm.trans (chartAt H (f x))
  chartAt x := (hf.localInverseAt x).symm.trans (chartAt H (f x))
  mem_chart_source x := by
    constructor
    · exact hf.self_mem_localInverseAt_target
    · simp
  chart_mem_atlas x := ⟨x, rfl⟩

omit [ChartedSpace H Y] in
/-- Transition maps pulled back along the same function are restrictions of the
original transition maps. -/
theorem pullback_transition_mem {G : StructureGroupoid H} [ClosedUnderRestriction G]
    {a b : OpenPartialHomeomorph X Y} (hab : (a : X → Y) = b)
    {e e' : OpenPartialHomeomorph Y H} (he : e.symm.trans e' ∈ G) :
    (a.trans e).symm.trans (b.trans e') ∈ G := by
  let c := (a.trans e).symm.trans (b.trans e')
  have hc (z : H) (hz : z ∈ c.source) :
      z ∈ e.target ∧ e.symm z ∈ a.target ∧
        a.symm (e.symm z) ∈ b.source ∧
        b (a.symm (e.symm z)) ∈ e'.source := by
    change z ∈ (a.trans e).target ∧ (a.trans e).symm z ∈ (b.trans e').source at hz
    exact ⟨hz.1.1, hz.1.2, hz.2.1, hz.2.2⟩
  have hcancel (z : H) (hz : z ∈ c.source) :
      b (a.symm (e.symm z)) = e.symm z := by
    rw [← hab]
    exact a.right_inv (hc z hz).2.1
  have hcG : c.restr c.source ∈ G :=
    StructureGroupoid.restr_mem_of_eqOn he c.open_source
      (fun z hz ↦ by
        change e' (e.symm z) = e' (b (a.symm (e.symm z)))
        rw [hcancel z hz])
      (fun z hz ↦ by
        refine ⟨(hc z hz.1).1, ?_⟩
        change e.symm z ∈ e'.source
        rw [← hcancel z hz.1]
        exact (hc z hz.1).2.2.2)
  simpa only [OpenPartialHomeomorph.restr_eq_of_source_subset (Subset.rfl)] using hcG

/-- A restriction-closed structure groupoid pulls back along local homeomorphisms. -/
theorem pullback_hasGroupoid (hf : IsLocalHomeomorph f) (G : StructureGroupoid H)
    [ClosedUnderRestriction G] [HasGroupoid Y G] :
    letI := pullbackChartedSpace (H := H) hf
    HasGroupoid X G := by
  let := pullbackChartedSpace (H := H) hf
  constructor
  rintro e e' ⟨x, rfl⟩ ⟨y, rfl⟩
  exact pullback_transition_mem
    ((hf.localInverseAt_symm x).trans (hf.localInverseAt_symm y).symm)
    (G.compatible (chart_mem_atlas H (f x)) (chart_mem_atlas H (f y)))

/-- Local homeomorphisms pull back smooth manifold structures without requiring
the source to be Hausdorff. -/
theorem pullback_isManifold {𝕜 E : Type*} [NontriviallyNormedField 𝕜]
    [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H)
    (n : ℕ∞ω) (hf : IsLocalHomeomorph f) [IsManifold I n Y] :
    letI := pullbackChartedSpace (H := H) hf
    IsManifold I n X := by
  let := pullbackChartedSpace (H := H) hf
  let := pullback_hasGroupoid hf (contDiffGroupoid n I)
  exact IsManifold.mk' I n X

end FCReview.Poincare

end

end Geometry

section Homotopy

/- Homotopies used in the non-Hausdorff smooth Poincaré counterexample. -/

open Set Filter Topology
open scoped ContinuousMap OnePoint

namespace FCReview.Poincare

/-- A uniformly proper family extends jointly continuously to one-point compactifications. -/
theorem continuous_onePointMap {A X Y : Type*}
    [TopologicalSpace A] [TopologicalSpace X] [TopologicalSpace Y]
    (f : A × X → Y) (hf : Continuous f)
    (hproper : ∀ K : Set Y, IsClosed K → IsCompact K →
      ∃ L : Set X, IsClosed L ∧ IsCompact L ∧
        ∀ a x, f (a, x) ∈ K → x ∈ L) :
    Continuous (fun p : A × OnePoint X => OnePoint.map (fun x => f (p.1, x)) p.2) := by
  rw [continuous_iff_continuousAt]
  rintro ⟨a, x⟩
  induction x using OnePoint.rec with
  | infty =>
    apply Filter.tendsto_def.2
    intro s hs
    obtain ⟨K, ⟨hKclosed, hKcompact⟩, hK⟩ := OnePoint.hasBasis_nhds_infty.mem_iff.mp hs
    obtain ⟨L, hLclosed, hLcompact, hL⟩ := hproper K hKclosed hKcompact
    have hLn : ((↑) '' Lᶜ ∪ {∞} : Set (OnePoint X)) ∈ 𝓝 ∞ :=
      OnePoint.hasBasis_nhds_infty.mem_of_mem ⟨hLclosed, hLcompact⟩
    apply Filter.mem_of_superset (prod_mem_nhds (Filter.univ_mem : univ ∈ 𝓝 a) hLn)
    rintro ⟨b, y⟩ ⟨_, hy⟩
    rcases hy with ⟨z, hz, rfl⟩ | hy
    · exact hK (Or.inl ⟨f (b, z), fun h => hz (hL b z h), rfl⟩)
    · have hy' : y = ∞ := hy
      subst y
      exact hK (Or.inr rfl)
  | coe x =>
    have he := (Topology.IsOpenEmbedding.id (X := A)).prodMap
      (OnePoint.isOpenEmbedding_coe (X := X))
    apply (he.continuousAt_iff (x := (a, x))).mp
    exact (OnePoint.continuous_coe.comp hf).continuousAt

/-- A retraction is a homotopy equivalence when its inclusion composite is homotopic to identity. -/
def homotopyEquivOfRetraction {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
    (r : C(X, Y)) (i : C(Y, X)) (hri : r.comp i = ContinuousMap.id Y)
    (hir : (i.comp r).Homotopic (ContinuousMap.id X)) : X ≃ₕ Y where
  toFun := r
  invFun := i
  left_inv := hir
  right_inv := hri ▸ ContinuousMap.Homotopic.refl _

section Translation

variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]

/-- Translation extends to a homotopy fixing the point at infinity. -/
theorem continuous_onePointTranslation (v : E) :
    Continuous (fun p : unitInterval × OnePoint E =>
      OnePoint.map (fun x => x - (p.1 : ℝ) • v) p.2) := by
  apply continuous_onePointMap _ (continuous_translation v)
  intro K _ hK
  obtain ⟨L, hL, h⟩ := translation_uniform_compact v K hK
  exact ⟨L, hL.isClosed, hL, h⟩

/-- A translation of Euclidean space extended by fixing infinity. -/
def onePointTranslate (v : E) : C(OnePoint E, OnePoint E) where
  toFun := OnePoint.map (fun x => x - v)
  continuous_toFun := by
    simpa [Function.comp_def] using
      (continuous_onePointTranslation v).comp
      ((continuous_const (y := (1 : unitInterval))).prodMk
        (continuous_id : Continuous (id : OnePoint E → OnePoint E)))

/-- The extended translation is homotopic to the identity. -/
def onePointTranslationHomotopy (v : E) :
    (ContinuousMap.id (OnePoint E)).Homotopy (onePointTranslate v) where
  toFun p := OnePoint.map (fun x => x - (p.1 : ℝ) • v) p.2
  continuous_toFun := continuous_onePointTranslation v
  map_zero_left x := by induction x using OnePoint.rec <;> simp
  map_one_left x := by induction x using OnePoint.rec <;> simp [onePointTranslate]

end Translation

/-- The standard sphere model used by the Poincaré statement. -/
noncomputable def euclideanOnePointSphere (n : ℕ) :
    OnePoint (EuclideanSpace ℝ (Fin n)) ≃ₜ
      Metric.sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 :=
  onePointEquivSphereOfFinrankEq (by simp)

end FCReview.Poincare


end Homotopy

section GluingHomotopy

/- Homotopy equivalences for gluing an open set to a space along an open subset. -/

open Set Topology
open scoped ContinuousMap

namespace FCReview.Poincare.Glued

variable {X : Type*} (B A : Set X)

/-- A map preserving both gluing sets induces a map of the glued space. -/
def map (f : X → X) (hB : MapsTo f B B) (hA : MapsTo f A A) :
    Glued B A → Glued B A :=
  Quotient.lift
    (Sum.elim (fun x => left B A (f x)) (fun x => right B A ⟨f x, hB x.property⟩))
    (by
      intro x y h
      cases x with
      | inl x =>
        cases y with
        | inl y => exact congrArg (fun z => left B A (f z)) h.1
        | inr y =>
          apply (left_eq_right B A _ _).2
          have h' : x = y ∧ x ∈ A := by
            change x = y ∧ (true = false ∨ x ∈ A) at h
            simpa using h
          exact ⟨congrArg f h'.1, hA h'.2⟩
      | inr x =>
        cases y with
        | inl y =>
          symm
          apply (left_eq_right B A _ _).2
          have h' : (x : X) = y ∧ (x : X) ∈ A := by
            change (x : X) = y ∧ (false = true ∨ (x : X) ∈ A) at h
            simpa using h
          exact ⟨congrArg f h'.1.symm, hA (h'.1 ▸ h'.2)⟩
        | inr y =>
          apply congrArg (right B A)
          apply Subtype.ext
          exact congrArg f h.1)

@[simp] theorem map_left (f : X → X) (hB : MapsTo f B B) (hA : MapsTo f A A) (x : X) :
    map B A f hB hA (left B A x) = left B A (f x) := rfl

@[simp] theorem map_right (f : X → X) (hB : MapsTo f B B) (hA : MapsTo f A A) (x : B) :
    map B A f hB hA (right B A x) = right B A ⟨f x, hB x.property⟩ := rfl

variable [TopologicalSpace X]

def leftMap : C(X, Glued B A) := ⟨left B A, continuous_left B A⟩

def projectMap : C(Glued B A, X) := ⟨project B A, continuous_project B A⟩

/-- A jointly continuous family preserving the overlap descends to the glued space. -/
theorem continuous_map_family (hB : IsOpen B) (hA : IsOpen A)
    (F : unitInterval × X → X) (hF : Continuous F)
    (hFB : ∀ t, MapsTo (fun x => F (t, x)) B B)
    (hFA : ∀ t, MapsTo (fun x => F (t, x)) A A) :
    Continuous (fun p : unitInterval × Glued B A =>
      map B A (fun x => F (p.1, x)) (hFB p.1) (hFA p.1) p.2) := by
  rw [continuous_iff_continuousAt]
  rintro ⟨t, x⟩
  refine Quotient.inductionOn x ?_
  intro y
  cases y with
  | inl x =>
    have he := (Topology.IsOpenEmbedding.id (X := unitInterval)).prodMap
      (isOpenEmbedding_left B A hA)
    apply (he.continuousAt_iff (x := (t, x))).mp
    exact ((continuous_left B A).comp hF).continuousAt
  | inr x =>
    have he := (Topology.IsOpenEmbedding.id (X := unitInterval)).prodMap
      (isOpenEmbedding_right B A hB hA)
    apply (he.continuousAt_iff (x := (t, x))).mp
    exact ((continuous_right B A).comp
      ((hF.comp (continuous_fst.prodMk (continuous_subtype_val.comp continuous_snd))).subtype_mk
        (fun p => hFB p.1 p.2.property))).continuousAt

/-- If the final map sends the attached set into the overlap, the descended homotopy ends
in the original copy of the space. -/
def mapHomotopy (hB : IsOpen B) (hA : IsOpen A) {f : C(X, X)}
    (F : (ContinuousMap.id X).Homotopy f)
    (hFB : ∀ t, MapsTo (fun x => F (t, x)) B B)
    (hFA : ∀ t, MapsTo (fun x => F (t, x)) A A)
    (hfinal : MapsTo f B A) :
    (ContinuousMap.id (Glued B A)).Homotopy
      ((leftMap B A).comp (f.comp (projectMap B A))) where
  toFun p := map B A (fun x => F (p.1, x)) (hFB p.1) (hFA p.1) p.2
  continuous_toFun := continuous_map_family B A hB hA F F.continuous hFB hFA
  map_zero_left x := by
    refine Quotient.inductionOn x ?_
    intro y
    cases y with
    | inl x =>
      change left B A (F (0, x)) = left B A x
      exact congrArg (left B A) (F.apply_zero x)
    | inr x =>
      change right B A ⟨F (0, x), _⟩ = right B A x
      apply congrArg (right B A)
      apply Subtype.ext
      exact F.apply_zero x
  map_one_left x := by
    refine Quotient.inductionOn x ?_
    intro y
    cases y with
    | inl x =>
      change left B A (F (1, x)) = left B A (f x)
      rw [F.apply_one]
    | inr x =>
      change right B A ⟨F (1, x), _⟩ = left B A (f x)
      symm
      apply (left_eq_right B A _ _).2
      exact ⟨(F.apply_one x).symm, hfinal x.property⟩

/-- Translating the extra open piece into the overlap gives a homotopy equivalence. -/
def homotopyEquiv (hB : IsOpen B) (hA : IsOpen A) {f : C(X, X)}
    (F : (ContinuousMap.id X).Homotopy f)
    (hFB : ∀ t, MapsTo (fun x => F (t, x)) B B)
    (hFA : ∀ t, MapsTo (fun x => F (t, x)) A A)
    (hfinal : MapsTo f B A) : Glued B A ≃ₕ X := by
  apply homotopyEquivOfRetraction (projectMap B A) (leftMap B A)
  · ext x
    rfl
  · let K := mapHomotopy B A hB hA F hFB hFA hfinal
    have J : ((leftMap B A).comp (projectMap B A)).Homotopy
        ((leftMap B A).comp (f.comp (projectMap B A))) := by
      simpa using ((ContinuousMap.Homotopy.refl (leftMap B A)).comp
        (F.compContinuousMap (projectMap B A)))
    exact ⟨J.trans K.symm⟩

end FCReview.Poincare.Glued


end GluingHomotopy

section Counterexample

/-
# Non-Hausdorff counterexamples to the audited smooth Poincaré predicate

The audited definition is at commit `84063d69421173d491cdae299fe766d3cd66c37c`.
An extra open halfspace is glued to the sphere along a smaller open halfspace.
Translation moves the attachment into the overlap up to homotopy. The
projection to the sphere pulls back a smooth atlas, but the glued space is not Hausdorff.
-/

noncomputable section

open Set Topology
open scoped Manifold ContDiff ContinuousMap

namespace FCReview.Poincare

/-- The audited smooth predicate is false in every positive dimension. -/
theorem not_smoothConjectureFor_succ (n : ℕ) :
    ¬ PoincareConjecture.SmoothConjectureFor (n + 1) := by
  intro h
  let E := EuclideanSpace ℝ (Fin (n + 1))
  let ℓ : E →L[ℝ] ℝ := EuclideanSpace.proj 0
  let v : E := EuclideanSpace.single 0 1
  have hv : ℓ v = 1 := by
    change (EuclideanSpace.single (0 : Fin (n + 1)) (1 : ℝ)) 0 = 1
    exact PiLp.single_eq_same 2 0 1
  let B := halfspace ℓ 1
  let A := halfspace ℓ 0
  have hB : IsOpen B := isOpen_halfspace ℓ 1
  have hA : IsOpen A := isOpen_halfspace ℓ 0
  let M := Glued B A
  let S := Metric.sphere (0 : EuclideanSpace ℝ (Fin ((n + 1) + 1))) 1
  let e : OnePoint E ≃ₜ S := euclideanOnePointSphere (n + 1)
  have hf : IsLocalHomeomorph (e ∘ Glued.project B A) :=
    e.isLocalHomeomorph.comp (Glued.isLocalHomeomorph_project B A hB hA)
  let : ChartedSpace E M := pullbackChartedSpace (H := E) hf
  let : IsManifold (𝓡 (n + 1)) ∞ M := pullback_isManifold (𝓡 (n + 1)) ∞ hf
  let hom : M ≃ₕ OnePoint E :=
    Glued.homotopyEquiv B A hB hA (onePointTranslationHomotopy v)
      (fun t => translation_preserves_halfspace ℓ v hv t 1)
      (fun t => translation_preserves_halfspace ℓ v hv t 0)
      (translation_one_halfspace ℓ v hv)
  obtain ⟨d⟩ := h M (hom.trans e.toHomotopyEquiv)
  have hnot : ¬ T2Space M :=
    Glued.not_t2Space B A hB ⟨OnePoint.some 0, zero_mem_halfspace_one ℓ⟩
      (zero_mem_closure_halfspace ℓ v hv) (zero_notMem_halfspace_zero ℓ)
  exact hnot d.toHomeomorph.symm.t2Space

/-- No positive dimension satisfies the audited smooth predicate. -/
theorem not_smoothConjectureFor (n : ℕ) (hn : 0 < n) :
    ¬ PoincareConjecture.SmoothConjectureFor n := by
  cases n with
  | zero => exact (lt_irrefl 0 hn).elim
  | succ n => exact not_smoothConjectureFor_succ n

/-- Refutation of the full proposition asserted by the audited three-dimensional smooth variant. -/
theorem refutes_smooth_for_three : ¬ PoincareConjecture.SmoothConjectureFor 3 :=
  not_smoothConjectureFor_succ 2

/-- Refutation of the full proposition asserted by the audited list of known smooth cases. -/
theorem refutes_smooth_known_cases :
    ¬ (∀ n : ℕ, n ∈ PoincareConjecture.SmoothTrueValues →
      PoincareConjecture.SmoothConjectureFor n) := by
  intro h
  exact not_smoothConjectureFor_succ 0 (h 1 (by simp [PoincareConjecture.SmoothTrueValues]))

/-- Refutation of the full proposition asserted by the audited four-dimensional smooth variant. -/
theorem refutes_smooth_dimension_four : ¬ PoincareConjecture.SmoothConjectureFor 4 :=
  not_smoothConjectureFor_succ 3

/-- The audited implication holds because its smooth premise is false. -/
theorem smooth_implication_from_false_premise :
    PoincareConjecture.SmoothConjectureFor 3 → PoincareConjecture.ConjectureFor 3 := by
  intro h
  exact (refutes_smooth_for_three h).elim

/-- The audited assertion in the remaining dimensions follows from the same separation defect. -/
theorem smooth_other_cases_from_missing_separation :
    ∀ n : ℕ, n > 4 → n ∉ PoincareConjecture.SmoothTrueValues →
      ¬ PoincareConjecture.SmoothConjectureFor n := by
  intro n hn _
  exact not_smoothConjectureFor n (lt_trans (by decide : 0 < 4) hn)

#print axioms not_smoothConjectureFor_succ
#print axioms not_smoothConjectureFor
#print axioms refutes_smooth_for_three
#print axioms refutes_smooth_known_cases
#print axioms refutes_smooth_dimension_four
#print axioms smooth_implication_from_false_premise
#print axioms smooth_other_cases_from_missing_separation

end FCReview.Poincare

end

end Counterexample
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Millenium.Poincare` passes.
- The Lean counterexample no longer applies, since the glued space is not Hausdorff.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Millenium/Poincare

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

