### PR TITLE
fix(Wikipedia/PierceBirkhoff): definition of IsSemiAlgebraic

### DIFF
--- a/FormalConjectures/Wikipedia/PierceBirkhoff.lean
+++ b/FormalConjectures/Wikipedia/PierceBirkhoff.lean
@@ -32,13 +32,13 @@ The conjecture has been proved for `n = 1` and `n = 2` by Louis Mahé.
 namespace PierceBirkhoff
 
 /--
-A set is semi-algebraic in `ℝⁿ` if it can be described by a finite union of sets defined by
-multivariate polynomial equations and inequalities.
+A set is semi-algebraic in `ℝⁿ` if it can be described by a finite union of sets, each defined by
+finitely many simultaneous multivariate polynomial equations and strict inequalities.
 -/
 def IsSemiAlgebraic {n : ℕ} (S : Set (Fin n → ℝ)) : Prop :=
-  ∃ (ι₀ ι₁ : Type) (p₀ : ι₀ → MvPolynomial (Fin n) ℝ) (p₁ : ι₁ → MvPolynomial (Fin n) ℝ),
-    Finite ι₀ ∧ Finite ι₁ ∧
-    S = (⋃ i, {x | MvPolynomial.eval x (p₀ i) = 0}) ∪ ⋃ i, {x | MvPolynomial.eval x (p₁ i) > 0}
+  ∃ (ι : Type) (p₀ p₁ : ι → Finset (MvPolynomial (Fin n) ℝ)), Finite ι ∧
+    S = ⋃ i, {x | (∀ p ∈ p₀ i, MvPolynomial.eval x p = 0) ∧
+      ∀ p ∈ p₁ i, MvPolynomial.eval x p > 0}
 
 /--
 A set is semi-algebraic in `ℝ` if it can be described by a finite boolean combination


### PR DESCRIPTION
fixes #5223

Fix found because of https://tadamcz.com/fc-review-results/#/f/Wikipedia/PierceBirkhoff?c=Wikipedia. 

The issue is that in the old definition:
```
def IsSemiAlgebraic {n : ℕ} (S : Set (Fin n → ℝ)) : Prop :=
  ∃ (ι₀ ι₁ : Type) (p₀ : ι₀ → MvPolynomial (Fin n) ℝ) (p₁ : ι₁ → MvPolynomial (Fin n) ℝ),
    Finite ι₀ ∧ Finite ι₁ ∧
    S = (⋃ i, {x | MvPolynomial.eval x (p₀ i) = 0}) ∪ ⋃ i, {x | MvPolynomial.eval x (p₁ i) > 0}
```
did not allow for conjuncts between the equality and inequality conditions.  For example, a set like:

`def S : Set (Fin 2 → ℝ) := {v : Fin 2 → ℝ | (v 0 = 0) ∧ (0 ≤ v 1)}` 

was _not_ IsSemiAlgebraic. The Wikipedia definition of a SemiAlgebraic set (https://en.wikipedia.org/wiki/Semialgebraic_set) is a finite union of _basic_ semi algebraic sets. A _basic_ semi algebraic set is  a set defined by a finite number of polynomial (in)equalities. 