### PR TITLE
fix(ErdosProblems/1167): add the target condition κ_α > r

### DIFF
--- a/FormalConjectures/ErdosProblems/1167.lean
+++ b/FormalConjectures/ErdosProblems/1167.lean
@@ -25,6 +25,9 @@ The original Erdős–Hajnal problem list gives the additional conditions $\gamm
 and $\kappa_\alpha > r$. Without $\gamma \geq 2$, the statement is false: taking $\gamma = 1$ and
 $\kappa_0 = \aleph_1$ with $\lambda = \aleph_0$ gives a counterexample, since the partition relation
 with one color degenerates to a cardinality comparison (see `erdos_1167.unrestricted_is_false`).
+Without $\kappa_\alpha > r$ it is also false: with $r = 2$, $\lambda = \aleph_0$ and targets
+$(2, \aleph_1)$, the premise $2^{\aleph_0} \to (3, \aleph_1)^3$ holds, but a constant colouring
+of the pairs of $\aleph_0$ has neither a red pair nor a blue set of size $\aleph_1$.
 -/
 
 open Cardinal Ordinal Combinatorics
@@ -35,7 +38,7 @@ universe u
 
 /--
 **Erdős Problem 1167.** Let $r \geq 2$ be finite, $\gamma \geq 2$, and $\lambda$ be an infinite
-cardinal. Let $\kappa_\alpha$ be cardinals for all $\alpha < \gamma$. Is it true
+cardinal. Let $\kappa_\alpha > r$ be cardinals for all $\alpha < \gamma$. Is it true
 that
 $$2^\lambda \to (\kappa_\alpha + 1)_{\alpha < \gamma}^{r+1}$$
 implies
@@ -50,7 +53,7 @@ theorem erdos_1167 : answer(sorry) ↔
     ∀ (r : ℕ), 2 ≤ r →
     ∀ (lam : Cardinal.{u}), ℵ₀ ≤ lam →
     ∀ (γ : Ordinal.{u}), 2 ≤ γ →
-    ∀ (κ : γ.ToType → Cardinal.{u}),
+    ∀ (κ : γ.ToType → Cardinal.{u}), (∀ α, (r : Cardinal.{u}) < κ α) →
       cardinalPartitionRel ((2 : Cardinal.{u}) ^ lam) (r + 1) γ (fun α => κ α + 1) →
       cardinalPartitionRel lam r γ κ := by
   sorry
