### PR TITLE
fix(ErdosProblems/520): require measurable prime values in IsRademacherMultiplicative

### DIFF
--- a/FormalConjectures/ErdosProblems/520.lean
+++ b/FormalConjectures/ErdosProblems/520.lean
@@ -30,11 +30,14 @@ variable {Ω : Type*} [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)
 
 /--
 A random function $f$ is Rademacher multiplicative if $f(1) = 1$,
-for each prime $p$, we independently choose $f(p) \in \{-1, 1\}$ uniformly at random,
+for each prime $p$, we independently choose $f(p) \in \{-1, 1\}$ uniformly at random (so each
+$f(p)$ is a measurable function of the sample point),
 for each square-free integer $n = p_1 \cdots p_r$, $f(n) = f(p_1) \cdots f(p_r)$, and
 for each non-squarefree integer $n$, $f(n) = 0$.
 -/
 structure IsRademacherMultiplicative (f : ℕ → Ω → ℝ) : Prop where
+  /-- Prime entries are random variables. -/
+  measurable_of_prime p : p.Prime → Measurable (f p)
   /-- Prime entries are independent. -/
   iIndepFun_primes : iIndepFun (fun p : Primes ↦ f p) ℙ
   /-- Primes entries are uniformly distributed on `{-1, 1}`. -/


### PR DESCRIPTION
**What changed**

- `IsRademacherMultiplicative` gains the field `measurable_of_prime p : p.Prime → Measurable (f p)`. The docstring mentions it.

**Why**

`iIndepFun` does not impose measurability, and the two equalities in `prob_of_prime` can be outer measures of nonmeasurable sets. So the structure admitted processes outside the random-variable model of the source. The construction below adds Boolean masks invisible to the σ-algebra to a genuine fair-coin sequence, sets each prime value to its coin sign or `0` according to its mask, and extends multiplicatively. Every field holds, yet `f 2 = 0` on a set of full outer measure, and on that set `f n = 1` only at `n = 1`, so the normalised limsup is `0`. This refutes the right-hand side of `erdos_520` for every `c > 0`. With measurability, `prob_of_prime` forces `f p ∈ {-1, 1}` almost surely.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«520»
/-! The missing measurability issue persists for whole independent families. -/

open MeasureTheory ProbabilityTheory Set
open scoped ENNReal Topology

namespace Counterexamples.Group2.Erdos520

structure Ghost (B I : Type) where
  base : B
  mask : I → Bool

variable {B I : Type} [MeasurableSpace B]

instance : MeasurableSpace (Ghost B I) := MeasurableSpace.comap Ghost.base inferInstance

def embed (x : B) : Ghost B I := ⟨x, fun _ ↦ true⟩

lemma measurable_embed : Measurable (embed (B := B) (I := I)) := by
  intro s hs
  obtain ⟨t, ht, rfl⟩ := hs
  exact ht

noncomputable def gm (μ : Measure B) : Measure (Ghost B I) := μ.map embed

instance (μ : Measure B) [IsProbabilityMeasure μ] : IsProbabilityMeasure (gm (I := I) μ) := by
  unfold gm
  exact Measure.isProbabilityMeasure_map measurable_embed.aemeasurable

