### PR TITLE
feat(Mathoverflow): add Conrad's question on group schemes over the dual numbers

### DIFF
--- a/FormalConjectures/Mathoverflow/22078.lean
+++ b/FormalConjectures/Mathoverflow/22078.lean
@@ -42,6 +42,9 @@ question is open.
 
 A group scheme is represented here by its coordinate Hopf algebra `A` over the base ring `R`.
 `A` is not assumed to be cocommutative, so the group scheme is not assumed to be commutative.
+Linearity is `HopfAlgebra.IsLinear`, which lives in
+`FormalConjecturesForMathlib/RingTheory/HopfAlgebra/Linear.lean` together with the multiplicative
+matrices that express a homomorphism into `GLₙ`, and with lemmas exercising both.
 
 *References:*
 - [mathoverflow/22078](https://mathoverflow.net/questions/22078) asked by
@@ -61,110 +64,9 @@ A group scheme is represented here by its coordinate Hopf algebra `A` over the b
 
 namespace Mathoverflow22078
 
-open Coalgebra TensorProduct
+open HopfAlgebra
 
 universe u v
-
-/-- A square matrix `a` over a Hopf algebra `A` is *multiplicative* when
-`Δ aᵢⱼ = ∑ₖ aᵢₖ ⊗ aₖⱼ` and `ε aᵢⱼ = δᵢⱼ`.
-
-Multiplicative `n × n` matrices over `A` are exactly the homomorphisms of group schemes
-`Spec A → GLₙ`: such a matrix is the image of the coordinates of `GLₙ` under the induced map of
-Hopf algebras. No invertibility hypothesis is needed: the determinant of a multiplicative matrix
-is group-like, hence a unit, by `IsMultiplicative.isGroupLikeElem_det` below. -/
-structure IsMultiplicative (R : Type u) [CommRing R] {A : Type v} [CommRing A] [HopfAlgebra R A]
-    {n : ℕ} (a : Matrix (Fin n) (Fin n) A) : Prop where
-  /-- The comultiplication of an entry is given by matrix multiplication. -/
-  comul_apply : ∀ i j, comul (R := R) (a i j) = ∑ k, a i k ⊗ₜ[R] a k j
-  /-- The counit of the matrix is the identity matrix. -/
-  counit_apply : ∀ i j, counit (R := R) (a i j) = (1 : Matrix (Fin n) (Fin n) R) i j
-
-/-- The affine group scheme `Spec A` over `R` is *linear* when it is a closed subgroup scheme of
-some `GLₙ`.
-
-By [BT84, 1.4.5] a homomorphism `Spec A → GLₙ` given by a multiplicative matrix `a` is a closed
-immersion exactly when the entries of `a` together with `(det a)⁻¹` generate `A` as an
-`R`-algebra. Asking instead that the entries alone generate `A` is equivalent: `(det a)⁻¹` is
-group-like, so appending it as an extra diagonal entry turns `a` into a multiplicative
-`(n + 1) × (n + 1)` matrix whose entries generate `A`. -/
-def IsLinear (R : Type u) [CommRing R] (A : Type v) [CommRing A] [HopfAlgebra R A] : Prop :=
-  ∃ (n : ℕ) (a : Matrix (Fin n) (Fin n) A), IsMultiplicative R a ∧
-    Algebra.adjoin R (Set.range fun ij : Fin n × Fin n ↦ a ij.1 ij.2) = ⊤
-
-/-- A `1 × 1` matrix is multiplicative exactly when its entry is group-like, that is, exactly
-when it is a character `Spec A → GL₁ = 𝔾ₘ`. -/
-@[category API, AMS 14 16]
-theorem isMultiplicative_fin_one_iff (R : Type u) [CommRing R] (A : Type v) [CommRing A]
-    [HopfAlgebra R A] (x : A) : IsMultiplicative R !![x] ↔ IsGroupLikeElem R x := by
-  constructor
-  · intro h
-    exact ⟨by simpa using h.counit_apply 0 0, by simpa using h.comul_apply 0 0⟩
-  · intro h
-    refine ⟨fun i j ↦ ?_, fun i j ↦ ?_⟩
-    · fin_cases i; fin_cases j; simpa using h.comul_eq_tmul_self
-    · fin_cases i; fin_cases j; simpa using h.counit_eq_one
-
-/-- The determinant of a multiplicative matrix is a group-like element. It is therefore a unit,
-by `IsGroupLikeElem.isUnit`, so a multiplicative matrix really does define a homomorphism of group
-schemes into `GLₙ` and not merely into the monoid scheme of `n × n` matrices. -/
-@[category API, AMS 14 16]
-theorem IsMultiplicative.isGroupLikeElem_det {R : Type u} [CommRing R] {A : Type v} [CommRing A]
-    [HopfAlgebra R A] {n : ℕ} {a : Matrix (Fin n) (Fin n) A} (h : IsMultiplicative R a) :
-    IsGroupLikeElem R a.det where
-  counit_eq_one := by
-    have h1 : (Bialgebra.counitAlgHom R A).mapMatrix a = 1 := by
-      ext i j
-      simpa using h.counit_apply i j
-    have h0 := AlgHom.map_det (Bialgebra.counitAlgHom R A) a
-    rw [h1, Matrix.det_one] at h0
-    simpa using h0
-  comul_eq_tmul_self := by
-    have h2 : (Bialgebra.comulAlgHom R A).mapMatrix a =
-        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := A) (B := A)).mapMatrix a *
-          (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := A)).mapMatrix a := by
-      ext i j
-      rw [Matrix.mul_apply]
-      simpa using h.comul_apply i j
-    have h3 := AlgHom.map_det (Bialgebra.comulAlgHom R A) a
-    rw [h2, Matrix.det_mul, ← AlgHom.map_det, ← AlgHom.map_det] at h3
-    simpa using h3
-
-/-- The trivial group scheme `Spec R` is linear, via the empty matrix. -/
-@[category test, AMS 14 16]
-theorem isLinear_self (R : Type u) [CommRing R] : IsLinear R R := by
-  refine ⟨0, (0 : Matrix (Fin 0) (Fin 0) R), ⟨fun i ↦ i.elim0, fun i ↦ i.elim0⟩, ?_⟩
-  exact Subsingleton.elim _ _
-
-open LaurentPolynomial in
-/-- The multiplicative group `𝔾ₘ = Spec R[T, T⁻¹]` is linear: it is the diagonal torus
-`diag(T, T⁻¹)` of `GL₂`. The `1 × 1` matrix `(T)` is multiplicative too, but `T` generates only
-the polynomial subring `R[T]`, which is why a larger matrix is needed. -/
-@[category test, AMS 14 16]
-theorem isLinear_laurentPolynomial (R : Type u) [CommRing R] :
-    IsLinear R (LaurentPolynomial R) := by
-  refine ⟨2, !![T 1, 0; 0, T (-1)], ⟨fun i j ↦ ?_, fun i j ↦ ?_⟩, ?_⟩
-  · fin_cases i <;> fin_cases j <;> simp [Fin.sum_univ_two, LaurentPolynomial.comul_T]
-  · fin_cases i <;> fin_cases j <;> simp [LaurentPolynomial.counit_T]
-  · set S := Algebra.adjoin R (Set.range fun ij : Fin 2 × Fin 2 ↦
-      (!![T 1, 0; 0, T (-1)] : Matrix (Fin 2) (Fin 2) (LaurentPolynomial R)) ij.1 ij.2)
-    have h1 : (T 1 : LaurentPolynomial R) ∈ S := Algebra.subset_adjoin ⟨(0, 0), by simp⟩
-    have h2 : (T (-1) : LaurentPolynomial R) ∈ S := Algebra.subset_adjoin ⟨(1, 1), by simp⟩
-    have hT : ∀ n : ℤ, (T n : LaurentPolynomial R) ∈ S := by
-      intro n
-      rcases le_or_gt 0 n with h | h
-      · lift n to ℕ using h
-        have : (T (n : ℤ) : LaurentPolynomial R) = T 1 ^ n := by simp
-        rw [this]
-        exact pow_mem h1 n
-      · obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = -(m : ℤ) := ⟨n.natAbs, by omega⟩
-        have : (T (-(m : ℤ)) : LaurentPolynomial R) = T (-1) ^ m := by rw [T_pow]; ring_nf
-        rw [this]
-        exact pow_mem h2 m
-    refine Algebra.eq_top_iff.2 fun p ↦ ?_
-    induction p using LaurentPolynomial.induction_on' with
-    | add p q hp hq => exact add_mem hp hq
-    | C_mul_T n a =>
-      exact mul_mem (by rw [C_eq_algebraMap]; exact Subalgebra.algebraMap_mem S a) (hT n)
 
 /--
 Conrad's question: is every smooth affine group scheme over the ring of dual numbers

