### PR TITLE
feat(ErdosProblems/672): link an external Lean proof of erdos_672.variants.euler

### DIFF
--- a/FormalConjectures/ErdosProblems/672.lean
+++ b/FormalConjectures/ErdosProblems/672.lean
@@ -39,7 +39,7 @@ theorem erdos_672 :
   sorry
 
 /-- According to https://www.erdosproblems.com/672, Euler proved this. -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/herakles-dev/erdos672-four-squares-lean/blob/68adec55180c6103ac5511a5c91c84b25a5044f9/Erdos672/Statement.lean#L41"]
 lemma erdos_672.variants.euler :
     Erdos672With 4 2 := by
   sorry


### PR DESCRIPTION
Records an external `formal_proof using lean4` link for `erdos_672.variants.euler`
(`Erdos672With 4 2`, Euler's variant). Per PROOFS.md the statement stays `by sorry`; the
proof is long, so it lives in the linked repo rather than in the tree.

The linked repo proves the *exact* statement: it copies `Erdos672With` and
`Set.IsAPOfLengthWith` verbatim (same Mathlib pin, `v4.33.1` / rev `0df444a`) and proves
`erdos_672_variants_euler : Erdos672With 4 2`. Worth checking before trusting it:

- `#print axioms erdos_672_variants_euler` → `{propext, Classical.choice, Quot.sound}` in the
  linked repo (no `sorryAx`, no custom axioms, no `native_decide`)
- linked repo's `lake build` clean, zero `sorry`
- the one-line edit here also builds clean in formal-conjectures (`lake build` exit 0,
  `FormalProofLinter` included)

The maths reduces (both parities, via concordant forms) to Fermat's "no four squares in
arithmetic progression" (1640), which the repo proves from scratch by an Euler
concordant-forms (1,4) infinite descent, a result currently absent from Mathlib.

AI usage (per the repo's AI policy): the proof in the linked repo was produced with Claude
(Anthropic) driving an agentic proving harness; I've been through it, and what should carry
the trust is the Lean kernel, not the tool — the `#print axioms` check above is exactly the
point. The one-line edit in this PR is hand-written.

One note in fairness: the earlier #3210 and #2688 on this same lemma used a
`formal_proof using formal_conjectures` self-link while leaving `sorryAx` in place (both
closed, #3210 by a maintainer). This is the opposite — a `using lean4` link to a
self-contained, `sorryAx`-free proof of the exact statement. Happy to repoint the link at
Mathlib instead once the reusable `no_four_squares_in_ap` lands upstream, if you'd rather
wait for that.
