### PR TITLE
fix(ForMathlib/DiamExtra): remove two false proof_wanted statements

### DIFF
--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/DiamExtra.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/DiamExtra.lean
@@ -16,7 +16,6 @@ limitations under the License.
 module
 
 public import Mathlib.Combinatorics.SimpleGraph.Diam
-public import Mathlib.Combinatorics.SimpleGraph.Metric
 
 @[expose] public section
 
@@ -31,19 +30,5 @@ this will be `0`.
 -/
 lemma diam_eq_zero_of_subsingleton [Subsingleton α] : G.diam = 0 := by
   simp [diam, ediam_eq_zero_iff_subsingleton.mpr (by assumption)]
-
-proof_wanted diam_ne_zero [Nontrivial α] : G.diam ≠ 0
-
-lemma nontrivial_of_diam_ne_zero' (h : G.diam ≠ 0) : Nontrivial α := by
-  contrapose! h
-  exact diam_eq_zero_of_subsingleton
-
-section Path
-open Path
-
-proof_wanted dist_le_diam_of_mem_path {G : SimpleGraph α} {u v : α} (p : G.Walk u v) (w : α)
-    (hw : w ∈ p.support) : G.dist w u ≤ G.diam
-
-end Path
 
 end SimpleGraph


### PR DESCRIPTION
**What changed**

- Removed `proof_wanted diam_ne_zero` and `proof_wanted dist_le_diam_of_mem_path`, which are false. Mathlib has the correct versions `SimpleGraph.diam_ne_zero_of_ediam_ne_top` and `SimpleGraph.dist_le_diam` (both assume `G.ediam ≠ ⊤`), and the unconditional `SimpleGraph.ediam_ne_zero` and `SimpleGraph.edist_le_ediam`.
- Removed `nontrivial_of_diam_ne_zero'`, a duplicate of `SimpleGraph.nontrivial_of_diam_ne_zero`, and the now unused import of `Mathlib.Combinatorics.SimpleGraph.Metric`.
- `diam_eq_zero_of_subsingleton` stays.

**Why**

`G.diam` is `0` whenever `G.ediam = ⊤`, for instance for every disconnected graph. So `[Nontrivial α]` does not give `G.diam ≠ 0` (take `⊥` on `Fin 2`), and membership in a walk does not bound `G.dist` by `G.diam` (on `Fin 3` with the single edge `0 – 1`, the walk `0 → 1` and `w = 1` give `G.dist 1 0 = 1` and `G.diam = 0`). Nothing in the repository uses these declarations; `proof_wanted` creates no constants.

<details>
<summary>Lean disproof (checked against current <code>main</code> (8faf8bcc) with <code>lake env lean</code>, no errors)</summary>

```lean
import FormalConjecturesForMathlib.Combinatorics.SimpleGraph.DiamExtra
open SimpleGraph

namespace DiamExtraDisproof
open SimpleGraph

theorem diam_ne_zero_false :
    ¬ (∀ {α : Type} {G : SimpleGraph α} [Nontrivial α], G.diam ≠ 0) := by
  intro h
  exact h (G := (⊥ : SimpleGraph (Fin 2))) (by simp)

def edgeAndIsolated : SimpleGraph (Fin 3) :=
  SimpleGraph.fromRel (fun u v => u = 0 ∧ v = 1)

instance : DecidableRel edgeAndIsolated.Adj := by
  unfold edgeAndIsolated
  infer_instance

lemma edge01 : edgeAndIsolated.Adj 0 1 := by decide
lemma noEdge2 : ∀ v : Fin 3, ¬ edgeAndIsolated.Adj 2 v := by decide

lemma disconnected : ¬ edgeAndIsolated.Connected := by
  intro hc
  obtain ⟨p⟩ := hc (2 : Fin 3) (0 : Fin 3)
  cases p with
  | cons h _ => exact noEdge2 _ h

theorem dist_le_diam_of_mem_path_false :
    ¬ (∀ {α : Type} {G : SimpleGraph α} {u v : α} (p : G.Walk u v) (w : α),
      w ∈ p.support → G.dist w u ≤ G.diam) := by
  intro h
  have hb := h edge01.toWalk 1 (by decide)
  rw [dist_eq_one_iff_adj.mpr edge01.symm, diam_eq_zero_of_not_connected disconnected] at hb
  exact Nat.not_succ_le_zero 0 hb

#print axioms diam_ne_zero_false
#print axioms dist_le_diam_of_mem_path_false
end DiamExtraDisproof
```


Both theorems depend only on `propext`, `Classical.choice`, `Quot.sound`.

</details>

**How I checked**

- `lake --wfail build FormalConjecturesForMathlib` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ForMathlib/Combinatorics/SimpleGraph/DiamExtra

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