--- a/FormalConjectures/Mathoverflow/22078.lean
+++ b/FormalConjectures/Mathoverflow/22078.lean
@@ -19,8 +19,8 @@ import FormalConjecturesUtil
 /-!
 # Mathoverflow 22078: is a smooth affine group scheme over the dual numbers linear?
 
-Every affine group scheme of finite type over a field `k` is a closed subgroup scheme of some
-`GLₙ`. Brian Conrad asked whether this stays true over the ring of dual numbers
+Every affine group scheme of finite type over a field $k$ is a closed subgroup scheme of some
+$\mathrm{GL}_n$. Brian Conrad asked whether this stays true over the ring of dual numbers
 $k[\epsilon] = k[x]/(x^2)$, or over any artinian local ring. The proof over a field produces a
 finite-dimensional subcomodule of the coordinate ring that generates it as an algebra, and uses
 that a finitely generated submodule of the coordinate ring is free. Over $k[\epsilon]$ a finitely
@@ -30,8 +30,9 @@ The answer is no in characteristic zero. Push out the Heisenberg central extensi
 $1 \to \mathbb{G}_a \to H \to \mathbb{G}_a^2 \to 1$ over $k[\epsilon]$ along the homomorphism
 $\mathbb{G}_a \to \mathbb{G}_m$, $x \mapsto 1 + \epsilon x$. This gives a smooth affine central
 extension $1 \to \mathbb{G}_m \to G \to \mathbb{G}_a^2 \to 1$ with no faithful representation on
-a finite free $k[\epsilon]$-module. Indeed, such a representation $M$ is the direct sum of the
-weight spaces $M_i$ of the central $\mathbb{G}_m$, and each $M_i$ is a subrepresentation. The
+a finite free $k[\epsilon]$-module, so with no closed immersion into any $\mathrm{GL}_n$. Indeed,
+such a representation $M$ is the direct sum of the weight spaces $M_i$ of the central
+$\mathbb{G}_m$; each $M_i$ is a direct summand of $M$, hence free, and a subrepresentation. The
 element $1 + \epsilon$ of $\mathbb{G}_m(k[\epsilon])$ is a commutator in $G(k[\epsilon])$, so it
 acts on $M_i$ with determinant $1$. It acts by the scalar $1 + i\epsilon$, so that determinant is
 $1 + i \operatorname{rank}(M_i)\epsilon$, forcing $i \operatorname{rank}(M_i) = 0$ in $k$. In
