### PR TITLE
Fix erdos_264.variants.ko_tao_neg

### DIFF
--- a/FormalConjectures/ErdosProblems/264.lean
+++ b/FormalConjectures/ErdosProblems/264.lean
@@ -77,7 +77,7 @@ is not an irrationality sequence.
 @[category research solved, AMS 11]
 theorem erdos_264.variants.ko_tao_neg {a : ℕ → ℕ} (h₁ : StrictMono a) (h₂ : 0 ∉ Set.range a)
     (h₃ : Summable ((1 : ℝ) / a ·))
-    (h₄ : 0 < atTop.liminf fun n ↦ a n ^ 2 * ∑' k : Set.Ioi n, (1 : ℝ) / a k ^ 2) :
+    (h₄ : ∃ C > 0, ∀ᶠ n in atTop, C ≤ a n ^ 2 * ∑' k : Set.Ioi n, (1 : ℝ) / a k ^ 2) :
     ¬IsIrrationalitySequence a := by
   sorry
 


### PR DESCRIPTION
Fix faithfulness of `erdos_264.variants.ko_tao_neg` by replacing `liminf > 0` in ℝ with an eventual positive lower bound.

Identified by @tadamcz using an AI pipeline: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/264