### PR TITLE
fix(ErdosProblems/707): exclude modulus 0 in the Mian–Chowla and Hall counterexamples

### DIFF
--- a/FormalConjectures/ErdosProblems/707.lean
+++ b/FormalConjectures/ErdosProblems/707.lean
@@ -94,12 +94,14 @@ theorem erdos_707.variants.counterexample_prime (A : Set ℕ) (hA : A = {1, 2, 4
 
 /--
 Alexeev and Mixon [arxiv/2510.19804] have disproved this conjecture,
-showing that $\{1, 2, 4, 8, 13\}$ cannot be extended to any perfect difference set.
+showing that $\{1, 2, 4, 8, 13\}$ cannot be extended to any perfect difference set modulo a
+positive integer. The modulus `0` is excluded, as in `erdos_707`: `IsPerfectDifferenceSet B 0`
+describes an infinite perfect difference set in `ℤ`, and every finite Sidon set extends to one.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_707.variants.counterexample_mian_chowla (A : Set ℕ) (hA : A = {1, 2, 4, 8, 13}) :
    Finite A ∧ IsSidon A ∧
-   ∀ (B : Set ℕ) (n : ℕ), A ⊆ B → ¬IsPerfectDifferenceSet B n := by
+   ∀ (B : Set ℕ) (n : ℕ), 0 < n → A ⊆ B → ¬IsPerfectDifferenceSet B n := by
   sorry
 
 /--
@@ -112,7 +114,7 @@ as pointed out in [arxiv/2510.19804].
 @[category research solved, AMS 5 11]
 theorem erdos_707.variants.counterexample_hall (A : Set ℕ) (hA : A = {1, 3, 9, 10, 13}) :
    Finite A ∧ IsSidon A ∧
-   ∀ (B : Set ℕ) (n : ℕ), A ⊆ B → ¬IsPerfectDifferenceSet B n := by
+   ∀ (B : Set ℕ) (n : ℕ), 0 < n → A ⊆ B → ¬IsPerfectDifferenceSet B n := by
   sorry
 
 


### PR DESCRIPTION
**Related.** #1137 reported the modulus-`0` gap for the main statement, and #1138 added `0 < n` to `erdos_707`. The two counterexample variants were introduced in the same PR without the restriction.

**What changed**

- The final clauses of `erdos_707.variants.counterexample_mian_chowla` and `erdos_707.variants.counterexample_hall` quantify over positive moduli, `∀ (B : Set ℕ) (n : ℕ), 0 < n → A ⊆ B → ¬IsPerfectDifferenceSet B n`, as `erdos_707` already does. The docstring explains the exclusion.

**Why**

`ZMod 0` is `ℤ`, so `IsPerfectDifferenceSet B 0` says that the ordered differences of distinct elements of `B` hit every nonzero integer exactly once, and `B` need not be finite. Every finite Sidon set extends to such an infinite set by a greedy construction, so both clauses were false at `n = 0`. The Lean file below builds these extensions for `{1, 2, 4, 8, 13}` and `{1, 3, 9, 10, 13}` and refutes both statements.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«707»

/-!
Every finite Sidon set extends to an infinite perfect difference set modulo zero. The explicit Mian–Chowla and Hall starting sets therefore refute the unrestricted no-extension conclusions.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/ErdosProblems/707.lean
-/

namespace Counterexamples.Group1.Erdos707
open Set
lemma sidon_iff_diff_inj (B : Set ℕ) : IsSidon B ↔
    B.offDiag.InjOn (fun (a, b) => ((a : ℤ) - (b : ℤ))) := by
  constructor
  · intro h
    rintro ⟨a,b⟩ ⟨ha,hb,hab⟩ ⟨c,d⟩ ⟨hc,hd,hcd⟩ heq
    have hsum : a + d = c + b := by dsimp at heq; omega
    rcases h a ha c hc d hd b hb hsum with ⟨hac,hdb⟩ | ⟨hab',hdc⟩
    · exact Prod.ext hac hdb.symm
    · exact (hab hab').elim
  · intro h a ha b hb c hc d hd hsum
    by_cases hab : a = b
    · exact Or.inl ⟨hab, by omega⟩
    · have hdc : d ≠ c := by omega
      have heq : (a, b) = (d, c) := h ⟨ha,hb,hab⟩ ⟨hd,hc,hdc⟩ (by dsimp; omega)
      exact Or.inr ⟨(Prod.mk.inj heq).1, (Prod.mk.inj heq).2.symm⟩

lemma pds_zero_iff (B : Set ℕ) : IsPerfectDifferenceSet B 0 ↔
    IsSidon B ∧ ∀ d : ℕ, 0 < d → ∃ a ∈ B, ∃ b ∈ B, a + d = b := by
  change B.offDiag.BijOn (fun (a,b) => ((a : ℤ) - (b : ℤ))) {z : ℤ | z ≠ 0} ↔ _
  constructor
  · intro h
    refine ⟨(sidon_iff_diff_inj B).mpr h.injOn, ?_⟩
    intro d hd
    obtain ⟨⟨b,a⟩, ⟨hb,ha,hba⟩, heq⟩ := h.surjOn (show (d : ℤ) ≠ 0 by omega)
    exact ⟨a, ha, b, hb, by dsimp at heq; omega⟩
  · rintro ⟨hs,hcover⟩
    refine ⟨?_, (sidon_iff_diff_inj B).mp hs, ?_⟩
    · rintro ⟨a,b⟩ ⟨ha,hb,hab⟩
      change (a : ℤ) - (b : ℤ) ≠ 0
      omega
    · intro z hz
      change z ≠ 0 at hz
      by_cases hpos : 0 < z
      · obtain ⟨a,ha,b,hb,heq⟩ := hcover z.toNat (by omega)
        exact ⟨(b,a), ⟨hb,ha,by omega⟩, by dsimp; omega⟩
      · obtain ⟨a,ha,b,hb,heq⟩ := hcover (-z).toNat (by omega)
        exact ⟨(a,b), ⟨ha,hb,by omega⟩, by dsimp; omega⟩

-- Extend a bounded Sidon set by a pair realising a missing positive difference.
lemma add_pair_sidon (S : Set ℕ) (hs : IsSidon S) (M d x : ℕ)
    (hbound : ∀ a ∈ S, a ≤ M) (hd : 0 < d) (hx : 2 * M + d < x)
    (hmissing : ∀ a ∈ S, ∀ b ∈ S, a + d ≠ b) :
    IsSidon ((S ∪ {x}) ∪ {x + d}) := by
  have hSx : IsSidon (S ∪ {x}) := by
    apply (Set.IsSidon.insert hs).mpr
    right
    intro a ha b hb
    have hba := hbound a ha
    have hbb := hbound b hb
    refine ⟨by omega, ?_⟩
    intro c hc
    have hbc := hbound c hc
    omega
  apply (Set.IsSidon.insert hSx).mpr
  right
  intro a ha b hb
  have ha_le : a ≤ x := by
    rcases ha with ha | ha
    · exact (hbound a ha).trans (by omega)
    · have : a = x := ha; omega
  have hb_le : b ≤ x := by
    rcases hb with hb | hb
    · exact (hbound b hb).trans (by omega)
    · have : b = x := hb; omega
  refine ⟨by omega, ?_⟩
  intro c hc
  simp only [Set.mem_union, Set.mem_singleton_iff] at ha hb hc
  rcases ha with ha | rfl <;> rcases hb with hb | rfl <;> rcases hc with hc | rfl
  all_goals
    try have ba := hbound a ha
    try have bb := hbound b hb
    try have bc := hbound c hc
    try have no_ab := hmissing a ha b hb
    try have no_ac := hmissing a ha c hc
    omega

lemma extend_finite (S : Finset ℕ) (hs : IsSidon (S : Set ℕ))
    (d : ℕ) (hd : 0 < d) :
    ∃ T : Finset ℕ, S ⊆ T ∧ IsSidon (T : Set ℕ) ∧ ∃ a ∈ T, ∃ b ∈ T, a + d = b := by
  classical
  by_cases he : ∃ a ∈ S, ∃ b ∈ S, a + d = b
  · exact ⟨S, Finset.Subset.refl _, hs, he⟩
  · have hmissing : ∀ a ∈ (S : Set ℕ), ∀ b ∈ (S : Set ℕ), a + d ≠ b := by
      intro a ha b hb hab
      exact he ⟨a, ha, b, hb, hab⟩
    let M := S.sup id
    let x := 2 * M + d + 1
    let T := (S ∪ {x}) ∪ {x + d}
    refine ⟨T, ?_, ?_, ?_⟩
    · intro a ha
      simp [T, ha]
    · simpa only [T, Finset.coe_union, Finset.coe_singleton] using
        add_pair_sidon (S : Set ℕ) hs M d x
          (fun a ha => Finset.le_sup (f := id) ha) hd (by dsimp [x]; omega) hmissing
    · exact ⟨x, by simp [T], x+d, by simp [T], rfl⟩

abbrev Good := {S : Finset ℕ // IsSidon (S : Set ℕ)}

noncomputable def next (S : Good) (d : ℕ) (hd : 0 < d) : Good :=
  ⟨(extend_finite S.val S.property d hd).choose,
   (extend_finite S.val S.property d hd).choose_spec.2.1⟩

lemma subset_next (S : Good) (d : ℕ) (hd : 0 < d) : S.val ⊆ (next S d hd).val :=
  (extend_finite S.val S.property d hd).choose_spec.1

lemma next_covers (S : Good) (d : ℕ) (hd : 0 < d) :
    ∃ a ∈ (next S d hd).val, ∃ b ∈ (next S d hd).val, a + d = b :=
  (extend_finite S.val S.property d hd).choose_spec.2.2

noncomputable def stages (S : Good) : ℕ → Good
  | 0 => S
  | n+1 => next (stages S n) (n+1) (by omega)

lemma stages_mono (S : Good) : Monotone (fun n => (stages S n).val) := by
  apply monotone_nat_of_le_succ
  intro n
  exact subset_next (stages S n) (n+1) (by omega)

noncomputable def completion (S : Good) : Set ℕ := {a | ∃ n, a ∈ (stages S n).val}

lemma completion_contains (S : Good) : (S.val : Set ℕ) ⊆ completion S := by
  intro a ha
  exact ⟨0,ha⟩

lemma completion_sidon (S : Good) : IsSidon (completion S) := by
  intro a ha b hb c hc d hd heq
  obtain ⟨i,hi⟩ := ha
  obtain ⟨j,hj⟩ := hb
  obtain ⟨k,hk⟩ := hc
  obtain ⟨l,hl⟩ := hd
  let n := i+j+k+l
  exact (stages S n).property a (stages_mono S (show i ≤ n by dsimp [n]; omega) hi)
    b (stages_mono S (show j ≤ n by dsimp [n]; omega) hj)
    c (stages_mono S (show k ≤ n by dsimp [n]; omega) hk)
    d (stages_mono S (show l ≤ n by dsimp [n]; omega) hl) heq

lemma completion_covers (S : Good) (d : ℕ) (hd : 0 < d) :
    ∃ a ∈ completion S, ∃ b ∈ completion S, a + d = b := by
  obtain ⟨k,rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : d ≠ 0)
  obtain ⟨a,ha,b,hb,heq⟩ := next_covers (stages S k) (k+1) (by omega)
  exact ⟨a,⟨k+1,ha⟩,b,⟨k+1,hb⟩,heq⟩

lemma completion_perfect (S : Good) : IsPerfectDifferenceSet (completion S) 0 :=
  (pds_zero_iff _).mpr ⟨completion_sidon S, completion_covers S⟩

-- This is the positive infinite analogue (Hall 1947, Theorem 3.1).
theorem every_finite_sidon_extends_at_zero (A : Set ℕ) (hfin : A.Finite) (hs : IsSidon A) :
    ∃ B : Set ℕ, A ⊆ B ∧ IsPerfectDifferenceSet B 0 := by
  classical
  let S : Good := ⟨hfin.toFinset, by simpa using hs⟩
  refine ⟨completion S, ?_, completion_perfect S⟩
  simpa [S] using completion_contains S

-- Refute the two unrestricted no-extension conclusions without using any sorry theorem.
theorem mian_chowla_zero_witness : ∃ B : Set ℕ,
    ({1,2,4,8,13} : Set ℕ) ⊆ B ∧ IsPerfectDifferenceSet B 0 := by
  apply every_finite_sidon_extends_at_zero
  · exact Set.toFinite _
  · simpa only [Finset.coe_insert, Finset.coe_singleton] using
      (show IsSidon (({1,2,4,8,13} : Finset ℕ) : Set ℕ) by decide)

theorem hall_zero_witness : ∃ B : Set ℕ,
    ({1,3,9,10,13} : Set ℕ) ⊆ B ∧ IsPerfectDifferenceSet B 0 := by
  apply every_finite_sidon_extends_at_zero
  · exact Set.toFinite _
  · simpa only [Finset.coe_insert, Finset.coe_singleton] using
      (show IsSidon (({1,3,9,10,13} : Finset ℕ) : Set ℕ) by decide)

theorem refute_mian_chowla_conclusion : ¬ (∀ (B : Set ℕ) (n : ℕ),
    ({1,2,4,8,13} : Set ℕ) ⊆ B → ¬ IsPerfectDifferenceSet B n) := by
  obtain ⟨B,hsub,hB⟩ := mian_chowla_zero_witness
  intro h
  exact h B 0 hsub hB

theorem refute_hall_conclusion : ¬ (∀ (B : Set ℕ) (n : ℕ),
    ({1,3,9,10,13} : Set ℕ) ⊆ B → ¬ IsPerfectDifferenceSet B n) := by
  obtain ⟨B,hsub,hB⟩ := hall_zero_witness
  intro h
  exact h B 0 hsub hB

theorem refutes_original_mian_chowla :
    ¬ (type_of% @Erdos707.erdos_707.variants.counterexample_mian_chowla) := by
  intro h
  exact refute_mian_chowla_conclusion (h {1, 2, 4, 8, 13} rfl).2.2

theorem refutes_original_hall :
    ¬ (type_of% @Erdos707.erdos_707.variants.counterexample_hall) := by
  intro h
  exact refute_hall_conclusion (h {1, 3, 9, 10, 13} rfl).2.2
#print axioms refutes_original_mian_chowla
#print axioms refutes_original_hall

end Counterexamples.Group1.Erdos707
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«707»'` passes.
- The extensions only witness modulus `0`, which is now excluded.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/707 and https://tadamcz.com/fc-review-results/#/f/ForMathlib/Data/ZMod/PerfectDifferenceSet

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