@@ -60,7 +61,7 @@ A group scheme is represented here by its coordinate Hopf algebra `A` over the b
 
 namespace Mathoverflow22078
 
-open Coalgebra LaurentPolynomial TensorProduct
+open Coalgebra TensorProduct
 
 universe u v
 
@@ -69,8 +70,8 @@ universe u v
 
 Multiplicative `n × n` matrices over `A` are exactly the homomorphisms of group schemes
 `Spec A → GLₙ`: such a matrix is the image of the coordinates of `GLₙ` under the induced map of
-Hopf algebras. The determinant of a multiplicative matrix is a group-like element, hence a unit,
-so no invertibility hypothesis is needed. -/
+Hopf algebras. No invertibility hypothesis is needed: the determinant of a multiplicative matrix
+is group-like, hence a unit, by `IsMultiplicative.isGroupLikeElem_det` below. -/
 structure IsMultiplicative (R : Type u) [CommRing R] {A : Type v} [CommRing A] [HopfAlgebra R A]
     {n : ℕ} (a : Matrix (Fin n) (Fin n) A) : Prop where
   /-- The comultiplication of an entry is given by matrix multiplication. -/
@@ -103,15 +104,41 @@ theorem isMultiplicative_fin_one_iff (R : Type u) [CommRing R] (A : Type v) [Com
     · fin_cases i; fin_cases j; simpa using h.comul_eq_tmul_self
     · fin_cases i; fin_cases j; simpa using h.counit_eq_one
 
+/-- The determinant of a multiplicative matrix is a group-like element. It is therefore a unit,
+by `IsGroupLikeElem.isUnit`, so a multiplicative matrix really does define a homomorphism of group
+schemes into `GLₙ` and not merely into the monoid scheme of `n × n` matrices. -/
+@[category API, AMS 14 16]
+theorem IsMultiplicative.isGroupLikeElem_det {R : Type u} [CommRing R] {A : Type v} [CommRing A]
+    [HopfAlgebra R A] {n : ℕ} {a : Matrix (Fin n) (Fin n) A} (h : IsMultiplicative R a) :
+    IsGroupLikeElem R a.det where
+  counit_eq_one := by
+    have h1 : (Bialgebra.counitAlgHom R A).mapMatrix a = 1 := by
+      ext i j
+      simpa using h.counit_apply i j
+    have h0 := AlgHom.map_det (Bialgebra.counitAlgHom R A) a
+    rw [h1, Matrix.det_one] at h0
+    simpa using h0
+  comul_eq_tmul_self := by
+    have h2 : (Bialgebra.comulAlgHom R A).mapMatrix a =
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := A) (B := A)).mapMatrix a *
+          (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := A)).mapMatrix a := by
+      ext i j
+      rw [Matrix.mul_apply]
+      simpa using h.comul_apply i j
+    have h3 := AlgHom.map_det (Bialgebra.comulAlgHom R A) a
+    rw [h2, Matrix.det_mul, ← AlgHom.map_det, ← AlgHom.map_det] at h3
+    simpa using h3
+
 /-- The trivial group scheme `Spec R` is linear, via the empty matrix. -/
 @[category test, AMS 14 16]
 theorem isLinear_self (R : Type u) [CommRing R] : IsLinear R R := by
   refine ⟨0, (0 : Matrix (Fin 0) (Fin 0) R), ⟨fun i ↦ i.elim0, fun i ↦ i.elim0⟩, ?_⟩
   exact Subsingleton.elim _ _
 
+open LaurentPolynomial in
 /-- The multiplicative group `𝔾ₘ = Spec R[T, T⁻¹]` is linear: it is the diagonal torus
-`diag(T, T⁻¹)` of `GL₂`. The `1 × 1` matrix `(T)` is multiplicative but its entry does not
-generate `R[T, T⁻¹]`, which is why a larger matrix is needed. -/
+`diag(T, T⁻¹)` of `GL₂`. The `1 × 1` matrix `(T)` is multiplicative too, but `T` generates only
+the polynomial subring `R[T]`, which is why a larger matrix is needed. -/
 @[category test, AMS 14 16]
 theorem isLinear_laurentPolynomial (R : Type u) [CommRing R] :
     IsLinear R (LaurentPolynomial R) := by
@@ -179,7 +206,7 @@ theorem isLinear_of_smooth_dualNumber.variants.charP : answer(sorry) ↔
 Over a field every affine group scheme of finite type is a closed subgroup scheme of some
 $\mathrm{GL}_n$. Smoothness is not needed.
 -/
-@[category research solved, AMS 14 16 20]
+@[category textbook, AMS 14 16 20]
 theorem isLinear_of_smooth_dualNumber.variants.field (k : Type u) [Field k] (A : Type v)
     [CommRing A] [HopfAlgebra k A] [Algebra.FiniteType k A] : IsLinear k A := by
   sorry

