### PR TITLE
fix(ErdosProblems/363): exclude 0 from the intervals in IsValidCollection

### DIFF
--- a/FormalConjectures/ErdosProblems/363.lean
+++ b/FormalConjectures/ErdosProblems/363.lean
@@ -38,10 +38,13 @@ open Finset
 def IsInterval (I : Finset ℕ) : Prop :=
   ∃ a b : ℕ, I = Icc a b
 
-/-- A collection of intervals as in Erdős Problem 363. -/
+/-- A collection of intervals as in Erdős Problem 363: disjoint intervals of positive integers,
+each of size at least `4`, whose product is a square. Intervals containing `0` are excluded, since
+their product is `0`, which is a square. -/
 def IsValidCollection (S : List (Finset ℕ)) : Prop :=
   (∀ I ∈ S, IsInterval I) ∧
   (∀ I ∈ S, 4 ≤ I.card) ∧
+  (∀ I ∈ S, 0 ∉ I) ∧
   S.Pairwise Disjoint ∧
   IsSquare ((S.map (fun I => ∏ m ∈ I, m)).prod)
 


### PR DESCRIPTION
**What changed**

- `IsValidCollection` requires `0 ∉ I` for every interval `I`. The docstring describes the collections.

**Why**

Without this condition `[Icc 0 (n + 3)]` is a valid collection for every `n`: it is a single interval of size `n + 4` whose product is `0`, a square. These collections form an infinite family, so `erdos_363` (`answer(False) ↔ {S | IsValidCollection S}.Finite`) was provable without Ulas's construction. The Lean proof below establishes the full statement from these degenerate collections.

Reviewer note: the `formal_proof` link points to an external proof with its own definitions; it should be checked against the corrected `IsValidCollection`.

<details>
<summary>Lean proof of the statement as written (compiled with <code>lake --wfail build</code>, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«363»

/-!
# A zero-product proof of the full Erdős 363 assertion

The lists consisting of [0,n+3] give an injective infinite family of valid collections.
-/

namespace Counterexamples.Group2.Erdos363

open Finset _root_.Erdos363

theorem zero_interval_valid (n : ℕ) : IsValidCollection [Icc 0 (n + 3)] := by
  have hz : (∏ m ∈ Icc 0 (n + 3), m) = 0 :=
    Finset.prod_eq_zero (by simp) rfl
  simp only [IsValidCollection, List.mem_singleton, forall_eq, List.pairwise_singleton,
    List.map_singleton, List.prod_singleton, hz]
  exact ⟨⟨0, n + 3, rfl⟩, by simp [Nat.card_Icc], trivial, ⟨0, rfl⟩⟩

theorem zero_intervals_injective :
    Function.Injective (fun n : ℕ => [Icc 0 (n + 3)]) := by
  intro a b h
  have hi : Icc 0 (a + 3) = Icc 0 (b + 3) := by simpa using h
  have hc := congrArg Finset.card hi
  simp only [Nat.card_Icc, Nat.sub_zero] at hc
  omega

theorem collections_infinite_due_to_zero :
    {S : List (Finset ℕ) | IsValidCollection S}.Infinite := by
  apply (Set.infinite_range_of_injective zero_intervals_injective).mono
  rintro S ⟨n, rfl⟩
  exact zero_interval_valid n

/-- The complete negative-answer theorem follows from the invalid zero-product family. -/
theorem proves_as_written : type_of% @Erdos363.erdos_363 := by
  simp only [false_iff]
  exact collections_infinite_due_to_zero

#print axioms proves_as_written

end Counterexamples.Group2.Erdos363
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«363»'` passes.
- The degenerate collections contain `0`, so they are no longer valid.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/363

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
