### PR TITLE
fix(ErdosProblems/830.lean)

### DIFF
--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -32,8 +32,8 @@ open scoped Classical in
 Let $A(x)$ counts the number of amicable $1\leq a\leq b\leq x$.
 -/
 noncomputable abbrev A (x : ℝ) : ℝ :=
-  Finset.card <| (Finset.Icc 1 ⌊x⌋₊ ×ˢ Finset.Icc 1 ⌊x⌋₊).filter fun (a, b) ↦
-    a ≤ b ∧ IsAmicable a b
+  (1 / 2) * Finset.card <| (Finset.Icc 1 ⌊x⌋₊ ×ˢ Finset.Icc 1 ⌊x⌋₊).filter
+    fun (a, b) ↦ IsAmicable a b
 
 /-- **Erdos Problem 830, Part 1**
 We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b$. Are there

--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -40,7 +40,7 @@ We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b
 infinitely many amicable pairs?
 -/
 @[category research open, AMS 11]
-theorem erdos_830.parts.i : answer(sorry) ↔ {(a, b) | IsAmicable a b ∧ a ≠ b}.Infinite := by
+theorem erdos_830.parts.i : answer(sorry) ↔ {(a, b) | IsAmicable a b}.Infinite := by
   sorry
 
 /-- **Erdos Problem 830, Part 2**

--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -40,7 +40,7 @@ We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b
 infinitely many amicable pairs?
 -/
 @[category research open, AMS 11]
-theorem erdos_830.parts.i : answer(sorry) ↔ {(a, b) | IsAmicable a b}.Infinite := by
+theorem erdos_830.parts.i : answer(sorry) ↔ {(a, b) | IsAmicable a b ∧ a ≠ b}.Infinite := by
   sorry
 
 /-- **Erdos Problem 830, Part 2**

--- a/FormalConjectures/Wikipedia/AmicableNumbers.lean
+++ b/FormalConjectures/Wikipedia/AmicableNumbers.lean
@@ -75,8 +75,7 @@ While many amicable pairs are known, it remains open whether there are infinitel
 [erdosproblems.com/830](https://www.erdosproblems.com/830)
 -/
 @[category research open, AMS 11]
-theorem infinitely_many_amicable :
-    answer(sorry) ↔ {p : ℕ × ℕ | IsAmicable p.1 p.2 ∧ p.1 ≠ p.2}.Infinite := by
+theorem infinitely_many_amicable : type_of% Erdos830.erdos_830.parts.i := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/AmicableNumbers.lean
+++ b/FormalConjectures/Wikipedia/AmicableNumbers.lean
@@ -75,7 +75,8 @@ While many amicable pairs are known, it remains open whether there are infinitel
 [erdosproblems.com/830](https://www.erdosproblems.com/830)
 -/
 @[category research open, AMS 11]
-theorem infinitely_many_amicable : type_of% Erdos830.erdos_830.parts.i := by
+theorem infinitely_many_amicable :
+    answer(sorry) ↔ {p : ℕ × ℕ | IsAmicable p.1 p.2 ∧ p.1 ≠ p.2}.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/AmicableNumbers.lean
+++ b/FormalConjectures/Wikipedia/AmicableNumbers.lean
@@ -76,7 +76,7 @@ While many amicable pairs are known, it remains open whether there are infinitel
 -/
 @[category research open, AMS 11]
 theorem infinitely_many_amicable :
-    type_of% Erdos830.erdos_830.parts.i := by
+    answer(sorry) ↔ {p : ℕ × ℕ | IsAmicable p.1 p.2 ∧ p.1 ≠ p.2}.Infinite := by
   sorry
 
 /--

--- a/FormalConjectures/Wikipedia/AmicableNumbers.lean
+++ b/FormalConjectures/Wikipedia/AmicableNumbers.lean
@@ -76,7 +76,7 @@ While many amicable pairs are known, it remains open whether there are infinitel
 -/
 @[category research open, AMS 11]
 theorem infinitely_many_amicable :
-    answer(sorry) ↔ {p : ℕ × ℕ | IsAmicable p.1 p.2 ∧ p.1 ≠ p.2}.Infinite := by
+    type_of% Erdos830.erdos_830.parts.i := by
   sorry
 
 /--

--- a/FormalConjecturesForMathlib/NumberTheory/Amicable.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Amicable.lean
@@ -35,3 +35,4 @@ We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b
 structure IsAmicable (a b : ℕ) : Prop where
   left : σ 1 a = a + b
   right : σ 1 b = a + b
+  ne : a ≠ b

--- a/FormalConjecturesForMathlib/NumberTheory/Amicable.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Amicable.lean
@@ -35,4 +35,3 @@ We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b
 structure IsAmicable (a b : ℕ) : Prop where
   left : σ 1 a = a + b
   right : σ 1 b = a + b
-  neq : a ≠ b

--- a/FormalConjecturesForMathlib/NumberTheory/Amicable.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Amicable.lean
@@ -35,3 +35,4 @@ We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b
 structure IsAmicable (a b : ℕ) : Prop where
   left : σ 1 a = a + b
   right : σ 1 b = a + b
+  neq : a ≠ b


### PR DESCRIPTION
Previously the type of Erdos380 was: `sorry ↔ {(a, b) | IsAmicable a b}.Infinite`. This doesn't impose that `a \neq b`, as the wikipedia definition does. This affected `infinitely_many_amicable` in `Wikipedia/AmicableNumbers` which had type `type_of% Erdos830.erdos_830.parts.i`. 

`IsAmicable n n ↔ n = 0 ∨ n.Perfect` was true in the old formulation, so a proof of infinitely many perfect numbers would have sufficed to prove the claim. Currently `IsAmicable` looks like:

```
structure IsAmicable (a b : ℕ) : Prop where
  left : σ 1 a = a + b
  right : σ 1 b = a + b
```

Perhaps it needs another field specifying `a \neq b`?