### PR TITLE
fix(ErdosProblems/1043): measure projections with the Lebesgue measure of the line

### DIFF
--- a/FormalConjectures/ErdosProblems/1043.lean
+++ b/FormalConjectures/ErdosProblems/1043.lean
@@ -32,8 +32,6 @@ namespace Erdos1043
 
 open MeasureTheory Polynomial
 
-attribute [local instance] Measure.Subtype.measureSpace
-
 /-- The set $\{ z \in \mathbb{C} : \lvert f(z)\rvert\leq 1\}$ -/
 def levelSet (f : Polynomial ℂ) : Set ℂ :=
   {z : ℂ | ‖f.eval z‖ ≤ 1}
@@ -46,6 +44,9 @@ $$\{ z: \lvert f(z)\rvert\leq 1\}$$
 onto $\ell$ has measure at most $2$?
 
 Pommerenke [Po61] proved that the answer is no.
+
+The projection onto the line $\ell = \mathbb{R} u$ is measured with the Lebesgue measure of that
+line, so `volume` of the projected set is its length.
 
 This was formalized in Lean by Alexeev using Aristotle.
 -/


### PR DESCRIPTION
**Related.** #3723 proved `erdos_1043` in this repository using the intrinsic measure of the line ("transfer to ℝ via `stdOrthonormalBasis`"). The local `Measure.Subtype.measureSpace` instance was added in the toolchain bump #3691 (2026-08-23), which changed the meaning of `volume` and made the statement false.

**What changed**

- Removed `attribute [local instance] Measure.Subtype.measureSpace`. `volume` on the line `ℝ ∙ u` is now the instance `measureSpaceOfInnerProductSpace`, the Lebesgue measure of the line. The docstring of `erdos_1043` says so.

**Why**

With the subtype instance, `volume` on `ℝ ∙ u` was `Measure.comap Subtype.val volume`, the restriction of the planar Lebesgue measure to a null set (`Measure.addHaar_submodule`), so every projection had measure `0`. The right-hand side of `erdos_1043` was then true for every polynomial with `u = 1`, which made `answer(False) ↔ …` false, and `variants.weak` held for every set with bound `0` instead of `3.3`.

The linked formal proof ([plby/lean-proofs, `Erdos1043.lean`](https://github.com/plby/lean-proofs/blob/main/src/v4.24.0/ErdosProblems/Erdos1043.lean)) does not use the subtype instance; its `volume` on `ℝ ∙ u` is the intrinsic one and its proof computes lengths of intervals on the line. So the statement now matches the proof it cites. For `f = X` the level set is the closed unit disc and every projection has length `2`, so the bound `2` is attained.

<details>
<summary>Lean disproof (checked against current <code>main</code> (8faf8bcc) with <code>lake env lean</code>, no errors)</summary>

```lean
import FormalConjectures.ErdosProblems.«1043»

namespace Erdos1043Disproof
open MeasureTheory Polynomial
attribute [local instance] Measure.Subtype.measureSpace

theorem line_is_null (u : ℂ) : volume (ℝ ∙ u : Set ℂ) = 0 := by
  classical
  apply Measure.addHaar_submodule
  intro h
  have hdim : Module.finrank ℝ (ℝ ∙ u) ≤ 1 := by
    simpa using (finrank_span_le_card (R := ℝ) ({u} : Set ℂ))
  rw [h, finrank_top, Complex.finrank_real_complex] at hdim
  omega

theorem projection_zero (u : ℂ) (s : Set ℂ) :
    volume ((ℝ ∙ u).orthogonalProjectionOnto '' s) = 0 := by
  apply measure_mono_null (Set.subset_univ _)
  rw [Measure.Subtype.volume_univ]
  · exact line_is_null u
  · exact (Submodule.closed_of_finiteDimensional _).measurableSet.nullMeasurableSet

/-- The right-hand side of `erdos_1043` holds for every polynomial, with bound `0`. -/
theorem rhs_trivial : ∀ (f : ℂ[X]), f.Monic → f.degree ≥ 1 →
    ∃ (u : ℂ), ‖u‖ = 1 ∧
      volume ((ℝ ∙ u).orthogonalProjectionOnto '' Erdos1043.levelSet f) ≤ 2 := by
  intro f _ _
  exact ⟨1, by simp, by rw [projection_zero]; exact bot_le⟩

theorem erdos_1043_false : False :=
  Erdos1043.erdos_1043.mpr rhs_trivial

theorem weak_variant_trivial : type_of% @Erdos1043.erdos_1043.variants.weak := by
  intro f _ _
  exact ⟨1, by simp, by rw [projection_zero]; exact bot_le⟩

#print axioms erdos_1043_false
#print axioms weak_variant_trivial
end Erdos1043Disproof
```


`erdos_1043_false` derives `False` from the admitted theorem, so `#print axioms` lists `sorryAx` for it; `weak_variant_trivial`, a proof of the full `variants.weak` statement, depends only on `propext`, `Classical.choice`, `Quot.sound`.

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«1043»'` passes.
- `volume` on `ℝ ∙ u` now unfolds to `(stdOrthonormalBasis ℝ (ℝ ∙ u)).toBasis.addHaar`, so the null-measure argument above no longer applies.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/1043

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

