### PR TITLE
ci: use targeted validation for problem-only pull requests

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -67,6 +67,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Select PR validation scope
+        id: scope
+        run: python3 scripts/build_changed_problems.py plan --out "$RUNNER_TEMP/problem-scope.json"
+
       # Two independent halves of this job, each with its own switch.
       #
       # `website_only` skips the slow Lean compilation and takes the data from
@@ -84,6 +88,7 @@ jobs:
       - name: Detect build mode
         id: mode
         env:
+          TARGETED_PROBLEMS: ${{ steps.scope.outputs.targeted }}
           WEBSITE_ONLY: ${{ inputs.website_only }}
           REF_NAME: ${{ github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
@@ -97,7 +102,9 @@ jobs:
           fi
 
           site=true
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if [[ "${TARGETED_PROBLEMS:-false}" == "true" ]]; then
+            site=false
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
             # A pull request is checked out as a merge commit, so HEAD^1 is the
             # base and this diff is exactly what the pull request changes. If
             # that fails for any reason, fall back to building the site.
@@ -155,7 +162,7 @@ jobs:
       # Generating All.lean aggregates all problem files into a single module to detect
       # clashing declaration names across problem modules during compilation.
       - name: Generate All.lean
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.scope.outputs.targeted != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           rm -f FormalConjectures/All.lean
           lake exe mk_all --lib FormalConjectures || true
@@ -169,20 +176,20 @@ jobs:
           action: add
           linters: lean
 
-      # Check a small PR's edited problems before compiling unrelated modules.
-      # The full build below still checks every library and cross-module clashes.
-      - name: Build changed problem files first
-        if: github.event_name == 'pull_request' && steps.mode.outputs.website_only != 'true'
-        run: python3 scripts/build_changed_problems.py --summary /tmp/build_summary_changed.json
+      # A targeted PR checks its files and metadata only. The merge queue still
+      # validates importers, aggregate imports, and every library/test target.
+      - name: Validate changed problem files
+        if: steps.scope.outputs.targeted == 'true' && steps.mode.outputs.website_only != 'true'
+        run: python3 scripts/build_changed_problems.py check --plan "$RUNNER_TEMP/problem-scope.json" --out "$RUNNER_TEMP/changed-problems"
 
       - name: Build ForMathlib, utilities, and test
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.scope.outputs.targeted != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           python3 scripts/lake-build-wrapper.py /tmp/build_summary_formathlib.json lake --wfail build FormalConjecturesForMathlib FormalConjecturesUtil
           lake --wfail test
 
       - name: Build problems
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.scope.outputs.targeted != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           python3 scripts/lake-build-wrapper.py /tmp/build_summary_problems.json lake --wfail build
           rm -f FormalConjectures/All.lean
@@ -270,7 +277,7 @@ jobs:
           node-version: '18'
 
       - name: Generate conjectures data for website
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.scope.outputs.targeted != 'true' && steps.mode.outputs.website_only != 'true'
         run: |
           mkdir -p site/data
           lake exe extract_names --exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified \
@@ -281,7 +288,7 @@ jobs:
       # written. The first is a contradiction and fails; the other two are counted
       # in the run summary without blocking.
       - name: Check category warnings
-        if: steps.mode.outputs.website_only != 'true'
+        if: steps.scope.outputs.targeted != 'true' && steps.mode.outputs.website_only != 'true'
         run: python3 scripts/check_category_warnings.py site/data/conjectures.json
 
       - name: Extract Verso fragments for website

--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -169,6 +169,12 @@ jobs:
           action: add
           linters: lean
 
+      # Check a small PR's edited problems before compiling unrelated modules.
+      # The full build below still checks every library and cross-module clashes.
+      - name: Build changed problem files first
+        if: github.event_name == 'pull_request' && steps.mode.outputs.website_only != 'true'
+        run: python3 scripts/build_changed_problems.py --summary /tmp/build_summary_changed.json
+
       - name: Build ForMathlib, utilities, and test
         if: steps.mode.outputs.website_only != 'true'
         run: |

--- a/scripts/build_changed_problems.py
+++ b/scripts/build_changed_problems.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Formal Conjectures Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prioritize changed problem files before the comprehensive PR build.
+
+Use the checked-out PR merge commit and its first parent. This is an early
+failure check, never a substitute for the full library, problem, and test build.
+"""
+
+import argparse
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+MAX_FILES = 20
+
+
+def changed_problems(base, head):
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "-z", "--no-renames", "--diff-filter=AM",
+         base, head, "--", "FormalConjectures/"],
+        check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    # With rename detection off, a renamed file is selected at its new path.
+    # Lake resolves paths itself, including numeric and quoted module names.
+    return sorted(path for path in result.stdout.decode("utf-8").split("\0")
+                  if path.endswith(".lean") and path != "FormalConjectures/All.lean")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="HEAD^1", help="PR merge commit's first parent")
+    parser.add_argument("--head", default="HEAD", help="Checked-out PR merge commit")
+    parser.add_argument("--summary", required=True, help="Build wrapper's output JSON file")
+    args = parser.parse_args(argv)
+    try:
+        paths = changed_problems(args.base, args.head)
+    except (subprocess.CalledProcessError, UnicodeError):
+        print("Cannot determine changed problem files; continuing to the full build.", flush=True)
+        return 0
+    if not paths:
+        print("No added or modified problem files; continuing to the full build.", flush=True)
+        return 0
+    if len(paths) > MAX_FILES:
+        print(f"{len(paths)} changed problem files exceed the {MAX_FILES}-file early-check limit; "
+              "continuing to the full build.", flush=True)
+        return 0
+    print("Checking changed problem files first: " + shlex.join(paths), flush=True)
+    wrapper = Path(__file__).with_name("lake-build-wrapper.py")
+    # One Lake invocation, in the same workspace and build context as the full
+    # build. Do not catch its failure: syntax, elaboration, and warnings must fail.
+    return subprocess.run([sys.executable, str(wrapper), args.summary,
+                           "lake", "--wfail", "build", *paths]).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_changed_problems.py
+++ b/scripts/build_changed_problems.py
@@ -13,57 +13,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Prioritize changed problem files before the comprehensive PR build.
+"""Plan and check a targeted problem-only PR build.
 
-Use the checked-out PR merge commit and its first parent. This is an early
-failure check, never a substitute for the full library, problem, and test build.
+All other changes and events retain full validation. Importers, aggregate
+conflicts, and repository-wide checks are deferred to the full merge-queue build.
 """
 
 import argparse
+import json
+import os
 from pathlib import Path
 import shlex
 import subprocess
 import sys
 
 MAX_FILES = 20
+EXCLUDES = "--exclude=statement,docstring,moduleDocstrings,fileFirstAdded,fileLastModified"
 
 
-def changed_problems(base, head):
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "-z", "--no-renames", "--diff-filter=AM",
-         base, head, "--", "FormalConjectures/"],
-        check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-    )
-    # With rename detection off, a renamed file is selected at its new path.
-    # Lake resolves paths itself, including numeric and quoted module names.
-    return sorted(path for path in result.stdout.decode("utf-8").split("\0")
-                  if path.endswith(".lean") and path != "FormalConjectures/All.lean")
+def git(*args):
+    return subprocess.run(["git", *args], check=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE).stdout.decode("utf-8")
+
+
+def plan_scope(event):
+    def full(reason):
+        return {"targeted": False, "reason": reason, "files": []}
+    if event != "pull_request":
+        return full("Only pull-request events use targeted validation.")
+    try:
+        parents = git("rev-list", "--parents", "-n", "1", "HEAD").split()
+        if len(parents) != 3:
+            return full("Checkout is not a two-parent PR merge commit.")
+        # Inspect every changed path, not just the problem directory. Disabling
+        # rename detection represents renames as delete/add, which forces full CI.
+        raw = git("diff", "--raw", "-z", "--no-renames", parents[1], parents[0], "--")
+        fields = raw.split("\0")
+        if fields.pop() != "" or len(fields) % 2:
+            return full("Cannot interpret the complete changed-file scope.")
+        paths = []
+        for record, path in zip(fields[::2], fields[1::2]):
+            old_mode, new_mode, _, _, status = record.split()
+            if (status not in ("A", "M") or new_mode != "100644"
+                    or old_mode not in (":000000", ":100644")
+                    or not path.startswith("FormalConjectures/")
+                    or not path.endswith(".lean") or path == "FormalConjectures/All.lean"):
+                return full("Scope includes a non-problem change, deletion, rename, or file-type change.")
+            paths.append(path)
+        if not paths or len(paths) > MAX_FILES:
+            return full(f"Targeted validation requires 1–{MAX_FILES} added/modified problem files.")
+        return {"targeted": True, "reason": "Only ordinary problem files changed.",
+                "files": sorted(paths), "head": parents[0]}
+    except (subprocess.CalledProcessError, UnicodeError, ValueError):
+        return full("Changed-file scope is unavailable; use full validation.")
+
+
+def describe(scope):
+    if scope["targeted"]:
+        return ("Targeted PR validation: " + shlex.join(scope["files"]) + "\n"
+                "Build dependencies and category checks are included. Importers, aggregate "
+                "conflicts, and repository-wide tests wait for full merge-queue validation.")
+    return "Full validation: " + scope["reason"]
+
+
+def check_scope(scope, out):
+    # Recompute from Git so an incomplete or outdated file list cannot select a
+    # smaller scope than this PR. Never turn a failed targeted check into success.
+    if not scope.get("targeted") or scope != plan_scope(os.environ.get("GITHUB_EVENT_NAME")):
+        raise ValueError("Targeted scope no longer matches this PR checkout.")
+    out.mkdir(parents=True, exist_ok=True)
+    scripts = Path(__file__).parent
+    print(describe(scope), flush=True)
+    subprocess.run([sys.executable, str(scripts / "lake-build-wrapper.py"),
+                    str(out / "build.json"), "lake", "--wfail", "build", *scope["files"]], check=True)
+    extractions = []
+    # The native exporter accepts one file per invocation. Preserve its output
+    # separately; these scoped diagnostics are never published as a full catalog.
+    for index, path in enumerate(scope["files"]):
+        metadata = out / f"metadata-{index:03d}.json"
+        with metadata.open("w") as stream:
+            subprocess.run(["lake", "exe", "extract_names", path, EXCLUDES],
+                           stdout=stream, check=True)
+        extractions.append(str(metadata))
+    subprocess.run([sys.executable, str(scripts / "check_category_warnings.py"),
+                    *extractions], check=True)
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--base", default="HEAD^1", help="PR merge commit's first parent")
-    parser.add_argument("--head", default="HEAD", help="Checked-out PR merge commit")
-    parser.add_argument("--summary", required=True, help="Build wrapper's output JSON file")
+    commands = parser.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan", help="Select full or targeted validation from the event and Git diff")
+    plan.add_argument("--out", required=True, type=Path, help="Scope JSON file")
+    check = commands.add_parser("check", help="Build selected files and check their native metadata")
+    check.add_argument("--plan", required=True, type=Path, help="Scope JSON from the plan operation")
+    check.add_argument("--out", required=True, type=Path, help="Directory for build and metadata diagnostics")
     args = parser.parse_args(argv)
+    if args.command == "plan":
+        scope = plan_scope(os.environ.get("GITHUB_EVENT_NAME"))
+        args.out.write_text(json.dumps(scope, indent=2) + "\n")
+        message = describe(scope)
+        print(message)
+        if output := os.environ.get("GITHUB_OUTPUT"):
+            with open(output, "a") as stream:
+                stream.write(f"targeted={str(scope['targeted']).lower()}\n")
+        if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+            with open(summary, "a") as stream:
+                stream.write(message + "\n")
+        return 0
     try:
-        paths = changed_problems(args.base, args.head)
-    except (subprocess.CalledProcessError, UnicodeError):
-        print("Cannot determine changed problem files; continuing to the full build.", flush=True)
+        check_scope(json.loads(args.plan.read_text()), args.out)
         return 0
-    if not paths:
-        print("No added or modified problem files; continuing to the full build.", flush=True)
-        return 0
-    if len(paths) > MAX_FILES:
-        print(f"{len(paths)} changed problem files exceed the {MAX_FILES}-file early-check limit; "
-              "continuing to the full build.", flush=True)
-        return 0
-    print("Checking changed problem files first: " + shlex.join(paths), flush=True)
-    wrapper = Path(__file__).with_name("lake-build-wrapper.py")
-    # One Lake invocation, in the same workspace and build context as the full
-    # build. Do not catch its failure: syntax, elaboration, and warnings must fail.
-    return subprocess.run([sys.executable, str(wrapper), args.summary,
-                           "lake", "--wfail", "build", *paths]).returncode
+    except subprocess.CalledProcessError as error:
+        return error.returncode
+    except (OSError, ValueError) as error:
+        print(f"Targeted validation failed: {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/check_category_warnings.py
+++ b/scripts/check_category_warnings.py
@@ -162,12 +162,14 @@ def report(found):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("extraction",
-                        help="the JSON written by `lake exe extract_names`")
+    parser.add_argument("extraction", nargs="+",
+                        help="one or more JSON files written by `lake exe extract_names`")
     args = parser.parse_args(argv)
 
     try:
-        found = load_extraction(args.extraction)
+        found = set()
+        for extraction in args.extraction:
+            found.update(load_extraction(extraction))
     except DataError as error:
         print(f"::error::{error}")
         return 2

--- a/scripts/test_build_changed_problems.py
+++ b/scripts/test_build_changed_problems.py
@@ -1,14 +1,20 @@
-"""Test early PR builds against real Git diffs and a stub Lake executable."""
+"""Exercise scope selection with real Git merges and retained check diagnostics."""
 
+import contextlib
+import io
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
+from unittest.mock import patch
 
 import build_changed_problems as changed
+import check_category_warnings as categories
 
 SCRIPT = Path(changed.__file__).resolve()
 
@@ -23,16 +29,27 @@ class ChangedProblemsTest(unittest.TestCase):
         self.git("config", "user.email", "test@example.invalid")
         self.write("FormalConjectures/Example.lean", "theorem old : True := by trivial\n")
         self.write("README.md", "Test\n")
-        self.commit()
-        self.base = self.git("rev-parse", "HEAD").strip()
+        self.git("add", ".")
+        self.git("commit", "-m", "base")
+        self.git("checkout", "-b", "topic")
         self.bin = self.root / "bin"
         self.bin.mkdir()
         lake = self.bin / "lake"
-        lake.write_text(f"#!{sys.executable}\n"
-                        "import json, os, pathlib, sys\n"
-                        "pathlib.Path('lake-args.json').write_text(json.dumps(sys.argv[1:]))\n"
-                        "raise SystemExit(int(os.environ.get('LAKE_EXIT', '0')))\n")
+        lake.write_text(f"#!{sys.executable}\n" + textwrap.dedent('''\
+            import json, os, pathlib, sys
+            with open('calls.jsonl', 'a') as log:
+                log.write(json.dumps(sys.argv[1:]) + '\\n')
+            if sys.argv[1] == '--wfail':
+                raise SystemExit(int(os.environ.get('BUILD_EXIT', '0')))
+            if os.environ.get('EXTRACT_EXIT'):
+                raise SystemExit(int(os.environ['EXTRACT_EXIT']))
+            print(os.environ.get('EXTRACT_JSON', '{"problems": []}'))
+            '''))
         lake.chmod(0o755)
+        self.env = {**os.environ, "GITHUB_EVENT_NAME": "pull_request",
+                    "PATH": str(self.bin) + os.pathsep + os.environ["PATH"],
+                    "GITHUB_OUTPUT": str(self.root / "output"),
+                    "GITHUB_STEP_SUMMARY": str(self.root / "summary.md")}
 
     def git(self, *args):
         return subprocess.run(["git", *args], cwd=self.root, check=True,
@@ -43,93 +60,175 @@ class ChangedProblemsTest(unittest.TestCase):
         file.parent.mkdir(parents=True, exist_ok=True)
         file.write_text(text)
 
-    def commit(self):
-        self.git("add", "FormalConjectures", "README.md")
-        self.git("commit", "-m", "fixture")
+    def merge(self, *paths):
+        self.git("add", "--", *paths)
+        self.git("commit", "-m", "topic")
+        self.git("checkout", "main")
+        self.git("merge", "--no-ff", "topic", "-m", "PR merge")
 
-    def run_check(self, base=None, lake_exit="0"):
-        return subprocess.run(
-            [sys.executable, str(SCRIPT), "--base", base or self.base,
-             "--summary", str(self.root / "summary.json")], cwd=self.root,
-            env={**os.environ, "PATH": str(self.bin) + os.pathsep + os.environ["PATH"],
-                 "LAKE_EXIT": lake_exit}, capture_output=True, text=True,
-        )
+    def command(self, operation, **env):
+        args = [sys.executable, str(SCRIPT), operation]
+        if operation == "plan":
+            args += ["--out", str(self.root / "scope.json")]
+        else:
+            args += ["--plan", str(self.root / "scope.json"), "--out", str(self.root / "diagnostics")]
+        return subprocess.run(args, cwd=self.root, env={**self.env, **env}, capture_output=True, text=True)
 
-    def test_paths_are_passed_as_separate_arguments_without_name_parsing(self):
+    def plan(self, **env):
+        result = self.command("plan", **env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads((self.root / "scope.json").read_text())
+
+    def test_problem_only_merge_checks_paths_and_metadata_without_full_extraction(self):
         paths = ["FormalConjectures/ErdosProblems/1014.lean",
-                 "FormalConjectures/Arxiv/1.2 space 'quote'.lean",
-                 "FormalConjectures/Examples/é.lean"]
+                 "FormalConjectures/Arxiv/1.2 space 'quote'.lean"]
         for path in paths:
             self.write(path)
-        self.write("FormalConjectures/All.lean", "-- generated aggregate\n")
-        self.write("FormalConjectures/notes.txt", "notes\n")
-        self.commit()
+        self.merge(*paths)
         before = self.git("status", "--porcelain", "--untracked-files=no")
-        head = self.git("rev-parse", "HEAD")
-        result = self.run_check()
+        self.assertEqual(self.plan()["files"], sorted(paths))
+        result = self.command("check")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(json.loads((self.root / "lake-args.json").read_text()),
-                         ["--wfail", "build", *sorted(paths)])
-        self.assertEqual(self.git("rev-parse", "HEAD"), head)
+        calls = [json.loads(line) for line in (self.root / "calls.jsonl").read_text().splitlines()]
+        self.assertEqual(calls[0], ["--wfail", "build", *sorted(paths)])
+        self.assertEqual(calls[1:], [["exe", "extract_names", path, changed.EXCLUDES] for path in sorted(paths)])
         self.assertEqual(self.git("status", "--porcelain", "--untracked-files=no"), before)
-        self.assertTrue((self.root / "summary.json").is_file())
+        self.assertIn("repository-wide tests wait", (self.root / "summary.md").read_text())
+        self.assertFalse((self.root / "site/data/conjectures.json").exists())
 
-    def test_deleted_files_are_excluded_and_renames_use_new_path(self):
-        self.git("mv", "FormalConjectures/Example.lean", "FormalConjectures/New.lean")
-        self.commit()
-        self.assertEqual(self.run_check().returncode, 0)
-        self.assertEqual(json.loads((self.root / "lake-args.json").read_text()),
-                         ["--wfail", "build", "FormalConjectures/New.lean"])
+    def test_shared_or_mixed_changes_force_full(self):
+        self.write("FormalConjectures/Example.lean", "-- changed\n")
+        self.write("README.md", "changed guidance\n")
+        self.merge("FormalConjectures/Example.lean", "README.md")
+        self.assertFalse(self.plan()["targeted"])
+        self.assertNotEqual(self.command("check").returncode, 0)
+        self.assertFalse((self.root / "calls.jsonl").exists())
 
-    def test_merge_first_parent_excludes_changes_already_on_main(self):
-        self.git("checkout", "-b", "topic")
-        self.write("FormalConjectures/PR.lean")
-        self.commit()
-        self.git("checkout", "main")
-        self.write("FormalConjectures/Base.lean")
-        self.commit()
-        self.git("merge", "--no-ff", "topic", "-m", "merge fixture")
-        self.assertEqual(self.run_check(base="HEAD^1").returncode, 0)
-        self.assertEqual(json.loads((self.root / "lake-args.json").read_text()),
-                         ["--wfail", "build", "FormalConjectures/PR.lean"])
+    def test_renames_and_deletions_force_full(self):
+        self.git("mv", "FormalConjectures/Example.lean", "FormalConjectures/Renamed.lean")
+        self.merge("FormalConjectures")
+        self.assertFalse(self.plan()["targeted"])
 
-    def test_build_failure_is_not_swallowed(self):
-        self.write("FormalConjectures/Example.lean", "invalid Lean\n")
-        self.commit()
-        self.assertEqual(self.run_check(lake_exit="7").returncode, 7)
+    def test_symlinks_force_full(self):
+        file = self.root / "FormalConjectures/Example.lean"
+        file.unlink()
+        file.symlink_to("../README.md")
+        self.merge("FormalConjectures")
+        self.assertFalse(self.plan()["targeted"])
 
-    def test_empty_scope_and_missing_base_leave_full_build_enabled(self):
-        for base in (self.base, "missing-revision"):
-            with self.subTest(base=base):
-                result = self.run_check(base=base)
-                self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertIn("continuing to the full build", result.stdout)
-                self.assertFalse((self.root / "lake-args.json").exists())
+    def test_generated_aggregate_forces_full(self):
+        self.write("FormalConjectures/All.lean", "-- aggregate\n")
+        self.merge("FormalConjectures")
+        self.assertFalse(self.plan()["targeted"])
 
-    def test_deleted_only_scope_does_not_call_lake(self):
-        self.git("rm", "FormalConjectures/Example.lean")
-        self.git("commit", "-m", "delete")
-        self.assertEqual(self.run_check().returncode, 0)
-        self.assertFalse((self.root / "lake-args.json").exists())
-
-    def test_broad_change_uses_full_build_without_duplicate_preflight(self):
+    def test_broad_change_forces_full(self):
         for index in range(changed.MAX_FILES + 1):
             self.write(f"FormalConjectures/Example{index}.lean")
-        self.commit()
-        result = self.run_check()
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("early-check limit", result.stdout)
-        self.assertFalse((self.root / "lake-args.json").exists())
+        self.merge("FormalConjectures")
+        self.assertFalse(self.plan()["targeted"])
 
-    def test_workflow_keeps_preflight_before_full_validation(self):
-        workflow = (SCRIPT.parent.parent / ".github/workflows/build-and-docs.yml").read_text()
-        early = workflow.index("- name: Build changed problem files first")
-        full = workflow.index("- name: Build ForMathlib, utilities, and test")
-        problems = workflow.index("- name: Build problems")
-        self.assertLess(early, full)
-        self.assertLess(full, problems)
-        self.assertIn("github.event_name == 'pull_request'", workflow[early:full])
-        self.assertNotIn("continue-on-error", workflow[early:problems])
+    def test_non_merge_checkout_and_non_pr_events_force_full(self):
+        self.assertFalse(self.plan()["targeted"])
+        self.write("FormalConjectures/New.lean")
+        self.merge("FormalConjectures")
+        for event in ("merge_group", "push", "workflow_dispatch", "pull_request_target", ""):
+            self.assertFalse(self.plan(GITHUB_EVENT_NAME=event)["targeted"])
+
+    def test_first_parent_excludes_updates_already_on_main(self):
+        self.write("FormalConjectures/PR.lean")
+        self.git("add", "FormalConjectures")
+        self.git("commit", "-m", "PR")
+        self.git("checkout", "main")
+        self.write("README.md", "main update\n")
+        self.git("add", "README.md")
+        self.git("commit", "-m", "main update")
+        self.git("merge", "--no-ff", "topic", "-m", "PR merge")
+        self.assertEqual(self.plan()["files"], ["FormalConjectures/PR.lean"])
+
+    def test_build_extraction_and_category_failures_are_not_swallowed(self):
+        self.write("FormalConjectures/Example.lean", "-- changed\n")
+        self.merge("FormalConjectures")
+        self.plan()
+        blocking = {"problems": [{"theorem": "example", "module": "FormalConjectures.Example",
+                                  "category": "research open", "hasSorryFreeProof": True}]}
+        for env, code in [({"BUILD_EXIT": "7"}, 7), ({"EXTRACT_EXIT": "9"}, 9),
+                          ({"EXTRACT_JSON": "invalid JSON"}, 2),
+                          ({"EXTRACT_JSON": json.dumps(blocking)}, 1)]:
+            with self.subTest(env=env):
+                self.assertEqual(self.command("check", **env).returncode, code)
+
+    def test_tampered_scope_is_rejected(self):
+        self.write("FormalConjectures/New.lean")
+        self.merge("FormalConjectures")
+        scope = self.plan()
+        scope["files"] = []
+        (self.root / "scope.json").write_text(json.dumps(scope))
+        self.assertNotEqual(self.command("check").returncode, 0)
+        self.assertFalse((self.root / "calls.jsonl").exists())
+
+    def test_category_checker_combines_native_extracts(self):
+        first = self.root / "first.json"
+        second = self.root / "second.json"
+        first.write_text(json.dumps({"problems": []}))
+        second.write_text(json.dumps({"problems": [{"theorem": "bad", "module": "FormalConjectures.Second",
+                                                    "category": "research open", "hasSorryFreeProof": True}]}))
+        with contextlib.redirect_stdout(io.StringIO()), patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": str(self.root / "summary.md")}):
+            self.assertEqual(categories.main([str(first), str(second)]), 1)
+
+
+class WorkflowScopeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        default = SCRIPT.parent.parent / ".github/workflows/build-and-docs.yml"
+        cls.workflow = Path(os.environ.get("FC_BUILD_WORKFLOW", default)).read_text()
+        build = cls.workflow.split("  build:\n", 1)[1].split("  # Deployment job", 1)[0]
+        cls.steps = dict(re.findall(r"^      - name: ([^\n]+)\n(.*?)(?=^      - name: |\Z)", build, re.M | re.S))
+
+    def enabled(self, name, targeted, site="false", event="pull_request"):
+        expr = re.search(r"^        if: (.+)$", self.steps[name], re.M)
+        if expr is None:
+            return True
+        expression = expr[1]
+        for key, value in {"steps.scope.outputs.targeted": targeted, "steps.mode.outputs.website_only": "false",
+                           "steps.mode.outputs.site": site, "github.event_name": event}.items():
+            expression = expression.replace(key, "'" + value + "'")
+        self.assertNotRegex(expression, r"steps\.|github\.|always\(")
+        result = subprocess.run(["bash", "-c", "[[ " + expression + " ]]"], capture_output=True)
+        self.assertIn(result.returncode, (0, 1), result.stderr)
+        return result.returncode == 0
+
+    def test_targeted_pr_skips_full_corpus_steps(self):
+        self.assertTrue(self.enabled("Validate changed problem files", "true"))
+        for name in ("Generate All.lean", "Build ForMathlib, utilities, and test", "Build problems",
+                     "Generate conjectures data for website", "Check category warnings", "Build literate source pages"):
+            self.assertFalse(self.enabled(name, "true"), name)
+        for name in self.steps:
+            if "actions/cache/save@" in self.steps[name]:
+                self.assertFalse(self.enabled(name, "true"), name)
+
+    def test_full_queue_and_main_keep_validation_and_cache_policy(self):
+        for event in ("merge_group", "push"):
+            self.assertFalse(self.enabled("Validate changed problem files", "false", event=event))
+            for name in ("Generate All.lean", "Build ForMathlib, utilities, and test", "Build problems",
+                         "Generate conjectures data for website", "Check category warnings", "Build literate source pages"):
+                self.assertTrue(self.enabled(name, "false", "true", event), name)
+            cache = "Save Lean build" if "Save Lean build" in self.steps else "Save local lake build"
+            self.assertEqual(self.enabled(cache, "false", "true", event), event == "push")
+
+    def test_mode_disables_site_only_for_targeted_scope(self):
+        mode = self.steps["Detect build mode"]
+        match = re.search(r"        run: \|\n((?:          .*\n|\n)+)", mode)
+        with tempfile.TemporaryDirectory() as temp:
+            for targeted in ("true", "false"):
+                out = Path(temp) / targeted
+                env = {**os.environ, "TARGETED_PROBLEMS": targeted, "WEBSITE_ONLY": "false",
+                       "GITHUB_OUTPUT": str(out), "EVENT_NAME": "pull_request", "REF_NAME": "pr",
+                       "REUSED_SITE": ""}
+                # Missing Git diff deliberately takes the existing full-site path.
+                subprocess.run(["bash", "-eu", "-c", textwrap.dedent(match[1])], cwd=temp,
+                               env=env, capture_output=True, check=True)
+                self.assertIn("website_only=false", out.read_text())
+                self.assertIn("site=" + ("false" if targeted == "true" else "true"), out.read_text())
 
 
 if __name__ == "__main__":

--- a/scripts/test_build_changed_problems.py
+++ b/scripts/test_build_changed_problems.py
@@ -1,0 +1,136 @@
+"""Test early PR builds against real Git diffs and a stub Lake executable."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import build_changed_problems as changed
+
+SCRIPT = Path(changed.__file__).resolve()
+
+
+class ChangedProblemsTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Test")
+        self.git("config", "user.email", "test@example.invalid")
+        self.write("FormalConjectures/Example.lean", "theorem old : True := by trivial\n")
+        self.write("README.md", "Test\n")
+        self.commit()
+        self.base = self.git("rev-parse", "HEAD").strip()
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        lake = self.bin / "lake"
+        lake.write_text(f"#!{sys.executable}\n"
+                        "import json, os, pathlib, sys\n"
+                        "pathlib.Path('lake-args.json').write_text(json.dumps(sys.argv[1:]))\n"
+                        "raise SystemExit(int(os.environ.get('LAKE_EXIT', '0')))\n")
+        lake.chmod(0o755)
+
+    def git(self, *args):
+        return subprocess.run(["git", *args], cwd=self.root, check=True,
+                              capture_output=True, text=True).stdout
+
+    def write(self, path, text="theorem test : True := by trivial\n"):
+        file = self.root / path
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text(text)
+
+    def commit(self):
+        self.git("add", "FormalConjectures", "README.md")
+        self.git("commit", "-m", "fixture")
+
+    def run_check(self, base=None, lake_exit="0"):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--base", base or self.base,
+             "--summary", str(self.root / "summary.json")], cwd=self.root,
+            env={**os.environ, "PATH": str(self.bin) + os.pathsep + os.environ["PATH"],
+                 "LAKE_EXIT": lake_exit}, capture_output=True, text=True,
+        )
+
+    def test_paths_are_passed_as_separate_arguments_without_name_parsing(self):
+        paths = ["FormalConjectures/ErdosProblems/1014.lean",
+                 "FormalConjectures/Arxiv/1.2 space 'quote'.lean",
+                 "FormalConjectures/Examples/é.lean"]
+        for path in paths:
+            self.write(path)
+        self.write("FormalConjectures/All.lean", "-- generated aggregate\n")
+        self.write("FormalConjectures/notes.txt", "notes\n")
+        self.commit()
+        before = self.git("status", "--porcelain", "--untracked-files=no")
+        head = self.git("rev-parse", "HEAD")
+        result = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads((self.root / "lake-args.json").read_text()),
+                         ["--wfail", "build", *sorted(paths)])
+        self.assertEqual(self.git("rev-parse", "HEAD"), head)
+        self.assertEqual(self.git("status", "--porcelain", "--untracked-files=no"), before)
+        self.assertTrue((self.root / "summary.json").is_file())
+
+    def test_deleted_files_are_excluded_and_renames_use_new_path(self):
+        self.git("mv", "FormalConjectures/Example.lean", "FormalConjectures/New.lean")
+        self.commit()
+        self.assertEqual(self.run_check().returncode, 0)
+        self.assertEqual(json.loads((self.root / "lake-args.json").read_text()),
+                         ["--wfail", "build", "FormalConjectures/New.lean"])
+
+    def test_merge_first_parent_excludes_changes_already_on_main(self):
+        self.git("checkout", "-b", "topic")
+        self.write("FormalConjectures/PR.lean")
+        self.commit()
+        self.git("checkout", "main")
+        self.write("FormalConjectures/Base.lean")
+        self.commit()
+        self.git("merge", "--no-ff", "topic", "-m", "merge fixture")
+        self.assertEqual(self.run_check(base="HEAD^1").returncode, 0)
+        self.assertEqual(json.loads((self.root / "lake-args.json").read_text()),
+                         ["--wfail", "build", "FormalConjectures/PR.lean"])
+
+    def test_build_failure_is_not_swallowed(self):
+        self.write("FormalConjectures/Example.lean", "invalid Lean\n")
+        self.commit()
+        self.assertEqual(self.run_check(lake_exit="7").returncode, 7)
+
+    def test_empty_scope_and_missing_base_leave_full_build_enabled(self):
+        for base in (self.base, "missing-revision"):
+            with self.subTest(base=base):
+                result = self.run_check(base=base)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("continuing to the full build", result.stdout)
+                self.assertFalse((self.root / "lake-args.json").exists())
+
+    def test_deleted_only_scope_does_not_call_lake(self):
+        self.git("rm", "FormalConjectures/Example.lean")
+        self.git("commit", "-m", "delete")
+        self.assertEqual(self.run_check().returncode, 0)
+        self.assertFalse((self.root / "lake-args.json").exists())
+
+    def test_broad_change_uses_full_build_without_duplicate_preflight(self):
+        for index in range(changed.MAX_FILES + 1):
+            self.write(f"FormalConjectures/Example{index}.lean")
+        self.commit()
+        result = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("early-check limit", result.stdout)
+        self.assertFalse((self.root / "lake-args.json").exists())
+
+    def test_workflow_keeps_preflight_before_full_validation(self):
+        workflow = (SCRIPT.parent.parent / ".github/workflows/build-and-docs.yml").read_text()
+        early = workflow.index("- name: Build changed problem files first")
+        full = workflow.index("- name: Build ForMathlib, utilities, and test")
+        problems = workflow.index("- name: Build problems")
+        self.assertLess(early, full)
+        self.assertLess(full, problems)
+        self.assertIn("github.event_name == 'pull_request'", workflow[early:full])
+        self.assertNotIn("continue-on-error", workflow[early:problems])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Use targeted validation for ordinary problem-only PRs instead of running the full build after checking the edited files. Full integration validation remains in the merge queue and on `main`.

