### PR TITLE
fix(GreensOpenProblems/49): allow the factor 2 in the number of translates

### DIFF
--- a/FormalConjectures/GreensOpenProblems/49.lean
+++ b/FormalConjectures/GreensOpenProblems/49.lean
@@ -44,7 +44,9 @@ namespace Green49
 Suppose that $A \subset \mathbb{F}_2^n$ is a set with $|A + A| \leq K|A|$. Is it true that $A$
 is covered by $K^{O(1)}$ translates of a subspace of size $\leq |A|$?
 
-Solved by [GGM25].
+Solved by [GGM25], with at most $2K^{12}$ translates. The factor $2$ cannot be omitted: for
+$A = \mathbb{F}_2^n \setminus \{0\}$ one has $K = 2^n / (2^n - 1)$, so $K^C \to 1$ as
+$n \to \infty$, while every subspace of size at most $|A|$ is proper and two translates are needed.
 -/
 @[category research solved, AMS 5 11]
 theorem green_49 : answer(True) ↔
@@ -53,7 +55,7 @@ theorem green_49 : answer(True) ↔
       ∀ K ≥ (1 : ℝ), (#(A + A) : ℝ) ≤ K * #A →
         ∃ (W : Submodule (ZMod 2) (𝔽₂ n)) (T : Finset (𝔽₂ n)),
           Nat.card W ≤ #A ∧
-          (#T : ℝ) ≤ K ^ C ∧
+          (#T : ℝ) ≤ 2 * K ^ C ∧
           (A : Set (𝔽₂ n)) ⊆ T + W := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `green_49` bounds the number of translates by `2 * K ^ C` instead of `K ^ C`. The docstring explains why the factor is needed and quotes the `2 K ^ 12` bound of Gowers–Green–Manners–Tao.

**Why**

The bound `#T ≤ K ^ C` fails for real `K` close to `1`. For `n ≥ 2` take `A = 𝔽₂ⁿ \ {0}` and `K = 2 ^ n / (2 ^ n - 1)`, so `#(A + A) = 2 ^ n ≤ K * #A`. Every subspace `W` with `Nat.card W ≤ #A` is proper, so at least two translates are needed to cover `A`, but `K ^ C → 1` as `n → ∞` for every fixed `C`. The Lean file below refutes the existential statement for every `C`.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.GreensOpenProblems.«49»

/-!
The nonzero vectors of finite F2-spaces have doubling constants approaching 1, while every admissible subspace cover requires at least two translates. This rules out every coefficient-one bound K^C in the original question.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/GreensOpenProblems/49.lean
-/
namespace Counterexamples.Group1.Green49
open scoped Pointwise Finset
open Filter
namespace Review49

def almostFull (n : ℕ) : Finset (𝔽₂ n) := Finset.univ.erase 0

lemma card_almostFull (n : ℕ) : (almostFull n).card = 2 ^ n - 1 := by
  simp [almostFull, 𝔽₂, 𝔽]

lemma almostFull_large (n : ℕ) : 3 ≤ (almostFull (n+2)).card := by
  rw [card_almostFull, pow_add]
  norm_num
  have hp : 0 < (2:ℕ)^n := pow_pos (by decide) _
  omega

lemma cover_card_bound {n : ℕ} (A T : Finset (𝔽₂ n))
    (W : Submodule (ZMod 2) (𝔽₂ n)) (hc : (A : Set (𝔽₂ n)) ⊆ T + W) :
    A.card ≤ T.card * Nat.card W := by
  classical
  have hsub : A ⊆ T + (W : Set (𝔽₂ n)).toFinset := by
    intro x hx
    rcases Set.mem_add.mp (hc hx) with ⟨t, ht, w, hw, heq⟩
    exact Finset.mem_add.mpr ⟨t, ht, w, by simpa using hw, heq⟩
  calc
    A.card ≤ (T + (W : Set (𝔽₂ n)).toFinset).card := Finset.card_le_card hsub
    _ ≤ T.card * (W : Set (𝔽₂ n)).toFinset.card := Finset.card_add_le
    _ = T.card * Nat.card W := by
      congr 1
      exact (Nat.card_eq_card_toFinset (W : Set (𝔽₂ n))).symm

lemma needs_two (n : ℕ) (W : Submodule (ZMod 2) (𝔽₂ (n+2)))
    (T : Finset (𝔽₂ (n+2))) (hw : Nat.card W ≤ (almostFull (n+2)).card)
    (hc : (almostFull (n+2) : Set (𝔽₂ (n+2))) ⊆ T + W) : 2 ≤ T.card := by
  by_contra h
  have ht : T.card ≤ 1 := by omega
  have ha := cover_card_bound (almostFull (n+2)) T W hc
  have hae : (almostFull (n+2)).card ≤ Nat.card W :=
    ha.trans (by simpa using Nat.mul_le_mul_right (Nat.card W) ht)
  have hw_eq := Nat.le_antisymm hw hae
  have hp : Nat.card W = 2 ^ Module.finrank (ZMod 2) W := by
    rw [Module.natCard_eq_pow_finrank (K := ZMod 2)]
    simp
  rw [card_almostFull, hp] at hw_eq
  cases hd : Module.finrank (ZMod 2) W with
  | zero =>
    rw [hd, pow_zero] at hw_eq
    have hs := almostFull_large n
    rw [card_almostFull] at hs
    omega
  | succ d =>
    rw [hd, pow_succ, pow_add] at hw_eq
    norm_num at hw_eq
    have hnp : 0 < (2:ℕ)^n := pow_pos (by decide) _
    have hdp : 0 < (2:ℕ)^d := pow_pos (by decide) _
    omega

noncomputable def nearOne (n : ℕ) : ℝ := 1 + ((2:ℝ)^n)⁻¹

lemma nearOne_limit : Tendsto nearOne atTop (nhds 1) := by
  change Tendsto (fun n : ℕ => 1 + ((2:ℝ)^n)⁻¹) atTop (nhds 1)
  have hp : Tendsto (fun n : ℕ => (2:ℝ)^n) atTop atTop :=
    tendsto_pow_atTop_atTop_of_one_lt (by norm_num)
  have hi := tendsto_inv_atTop_zero.comp hp
  simpa [nearOne] using (tendsto_const_nhds.add hi :
    Tendsto (fun n => 1 + ((2:ℝ)^n)⁻¹) atTop (nhds (1 + 0)))

lemma nearOne_ge (n : ℕ) : 1 ≤ nearOne n := by
  simp only [nearOne, le_add_iff_nonneg_right]
  positivity

lemma doubling_bound (n : ℕ) :
    ((almostFull (n+2) + almostFull (n+2)).card : ℝ) ≤
      nearOne n * (almostFull (n+2)).card := by
  have ha : (almostFull (n+2) + almostFull (n+2)).card ≤ 2 ^ (n+2) := by
    simpa [𝔽₂, 𝔽] using (almostFull (n+2) + almostFull (n+2)).card_le_univ
  have hcast : ((almostFull (n+2)).card : ℝ) = (2:ℝ)^(n+2) - 1 := by
    rw [card_almostFull, Nat.cast_sub (one_le_pow₀ (by decide : 1 ≤ (2:ℕ)))]
    simp
  have hp : (1:ℝ) ≤ 2^n := one_le_pow₀ (by norm_num)
  have hp0 : (2:ℝ)^n ≠ 0 := by positivity
  have hprod := inv_mul_cancel₀ hp0
  have hinv : ((2:ℝ)^n)⁻¹ ≤ 1 := inv_le_one_of_one_le₀ hp
  have har : ((almostFull (n+2) + almostFull (n+2)).card : ℝ) ≤ (2:ℝ) ^ (n+2) := by
    exact_mod_cast ha
  rw [hcast]
  simp only [nearOne, pow_add, show (2:ℝ)^2 = 4 by norm_num] at har ⊢
  nlinarith

theorem no_uniform_coefficient_one : ¬ (
    ∃ C > 0,
      ∀ n (A : Finset (𝔽₂ n)), A.Nonempty →
      ∀ K ≥ (1 : ℝ), (#(A + A) : ℝ) ≤ K * #A →
        ∃ (W : Submodule (ZMod 2) (𝔽₂ n)) (T : Finset (𝔽₂ n)),
          Nat.card W ≤ #A ∧
          (#T : ℝ) ≤ K ^ C ∧
          (A : Set (𝔽₂ n)) ⊆ T + W) := by
  rintro ⟨C, _, hC⟩
  have he : ∀ᶠ n in atTop, nearOne n ^ C < (2:ℝ) := by
    have hl : Tendsto (fun n => nearOne n ^ C) atTop (nhds 1) := by
      simpa using nearOne_limit.pow C
    exact hl.eventually_lt_const (by norm_num)
  obtain ⟨n, hn⟩ := he.exists
  have hne : (almostFull (n+2)).Nonempty := Finset.card_pos.mp (by
    have := almostFull_large n
    omega)
  obtain ⟨W, T, hw, ht, hc⟩ := hC (n+2) (almostFull (n+2)) hne
    (nearOne n) (nearOne_ge n) (doubling_bound n)
  have htwo : (2:ℝ) ≤ T.card := by exact_mod_cast needs_two n W T hw hc
  linarith

end Review49

end Counterexamples.Group1.Green49
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.GreensOpenProblems.«49»'` passes.
- Two translates satisfy `2 ≤ 2 * K ^ C`, so the example no longer contradicts the statement.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/GreensOpenProblems/49

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