@@ -74,7 +77,7 @@ theorem finite_targets (r : ℕ) (hr : 2 ≤ r) (lam : Cardinal.{u}) (hlam : ℵ
 -/
 @[category research open, AMS 5]
 theorem binary_colors (r : ℕ) (hr : 2 ≤ r) (lam : Cardinal.{u}) (hlam : ℵ₀ ≤ lam)
-    (κ : (2 : Ordinal.{u}).ToType → Cardinal.{u}) :
+    (κ : (2 : Ordinal.{u}).ToType → Cardinal.{u}) (hκ : ∀ α, (r : Cardinal.{u}) < κ α) :
     cardinalPartitionRel ((2 : Cardinal.{u}) ^ lam) (r + 1) 2 (fun α => κ α + 1) →
     cardinalPartitionRel lam r 2 κ := by
   sorry
@@ -105,7 +108,8 @@ Erdős–Rado stepping-up/down theorem for pairs.
 -/
 @[category research open, AMS 5]
 theorem r_eq_two (lam : Cardinal.{u}) (hlam : ℵ₀ ≤ lam)
-    (γ : Ordinal.{u}) (hγ : 2 ≤ γ) (κ : γ.ToType → Cardinal.{u}) :
+    (γ : Ordinal.{u}) (hγ : 2 ≤ γ) (κ : γ.ToType → Cardinal.{u})
+    (hκ : ∀ α, (2 : Cardinal.{u}) < κ α) :
     cardinalPartitionRel ((2 : Cardinal.{u}) ^ lam) 3 γ (fun α => κ α + 1) →
     cardinalPartitionRel lam 2 γ κ := by
   sorry


### PR DESCRIPTION
**Related.** This is the "Erdős 1167 — omitted `κ α > r` condition" item in the tracking issue #4896.

**What changed**

- `erdos_1167`, `erdos_1167.variants.binary_colors` and `erdos_1167.variants.r_eq_two` assume `κ α > r` for every colour `α` (`2 < κ α` in the `r = 2` case). The docstrings record the condition, which the module docstring already attributes to the original Erdős–Hajnal list.

**Why**

Without it a target may equal `r`, and `2 ≤ γ` no longer gives two nondegenerate colours. With `r = 2`, `λ = ℵ₀`, `γ = 2` and targets `(2, ℵ₁)`, the premise `2 ^ ℵ₀ → (3, ℵ₁)^3` holds (either some triple is red, or all triples are blue and any `ℵ₁`-sized set is blue-homogeneous), but the conclusion `ℵ₀ → (2, ℵ₁)^2` fails for the constant-blue colouring of pairs. The Lean file below refutes the question side of `erdos_1167` and the two variants. `finite_targets` and `infinite_targets` are unaffected: targets `≤ r` make their conclusions trivial, and infinite targets exceed `r`.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«1167»

/-!
Unequal cardinal targets separate the triple-partition premise at the continuum from the pair-partition conclusion on a countable set. The complete original question and both specializations are refuted with all their hypotheses retained.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/ErdosProblems/1167.lean
-/
namespace Counterexamples.Group1.Erdos1167
/- Independent boundary checks for Erdős 1167. -/
open Cardinal Ordinal Combinatorics
noncomputable def colorsEquiv : (2 : Ordinal).ToType ≃ Bool :=
  Classical.choice (Cardinal.eq.mp (by simp))
noncomputable def red : (2 : Ordinal).ToType := colorsEquiv.symm false
noncomputable def blue : (2 : Ordinal).ToType := colorsEquiv.symm true
@[simp] lemma colors_red : colorsEquiv red = false := by simp [red]
@[simp] lemma colors_blue : colorsEquiv blue = true := by simp [blue]
lemma red_ne_blue : red ≠ blue := by
  intro h
  have := congrArg colorsEquiv h
  simp at this
lemma colors_cases (i : (2 : Ordinal).ToType) : i = red ∨ i = blue := by
  cases h : colorsEquiv i with
  | false => exact Or.inl (colorsEquiv.injective (by simpa using h))
  | true => exact Or.inr (colorsEquiv.injective (by simpa using h))
noncomputable def badTargets (i : (2 : Ordinal).ToType) : Cardinal.{0} :=
  if colorsEquiv i = false then 2 else ℵ₁
@[simp] lemma target_red : badTargets red = 2 := by simp [badTargets]
@[simp] lemma target_blue : badTargets blue = ℵ₁ := by simp [badTargets]

-- Every coloring of triples on the continuum has either a red triple,
-- or an aleph-one-sized blue homogeneous set (because all triples are blue).
theorem counterexample_premise :
    cardinalPartitionRel ((2 : Cardinal) ^ ℵ₀) 3 2 (fun i => badTargets i + 1) := by
  classical
  intro A hA col
  by_cases h : ∃ s, col s = red
  · obtain ⟨⟨s, hs⟩, hc⟩ := h
    refine ⟨red, (s : Set A), ?_, ?_⟩
    · norm_num [hs]
    · intro t ht hts
      have hts' : t ⊆ s := hts
      have heq : t = s := Finset.eq_of_subset_of_card_le hts' (by omega)
      subst t
      exact hc
  · obtain ⟨H, hH⟩ := Cardinal.le_mk_iff_exists_set.mp
      (show (ℵ₁ : Cardinal) ≤ #A by rw [hA]; exact aleph_one_le_continuum)
    refine ⟨blue, H, ?_, ?_⟩
    · simpa only [target_blue, add_one_of_aleph0_le (aleph0_le_aleph 1)] using hH
    · intro s hs _
      rcases colors_cases (col ⟨s, hs⟩) with hr | hb
      · exact False.elim (h ⟨⟨s, hs⟩, hr⟩)
      · exact hb

-- A constant-blue coloring of pairs on a countable set cannot give either target.
theorem counterexample_conclusion :
    ¬ cardinalPartitionRel (ℵ₀ : Cardinal) 2 2 badTargets := by
  classical
  intro h
  obtain ⟨i, H, hH, hhom⟩ := h ℕ Cardinal.mk_nat (fun _ => blue)
  rcases colors_cases i with rfl | rfl
  · rw [target_red] at hH
    obtain ⟨s, hs, hscard⟩ := Cardinal.mk_set_eq_nat_iff_finset.mp hH
    have heq : blue = red := hhom s hscard (by rw [hs])
    exact red_ne_blue heq.symm
  · rw [target_blue] at hH
    have hle := Cardinal.mk_set_le H
    rw [hH, Cardinal.mk_nat] at hle
    exact aleph0_lt_aleph_one.not_ge hle

theorem main_rhs_is_false :
    ¬ (∀ (r : ℕ), 2 ≤ r → ∀ (lam : Cardinal.{0}), ℵ₀ ≤ lam →
       ∀ (γ : Ordinal.{0}), 2 ≤ γ → ∀ κ : γ.ToType → Cardinal,
       cardinalPartitionRel ((2 : Cardinal) ^ lam) (r + 1) γ (fun i => κ i + 1) →
       cardinalPartitionRel lam r γ κ) := by
  intro h
  exact counterexample_conclusion
    (h 2 le_rfl ℵ₀ le_rfl 2 le_rfl badTargets counterexample_premise)

-- Both stated specializations have exactly the same failing instance.
theorem binary_rhs_is_false :
    ¬ (∀ (r : ℕ), 2 ≤ r → ∀ (lam : Cardinal.{0}), ℵ₀ ≤ lam →
       ∀ κ : (2 : Ordinal.{0}).ToType → Cardinal.{0},
       cardinalPartitionRel ((2 : Cardinal.{0}) ^ lam) (r + 1) 2 (fun i => κ i + 1) →
       cardinalPartitionRel lam r 2 κ) := by
  intro h
  exact counterexample_conclusion
    (h 2 le_rfl ℵ₀ le_rfl badTargets counterexample_premise)

theorem r_two_rhs_is_false :
    ¬ (∀ (lam : Cardinal.{0}), ℵ₀ ≤ lam → ∀ (γ : Ordinal.{0}), 2 ≤ γ →
       ∀ κ : γ.ToType → Cardinal.{0},
       cardinalPartitionRel ((2 : Cardinal.{0}) ^ lam) 3 γ (fun i => κ i + 1) →
       cardinalPartitionRel lam 2 γ κ) := by
  intro h
  exact counterexample_conclusion
    (h ℵ₀ le_rfl 2 le_rfl badTargets counterexample_premise)

/-- Refutes the complete original binary statement. -/
theorem refutes_original_binary :
    ¬ (type_of% @Erdos1167.erdos_1167.variants.binary_colors.{0}) := binary_rhs_is_false

/-- Refutes the complete original r=2 statement. -/
theorem refutes_original_r_two :
    ¬ (type_of% @Erdos1167.erdos_1167.variants.r_eq_two.{0}) := r_two_rhs_is_false

#print axioms main_rhs_is_false
#print axioms refutes_original_binary
#print axioms refutes_original_r_two

end Counterexamples.Group1.Erdos1167
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«1167»'` passes.
- The counterexample uses the target `2 = r`, which the new hypothesis excludes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/1167 (findings 1 to 3)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