lemma gm_preimage (μ : Measure B) (t : Set B) (ht : MeasurableSet t) :
    gm (I := I) μ (Ghost.base ⁻¹' t) = μ t := by
  rw [gm, Measure.map_apply measurable_embed ⟨t, ht, rfl⟩]
  rfl

lemma gm_eq_projected (μ : Measure B) (s : Set (Ghost B I))
    (hs : MeasurableSet (Ghost.base '' s)) :
    gm μ s = μ (Ghost.base '' s) := by
  apply le_antisymm
  · calc
      _ ≤ gm μ (Ghost.base ⁻¹' (Ghost.base '' s)) := measure_mono (subset_preimage_image _ _)
      _ = _ := gm_preimage μ _ hs
  · rw [measure_eq_iInf s]
    refine le_iInf fun t ↦ le_iInf fun hst ↦ le_iInf fun ht ↦ ?_
    obtain ⟨v, hv, rfl⟩ := ht
    rw [gm_preimage μ v hv]
    apply measure_mono
    rintro _ ⟨w, hw, rfl⟩
    exact hst hw

variable (X : I → B → ℝ)

def masked (i : I) (w : Ghost B I) : ℝ := if w.mask i then X i w.base else 0

noncomputable def expanded (s : Set ℝ) : Set ℝ := by
  classical
  exact if 0 ∈ s then univ else s

lemma expanded_measurable (s : Set ℝ) (hs : MeasurableSet s) : MeasurableSet (expanded s) := by
  classical
  unfold expanded
  split_ifs
  · exact MeasurableSet.univ
  · exact hs

omit [MeasurableSpace B] in
lemma project_masked_preimage (i : I) (s : Set ℝ) :
    Ghost.base '' (masked X i ⁻¹' s) = X i ⁻¹' expanded s := by
  classical
  ext x
  constructor
  · rintro ⟨w, hw, rfl⟩
    simp only [mem_preimage, masked] at hw
    by_cases hz : 0 ∈ s
    · simp [expanded, hz]
    · cases hm : w.mask i <;> simp_all [expanded]
  · intro hx
    by_cases hz : 0 ∈ s
    · exact ⟨⟨x, fun _ ↦ false⟩, by simpa [masked] using hz, rfl⟩
    · exact ⟨embed x, by simpa [masked, embed, expanded, hz] using hx, rfl⟩

omit [MeasurableSpace B] in
lemma project_masked_inter (S : Finset I) (s : I → Set ℝ) :
    Ghost.base '' (⋂ i ∈ S, masked X i ⁻¹' s i) = ⋂ i ∈ S, X i ⁻¹' expanded (s i) := by
  classical
  ext x
  constructor
  · rintro ⟨w, hw, rfl⟩
    simp only [mem_iInter] at *
    intro i hi
    rw [← project_masked_preimage]
    exact ⟨w, hw i hi, rfl⟩
  · intro hx
    refine ⟨⟨x, fun i ↦ if 0 ∈ s i then false else true⟩, ?_, rfl⟩
    simp only [mem_iInter, mem_preimage] at *
    intro i hi
    have hx' := hx i hi
    by_cases hz : 0 ∈ s i <;> simp_all [masked, expanded]

lemma gm_masked_preimage (μ : Measure B) (hX : ∀ i, Measurable (X i)) (i : I)
    (s : Set ℝ) (hs : MeasurableSet s) :
    gm μ (masked X i ⁻¹' s) = μ (X i ⁻¹' expanded s) := by
  rw [gm_eq_projected, project_masked_preimage]
  rw [project_masked_preimage]
  exact hX i (expanded_measurable s hs)

lemma masked_independent (μ : Measure B) (hX : ∀ i, Measurable (X i))
    (hind : iIndepFun X μ) : iIndepFun (masked X) (gm μ) := by
  classical
  apply iIndepFun_iff_measure_inter_preimage_eq_mul.mpr
  intro S sets hsets
  calc
    _ = μ (⋂ i ∈ S, X i ⁻¹' expanded (sets i)) := by
      rw [gm_eq_projected, project_masked_inter]
      rw [project_masked_inter]
      exact MeasurableSet.biInter (s := (S : Set I)) S.countable_toSet
        (fun i hi ↦ hX i (expanded_measurable _ (hsets i hi)))
    _ = ∏ i ∈ S, μ (X i ⁻¹' expanded (sets i)) :=
      hind.measure_inter_preimage_eq_mul S (fun i hi ↦ expanded_measurable _ (hsets i hi))
    _ = ∏ i ∈ S, gm μ (masked X i ⁻¹' sets i) := by
      apply Finset.prod_congr rfl
      intro i hi
      exact (gm_masked_preimage X μ hX i _ (hsets i hi)).symm

lemma masked_zero_mass (μ : Measure B) [IsProbabilityMeasure μ]
    (hX : ∀ i, Measurable (X i)) (i : I) :
    gm μ {w | masked X i w = 0} = 1 := by
  change gm μ (masked X i ⁻¹' {0}) = 1
  rw [gm_masked_preimage X μ hX i _ (MeasurableSet.singleton _)]
  simp [expanded]

lemma masked_sign_mass (μ : Measure B) (hX : ∀ i, Measurable (X i))
    (i : I) (v : ℝ) (hv : v ≠ 0) :
    gm μ {w | masked X i w = v} = μ {x | X i x = v} := by
  change gm μ (masked X i ⁻¹' {v}) = μ (X i ⁻¹' {v})
  rw [gm_masked_preimage X μ hX i _ (MeasurableSet.singleton _)]
  simp [expanded, Ne.symm hv]

lemma zero_slice_mass (μ : Measure B) [IsProbabilityMeasure μ] :
    gm (I := I) μ {w | w.mask = fun _ ↦ false} = 1 := by
  have hp : Ghost.base '' {w : Ghost B I | w.mask = fun _ ↦ false} = univ := by
    ext x
    simp only [mem_image, mem_univ, iff_true]
    exact ⟨⟨x, fun _ ↦ false⟩, rfl, rfl⟩
  rw [gm_eq_projected, hp, measure_univ]
  rw [hp]
  exact MeasurableSet.univ

-- A concrete countable independent family of fair signs.
noncomputable def coin : Measure Bool :=
  (1 / 2 : ℝ≥0∞) • Measure.dirac false + (1 / 2 : ℝ≥0∞) • Measure.dirac true

instance : IsProbabilityMeasure coin := by
  constructor
  simp [coin, ENNReal.inv_two_add_inv_two]

noncomputable def bm : Measure (ℕ → Bool) := Measure.infinitePi (fun _ : ℕ ↦ coin)

instance : IsProbabilityMeasure bm := by
  unfold bm
  infer_instance

def sign (n : ℕ) (x : ℕ → Bool) : ℝ := if x n then 1 else -1

lemma sign_measurable (n : ℕ) : Measurable (sign n) :=
  (measurable_of_finite (fun b : Bool ↦ if b then (1 : ℝ) else -1)).comp (measurable_pi_apply n)

lemma sign_independent : iIndepFun sign bm := by
  exact iIndepFun_infinitePi (X := fun (_ : ℕ) (b : Bool) ↦ if b then (1 : ℝ) else -1)
    (fun _ ↦ measurable_of_finite _)

lemma sign_positive_mass (n : ℕ) : bm {x | sign n x = 1} = 1 / 2 := by
  have heq : {x | sign n x = 1} = (fun x : ℕ → Bool ↦ x n) ⁻¹' {true} := by
    ext x
    cases h : x n <;> norm_num [sign, h]
  rw [heq, bm, ← Measure.map_apply (measurable_pi_apply n) (MeasurableSet.singleton true),
    Measure.infinitePi_map_eval]
  simp [coin]

lemma sign_negative_mass (n : ℕ) : bm {x | sign n x = -1} = 1 / 2 := by
  have heq : {x | sign n x = -1} = (fun x : ℕ → Bool ↦ x n) ⁻¹' {false} := by
    ext x
    cases h : x n <;> norm_num [sign, h]
  rw [heq, bm, ← Measure.map_apply (measurable_pi_apply n) (MeasurableSet.singleton false),
    Measure.infinitePi_map_eval]
  simp [coin]

abbrev CoinGhost := Ghost (ℕ → Bool) ℕ

noncomputable instance : MeasureSpace CoinGhost where
  toMeasurableSpace := inferInstance
  volume := gm bm

instance : IsProbabilityMeasure (ℙ : Measure CoinGhost) := by
  change IsProbabilityMeasure (gm bm)
  infer_instance

noncomputable def fake (n : ℕ) (w : CoinGhost) : ℝ :=
  if Squarefree n then ∏ p ∈ n.primeFactors, masked sign p w else 0

lemma fake_prime (p : ℕ) (hp : p.Prime) (w : CoinGhost) : fake p w = masked sign p w := by
  simp [fake, hp.squarefree, hp.primeFactors]

lemma fake_is_rademacher : Erdos520.IsRademacherMultiplicative fake := by
  constructor
  · have heq : (fun p : Nat.Primes ↦ fake p) = (fun p : Nat.Primes ↦ masked sign p) := by
      funext p w
      exact fake_prime p p.property w
    rw [heq]
    exact iIndepFun.precomp Subtype.val_injective (masked_independent sign bm sign_measurable sign_independent)
  · intro p hp
    simp only [fake_prime p hp]
    constructor
    · change gm bm {w | masked sign p w = 1} = 1 / 2
      rw [masked_sign_mass sign bm sign_measurable p 1 one_ne_zero, sign_positive_mass]
    · change gm bm {w | masked sign p w = -1} = 1 / 2
      rw [masked_sign_mass sign bm sign_measurable p (-1) (by norm_num), sign_negative_mass]
  · intro w
    simp [fake]
  · intro a b w hab
    by_cases ha : Squarefree a <;> by_cases hb : Squarefree b <;>
      simp [fake, Nat.squarefree_mul hab, ha, hb, hab.primeFactors_mul,
        Finset.prod_union hab.disjoint_primeFactors]
  · intro n w hn
    simp [fake, hn]

lemma fake_zero_prime_outer_mass : ℙ {w | fake 2 w = 0} = 1 := by
  simp only [fake_prime 2 Nat.prime_two]
  exact masked_zero_mass sign bm sign_measurable 2

lemma fake_not_ae_sign : ¬ (∀ᵐ w, fake 2 w = 1 ∨ fake 2 w = -1) := by
  intro h
  have hz : ℙ {w | fake 2 w = 0} = 0 := by
    apply measure_mono_null (t := {w | ¬ (fake 2 w = 1 ∨ fake 2 w = -1)}) _ h
    intro w hw
    simp only [mem_ofPred_eq] at *
    simp [hw]
  rw [fake_zero_prime_outer_mass] at hz
  exact one_ne_zero hz

open Filter Real

lemma fake_on_zero_mask {w : CoinGhost} (hw : w.mask = fun _ ↦ false) (n : ℕ) :
    fake n w = if n = 1 then 1 else 0 := by
  by_cases hn : n = 1
  · simp [hn, fake]
  · by_cases hs : Squarefree n
    · have hnon : n.primeFactors.Nonempty := Nat.nonempty_primeFactors.mpr (by
        have hne := hs.ne_zero
        omega)
      simp only [fake, if_pos hs, if_neg hn]
      obtain ⟨p, hp⟩ := hnon
      exact Finset.prod_eq_zero hp (by simp [masked, hw])
    · simp [fake, hn, hs]

lemma fake_limsup_zero_on_slice {w : CoinGhost} (hw : w.mask = fun _ ↦ false) :
    limsup (fun N ↦ ∑ m ≤ N, fake m w / sqrt (N * log (log N))) atTop = 0 := by
  have hn : Tendsto (fun n : ℕ ↦ (n : ℝ)) atTop atTop := tendsto_natCast_atTop_atTop
  have hd : Tendsto (fun n : ℕ ↦ sqrt ((n : ℝ) * log (log (n : ℝ)))) atTop atTop :=
    tendsto_sqrt_atTop.comp (hn.atTop_mul_atTop₀ (tendsto_log_atTop.comp (tendsto_log_atTop.comp hn)))
  have hr : Tendsto (fun n : ℕ ↦ (1 : ℝ) / sqrt ((n : ℝ) * log (log (n : ℝ)))) atTop (𝓝 0) :=
    tendsto_const_nhds.div_atTop hd
  have heq : (fun N ↦ ∑ m ≤ N, fake m w / sqrt (N * log (log N))) =ᶠ[atTop]
      (fun N : ℕ ↦ (1 : ℝ) / sqrt (N * log (log N))) := by
    filter_upwards [eventually_ge_atTop 1] with N hN
    rw [← Finset.sum_div]
    simp [fake_on_zero_mask hw, hN]
  exact ((tendsto_congr' heq).mpr hr).limsup_eq

lemma fake_no_positive_limsup (c : ℝ) (hc : 0 < c) :
    ¬ (∀ᵐ w, limsup (fun N ↦ ∑ m ≤ N, fake m w / sqrt (N * log (log N))) atTop = c) := by
  intro h
  have hz : ℙ {w : CoinGhost | w.mask = fun _ ↦ false} = 0 := by
    apply measure_mono_null (t := {w | ¬ (limsup
      (fun N ↦ ∑ m ≤ N, fake m w / sqrt (N * log (log N))) atTop = c)}) _ h
    intro w hw heq
    have hzero := fake_limsup_zero_on_slice hw
    have heq' : (0 : ℝ) = c := hzero.symm.trans heq
    exact (ne_of_gt hc) heq'.symm
  have hone : ℙ {w : CoinGhost | w.mask = fun _ ↦ false} = 1 := zero_slice_mass bm
  rw [hone] at hz
  exact one_ne_zero hz

lemma original_rhs_false :
    ¬ (∃ c > 0, ∀ (Ω : Type) [MeasureSpace Ω] [IsProbabilityMeasure (ℙ : Measure Ω)]
      (f : ℕ → Ω → ℝ), Erdos520.IsRademacherMultiplicative f →
      ∀ᵐ ω, limsup (fun N ↦ ∑ m ≤ N, f m ω / sqrt (N * log (log N))) atTop = c) := by
  rintro ⟨c, hc, h⟩
  exact fake_no_positive_limsup c hc (h CoinGhost fake fake_is_rademacher)

end Counterexamples.Group2.Erdos520
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«520»'` passes.
- The masked process is not measurable, so it no longer satisfies the structure.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/520

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