| Change/event | Validation |
| --- | --- |
| PR with 1–20 added/modified ordinary problem files only | Changed files + dependencies, native metadata, category checks |
| Mixed/shared/configuration changes, deletions, renames, file-type changes, broader edits, or uncertain scope | Existing full validation |
| Merge queue and `main` | Full libraries, utility tests, problems, aggregate imports, and metadata checks |
| Website-only preview | Existing preview behavior |

```mermaid
flowchart LR
  P[PR revision] --> S{Only eligible problem files?}
  S -->|Yes| T[Build selected files + scoped category checks]
  S -->|No| F[Full validation]
  T --> Q[Merge queue: full integration validation]
  F --> Q
  Q --> M[main: validate + refresh shared cache + deploy]
```

**Targeted PRs stop after scoped validation.** They do not generate the all-problem aggregate, run the comprehensive library/test build, extract the entire corpus, or build the website. The ordinary fast script tests still run. Dependencies are built by Lake using source-file targets; no custom Lean name parser is introduced.

The native extractor accepts one file per invocation. Its extracts remain separate local diagnostics; the existing category checker accepts one or more extracts and combines its findings. Partial metadata is never published as a complete catalog. Build, extraction, and blocking category failures fail the targeted check.

**Coverage tradeoff:** a targeted PR check does not validate downstream importers or cross-file declaration conflicts. The full merge-queue check must pass before acceptance. Targeted PRs do not write shared caches; `main` retains cache refresh. This proposal needs maintainer acceptance of the PR/queue validation split.

