### PR TITLE
fix(ErdosProblems/593): bipartite obligatory graphs need a copy, not an induced embedding

### DIFF
--- a/FormalConjectures/ErdosProblems/593.lean
+++ b/FormalConjectures/ErdosProblems/593.lean
@@ -27,6 +27,9 @@ import FormalConjecturesUtil
   birthday), Vol. I. Colloq. Math. Soc. János Bolyai 10, North-Holland (1975), 425–513.
 - [Er95d] Erdős, Paul, Some of my favourite problems in various branches of combinatorics.
   Matematiche (Catania) 47 (1992), no. 2, 231–240 (1995).
+- [EHR73] Erdős, Paul and Hajnal, András and Rothschild, Bruce, On chromatic number of graphs
+  and set-systems. Cambridge Summer School in Mathematical Logic (Cambridge, 1971),
+  Lecture Notes in Math. 337, Springer (1973), 531–538.
 -/
 
 open Cardinal Set SimpleGraph
@@ -39,65 +42,77 @@ namespace Erdos593
 **Erdős Problem 593 (\$500)**: Characterize those finite 3-uniform hypergraphs which appear
 in every 3-uniform hypergraph of chromatic number $> \aleph_0$.
 
-A natural conjectural characterization, recorded here, is that the obligatory finite 3-uniform
-hypergraphs are exactly the 2-colorable ones (Property B). The forward direction
-(`IsObligatory → IsTwoColorable`) and converse (`IsTwoColorable → IsObligatory`) are stated as
-separate variants below; in the graph case ($r = 2$), Erdős–Galvin–Hajnal [EGH75] proved the
-analogous result (obligatory ⇔ bipartite).
+The answer is the set of obligatory finite 3-uniform hypergraphs, represented here on the
+labelled vertex sets `Fin n`.
+
+Two-colorability (Property B) is a necessary condition, see
+`erdos_593.variants.obligatory_implies_two_colorable`, but it is not sufficient: two triples
+sharing a pair form a 2-colorable hypergraph that is not obligatory, see
+`erdos_593.variants.common_pair_not_obligatory`. In the graph case ($r = 2$) the problem is
+completely solved by Erdős–Galvin–Hajnal [EGH75]: the obligatory graphs are exactly the finite
+bipartite graphs.
+
+A resolution has been claimed by E. Li (arXiv:2606.24882, 2026); at the time of writing
+erdosproblems.com still lists the problem as open.
 -/
 @[category research open, AMS 5]
-theorem erdos_593 : answer(sorry) ↔
-    ∀ (W : Type) [Fintype W] (F : ThreeUniformHypergraph W),
-      IsObligatory F ↔ F.IsTwoColorable := by
+theorem erdos_593 :
+    {p : Σ n : ℕ, ThreeUniformHypergraph (Fin n) | IsObligatory p.2} = answer(sorry) := by
   sorry
 
 /--
-**Erdős Problem 593 — Necessary direction**: Every obligatory finite 3-uniform
-hypergraph is 2-colorable.
+**Necessary direction**: every obligatory finite 3-uniform hypergraph is 2-colorable.
 
-This is the natural necessary condition for the conjectural characterization in `erdos_593`:
-if a finite 3-uniform hypergraph `F` is not 2-colorable, one expects to construct a
-hypergraph with large chromatic number that contains no copy of `F`.
+This follows from two constructions in [EGH75]. By [EHR73] (see [EGH75, p. 426]) there are
+3-uniform hypergraphs of arbitrarily large chromatic number consisting of edge-disjoint
+triples, so an obligatory `F` is linear (no two edges share two vertices). By the remark
+preceding [EGH75, Theorem 10.9] there are, for every infinite cardinal $\kappa$, 3-uniform
+hypergraphs of chromatic number $> \kappa$ all of whose linear sub-hypergraphs are
+2-colorable. An obligatory `F` appears in such a hypergraph, hence is 2-colorable.
 -/
-@[category research open, AMS 5]
-theorem erdos_593.variants.obligatory_implies_two_colorable : answer(sorry) ↔
+@[category research solved, AMS 5]
+theorem erdos_593.variants.obligatory_implies_two_colorable : answer(True) ↔
     ∀ (W : Type) [Fintype W] (F : ThreeUniformHypergraph W),
       IsObligatory F → F.IsTwoColorable := by
   sorry
 
 /--
-**Erdős Problem 593 — Sufficient direction**: Every finite 2-colorable 3-uniform
+**Sufficient direction fails**: it is not the case that every finite 2-colorable 3-uniform
 hypergraph is obligatory.
 
