### PR TITLE
fix(GreensOpenProblems/32): dirichlet_regime needs ⌊ω p⌋₊ > 100

### DIFF
--- a/FormalConjectures/GreensOpenProblems/32.lean
+++ b/FormalConjectures/GreensOpenProblems/32.lean
@@ -116,10 +116,14 @@ theorem green_32.variants.szemeredi_regime :
 /--
 In the regime $\omega(p) \le c \log p$, this is basically Dirichlet's lower bound for the size of
 Bohr sets [Gr24].
+
+The lower bound $101 \le \omega(p)$ makes the set size $\lfloor \omega(p) \rfloor$ exceed $100$.
+With only $100 < \omega(p)$, a function with $100 < \omega(p) < 101$ asks for sets of size $100$
+with a gap of length $p - 1$ in some dilate, which is impossible.
 -/
 @[category research solved, AMS 5 11]
 theorem green_32.variants.dirichlet_regime :
-    ∃ c > 0, ∀ ω : ℕ → ℝ, (∀ᶠ p in atTop, 100 < ω p ∧ ω p ≤ c * Real.log p) →
+    ∃ c > 0, ∀ ω : ℕ → ℝ, (∀ᶠ p in atTop, 101 ≤ ω p ∧ ω p ≤ c * Real.log p) →
       HasLargeGapDilate ω := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `green_32.variants.dirichlet_regime` assumes `101 ≤ ω p` instead of `100 < ω p`. The docstring explains the rounding issue.

**Why**

`ω` is real-valued, but the set size is `⌊ω p⌋₊` and the required gap is `⌊100 * p / ω p⌋₊`. For `ω p = 100 * p / (p - 1)` and every `c > 0`, eventually `100 < ω p < 101 ≤ c * log p`, so the old hypothesis held, while `⌊ω p⌋₊ = 100` and `⌊100 p / ω p⌋₊ = p - 1`. No dilate of a `100`-element subset of `ZMod p` has a gap of length `p - 1`, so `HasLargeGapDilate ω` fails and the existential statement was false. With `101 ≤ ω p` the size exceeds `100`, and the statement is the Dirichlet bound described in the source.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.GreensOpenProblems.«32»
/-! Independent counterexample tests for the Dirichlet variant of Green 32. -/

open Filter
open scoped Pointwise

namespace Counterexamples.Group2.Green32

theorem gap_card_bound {p L : ℕ} [NeZero p] (A : Finset (ZMod p)) (hL : L ≤ p)
    (hA : Green32.HasGap A L) : L + A.card ≤ p := by
  rcases hA with ⟨x, hx⟩
  let I : Finset (ZMod p) := (Finset.range L).image (fun i : ℕ => x + (i : ZMod p))
  have hinj : Set.InjOn (fun i : ℕ => x + (i : ZMod p)) (Finset.range L) := by
    intro i hi j hj hij
    have heq : (i : ZMod p) = (j : ZMod p) := add_left_cancel hij
    have hi' : i < p := lt_of_lt_of_le (Finset.mem_range.mp hi) hL
    have hj' : j < p := lt_of_lt_of_le (Finset.mem_range.mp hj) hL
    simpa only [ZMod.val_natCast_of_lt hi', ZMod.val_natCast_of_lt hj'] using
      congrArg ZMod.val heq
  have hI : I.card = L := by
    dsimp [I]
    rw [Finset.card_image_of_injOn hinj, Finset.card_range]
  have hsub : I ⊆ Finset.univ \ A := by
    intro y hy
    rcases Finset.mem_image.mp hy with ⟨i, hi, rfl⟩
    exact Finset.mem_sdiff.mpr ⟨Finset.mem_univ _, hx i (Finset.mem_range.mp hi)⟩
  have hcard := Finset.card_le_card hsub
  rw [hI, Finset.card_sdiff_of_subset (Finset.subset_univ A), Finset.card_univ,
    ZMod.card] at hcard
  have hAp : A.card ≤ p := by simpa only [ZMod.card] using Finset.card_le_univ A
  omega

