### PR TITLE
fix(HilbertProblems/5): state the manifold hypothesis in the Hilbert–Smith theorems

### DIFF
--- a/FormalConjectures/HilbertProblems/5.lean
+++ b/FormalConjectures/HilbertProblems/5.lean
@@ -47,6 +47,10 @@ instance `ℝ` with the discrete topology acting on `ℝ` by translations.
 The acting group is not assumed Hausdorff: a topological group acting continuously and
 faithfully on a Hausdorff space is Hausdorff, because the closure of the identity acts trivially.
 
+The hypotheses on the manifold `X` are written in each theorem. A section variable
+`[ChartedSpace (EuclideanSpace ℝ (Fin n)) X]` is included only in a theorem that mentions `n`,
+so it would be dropped silently from a statement that mentions only `X`.
+
 *References:*
 - [Wikipedia](https://en.wikipedia.org/wiki/Hilbert%E2%80%93Smith_conjecture)
 - [Tao's blog](https://terrytao.wordpress.com/2011/08/13/the-hilbert-smith-conjecture/)
@@ -63,9 +67,7 @@ namespace Hilbert5
 
 open scoped Manifold ContDiff Bundle
 
-variable {G : Type*} [Group G] [TopologicalSpace G]
-variable {n : ℕ} {X : Type*} [TopologicalSpace X] [T2Space X] [ConnectedSpace X]
-  [ChartedSpace (EuclideanSpace ℝ (Fin n)) X]
+variable {G : Type*} [Group G] [TopologicalSpace G] {n : ℕ}
 
 /-- The circle group admits a Lie group structure. -/
 @[category test, AMS 22]
@@ -81,7 +83,9 @@ theorem admitsLieGroupStructure_multiplicative_int :
 /-- **Hilbert–Smith conjecture**: every locally compact topological group acting continuously
 and faithfully on a connected finite-dimensional topological manifold is a Lie group. -/
 @[category research open, AMS 22 57 58]
-theorem hilbert_smith_conjecture
+theorem hilbert_smith_conjecture {X : Type*}
+    [TopologicalSpace X] [T2Space X] [ConnectedSpace X]
+    [ChartedSpace (EuclideanSpace ℝ (Fin n)) X]
     [IsTopologicalGroup G] [LocallyCompactSpace G]
     [MulAction G X] [ContinuousSMul G X] [FaithfulSMul G X] :
     AdmitsLieGroupStructure G := by
@@ -122,8 +126,10 @@ on a connected finite-dimensional topological manifold. This is equivalent to
 `hilbert_smith_conjecture` by the Gleason–Yamabe theorem together with Newman's theorem on
 periodic transformations of manifolds. -/
 @[category research open, AMS 22 57 58]
-theorem hilbert_smith_padic_formulation (p : ℕ) [Fact p.Prime]
-    [AddAction ℤ_[p] X] [ContinuousVAdd ℤ_[p] X] :
+theorem hilbert_smith_padic_formulation {X : Type*}
+    [TopologicalSpace X] [T2Space X] [ConnectedSpace X]
+    [ChartedSpace (EuclideanSpace ℝ (Fin n)) X]
+    (p : ℕ) [Fact p.Prime] [AddAction ℤ_[p] X] [ContinuousVAdd ℤ_[p] X] :
     ¬ FaithfulVAdd ℤ_[p] X := by
   sorry
 


### PR DESCRIPTION
Follow-up to #5366 and #5365; independent of #5402.

**What changed**

- `hilbert_smith_conjecture` and `hilbert_smith_padic_formulation` now bind `X` and its hypotheses `[TopologicalSpace X] [T2Space X] [ConnectedSpace X] [ChartedSpace (EuclideanSpace ℝ (Fin n)) X]` themselves, as `variants.dimension_three` already does.
- The section `variable` line keeps only `G` and `n`. The module docstring records why.

**Why**

The section variable `[ChartedSpace (EuclideanSpace ℝ (Fin n)) X]` is included only in a theorem that mentions `n`. These two theorems mention only `X`, so their elaborated statements quantified over arbitrary connected Hausdorff spaces:

```lean
#check @Hilbert5.hilbert_smith_conjecture
-- ∀ {G : Type u_1} [Group G] [TopologicalSpace G] {X : Type u_2} [TopologicalSpace X] [T2Space X]
--   [ConnectedSpace X] [IsTopologicalGroup G] [LocallyCompactSpace G] [MulAction G X]
--   [ContinuousSMul G X] [FaithfulSMul G X], AdmitsLieGroupStructure G
```

Both were false: `ℤ_[2]` acts continuously and faithfully on `X = C(ℤ_[2], ℝ)` by translation of the argument, `X` is connected and Hausdorff, and `Multiplicative ℤ_[2]` is compact, infinite and totally disconnected, so it has no Lie group structure. This is independent of the second-countability defect fixed in #5366 (both spaces here are second countable).

<details>
<summary>Lean disproof (checked against current <code>main</code> (8faf8bcc) with <code>lake env lean</code>, no errors)</summary>

```lean
import FormalConjectures.HilbertProblems.«5»
noncomputable section
namespace HilbertSmithDisproof

abbrev A := PadicInt 2
abbrev X := C(A, ℝ)

instance : AddAction A X where
  vadd g f := ⟨fun x => f (x + g), f.continuous.comp (continuous_id.add continuous_const)⟩
  zero_vadd f := by
    ext x
    change f (x + 0) = f x
    rw [add_zero]
  add_vadd g h f := by
    ext x
    change f (x + (g + h)) = f ((x + g) + h)
    rw [add_assoc]

instance : ContinuousVAdd A X where
  continuous_vadd := by
    apply ContinuousMap.continuous_of_continuous_uncurry
    change Continuous (fun z : (A × X) × A => z.1.2 (z.2 + z.1.1))
    fun_prop

instance : FaithfulVAdd A X where
  eq_of_vadd_eq_vadd {g h} hh := by
    let f : X := ⟨fun x => dist x g, continuous_id.dist continuous_const⟩
    have heq := congrArg (fun f : X => f 0) (hh f)
    change dist (0 + g) g = dist (0 + h) g at heq
    have hge : h = g := by simpa using heq.symm
    exact hge.symm

abbrev GP := Multiplicative A

instance : FaithfulSMul GP X where
  eq_of_smul_eq_smul {g h} hh := by
    apply Multiplicative.toAdd.injective
    exact eq_of_vadd_eq_vadd hh

instance : ContinuousSMul GP X where
  continuous_smul := by
    change Continuous (fun z : GP × X => z.1.toAdd +ᵥ z.2)
    fun_prop

/-- `ℤ_[2]` is compact, infinite and totally disconnected, so it is not a Lie group. -/
theorem not_admitsLieGroupStructure : ¬ AdmitsLieGroupStructure GP := by
  rintro ⟨n, ⟨p⟩⟩
  let _ := p.topologicalSpace
  let _ := p.group
  let _ := p.chartedSpace
  let _ : LocallyConnectedSpace p.carrier :=
    ChartedSpace.locallyConnectedSpace (EuclideanSpace ℝ (Fin n)) p.carrier
  let _ : LocallyConnectedSpace GP := p.equiv.toHomeomorph.locallyConnectedSpace
  let _ : DiscreteTopology GP := discreteTopology_iff_isOpen_singleton.mpr fun x => by
    simpa only [connectedComponent_eq_singleton] using
      (isOpen_connectedComponent (x := x))
  let _ : Finite GP := finite_of_compact_of_discrete
  exact not_finite GP

theorem hilbert_smith_conjecture_false : False :=
  not_admitsLieGroupStructure (Hilbert5.hilbert_smith_conjecture (G := GP) (X := X))

theorem hilbert_smith_padic_formulation_false : False :=
  Hilbert5.hilbert_smith_padic_formulation (X := X) 2 inferInstance

#print axioms not_admitsLieGroupStructure
#print axioms hilbert_smith_conjecture_false
#print axioms hilbert_smith_padic_formulation_false
end HilbertSmithDisproof
end
```


`hilbert_smith_conjecture_false` and `hilbert_smith_padic_formulation_false` derive `False` from the admitted theorems, so `#print axioms` lists `sorryAx` for them; the witness `not_admitsLieGroupStructure` depends only on `propext`, `Classical.choice`, `Quot.sound`.

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.HilbertProblems.«5»'` passes.
- `#check` on both theorems now shows the `ChartedSpace` hypothesis, and the disproof above no longer elaborates, since `C(ℤ_[2], ℝ)` is not a charted space over a Euclidean space.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/HilbertProblems/5 (findings 1 and 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