-This is the converse direction of the `erdos_593` characterization: if 2-colorability
-matches the graph-case characterization (bipartite ⇔ obligatory), then every 2-colorable
-finite 3-uniform hypergraph must appear in every 3-uniform hypergraph of chromatic number
-$> \aleph_0$.
-
-Together with `erdos_593.variants.obligatory_implies_two_colorable`, this implies `erdos_593`.
+The hypergraph `commonPair` with edges $\{0,1,2\}$ and $\{0,1,3\}$ is 2-colorable but does
+not appear in the 3-uniform hypergraphs of large chromatic number consisting of edge-disjoint
+triples constructed in [EHR73], see `erdos_593.variants.common_pair_not_obligatory`.
 -/
-@[category research open, AMS 5]
-theorem erdos_593.variants.two_colorable_implies_obligatory : answer(sorry) ↔
+@[category research solved, AMS 5]
+theorem erdos_593.variants.two_colorable_implies_obligatory : answer(False) ↔
     ∀ (W : Type) [Fintype W] (F : ThreeUniformHypergraph W),
       F.IsTwoColorable → IsObligatory F := by
   sorry
 
-/--
-**Conjunction of the two open implications gives the conjectured characterization**: if both
-`obligatory_implies_two_colorable` and `two_colorable_implies_obligatory` hold, then the
-characterization conjectured in `erdos_593` (`IsObligatory F ↔ F.IsTwoColorable`) follows by
-elementary `Iff` manipulation.
--/
+/-- The 3-uniform hypergraph on four vertices consisting of two triples sharing a pair,
+$\{0,1,2\}$ and $\{0,1,3\}$. -/
+def commonPair : ThreeUniformHypergraph (Fin 4) :=
+  ThreeUniformHypergraph.ofFinset {{0, 1, 2}, {0, 1, 3}} (by unfold Finset.IsThreeUniform; decide)
+
+/-- Two triples sharing a pair are 2-colorable: color the shared pair with one color and the
+remaining two vertices with the other. -/
 @[category test, AMS 5]
-theorem erdos_593.variants.implications_combine
-    (h₁ : ∀ (W : Type) [Fintype W] (F : ThreeUniformHypergraph W),
-            IsObligatory F → F.IsTwoColorable)
-    (h₂ : ∀ (W : Type) [Fintype W] (F : ThreeUniformHypergraph W),
-            F.IsTwoColorable → IsObligatory F) :
-    ∀ (W : Type) [Fintype W] (F : ThreeUniformHypergraph W),
-      IsObligatory F ↔ F.IsTwoColorable := by
-  intro W _ F
-  exact ⟨h₁ W F, h₂ W F⟩
+theorem erdos_593.variants.commonPair_isTwoColorable : commonPair.IsTwoColorable :=
+  ⟨fun i => if i.val < 2 then 0 else 1, by
+    intro e he
+    simp only [commonPair, ThreeUniformHypergraph.mem_edges_ofFinset] at he
+    revert e
+    decide⟩
+
+/--
+Two triples sharing a pair are **not** obligatory: by [EHR73] (see [EGH75, p. 426]) there are
+3-uniform hypergraphs of arbitrarily large chromatic number consisting of edge-disjoint
+triples, and `commonPair` does not appear in any of them.
+-/
+@[category research solved, AMS 5]
+theorem erdos_593.variants.common_pair_not_obligatory : ¬ IsObligatory commonPair := by
+  sorry
 
 /- ## Variants and partial results -/
 

--- a/FormalConjectures/ErdosProblems/593.lean
+++ b/FormalConjectures/ErdosProblems/593.lean
@@ -107,8 +107,9 @@ For the 2-uniform (graph) case, a graph of chromatic cardinal $> \aleph_0$ must 
 finite bipartite graphs. Specifically, for every finite bipartite graph `F` and every graph
 `G` with chromatic cardinal $> \aleph_0$, there is a graph embedding from `F` into `G`.
 
-This uses `Nonempty (F ↪g G)` (graph embedding), aligned with the injective vertex map
-used in the hypergraph `Appears` definition.
+This uses `F ⊑ G` (`SimpleGraph.IsContained`, an injective graph homomorphism), aligned with
+the injective edge-preserving map used in the hypergraph `Appears` definition. A graph embedding
+`F ↪g G` would require an induced copy, which the theorem does not provide.
 -/
 @[category research solved, AMS 5]
 theorem erdos_593.variants.graph_case_bipartite_obligatory :
@@ -116,7 +117,7 @@ theorem erdos_593.variants.graph_case_bipartite_obligatory :
     ∀ (V : Type*) (G : SimpleGraph V),
       ℵ₀ < G.chromaticCardinal →
       ∀ (W : Type*) [Fintype W] (F : SimpleGraph W), F.IsBipartite →
-        Nonempty (F ↪g G) := by
+        F ⊑ G := by
   simp only [true_iff]
   -- This is the Erdős–Galvin–Hajnal theorem [EGH75].
   sorry


