### PR TITLE
fix(ErdosProblems/978): sub_two needs no fixed (k - 2)-th power divisor

### DIFF
--- a/FormalConjectures/ErdosProblems/978.lean
+++ b/FormalConjectures/ErdosProblems/978.lean
@@ -50,11 +50,12 @@ theorem erdos_978.parts.i {f : ℤ[X]} (hi : Irreducible f) (hd : 2 < f.natDegre
     HasPosDensity {n : ℕ | Powerfree (f.natDegree - 1) (f.eval (n : ℤ))} := by
   sorry
 
-/-- If the degree `k` of `f` is larger than or equal to `9`, then the set of `n` such that `f n` is
-`(k - 2)`-th power free has infinitely many elements. This result is proved in [Br11]. -/
+/-- If the degree `k` of `f` is larger than or equal to `9`, and `f n` has no fixed `(k - 2)`-th
+power divisors other than `1`, then the set of `n` such that `f n` is `(k - 2)`-th power free has
+infinitely many elements. This result is proved in [Br11]. -/
 @[category research solved, AMS 11]
 theorem erdos_978.variants.sub_two {f : ℤ[X]} (hi : Irreducible f) (hd : 9 ≤ f.natDegree)
-    (hp : ∀ (p : ℕ), p.Prime → ∃ n : ℕ, ¬ (p : ℤ) ^ (f.natDegree - 1) ∣ f.eval (n : ℤ)) :
+    (hp : ∀ (p : ℕ), p.Prime → ∃ n : ℕ, ¬ (p : ℤ) ^ (f.natDegree - 2) ∣ f.eval (n : ℤ)) :
     {n : ℕ | Powerfree (f.natDegree - 2) (f.eval (n : ℤ))}.Infinite := by
   sorry
 


### PR DESCRIPTION
**Related.** #3408 added the fixed-divisor hypotheses to `sub_one_density` and `parts.ii` (already in the `k - 2` form there); the exponent in `sub_two` was not changed then.

**What changed**

- In `erdos_978.variants.sub_two` the local hypothesis `hp` now excludes fixed `(f.natDegree - 2)`-th power divisors, matching the conclusion. The docstring mentions the hypothesis.

**Why**

The conclusion is about `(k - 2)`-power-free values, but `hp` only excluded fixed `(k - 1)`-th powers, which is too weak. For `f = ∏ i < 9, (X - 3 i) + 384`: `f` is monic of degree `9` and Eisenstein at `3`, hence irreducible; `2 ^ 7` divides `f n` for every `n`, so no value is `7`-power-free; and `f 0 = 384` is not divisible by `p ^ 8` for any prime `p`, so the old `hp` held. `erdos_978.parts.ii` in the same file already uses the `k - 2` form.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«978»
/-! Independent counterexample test for the (k-1)/(k-2) local condition. -/
namespace Counterexamples.Group2.Erdos978

open Polynomial Set
set_option maxHeartbeats 2000000

noncomputable def G : ℤ[X] :=
  ∏ i ∈ Finset.range 9, (X - C (3 * (i : ℤ)))
noncomputable def F : ℤ[X] := G + C 384

lemma G_deg : G.natDegree = 9 := by
  unfold G
  rw [Polynomial.natDegree_prod (Finset.range 9) (fun i : ℕ => X - C (3 * (i : ℤ)))
    (fun i _ => (monic_X_sub_C (3 * (i : ℤ))).ne_zero)]
  simp only [natDegree_X_sub_C, Finset.sum_const, Finset.card_range, smul_eq_mul, mul_one]

lemma F_deg : F.natDegree = 9 := by
  simpa only [F, natDegree_add_C] using G_deg

lemma G_monic : G.Monic :=
  monic_prod_of_monic _ _ (fun i _ => monic_X_sub_C (3 * (i : ℤ)))

lemma F_monic : F.Monic := by
  apply monic_of_natDegree_le_of_coeff_eq_one (n := 9)
  · exact F_deg.le
  · have h : G.coeff 9 = 1 := G_deg ▸ G_monic.coeff_natDegree
    simpa [F] using h

lemma F_zero : F.eval 0 = 384 := by
  norm_num [F, G, Finset.prod_range_succ]

lemma prime_ideal_three : (Ideal.span {(3 : ℤ)}).IsPrime := by
  apply (Ideal.span_singleton_prime (by norm_num)).mpr
  exact Int.prime_iff_natAbs_prime.mpr (by norm_num)

lemma F_map_three : F.map (Int.castRingHom (ZMod 3)) = X^9 := by
  let φ := Int.castRingHom (ZMod 3)
  have hroot (i : ℕ) : φ (3 * (i : ℤ)) = 0 := by
    rw [map_mul, show φ 3 = 0 by decide, zero_mul]
  have hrootpoly (i : ℕ) : (X - C (3 * (i : ℤ))).map φ = X := by
    rw [Polynomial.map_sub, Polynomial.map_X, Polynomial.map_C, hroot, C_0, sub_zero]
  change F.map φ = X^9
  simp only [F, G, Polynomial.map_add, Polynomial.map_prod, hrootpoly,
    Polynomial.map_C, show φ 384 = 0 by decide]
  simp

lemma F_eisenstein : F.IsEisensteinAt (Ideal.span {(3 : ℤ)}) := by
  refine ⟨?_, ?_, ?_⟩
  · rw [F_monic.leadingCoeff, Ideal.mem_span_singleton]
    norm_num
  · intro n hn
    rw [F_deg] at hn
    rw [Ideal.mem_span_singleton]
    apply (ZMod.intCast_zmod_eq_zero_iff_dvd (F.coeff n) 3).mp
    have hh := congrArg (fun p : (ZMod 3)[X] => p.coeff n) F_map_three
    simpa [coeff_map, coeff_X_pow, ne_of_lt hn] using hh
  · rw [Ideal.span_singleton_pow, Ideal.mem_span_singleton]
    have h : F.coeff 0 = 384 := by norm_num [F, G, Finset.prod_range_succ, coeff_mul]
    rw [h]
    norm_num

lemma F_irreducible : Irreducible F :=
  F_eisenstein.irreducible prime_ideal_three F_monic.isPrimitive (by rw [F_deg]; norm_num)

lemma mod128 : ∀ z : ZMod 128,
    (∏ i ∈ Finset.range 9, (z - 3 * (i : ZMod 128))) + 384 = 0 := by
  decide +kernel

lemma F_fixed_seventh (n : ℕ) : (2 : ℤ)^7 ∣ F.eval (n : ℤ) := by
  norm_num only [show (2 : ℤ)^7 = 128 by norm_num]
  apply (ZMod.intCast_zmod_eq_zero_iff_dvd (F.eval (n : ℤ)) 128).mp
  simpa [F, G, Polynomial.eval_prod, Int.cast_prod] using mod128 (n : ZMod 128)

lemma no_eighth (p : ℕ) (hp : p.Prime) : ¬ (p : ℤ)^8 ∣ (384 : ℤ) := by
  intro h
  by_cases h2 : p = 2
  · subst p
    norm_num at h
  have hp3 : 3 ≤ p := by have := hp.two_le; omega
  have hn : p^8 ∣ 384 := by exact_mod_cast h
  have hle := Nat.le_of_dvd (by decide : 0 < 384) hn
  have hge : 3^8 ≤ p^8 := Nat.pow_le_pow_left hp3 8
  norm_num at hge
  omega

lemma F_no_fixed_eighth : ∀ p : ℕ, p.Prime → ∃ n : ℕ,
    ¬ (p : ℤ)^(F.natDegree-1) ∣ F.eval (n : ℤ) := by
  intro p hp
  use 0
  simpa [F_deg, F_zero] using no_eighth p hp

lemma F_no_powerfree_values :
    {n : ℕ | Powerfree (F.natDegree - 2) (F.eval (n : ℤ))} = ∅ := by
  ext n
  simp only [Set.mem_ofPred_eq, Set.mem_empty_iff_false, iff_false]
  intro h
  rw [F_deg] at h
  have hu := h (x := 2) (F_fixed_seventh n)
  norm_num [Int.isUnit_iff] at hu

theorem refutes_sub_two : ¬ (∀ {f : ℤ[X]}, Irreducible f → 9 ≤ f.natDegree →
    (∀ p : ℕ, p.Prime → ∃ n : ℕ, ¬ (p : ℤ)^(f.natDegree-1) ∣ f.eval (n : ℤ)) →
    {n : ℕ | Powerfree (f.natDegree - 2) (f.eval (n : ℤ))}.Infinite) := by
  intro h
  have hh := h F_irreducible (by rw [F_deg]) F_no_fixed_eighth
  simp [F_no_powerfree_values] at hh

/-- Refutation of the exact audited declaration type. -/
theorem refutes : ¬ (type_of% @Erdos978.erdos_978.variants.sub_two) := refutes_sub_two

#print axioms refutes

end Counterexamples.Group2.Erdos978
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«978»'` passes.
- The polynomial above fails the new hypothesis at `p = 2`, since `2 ^ 7` divides every value.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/978

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

