### PR TITLE
fix(ErdosProblems/951): add the separation hypothesis to the Beurling variant

### DIFF
--- a/FormalConjectures/ErdosProblems/951.lean
+++ b/FormalConjectures/ErdosProblems/951.lean
@@ -61,11 +61,13 @@ theorem erdos_951 : answer(sorry) ↔
       ∀ᶠ (x : ℝ) in Filter.atTop, {i : ℕ | a i ≤ x}.ncard ≤ π ⌊x⌋₊ := by
   sorry
 
-/-- Beurling conjectured that if the number of Beurling integer in `[1, x]`
-is `x + o(log x)`, then `a` must be the sequence of primes. -/
+/-- Beurling conjectured that if `1 < a 0 < a 1 < ⋯` has property `Erdos951Prop` and the number
+of reals in $[1, x]$ of the form $\prod_i a_i^{k_i}$ is $x + o(\log x)$, then `a` must be the
+sequence of primes. Property `Erdos951Prop` makes distinct exponent vectors give distinct
+Beurling integers, so counting the set `BeurlingIntegers a` counts the generalised integers. -/
 @[category research solved, AMS 11]
 theorem erdos_951.variants.beurling :
-    ∀ a : ℕ → ℝ, IsBeurlingPrimes a →
+    ∀ a : ℕ → ℝ, IsBeurlingPrimes a → Erdos951Prop a →
     ((fun x => (BeurlingIntegers a ∩ .Iic x).ncard - x) =o[atTop] Real.log) →
     a = Nat.cast ∘ Nat.nth Nat.Prime := by
   sorry


### PR DESCRIPTION
**Related.** #5479 (merged today) only changed the docstring of `erdos_951.variants.isBeurlingPrimes`; there is no overlap with this change.

**What changed**

- `erdos_951.variants.beurling` now assumes `Erdos951Prop a` in addition to `IsBeurlingPrimes a`. The docstring quotes the source and explains why the set count is then the count of generalised integers.

**Why**

`IsBeurlingPrimes a` only asks for `1 < a 0`, strict monotonicity and divergence, and `BeurlingIntegers a` is the *set* of values `∏ i, a i ^ k i`, so the counting function ignored multiplicity. For `a n = n + 2` the set of values is exactly the positive integers, the count is `⌊x⌋₊ = x + O(1)`, and `a 2 = 4 ≠ 5`, so the statement was false.

The source states Beurling's conjecture for the sequences of the problem, which satisfy the separation property `Erdos951Prop`: "Beurling conjectured that if the number of reals in $[1,x]$ of the form $\prod a_i^{k_i}$ is $x+o(\log x)$ then the $a_i$ must be the sequence of primes" ([erdosproblems.com/951](https://www.erdosproblems.com/951)). Under `Erdos951Prop a` distinct exponent vectors give distinct values, so counting the set agrees with counting generalised integers with multiplicity, and `a n = n + 2` is excluded (`4 = a 0 ^ 2 = a 2`; this is also the AlphaProof sequence behind #3643).

<details>
<summary>Lean disproof (checked against current <code>main</code> (8faf8bcc) with <code>lake env lean</code>, no errors)</summary>

```lean
import FormalConjectures.ErdosProblems.«951»
open Filter
open scoped Finsupp Nat.Prime Topology

namespace BeurlingDisproof

def allIntegers (n : ℕ) : ℝ := (n : ℝ) + 2

theorem allIntegers_isBeurling : IsBeurlingPrimes allIntegers := by
  refine ⟨by norm_num [allIntegers], ?_, ?_⟩
  · intro m n h
    simpa [allIntegers] using (Nat.cast_lt (α := ℝ)).2 h
  · exact tendsto_atTop_add_const_right _ 2 tendsto_natCast_atTop_atTop

theorem allIntegers_ne_primes : allIntegers ≠ Nat.cast ∘ Nat.nth Nat.Prime := by
  intro h
  have h2 := congrFun h 2
  norm_num [allIntegers, Function.comp_def] at h2

theorem integers_of_allIntegers :
    BeurlingIntegers allIntegers = Nat.cast '' (Set.Ici 1 : Set ℕ) := by
  ext x
  constructor
  · rintro ⟨k, rfl⟩
    refine ⟨k.prod (fun i e => (i + 2) ^ e), ?_, ?_⟩
    · change 1 ≤ ∏ i ∈ k.support, (i + 2) ^ k i
      exact Finset.one_le_prod fun i hi => one_le_pow₀ (by omega)
    · simp [beurlingInteger, Finsupp.prod, allIntegers]
  · rintro ⟨n, hn, rfl⟩
    rcases eq_or_lt_of_le (show 1 ≤ n from hn) with heq | hlt
    · subst n
      exact ⟨0, by simp⟩
    · refine ⟨Finsupp.single (n - 2) 1, ?_⟩
      have hn2 : 2 ≤ n := hlt
      simp [allIntegers, Nat.cast_sub hn2]

theorem allIntegers_count (x : ℝ) (hx : 0 ≤ x) :
    (BeurlingIntegers allIntegers ∩ Set.Iic x).ncard = ⌊x⌋₊ := by
  have hset : BeurlingIntegers allIntegers ∩ Set.Iic x =
      Nat.cast '' (Set.Icc 1 ⌊x⌋₊ : Set ℕ) := by
    rw [integers_of_allIntegers]
    ext y
    constructor
    · rintro ⟨⟨n, hn, rfl⟩, hnx⟩
      exact ⟨n, ⟨hn, (Nat.le_floor_iff hx).2 hnx⟩, rfl⟩
    · rintro ⟨n, ⟨hn, hnx⟩, rfl⟩
      exact ⟨⟨n, hn, rfl⟩, (Nat.le_floor_iff hx).1 hnx⟩
  rw [hset, Set.ncard_image_of_injective _ Nat.cast_injective]
  simp

theorem allIntegers_count_littleO :
    (fun x : ℝ => ((BeurlingIntegers allIntegers ∩ Set.Iic x).ncard : ℝ) - x)
      =o[atTop] Real.log := by
  apply Asymptotics.IsBigO.trans_isLittleO (g := fun _ : ℝ => (1 : ℝ))
    (hfg := ?_) Real.isLittleO_const_log_atTop
  apply Asymptotics.IsBigO.of_bound 1
  filter_upwards [eventually_ge_atTop (0 : ℝ)] with x hx
  simpa [allIntegers_count x hx, Real.norm_eq_abs] using Nat.abs_floor_sub_le hx

theorem beurling_variant_false : False :=
  allIntegers_ne_primes
    (Erdos951.erdos_951.variants.beurling allIntegers allIntegers_isBeurling
      allIntegers_count_littleO)

#print axioms beurling_variant_false
end BeurlingDisproof
```


`beurling_variant_false` derives `False` from the admitted theorem, so `#print axioms` lists `sorryAx` for it; every other declaration depends only on `propext`, `Classical.choice`, `Quot.sound`.

</details>

**Reviewer note**

The source does not say that this conjecture has been proved; it only says that the "for all $x$" reading is refuted by a finite computation. I left the `research solved` tag unchanged, but it may need checking.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«951»'` passes.
- `a n = n + 2` fails `Erdos951Prop`, so the disproof above no longer applies.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/951

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