noncomputable def near100 (p : ℕ) : ℝ := 100 * (p : ℝ) / ((p : ℝ) - 1)

theorem near100_bounds {p : ℕ} (hp : 102 ≤ p) :
    100 < near100 p ∧ near100 p < 101 := by
  have hpr : (102 : ℝ) ≤ p := by exact_mod_cast hp
  have hd : 0 < (p : ℝ) - 1 := by linarith
  constructor
  · exact (lt_div_iff₀ hd).2 (by linarith)
  · exact (div_lt_iff₀ hd).2 (by linarith)

theorem near100_floor {p : ℕ} (hp : 102 ≤ p) : ⌊near100 p⌋₊ = 100 := by
  have hb := near100_bounds hp
  apply (Nat.floor_eq_iff (by linarith : 0 ≤ near100 p)).2
  norm_num
  exact ⟨hb.1.le, hb.2⟩

theorem near100_length {p : ℕ} (hp : 102 ≤ p) :
    100 * (p : ℝ) / near100 p = (p : ℝ) - 1 := by
  have hpr : (102 : ℝ) ≤ p := by exact_mod_cast hp
  have hp0 : (p : ℝ) ≠ 0 := by linarith
  dsimp [near100]
  field_simp

theorem near100_length_floor {p : ℕ} (hp : 102 ≤ p) :
    ⌊100 * (p : ℝ) / near100 p⌋₊ = p - 1 := by
  rw [near100_length hp]
  simp

theorem near100_fails : ¬ Green32.HasLargeGapDilate near100 := by
  intro h
  rcases eventually_atTop.mp h with ⟨P, hP⟩
  obtain ⟨p, hp, pp⟩ := Nat.exists_infinite_primes (max P 102)
  have hp102 : 102 ≤ p := le_trans (le_max_right _ _) hp
  have hpP : P ≤ p := le_trans (le_max_left _ _) hp
  have : NeZero p := ⟨pp.ne_zero⟩
  obtain ⟨_, _, hAll⟩ := hP p hpP pp
  have h100 : 100 ≤ (Finset.univ : Finset (ZMod p)).card := by
    simp only [Finset.card_univ, ZMod.card]
    omega
  obtain ⟨A, _, hA⟩ := Finset.exists_subset_card_eq h100
  obtain ⟨c, hc⟩ := hAll A (by simpa only [near100_floor hp102] using hA)
  rw [near100_length_floor hp102] at hc
  have hbound := gap_card_bound (c • A) (Nat.sub_le p 1) hc
  rw [Finset.card_smul_finset, hA] at hbound
  omega

theorem near100_satisfies_dirichlet_hypothesis (c : ℝ) (hc : 0 < c) :
    ∀ᶠ p : ℕ in atTop, 100 < near100 p ∧ near100 p ≤ c * Real.log p := by
  have ht : Tendsto (fun p : ℕ => c * Real.log p) atTop atTop :=
    Tendsto.const_mul_atTop hc (Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop)
  have hlog : ∀ᶠ p : ℕ in atTop, (101 : ℝ) ≤ c * Real.log p :=
    ht.eventually (eventually_ge_atTop 101)
  filter_upwards [eventually_ge_atTop 102, hlog] with p hp hpl
  have hb := near100_bounds hp
  exact ⟨hb.1, hb.2.le.trans hpl⟩

theorem dirichlet_body_is_false :
    ¬ (∃ c > 0, ∀ ω : ℕ → ℝ, (∀ᶠ p in atTop, 100 < ω p ∧ ω p ≤ c * Real.log p) →
      Green32.HasLargeGapDilate ω) := by
  rintro ⟨c, hc, hAll⟩
  exact near100_fails (hAll near100 (near100_satisfies_dirichlet_hypothesis c hc))

theorem refutes : ¬ (type_of% @Green32.green_32.variants.dirichlet_regime) := dirichlet_body_is_false
#print axioms refutes
end Counterexamples.Group2.Green32
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.GreensOpenProblems.«32»'` passes.
- The function above has `ω p < 101` for `p ≥ 102`, so it no longer satisfies the hypothesis.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/GreensOpenProblems/32

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
