### PR TITLE
Mark Erdős 944 Dirac conjecture and k = 4 case as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/944.lean
+++ b/FormalConjectures/ErdosProblems/944.lean
@@ -51,9 +51,9 @@ such that every vertex is critical, yet every critical set of edges has size $>1
 
 This was conjectured by Dirac in 1970.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11]
 theorem erdos_944.variants.dirac_conjecture :
-    answer(sorry) ↔ ∀ k ≥ 4, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1 := by
+    answer(True) ↔ ∀ k ≥ 4, ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 k 1 := by
   sorry
 
 
@@ -93,9 +93,11 @@ theorem erdos_944.variants.dirac_conjecture.k_ge_five (k : ℕ) (hk : 5 ≤ k) :
 /--
 The case $k=4$ and $r=1$ remains open: Are there $4$-critical graphs without any critical edges?
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at
+    "https://github.com/KitaKen1/erdos-944-dirac-k4-lean/blob/9606d77/lean4web/Erdos944K4R1Lean4Web.lean#L676-L690"]
 theorem erdos_944.variants.dirac_conjecture.k_eq_four :
-    answer(sorry) ↔ ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 4 1 := by
+    answer(True) ↔ ∃ (V : Type u) (G : SimpleGraph V), G.IsErdos944 4 1 := by
   sorry
 
 /--


### PR DESCRIPTION
This PR marks both `erdos_944.variants.dirac_conjecture` and `erdos_944.variants.dirac_conjecture.k_eq_four` as solved, changing their answers from `answer(sorry)` to `answer(True)`.

The Lean proof here for `k = 4`, together with Jensen's result for every `k ≥ 5`, completes Dirac's conjecture for all `k ≥ 4`.

The Lean formalization was prepared by KitaKen1 (Kenta Kitamura).

The external proof establishes the affirmative target:

```lean
theorem Erdos944.erdos_944.variants.dirac_conjecture.k_eq_four :
    True ↔ ∃ (V : Type u) (G : SimpleGraph V),
      Erdos944.SimpleGraph.IsErdos944 G 4 1
```

Proof: https://github.com/KitaKen1/erdos-944-dirac-k4-lean/blob/9606d77/lean4web/Erdos944K4R1Lean4Web.lean#L676-L690

Repository: https://github.com/KitaKen1/erdos-944-dirac-k4-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-944-dirac-k4-lean%2Frefs%2Fheads%2Fmain%2Flean4web%2FErdos944K4R1Lean4Web.lean

`#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`;
there is no `sorryAx`.

AI Usage Disclosure: This formalization was assisted by ChatGPT GPT-6 ASTRA
and Codex GPT-6 ASTRA.