### PR TITLE
fix(ErdosProblems/318): infinite set and positive even member in contain_single_even

### DIFF
--- a/FormalConjectures/ErdosProblems/318.lean
+++ b/FormalConjectures/ErdosProblems/318.lean
@@ -99,11 +99,13 @@ theorem erdos_318.variants.squares : ¬ P₁ ({n | IsSquare n}) := by
     have : p ≠ 1 := by grind
     simp_all [neg_div, zero_lt_iff, (not_iff_not.2 mem_singleton_iff).1 (hs hp).2]
 
-/-- For any set `A` containing exactly one even number, `A` does not have property `P₁`. Sattler
-[Sa82] credits this observation to Erdős, who presumably found this after [ErGr80]. -/
+/-- For any infinite set `A` containing exactly one positive even number, `A` does not have
+property `P₁`. Sattler [Sa82] credits this observation to Erdős, who presumably found this after
+[ErGr80]. The element `0` is not counted, since `P₁` ignores it, and the infinitude hypothesis
+excludes degenerate sets such as `{2}`, on which `P₁` holds vacuously. -/
 @[category research solved, AMS 11]
-theorem erdos_318.variants.contain_single_even {A : Set ℕ} (hA : {n | n ∈ A ∧ Even n}.ncard = 1) :
-    ¬ P₁ A := by
+theorem erdos_318.variants.contain_single_even {A : Set ℕ} (hA : A.Infinite)
+    (hA' : {n | n ∈ A \ {0} ∧ Even n}.ncard = 1) : ¬ P₁ A := by
   sorry
 
 /-- There exists a set `A` with positive density that does not have property `P₁`.


### PR DESCRIPTION
**Related.** #3741 fixed the conclusion of this statement (it previously read `¬ P₁ {n | IsSquare n}`); the hypothesis was not changed then. #4760 touched the neighbouring `parts.i` docstring, which still applies.

**What changed**

- `erdos_318.variants.contain_single_even` now assumes `A.Infinite` and that `A \ {0}` contains exactly one even number. The docstring explains both conditions.

**Why**

The old hypothesis `{n | n ∈ A ∧ Even n}.ncard = 1` admitted `A = {2}`, where `P₁` holds vacuously: every sign function on `{2}` is constant, so the two nonconstancy premises of `P₁` cannot both hold. The Lean counterexample below refutes the whole statement this way.

It also counted `0` as an even member, although `P₁` only looks at `A \ {0}`. So `A = insert 0 {n | Odd n}` satisfied the hypothesis with unique even member `0`, while `P₁ A ↔ P₁ {n | Odd n}` by unfolding `P₁`, and the latter is Sattler's theorem `erdos_318.variants.odd` in the same file. Counting even members of `A \ {0}` removes this second case.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«318»

/-!
# The singleton obstruction in Erdős 318

The full single-even-member assertion admits the set {2}, where its sign-function
property is vacuous. The proof does not use any solved variant from the problem file.
-/

namespace Counterexamples.Group2.Erdos318

open Set _root_.Erdos318

lemma singleton_property (a : ℕ) : P₁ ({a} : Set ℕ) := by
  classical
  intro f hplus hminus hrange
  have ha : f a = 1 ∨ f a = -1 := by simpa using hrange (Set.mem_range_self a)
  rcases ha with ha | ha
  · apply (hplus ?_).elim
    funext n
    have hn : n.val = a := n.property.1
    simpa [Function.comp_apply, hn] using ha
  · apply (hminus ?_).elim
    funext n
    have hn : n.val = a := n.property.1
    simpa [Function.comp_apply, hn] using ha

lemma two_even_count : {n : ℕ | n ∈ ({2} : Set ℕ) ∧ Even n}.ncard = 1 := by
  have h : {n : ℕ | n ∈ ({2} : Set ℕ) ∧ Even n} = {2} := by
    ext n
    simp only [Set.mem_ofPred_eq, Set.mem_singleton_iff]
    exact ⟨And.left, fun hn => ⟨hn, hn ▸ (by decide : Even 2)⟩⟩
  rw [h, Set.ncard_singleton]

/-- Negation of the exact elaborated universally quantified declaration. -/
theorem refutes : ¬ (type_of% @Erdos318.erdos_318.variants.contain_single_even) := by
  intro h
  exact h two_even_count (singleton_property 2)

#print axioms refutes

end Counterexamples.Group2.Erdos318
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«318»'` passes.
- `{2}` is finite and `insert 0 {n | Odd n}` has no positive even member, so neither counterexample satisfies the new hypotheses. The intended proof (a sign function that is `-1` on the even element and `1` on the odd ones, with a parity argument on denominators) works for every infinite `A` with exactly one positive even element.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/318 (findings 1 and 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