### PR DESCRIPTION
**Related.** #5495 migrates this file to `UniformHypergraph`. It does not touch `graph_case_bipartite_obligatory`, but the follow-up commit rewrites the main statements, so this PR will conflict with #5495; whichever lands second needs a rebase.

**What changed**

- (Second commit, by @mo271, cherry-picked from their `erdos-593-followup` branch.) `erdos_593` now asks for the set of obligatory finite 3-uniform hypergraphs on the vertex sets `Fin n`, instead of a yes/no question about the candidate characterisation `IsObligatory ↔ IsTwoColorable`, which the cited literature already rules out. `obligatory_implies_two_colorable` is `research solved` with `answer(True)`; `two_colorable_implies_obligatory` is `research solved` with `answer(False)`, witnessed by the new `commonPair` hypergraph (two triples sharing a pair), its 2-colourability test, and `common_pair_not_obligatory`. The `implications_combine` test theorem is removed and the [EHR73] reference is added.
- `erdos_593.variants.graph_case_bipartite_obligatory` concludes `F ⊑ G` (`SimpleGraph.IsContained`, an injective graph homomorphism) instead of `Nonempty (F ↪g G)`. The docstring explains the choice.

**Why**

A graph embedding `F ↪g G` preserves and reflects adjacency, so it is an induced copy. The Erdős–Galvin–Hajnal theorem only gives an ordinary subgraph copy, and the induced version is false: take `F = ⊥` on `Fin 2` and `G = ⊤` on `Set ℕ`. Then `G.chromaticCardinal = 2 ^ ℵ₀ > ℵ₀`, but any two distinct vertices of `G` are adjacent, so `F` has no induced copy in `G`. `F ⊑ G` matches the injective edge-preserving map used by `ThreeUniformHypergraph.Appears`.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«593»
/-! Independent tests of the graph claims in Erdős 593. -/
namespace Counterexamples.Group2.Erdos593
open Cardinal Set SimpleGraph

-- A complete graph needs a distinct color at every vertex.
theorem complete_chromatic (V : Type) :
    (⊤ : SimpleGraph V).chromaticCardinal = #V := by
  have hc : Nonempty ((⊤ : SimpleGraph V).Coloring V) :=
    ⟨SimpleGraph.Coloring.mk id (fun h => h)⟩
  apply le_antisymm
  · exact csInf_le' ⟨V, rfl, hc⟩
  · refine le_csInf ?_ ?_
    · exact ⟨#V, V, rfl, hc⟩
    · rintro κ ⟨C, rfl, ⟨c⟩⟩
      apply Cardinal.mk_le_of_injective (f := c)
      intro v w h
      by_contra hvw
      exact c.valid hvw h

-- Even the edgeless two-vertex graph cannot be an induced subgraph of a complete graph.
theorem no_induced_two_isolates (V : Type) :
    ¬ Nonempty ((⊥ : SimpleGraph (Fin 2)) ↪g (⊤ : SimpleGraph V)) := by
  rintro ⟨e⟩
  have hne : e 0 ≠ e 1 := fun h => (by decide : (0 : Fin 2) ≠ 1) (e.injective h)
  have h : (⊥ : SimpleGraph (Fin 2)).Adj 0 1 := e.map_rel_iff.mp hne
  exact h

-- The precise RHS of the file's bipartite-graph theorem is false.
theorem bipartite_graph_claim_false :
    ¬ (∀ (V : Type) (G : SimpleGraph V),
      ℵ₀ < G.chromaticCardinal →
      ∀ (W : Type) [Fintype W] (F : SimpleGraph W), F.IsBipartite →
        Nonempty (F ↪g G)) := by
  intro h
  have hχ : ℵ₀ < (⊤ : SimpleGraph (Set ℕ)).chromaticCardinal := by
    rw [complete_chromatic, Cardinal.mk_set, Cardinal.mk_nat]
    exact Cardinal.cantor ℵ₀
  have hb : (⊥ : SimpleGraph (Fin 2)).IsBipartite := by
    exact ⟨SimpleGraph.Coloring.mk (fun _ => 0) (fun h => False.elim h)⟩
  exact no_induced_two_isolates (Set ℕ) (h _ _ hχ _ _ hb)

theorem refutes : ¬ (type_of% (@Erdos593.erdos_593.variants.graph_case_bipartite_obligatory.{0, 0})) := by
  intro h
  apply bipartite_graph_claim_false
  simpa only [true_iff] using h
#print axioms refutes
end Counterexamples.Group2.Erdos593
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«593»'` passes.
- With `F ⊑ G`, the counterexample no longer applies: the edgeless graph on two vertices is contained in every graph with two vertices.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/593 (finding 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


