### PR TITLE
fix(ErdosProblems/516): strictly increasing exponents in the Kövari variant

### DIFF
--- a/FormalConjectures/ErdosProblems/516.lean
+++ b/FormalConjectures/ErdosProblems/516.lean
@@ -49,10 +49,12 @@ theorem erdos_516 {f : ℂ → ℂ} {n : ℕ → ℕ}
     limsup (fun r => ratio r f) atTop = 1 := by
   sorry
 
-/-- Let `f = ∑ aₖzⁿₖ` be an entire function such that `nₖ > k (log k) ^ (2 + c)`.
-Then `limsup (fun r => ratio r f) atTop = 1`. This is proved in [Ko65]. -/
+/-- Let `f = ∑ aₖzⁿₖ` be an entire function with strictly increasing exponents such that
+`nₖ > k (log k) ^ (2 + c)`. Then `limsup (fun r => ratio r f) atTop = 1`. This is proved in [Ko65].
+Without `StrictMono n`, repeated exponents let nonzero coefficients cancel, and `f = 0` satisfies
+the other hypotheses. -/
 @[category research solved, AMS 30]
-theorem erdos_516.variants.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → ℕ}
+theorem erdos_516.variants.limsup_ratio_eq_one {f : ℂ → ℂ} {n : ℕ → ℕ} (hmono : StrictMono n)
     (hn : ∃ c > (0 : ℝ), ∀ k, n k > k * log k ^ (2 + c)) {a : ℕ → ℂ} (ha : ∀ n, a n ≠ 0)
     (hfn : ∀ z, HasSum (fun k => a k * z ^ n k) (f z)) :
     limsup (fun r => ratio r f) atTop = 1 := by


### PR DESCRIPTION
**What changed**

- `erdos_516.variants.limsup_ratio_eq_one` now assumes `StrictMono n`. The docstring explains why.

**Why**

The growth hypothesis `n k > k * log k ^ (2 + c)` does not make the exponents distinct, so nonzero coefficients can cancel at repeated exponents. With `n k = (2 * (k / 2 + 1)) ^ 4` and `a k = (-1) ^ k / (n k)!`, the growth bound holds with `c = 1`, every coefficient is nonzero, and the series converges to `f = 0` everywhere. Then `ratio r f = 0` for every `r`, so the limsup is `0`, not `1`. The other two statements in the file exclude this through the `StrictMono` part of their gap predicates.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«516»
/-! Experiments for the independent review of problem 516. -/

open Filter Real Set
open scoped Nat Topology

namespace Counterexamples.Group2.Erdos516

def g (m : ℕ) : ℕ := (2 * (m + 1)) ^ 4
def n (k : ℕ) : ℕ := g (k / 2)
noncomputable def a (k : ℕ) : ℂ := (-1 : ℂ) ^ k / (n k)!

lemma g_strictMono : StrictMono g := by
  intro i j hij
  dsimp [g]
  gcongr

lemma growth : ∃ c > (0 : ℝ), ∀ k, (n k : ℝ) > k * log k ^ (2 + c) := by
  refine ⟨1, by norm_num, ?_⟩
  intro k
  have hlog : log (k : ℝ) ≤ k := Real.log_le_self (Nat.cast_nonneg k)
  have hlog0 : 0 ≤ log (k : ℝ) := by
    rcases k with _ | k
    · simp
    · exact Real.log_nonneg (by norm_cast; omega)
  have hk : (k : ℝ) < (2 * (k / 2 + 1) : ℕ) := by
    exact_mod_cast (show k < 2 * (k / 2 + 1) from by omega)
  calc
    (k : ℝ) * log (k : ℝ) ^ (2 + (1 : ℝ)) =
        (k : ℝ) * log (k : ℝ) ^ (3 : ℕ) := by norm_num
    _ ≤ (k : ℝ) * (k : ℝ) ^ (3 : ℕ) := by gcongr
    _ = (k : ℝ) ^ (4 : ℕ) := by ring
    _ < (n k : ℝ) := by
      dsimp [n, g]
      push_cast
      gcongr
      exact_mod_cast (show k < 2 * (k / 2 + 1) from by omega)

lemma coeff_nonzero (k : ℕ) : a k ≠ 0 := by
  exact div_ne_zero (pow_ne_zero _ (by norm_num)) (by exact_mod_cast Nat.factorial_ne_zero (n k))

lemma sum_zero (z : ℂ) : HasSum (fun k => a k * z ^ n k) 0 := by
  have hs : Summable (fun m => z ^ g m / (g m)!) :=
    (NormedSpace.expSeries_div_hasSum_exp z).summable.comp_injective g_strictMono.injective
  have he : HasSum (fun m => a (2 * m) * z ^ n (2 * m))
      (∑' m, z ^ g m / (g m)!) := by
    apply hs.hasSum.congr_fun
    intro m
    have hdiv : 2 * m / 2 = m := by omega
    have hsign : (-1 : ℂ) ^ (2 * m) = 1 := by rw [pow_mul]; norm_num
    change (-1 : ℂ) ^ (2 * m) / (g (2 * m / 2))! * z ^ g (2 * m / 2) = _
    rw [hdiv, hsign]
    simp [div_eq_mul_inv, mul_comm]
  have ho : HasSum (fun m => a (2 * m + 1) * z ^ n (2 * m + 1))
      (-(∑' m, z ^ g m / (g m)!)) := by
    apply hs.hasSum.neg.congr_fun
    intro m
    have hdiv : (2 * m + 1) / 2 = m := by omega
    have hsign : (-1 : ℂ) ^ (2 * m + 1) = -1 := by rw [pow_add, pow_mul]; norm_num
    change (-1 : ℂ) ^ (2 * m + 1) / (g ((2 * m + 1) / 2))! * z ^ g ((2 * m + 1) / 2) = _
    rw [hdiv, hsign]
    simp [div_eq_mul_inv, mul_comm]
  simpa using HasSum.even_add_odd (f := fun k => a k * z ^ n k) he ho

lemma zero_ratio (r : ℝ) : Erdos516.ratio r (fun _ => 0) = 0 := by
  simp [Erdos516.ratio]

lemma zero_ratio_limsup : limsup (fun r => Erdos516.ratio r (fun _ => 0)) atTop = 0 := by
  simp [zero_ratio]

lemma counterexample :
    ∃ (f : ℂ → ℂ) (n : ℕ → ℕ) (a : ℕ → ℂ),
      (∃ c > (0 : ℝ), ∀ k, (n k : ℝ) > k * log k ^ (2 + c)) ∧
      (∀ k, a k ≠ 0) ∧
      (∀ z, HasSum (fun k => a k * z ^ n k) (f z)) ∧
      limsup (fun r => Erdos516.ratio r f) atTop ≠ 1 := by
  refine ⟨fun _ => 0, n, a, growth, coeff_nonzero, sum_zero, ?_⟩
  rw [zero_ratio_limsup]
  norm_num

theorem refutes : ¬ (type_of% @Erdos516.erdos_516.variants.limsup_ratio_eq_one) := by
  intro h
  have bad := h growth coeff_nonzero sum_zero
  rw [zero_ratio_limsup] at bad
  norm_num at bad
#print axioms refutes
end Counterexamples.Group2.Erdos516
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«516»'` passes.
- The counterexample's exponent sequence is not strictly monotone (`n (2 j) = n (2 j + 1)`).

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/516 and https://tadamcz.com/fc-review-results/#/f/ForMathlib/Analysis/HasGaps

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