--- a/FormalConjectures/Mathoverflow/22078.lean
+++ b/FormalConjectures/Mathoverflow/22078.lean
@@ -1,0 +1,199 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Mathoverflow 22078: is a smooth affine group scheme over the dual numbers linear?
+
+Every affine group scheme of finite type over a field `k` is a closed subgroup scheme of some
+`GLₙ`. Brian Conrad asked whether this stays true over the ring of dual numbers
+$k[\epsilon] = k[x]/(x^2)$, or over any artinian local ring. The proof over a field produces a
+finite-dimensional subcomodule of the coordinate ring that generates it as an algebra, and uses
+that a finitely generated submodule of the coordinate ring is free. Over $k[\epsilon]$ a finitely
+generated submodule need not be free, and the argument breaks down.
+
+The answer is no in characteristic zero. Push out the Heisenberg central extension
+$1 \to \mathbb{G}_a \to H \to \mathbb{G}_a^2 \to 1$ over $k[\epsilon]$ along the homomorphism
+$\mathbb{G}_a \to \mathbb{G}_m$, $x \mapsto 1 + \epsilon x$. This gives a smooth affine central
+extension $1 \to \mathbb{G}_m \to G \to \mathbb{G}_a^2 \to 1$ with no faithful representation on
+a finite free $k[\epsilon]$-module. Indeed, such a representation $M$ is the direct sum of the
+weight spaces $M_i$ of the central $\mathbb{G}_m$, and each $M_i$ is a subrepresentation. The
+element $1 + \epsilon$ of $\mathbb{G}_m(k[\epsilon])$ is a commutator in $G(k[\epsilon])$, so it
+acts on $M_i$ with determinant $1$. It acts by the scalar $1 + i\epsilon$, so that determinant is
+$1 + i \operatorname{rank}(M_i)\epsilon$, forcing $i \operatorname{rank}(M_i) = 0$ in $k$. In
+characteristic zero this kills every weight $i \neq 0$, so $\mathbb{G}_m$ acts trivially on $M$.
+In characteristic $p$ the ranks may be multiples of $p$, the argument gives nothing, and the
+question is open.
+
+A group scheme is represented here by its coordinate Hopf algebra `A` over the base ring `R`.
+`A` is not assumed to be cocommutative, so the group scheme is not assumed to be commutative.
+
+*References:*
+- [mathoverflow/22078](https://mathoverflow.net/questions/22078) asked by
+  [*Brian Conrad*](https://mathoverflow.net/users/3927/bcnrd); the counterexample in
+  characteristic zero is the [answer](https://mathoverflow.net/a/513098) by
+  [*Akhil Mathew*](https://mathoverflow.net/users/594987/akhil-mathew).
+- [B. Conrad, *Reductive group schemes*](http://math.stanford.edu/~conrad/papers/luminysga3.pdf),
+  Rem. 2.3.3, which states the question and refers to [SGA 3], Exp. VIB, 13.2 and 13.5, and
+  Exp. XI, 4.3.
+- [F. Bruhat and J. Tits, *Groupes réductifs sur un corps local
+  II*](http://www.numdam.org/item/PMIHES_1984__60__5_0/), 1.4.5, for the criterion used in
+  `IsLinear` below and for the case of a Dedekind base.
+- [G. Battiston and M. Romagny, *Representations of affine group schemes over general
+  rings*](https://arxiv.org/abs/1807.01009), which claimed an affirmative answer over an artinian
+  base and was withdrawn because of an error in its Thm. 4.1.
+-/
+
+namespace Mathoverflow22078
+
+open Coalgebra LaurentPolynomial TensorProduct
+
+universe u v
+
+/-- A square matrix `a` over a Hopf algebra `A` is *multiplicative* when
+`Δ aᵢⱼ = ∑ₖ aᵢₖ ⊗ aₖⱼ` and `ε aᵢⱼ = δᵢⱼ`.
+
+Multiplicative `n × n` matrices over `A` are exactly the homomorphisms of group schemes
+`Spec A → GLₙ`: such a matrix is the image of the coordinates of `GLₙ` under the induced map of
+Hopf algebras. The determinant of a multiplicative matrix is a group-like element, hence a unit,
+so no invertibility hypothesis is needed. -/
+structure IsMultiplicative (R : Type u) [CommRing R] {A : Type v} [CommRing A] [HopfAlgebra R A]
+    {n : ℕ} (a : Matrix (Fin n) (Fin n) A) : Prop where
+  /-- The comultiplication of an entry is given by matrix multiplication. -/
+  comul_apply : ∀ i j, comul (R := R) (a i j) = ∑ k, a i k ⊗ₜ[R] a k j
+  /-- The counit of the matrix is the identity matrix. -/
+  counit_apply : ∀ i j, counit (R := R) (a i j) = (1 : Matrix (Fin n) (Fin n) R) i j
+
+/-- The affine group scheme `Spec A` over `R` is *linear* when it is a closed subgroup scheme of
+some `GLₙ`.
+
+By [BT84, 1.4.5] a homomorphism `Spec A → GLₙ` given by a multiplicative matrix `a` is a closed
+immersion exactly when the entries of `a` together with `(det a)⁻¹` generate `A` as an
+`R`-algebra. Asking instead that the entries alone generate `A` is equivalent: `(det a)⁻¹` is
+group-like, so appending it as an extra diagonal entry turns `a` into a multiplicative
+`(n + 1) × (n + 1)` matrix whose entries generate `A`. -/
+def IsLinear (R : Type u) [CommRing R] (A : Type v) [CommRing A] [HopfAlgebra R A] : Prop :=
+  ∃ (n : ℕ) (a : Matrix (Fin n) (Fin n) A), IsMultiplicative R a ∧
+    Algebra.adjoin R (Set.range fun ij : Fin n × Fin n ↦ a ij.1 ij.2) = ⊤
+
+/-- A `1 × 1` matrix is multiplicative exactly when its entry is group-like, that is, exactly
+when it is a character `Spec A → GL₁ = 𝔾ₘ`. -/
+@[category API, AMS 14 16]
+theorem isMultiplicative_fin_one_iff (R : Type u) [CommRing R] (A : Type v) [CommRing A]
+    [HopfAlgebra R A] (x : A) : IsMultiplicative R !![x] ↔ IsGroupLikeElem R x := by
+  constructor
+  · intro h
+    exact ⟨by simpa using h.counit_apply 0 0, by simpa using h.comul_apply 0 0⟩
+  · intro h
+    refine ⟨fun i j ↦ ?_, fun i j ↦ ?_⟩
+    · fin_cases i; fin_cases j; simpa using h.comul_eq_tmul_self
+    · fin_cases i; fin_cases j; simpa using h.counit_eq_one
+
+/-- The trivial group scheme `Spec R` is linear, via the empty matrix. -/
+@[category test, AMS 14 16]
+theorem isLinear_self (R : Type u) [CommRing R] : IsLinear R R := by
+  refine ⟨0, (0 : Matrix (Fin 0) (Fin 0) R), ⟨fun i ↦ i.elim0, fun i ↦ i.elim0⟩, ?_⟩
+  exact Subsingleton.elim _ _
+
+/-- The multiplicative group `𝔾ₘ = Spec R[T, T⁻¹]` is linear: it is the diagonal torus
+`diag(T, T⁻¹)` of `GL₂`. The `1 × 1` matrix `(T)` is multiplicative but its entry does not
+generate `R[T, T⁻¹]`, which is why a larger matrix is needed. -/
+@[category test, AMS 14 16]
+theorem isLinear_laurentPolynomial (R : Type u) [CommRing R] :
+    IsLinear R (LaurentPolynomial R) := by
+  refine ⟨2, !![T 1, 0; 0, T (-1)], ⟨fun i j ↦ ?_, fun i j ↦ ?_⟩, ?_⟩
+  · fin_cases i <;> fin_cases j <;> simp [Fin.sum_univ_two, LaurentPolynomial.comul_T]
+  · fin_cases i <;> fin_cases j <;> simp [LaurentPolynomial.counit_T]
+  · set S := Algebra.adjoin R (Set.range fun ij : Fin 2 × Fin 2 ↦
+      (!![T 1, 0; 0, T (-1)] : Matrix (Fin 2) (Fin 2) (LaurentPolynomial R)) ij.1 ij.2)
+    have h1 : (T 1 : LaurentPolynomial R) ∈ S := Algebra.subset_adjoin ⟨(0, 0), by simp⟩
+    have h2 : (T (-1) : LaurentPolynomial R) ∈ S := Algebra.subset_adjoin ⟨(1, 1), by simp⟩
+    have hT : ∀ n : ℤ, (T n : LaurentPolynomial R) ∈ S := by
+      intro n
+      rcases le_or_gt 0 n with h | h
+      · lift n to ℕ using h
+        have : (T (n : ℤ) : LaurentPolynomial R) = T 1 ^ n := by simp
+        rw [this]
+        exact pow_mem h1 n
+      · obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = -(m : ℤ) := ⟨n.natAbs, by omega⟩
+        have : (T (-(m : ℤ)) : LaurentPolynomial R) = T (-1) ^ m := by rw [T_pow]; ring_nf
+        rw [this]
+        exact pow_mem h2 m
+    refine Algebra.eq_top_iff.2 fun p ↦ ?_
+    induction p using LaurentPolynomial.induction_on' with
+    | add p q hp hq => exact add_mem hp hq
+    | C_mul_T n a =>
+      exact mul_mem (by rw [C_eq_algebraMap]; exact Subalgebra.algebraMap_mem S a) (hT n)
+
+/--
+Conrad's question: is every smooth affine group scheme over the ring of dual numbers
+$k[\epsilon]$ a closed subgroup scheme of some $\mathrm{GL}_n$?
+
+The answer is no: over a field of characteristic zero there is a counterexample.
+-/
+@[category research solved, AMS 14 16 20]
+theorem isLinear_of_smooth_dualNumber : answer(False) ↔
+    ∀ (k : Type u) [Field k] (A : Type v) [CommRing A] [HopfAlgebra (DualNumber k) A]
+      [Algebra.Smooth (DualNumber k) A], IsLinear (DualNumber k) A := by
+  sorry
+
+/--
+Over a field of characteristic zero there is a smooth affine group scheme over $k[\epsilon]$
+that is not a closed subgroup scheme of any $\mathrm{GL}_n$, namely the pushout of the Heisenberg
+extension of $\mathbb{G}_a^2$ by $\mathbb{G}_a$ along $\mathbb{G}_a \to \mathbb{G}_m$,
+$x \mapsto 1 + \epsilon x$.
+-/
+@[category research solved, AMS 14 16 20]
+theorem isLinear_of_smooth_dualNumber.variants.charZero (k : Type u) [Field k] [CharZero k] :
+    ∃ (A : Type u) (_ : CommRing A) (_ : HopfAlgebra (DualNumber k) A)
+      (_ : Algebra.Smooth (DualNumber k) A), ¬ IsLinear (DualNumber k) A := by
+  sorry
+
+/--
+Is every smooth affine group scheme over $k[\epsilon]$, for $k$ a field of characteristic
+$p > 0$, a closed subgroup scheme of some $\mathrm{GL}_n$? This case of Conrad's question is
+open.
+-/
+@[category research open, AMS 14 16 20]
+theorem isLinear_of_smooth_dualNumber.variants.charP : answer(sorry) ↔
+    ∀ (p : ℕ) (_ : p.Prime) (k : Type u) [Field k] [CharP k p] (A : Type v) [CommRing A]
+      [HopfAlgebra (DualNumber k) A] [Algebra.Smooth (DualNumber k) A],
+      IsLinear (DualNumber k) A := by
+  sorry
+
+/--
+Over a field every affine group scheme of finite type is a closed subgroup scheme of some
+$\mathrm{GL}_n$. Smoothness is not needed.
+-/
+@[category research solved, AMS 14 16 20]
+theorem isLinear_of_smooth_dualNumber.variants.field (k : Type u) [Field k] (A : Type v)
+    [CommRing A] [HopfAlgebra k A] [Algebra.FiniteType k A] : IsLinear k A := by
+  sorry
+
+/--
+Over a Dedekind domain every flat affine group scheme of finite type is a closed subgroup scheme
+of some $\mathrm{GL}_n$. This is [BT84, 1.4.5], which produces a closed immersion into
+$\mathrm{GL}(M)$ for a finitely generated projective module $M$; choosing $N$ with $M \oplus N$
+finite free embeds $\mathrm{GL}(M)$ into a $\mathrm{GL}_n$.
+-/
+@[category research solved, AMS 14 16 20]
+theorem isLinear_of_smooth_dualNumber.variants.dedekindDomain (R : Type u) [CommRing R]
+    [IsDedekindDomain R] (A : Type v) [CommRing A] [HopfAlgebra R A]
+    [Algebra.FiniteType R A] [Module.Flat R A] : IsLinear R A := by
+  sorry
+
+end Mathoverflow22078

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -172,6 +172,7 @@ public import FormalConjecturesForMathlib.Order.Interval.Finset.Nat
 public import FormalConjecturesForMathlib.Order.Nat
 public import FormalConjecturesForMathlib.Order.Unimodular
 public import FormalConjecturesForMathlib.Probability.FiniteMethod
+public import FormalConjecturesForMathlib.RingTheory.HopfAlgebra.Linear
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Basic
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Defs
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Maximal

--- a/FormalConjecturesForMathlib/RingTheory/HopfAlgebra/Linear.lean
+++ b/FormalConjecturesForMathlib/RingTheory/HopfAlgebra/Linear.lean
@@ -1,0 +1,171 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.Laurent
+public import Mathlib.Data.Matrix.Basic
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+public import Mathlib.LinearAlgebra.Matrix.Notation
+public import Mathlib.RingTheory.Adjoin.Basic
+public import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+public import Mathlib.RingTheory.HopfAlgebra.GroupLike
+public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
+public import Mathlib.RingTheory.TensorProduct.Basic
+
+/-!
+# Multiplicative matrices and linear affine group schemes
+
+An affine group scheme over a commutative ring `R` is `Spec A` for a commutative `R`-Hopf algebra
+`A`. This file says what it means for such a group scheme to be *linear*, that is, a closed
+subgroup scheme of some `GLₙ`.
+
+## Main definitions
+
+* `Matrix.IsMultiplicative R a`: the entries of a square matrix `a` over a bialgebra `A` satisfy
+  `Δ aᵢⱼ = ∑ₖ aᵢₖ ⊗ aₖⱼ` and `ε aᵢⱼ = δᵢⱼ`. Such matrices are exactly the homomorphisms of group
+  schemes `Spec A → GLₙ`: `a` is the image of the matrix of coordinates of `GLₙ` under the
+  corresponding map of Hopf algebras.
+* `HopfAlgebra.IsLinear R A`: the entries of some multiplicative matrix over `A` generate `A` as
+  an `R`-algebra, that is, `Spec A` is a closed subgroup scheme of some `GLₙ`.
+
+## Main results
+
+* `Matrix.IsMultiplicative.isGroupLikeElem_det`: the determinant of a multiplicative matrix is
+  group-like, hence a unit by `IsGroupLikeElem.isUnit`. A multiplicative matrix therefore does
+  define a homomorphism into `GLₙ`, and not merely into the monoid scheme of `n × n` matrices.
+* `HopfAlgebra.isLinear_self` and `LaurentPolynomial.isLinear`: the trivial group scheme and the
+  multiplicative group are linear.
+
+## Implementation notes
+
+`HopfAlgebra.IsLinear` asks that the entries of `a` alone generate `A`. Bruhat and Tits state the
+criterion for `Spec A → GLₙ` to be a closed immersion with `(det a)⁻¹` adjoined as well. The two
+conditions agree: `(det a)⁻¹` is group-like, so appending it to `a` as an extra diagonal entry
+gives a multiplicative matrix, one size larger, whose entries generate `A`.
+
+## References
+
+- [F. Bruhat and J. Tits, *Groupes réductifs sur un corps local
+  II*](http://www.numdam.org/item/PMIHES_1984__60__5_0/), 1.4.5
+-/
+
+@[expose] public section
+
+open Coalgebra TensorProduct
+
+universe u v w
+
+namespace Matrix
+
+/-- A square matrix `a` over a bialgebra `A` is *multiplicative* when `Δ aᵢⱼ = ∑ₖ aᵢₖ ⊗ aₖⱼ` and
+`ε aᵢⱼ = δᵢⱼ`.
+
+Multiplicative matrices indexed by `ι` are exactly the homomorphisms of group schemes
+`Spec A → GL(ι)`: such a matrix is the image of the matrix of coordinates of `GL(ι)` under the
+induced map of Hopf algebras. No invertibility hypothesis is needed, by
+`Matrix.IsMultiplicative.isGroupLikeElem_det`. -/
+structure IsMultiplicative (R : Type u) [CommRing R] {A : Type v} [CommRing A] [Bialgebra R A]
+    {ι : Type w} [Fintype ι] [DecidableEq ι] (a : Matrix ι ι A) : Prop where
+  /-- The comultiplication of an entry is given by matrix multiplication. -/
+  comul_apply : ∀ i j, comul (R := R) (a i j) = ∑ k, a i k ⊗ₜ[R] a k j
+  /-- The counit of the matrix is the identity matrix. -/
+  counit_apply : ∀ i j, counit (R := R) (a i j) = (1 : Matrix ι ι R) i j
+
+/-- A `1 × 1` matrix is multiplicative exactly when its entry is group-like, that is, exactly when
+it is a character `Spec A → GL₁ = 𝔾ₘ`. -/
+theorem isMultiplicative_fin_one_iff (R : Type u) [CommRing R] {A : Type v} [CommRing A]
+    [Bialgebra R A] (x : A) : IsMultiplicative R !![x] ↔ IsGroupLikeElem R x := by
+  constructor
+  · intro h
+    exact ⟨by simpa using h.counit_apply 0 0, by simpa using h.comul_apply 0 0⟩
+  · intro h
+    refine ⟨fun i j ↦ ?_, fun i j ↦ ?_⟩
+    · fin_cases i; fin_cases j; simpa using h.comul_eq_tmul_self
+    · fin_cases i; fin_cases j; simpa using h.counit_eq_one
+
+/-- The determinant of a multiplicative matrix is a group-like element. Over a Hopf algebra it is
+therefore a unit, by `IsGroupLikeElem.isUnit`, so a multiplicative matrix defines a homomorphism
+of group schemes into `GL(ι)` and not merely into the monoid scheme of matrices. -/
+theorem IsMultiplicative.isGroupLikeElem_det {R : Type u} [CommRing R] {A : Type v} [CommRing A]
+    [Bialgebra R A] {ι : Type w} [Fintype ι] [DecidableEq ι] {a : Matrix ι ι A}
+    (h : IsMultiplicative R a) : IsGroupLikeElem R a.det where
+  counit_eq_one := by
+    have h1 : (Bialgebra.counitAlgHom R A).mapMatrix a = 1 := by
+      ext i j
+      simpa using h.counit_apply i j
+    have h0 := AlgHom.map_det (Bialgebra.counitAlgHom R A) a
+    rw [h1, Matrix.det_one] at h0
+    simpa using h0
+  comul_eq_tmul_self := by
+    have h2 : (Bialgebra.comulAlgHom R A).mapMatrix a =
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := A) (B := A)).mapMatrix a *
+          (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := A)).mapMatrix a := by
+      ext i j
+      rw [Matrix.mul_apply]
+      simpa using h.comul_apply i j
+    have h3 := AlgHom.map_det (Bialgebra.comulAlgHom R A) a
+    rw [h2, Matrix.det_mul, ← AlgHom.map_det, ← AlgHom.map_det] at h3
+    simpa using h3
+
+end Matrix
+
+namespace HopfAlgebra
+
+/-- The affine group scheme `Spec A` over `R` is *linear* when it is a closed subgroup scheme of
+some `GLₙ`, that is, when the entries of some multiplicative `n × n` matrix over `A` generate `A`
+as an `R`-algebra. -/
+def IsLinear (R : Type u) [CommRing R] (A : Type v) [CommRing A] [HopfAlgebra R A] : Prop :=
+  ∃ (n : ℕ) (a : Matrix (Fin n) (Fin n) A), Matrix.IsMultiplicative R a ∧
+    Algebra.adjoin R (Set.range fun ij : Fin n × Fin n ↦ a ij.1 ij.2) = ⊤
+
+/-- The trivial group scheme `Spec R` is linear, via the empty matrix. -/
+theorem isLinear_self (R : Type u) [CommRing R] : IsLinear R R := by
+  refine ⟨0, (0 : Matrix (Fin 0) (Fin 0) R), ⟨fun i ↦ i.elim0, fun i ↦ i.elim0⟩, ?_⟩
+  exact Subsingleton.elim _ _
+
+end HopfAlgebra
+
+namespace LaurentPolynomial
+
+/-- The multiplicative group `𝔾ₘ = Spec R[T, T⁻¹]` is linear: it is the diagonal torus
+`diag(T, T⁻¹)` of `GL₂`. The `1 × 1` matrix `(T)` is multiplicative too, but `T` generates only
+the polynomial subring `R[T]`, which is why a larger matrix is needed. -/
+theorem isLinear (R : Type u) [CommRing R] : HopfAlgebra.IsLinear R (LaurentPolynomial R) := by
+  refine ⟨2, !![T 1, 0; 0, T (-1)], ⟨fun i j ↦ ?_, fun i j ↦ ?_⟩, ?_⟩
+  · fin_cases i <;> fin_cases j <;> simp [Fin.sum_univ_two, LaurentPolynomial.comul_T]
+  · fin_cases i <;> fin_cases j <;> simp [LaurentPolynomial.counit_T]
+  · set S := Algebra.adjoin R (Set.range fun ij : Fin 2 × Fin 2 ↦
+      (!![T 1, 0; 0, T (-1)] : Matrix (Fin 2) (Fin 2) (LaurentPolynomial R)) ij.1 ij.2)
+    have h1 : (T 1 : LaurentPolynomial R) ∈ S := Algebra.subset_adjoin ⟨(0, 0), by simp⟩
+    have h2 : (T (-1) : LaurentPolynomial R) ∈ S := Algebra.subset_adjoin ⟨(1, 1), by simp⟩
+    have hT : ∀ n : ℤ, (T n : LaurentPolynomial R) ∈ S := by
+      intro n
+      rcases le_or_gt 0 n with h | h
+      · lift n to ℕ using h
+        have : (T (n : ℤ) : LaurentPolynomial R) = T 1 ^ n := by simp
+        rw [this]
+        exact pow_mem h1 n
+      · obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = -(m : ℤ) := ⟨n.natAbs, by omega⟩
+        have : (T (-(m : ℤ)) : LaurentPolynomial R) = T (-1) ^ m := by rw [T_pow]; ring_nf
+        rw [this]
+        exact pow_mem h2 m
+    refine Algebra.eq_top_iff.2 fun p ↦ ?_
+    induction p using LaurentPolynomial.induction_on' with
+    | add p q hp hq => exact add_mem hp hq
+    | C_mul_T n a =>
+      exact mul_mem (by rw [C_eq_algebraMap]; exact Subalgebra.algebraMap_mem S a) (hT n)
+
+end LaurentPolynomial


### PR DESCRIPTION
Adds `FormalConjectures/Mathoverflow/22078.lean`, stating Brian Conrad's question from
[MathOverflow 22078](https://mathoverflow.net/questions/22078): is every smooth affine group
scheme over the dual numbers $k[\epsilon]$ a closed subgroup scheme of some $\mathrm{GL}_n$?

* `isLinear_of_smooth_dualNumber` states the question and records its negative answer.
* `isLinear_of_smooth_dualNumber.variants.charZero` is the counterexample over a field of
  characteristic zero: the pushout of the Heisenberg extension of $\mathbb{G}_a^2$ by
  $\mathbb{G}_a$ along $\mathbb{G}_a \to \mathbb{G}_m$, $x \mapsto 1 + \epsilon x$.
* `isLinear_of_smooth_dualNumber.variants.charP` is the open case, characteristic $p$.
* `isLinear_of_smooth_dualNumber.variants.field` and `.variants.dedekindDomain` are the known
  affirmative cases: a field, and a Dedekind base (Bruhat-Tits II, 1.4.5).

It also adds `FormalConjecturesForMathlib/RingTheory/HopfAlgebra/Linear.lean`, which carries the
general theory the statements need, since Mathlib has no comodules:

* `Matrix.IsMultiplicative R a` says `Δ aᵢⱼ = ∑ₖ aᵢₖ ⊗ aₖⱼ` and `ε aᵢⱼ = δᵢⱼ`. Such matrices are
  exactly the images of the coordinates of `GLₙ` under a map of Hopf algebras `O(GLₙ) → A`, so
  they are exactly the homomorphisms of group schemes `Spec A → GLₙ`. Only a bialgebra structure
  and an arbitrary finite index type are needed, so that is the generality used.
* `Matrix.IsMultiplicative.isGroupLikeElem_det` proves that the determinant of a multiplicative
  matrix is group-like, hence a unit in a Hopf algebra. So a multiplicative matrix really does
  define a homomorphism into `GLₙ`, and not merely into the monoid scheme of matrices.
* `HopfAlgebra.IsLinear R A` asks that the entries of some multiplicative matrix generate `A` as
  an `R`-algebra.
* `HopfAlgebra.isLinear_self` and `LaurentPolynomial.isLinear` exercise the definitions: the
  trivial group scheme is linear via the empty matrix, and `𝔾ₘ` is linear as the diagonal torus of
  `GL₂`. The second is the interesting case, since `T` alone generates only `R[T]`, so the `1 × 1`
  matrix `(T)` does not witness linearity.

### Formalisation choices

* A group scheme is represented by its coordinate Hopf algebra `A` over `R`, as in
  `FormalConjectures/Paper/FiniteLocallyFreeGroupSchemeExponent.lean`. `A` is not assumed
  cocommutative, so the group scheme is not assumed commutative.
* `IsLinear` asks for generation by the entries alone. Bruhat-Tits 1.4.5 states the criterion for a
  closed immersion with `(det a)⁻¹` adjoined as well; the two agree, because `(det a)⁻¹` is
  group-like and appending it to `a` as an extra diagonal entry gives a multiplicative
  `(n + 1) × (n + 1)` matrix. Generation by the entries alone is the more convenient form.
* Smooth and affine of finite type is `Algebra.Smooth R A`, which is formally smooth plus of finite
  presentation. `.variants.field` and `.variants.dedekindDomain` weaken this to
  `Algebra.FiniteType`, with `Module.Flat` in the Dedekind case, matching their sources.
* `.variants.field` is tagged `textbook` rather than `research solved`: it is Waterhouse,
  *Introduction to affine group schemes*, Thm. 3.4.

### Note on the sources

A claimed affirmative answer over an artinian base, [arXiv:1807.01009](https://arxiv.org/abs/1807.01009),
was withdrawn by its authors because of an error in its Thm. 4.1. The module docstring says so, so
that a later reader does not take the preprint as settling the question. The counterexample in
characteristic zero is a MathOverflow answer, https://mathoverflow.net/a/513098, which I wrote; it
is elementary and self-contained, and the docstring reproduces the argument in full.

### Checks

`lake --wfail build 'FormalConjectures.Mathoverflow.«22078»' FormalConjecturesForMathlib` is
clean, and `FormalConjecturesForMathlib/RingTheory/HopfAlgebra/Linear.lean` is `sorry`-free.

Fixes #5475.

Following the repository's AI usage conventions: this formalisation was drafted with Claude Code.