**Validation:** 40 script tests and 6 website tests pass; all workflows pass `actionlint` 1.7.7. Tests cover real Git merge scopes, mixed changes, renames, symlinks, broad edits, non-PR events, altered scope records, failed builds/extraction, and blocking category findings. The 14 scope/workflow tests also pass with #5435 applied. A Lean 4.33.1 smoke test rejects a syntax error, accepts its correction, and reuses compiled modules in a later full build; that smoke test stubs the metadata process.

**Hosted qualification passed:** [fork run 34482000785](https://github.com/williamjblair/formal-conjectures/actions/runs/34482000785) exercised implementation revision `5986745f79fd95d7af504e89010b4afc98b198c6` through [disposable PR #11](https://github.com/williamjblair/formal-conjectures/pull/11). Its single whitespace change selected Erdős 1014, built the module and dependencies, passed native extraction and scoped category checks, and skipped full-corpus and website steps. The build job took 4m 51s; this single run is not a comparative speed benchmark. The test PR is closed without merging. **Still draft:** maintainer acceptance of reduced PR coverage remains required.

Based directly on `main`; no toolkit dependency or new GitHub setting. #5435 improves cache quality, #5460 cancels obsolete runs and lints workflows (consolidating #5469), and #5461 separately reuses website output after merge. Workflow hunks should be rebased as those PRs land.
