### PR TITLE
ci: lint GitHub Actions workflows in the fast test job

### DIFF
--- a/.github/workflows/build-and-docs.yml
+++ b/.github/workflows/build-and-docs.yml
@@ -45,6 +45,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check GitHub Actions workflows
+        # Pin the checker and archive digest; optional shell/Python linters are
+        # excluded so validation does not depend on the runner's installed tools.
+        run: |
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
+            -o "$RUNNER_TEMP/actionlint.tar.gz"
+          echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  $RUNNER_TEMP/actionlint.tar.gz" | sha256sum --check
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" -shellcheck= -pyflakes=
+
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:


### PR DESCRIPTION
Run `actionlint` in the existing **Test scripts** job to catch workflow syntax, expression, action-input, and dependency errors without waiting for Lean compilation.

- Pin `actionlint` 1.7.7 and verify the release archive's SHA-256 before execution.
- Check all repository workflows. Disable optional ShellCheck/Pyflakes integrations so results do not depend on which extra tools the runner has installed.
- Keep the existing job, permissions, and required check names.

**Validation:** all current workflows pass; a deliberately invalid workflow expression is rejected. Downloaded and verified the Linux archive checksum. The 26 script tests pass, and the combined workflow with #5435, #5461, and the changed-problem preflight passes lint.

Based directly on `main` and independently mergeable. No new credential or repository setting. This adds early diagnostics; it does not claim to shorten successful Lean builds.
