### PR TITLE
feat(Wikipedia): add exponential boundedness of o-minimal expansions of ℝ

### DIFF
--- a/FormalConjectures/Wikipedia/TarskiExponentialFunctionProblem.lean
+++ b/FormalConjectures/Wikipedia/TarskiExponentialFunctionProblem.lean
@@ -1,0 +1,123 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Tarski's exponential function problem
+
+Tarski proved that the first-order theory of the real ordered field
+$(\mathbb{R}, +, \cdot, -, 0, 1, \le)$ is decidable, and asked whether the same holds for the
+real exponential field $\mathbb{R}_{\exp} = (\mathbb{R}, +, \cdot, -, 0, 1, \le, \exp)$.
+The problem is open. Macintyre and Wilkie proved that the theory of $\mathbb{R}_{\exp}$ is
+decidable if the real version of Schanuel's conjecture holds.
+
+Decidability of a theory is formalised in `FirstOrder.Language.Theory.IsDecidable`: the set of
+consequences of the theory is computable, with respect to the Gödel numbering of sentences from
+`FormalConjecturesForMathlib.ModelTheory.Encoding`. The theory in question is the complete
+theory of $\mathbb{R}_{\exp}$, which contains every sentence true in $\mathbb{R}_{\exp}$, so
+this is the same as asking for an algorithm deciding membership
+(`FirstOrder.Language.Theory.isDecidable_completeTheory_iff`). The statements use the language
+of ordered rings with the order symbol `≤` in place of `<`. Some sources state the problem for
+$(\mathbb{R}, +, \cdot, \exp)$ instead. Since $<$, $\le$, $-$, $0$ and $1$ are definable
+from $+$ and $\cdot$, all these structures are interdefinable, and the choice does not affect
+decidability.
+
+*References:*
+- [Wikipedia, *Tarski's exponential function problem*](https://en.wikipedia.org/wiki/Tarski%27s_exponential_function_problem),
+  listed in [Wikipedia, *List of unsolved problems in mathematics*](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics#Model_theory_and_formal_languages).
+- A. Tarski, *A decision method for elementary algebra and geometry*, 2nd ed., University of
+  California Press, Berkeley and Los Angeles, 1951.
+- A. Macintyre, A. J. Wilkie, *On the decidability of the real exponential field*, in:
+  P. Odifreddi (ed.), *Kreiseliana: about and around Georg Kreisel*, A K Peters, Wellesley, MA,
+  1996, pp. 441–467.
+- S. Kuhlmann, [*Model theory of the real exponential function*](https://encyclopediaofmath.org/wiki/Model_theory_of_the_real_exponential_function),
+  Encyclopedia of Mathematics.
+- A. Berarducci, F. Gallinaro, [*On the elementary theory of the real exponential field*](https://arxiv.org/abs/2603.08365),
+  arXiv:2603.08365 (2026). Assuming Schanuel's conjecture, gives an axiomatisation of the
+  theory of $\mathbb{R}_{\exp}$ and recovers the Macintyre–Wilkie decidability result.
+-/
+
+namespace TarskiExponentialFunctionProblem
+
+open FirstOrder FirstOrder.Language FirstOrder.Language.Structure
+
+/-- In the real exponential field, the symbol `exp` is interpreted as the exponential
+function. -/
+@[category test, AMS 3]
+theorem funMap_exp (x : ℝ) :
+    funMap (L := Language.orderedExpField) (Sum.inr (Sum.inl expFunc.exp)) ![x] = Real.exp x :=
+  rfl
+
+/-- In the real exponential field, the symbol `+` is interpreted as addition. -/
+@[category test, AMS 3]
+theorem funMap_add (x y : ℝ) :
+    funMap (L := Language.orderedExpField) (Sum.inl Ring.addFunc) ![x, y] = x + y :=
+  rfl
+
+/-- In the real exponential field, the symbol `≤` is interpreted as the order of `ℝ`. -/
+@[category test, AMS 3]
+theorem relMap_le (x y : ℝ) :
+    RelMap (L := Language.orderedExpField) leSymb ![x, y] ↔ x ≤ y :=
+  Iff.rfl
+
+/-- For the complete theory of the real exponential field, deciding consequences is the same
+as deciding membership, since the theory contains every sentence true in $\mathbb{R}_{\exp}$.
+This also checks that the Gödel numbering of sentences of `Language.orderedExpField` is found by
+instance resolution. -/
+@[category test, AMS 3]
+theorem isDecidable_iff_isRecursive :
+    (Language.orderedExpField.completeTheory ℝ).IsDecidable ↔
+      (Language.orderedExpField.completeTheory ℝ).IsRecursive :=
+  Theory.isDecidable_completeTheory_iff ℝ
+
+/--
+**Tarski's theorem.** The first-order theory of the real ordered field
+$(\mathbb{R}, +, \cdot, -, 0, 1, \le)$ is decidable.
+-/
+@[category research solved, AMS 3 12]
+theorem isDecidable_completeTheory_real_orderedField :
+    ((Language.ring.sum Language.order).completeTheory ℝ).IsDecidable := by
+  sorry
+
+/--
+**Tarski's exponential function problem.** Is the first-order theory of the real exponential
+field $\mathbb{R}_{\exp} = (\mathbb{R}, +, \cdot, -, 0, 1, \le, \exp)$ decidable?
+-/
+@[category research open, AMS 3 12]
+theorem tarski_exponential_function_problem :
+    answer(sorry) ↔ (Language.orderedExpField.completeTheory ℝ).IsDecidable := by
+  sorry
+
+/-- The real version of Schanuel's conjecture: if $x_1, \ldots, x_n$ are real numbers that are
+linearly independent over $\mathbb{Q}$, then the field
+$\mathbb{Q}(x_1, \ldots, x_n, e^{x_1}, \ldots, e^{x_n})$ has transcendence degree at least $n$
+over $\mathbb{Q}$. -/
+def RealSchanuelConjecture : Prop :=
+  ∀ (n : ℕ) (x : Fin n → ℝ), LinearIndependent ℚ x →
+    n ≤ Algebra.trdeg ℚ (IntermediateField.adjoin ℚ (Set.range x ∪ Set.range (Real.exp ∘ x)))
+
+/--
+**Macintyre–Wilkie.** If the real version of Schanuel's conjecture holds, then the first-order
+theory of the real exponential field is decidable.
+-/
+@[category research solved, AMS 3 11 12]
+theorem isDecidable_completeTheory_realExp_of_realSchanuelConjecture
+    (h : RealSchanuelConjecture) :
+    (Language.orderedExpField.completeTheory ℝ).IsDecidable := by
+  sorry
+
+end TarskiExponentialFunctionProblem

--- a/FormalConjectures/Wikipedia/TarskiExponentialFunctionProblem.lean
+++ b/FormalConjectures/Wikipedia/TarskiExponentialFunctionProblem.lean
@@ -53,31 +53,10 @@ decidability.
 
 namespace TarskiExponentialFunctionProblem
 
-open FirstOrder FirstOrder.Language FirstOrder.Language.Structure
-
-/-- In the real exponential field, the symbol `exp` is interpreted as the exponential
-function. -/
-@[category test, AMS 3]
-theorem funMap_exp (x : ℝ) :
-    funMap (L := Language.orderedExpField) (Sum.inr (Sum.inl expFunc.exp)) ![x] = Real.exp x :=
-  rfl
-
-/-- In the real exponential field, the symbol `+` is interpreted as addition. -/
-@[category test, AMS 3]
-theorem funMap_add (x y : ℝ) :
-    funMap (L := Language.orderedExpField) (Sum.inl Ring.addFunc) ![x, y] = x + y :=
-  rfl
-
-/-- In the real exponential field, the symbol `≤` is interpreted as the order of `ℝ`. -/
-@[category test, AMS 3]
-theorem relMap_le (x y : ℝ) :
-    RelMap (L := Language.orderedExpField) leSymb ![x, y] ↔ x ≤ y :=
-  Iff.rfl
+open FirstOrder FirstOrder.Language
 
 /-- For the complete theory of the real exponential field, deciding consequences is the same
-as deciding membership, since the theory contains every sentence true in $\mathbb{R}_{\exp}$.
-This also checks that the Gödel numbering of sentences of `Language.orderedExpField` is found by
-instance resolution. -/
+as deciding membership, since the theory contains every sentence true in $\mathbb{R}_{\exp}$. -/
 @[category test, AMS 3]
 theorem isDecidable_iff_isRecursive :
     (Language.orderedExpField.completeTheory ℝ).IsDecidable ↔

--- a/FormalConjectures/Wikipedia/TransExponentialOMinimal.lean
+++ b/FormalConjectures/Wikipedia/TransExponentialOMinimal.lean
@@ -1,0 +1,107 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# O-minimal expansions of the real field and exponential boundedness
+
+An expansion of the real ordered field $\bar{\mathbb{R}} = (\mathbb{R}, \le, +, \cdot)$ is
+*exponentially bounded* if every definable function $f : \mathbb{R} \to \mathbb{R}$ satisfies
+$f(t) = O(\exp_N(t))$ as $t \to +\infty$ for some compositional iterate $\exp_N$ of $\exp$.
+All known o-minimal expansions of $\bar{\mathbb{R}}$ are exponentially bounded, and van den
+Dries and Miller write that they do not know whether there are o-minimal structures on
+$(\mathbb{R}, +, \cdot)$ that are not exponentially bounded. Wikipedia's list of unsolved
+problems states the question in the form "Does there exist an o-minimal first order theory with a
+trans-exponential (rapid growth) function?", where a function is *trans-exponential* if it
+eventually exceeds every iterate of $\exp$; the list does not name the underlying field. We follow
+the literature and formalise both forms for expansions of $\bar{\mathbb{R}}$.
+
+Definable means definable with parameters. Expansions of $\bar{\mathbb{R}}$ are formalised as
+structures on `ℝ` in a language `L` containing the order symbol `≤` and the image of the
+language of rings under a language map `φ : Language.ring →ᴸ L`, such that the symbols are
+interpreted in the standard way. Since $\le$ is definable from $+$ and $\cdot$, requiring it in
+the language loses no generality. The languages range over arbitrary universes.
+
+*References:*
+- [Wikipedia, *List of unsolved problems in mathematics*](https://en.wikipedia.org/wiki/List_of_unsolved_problems_in_mathematics#Model_theory_and_formal_languages).
+- L. van den Dries, C. Miller, *Geometric categories and o-minimal structures*, Duke Math. J.
+  84 (1996), 497–540. See the remark following 5.5.
+- C. Miller, *Exponentiation is hard to avoid*, Proc. Amer. Math. Soc. 122 (1994), 257–259
+  (the growth dichotomy).
+- C. Miller, S. Starchenko, [*Status of the o-minimal two-group question*](https://people.math.osu.edu/miller.1987/tg.pdf),
+  note, 2003.
+- Y. Fu, [*Towards trans-exponential o-minimal expansion of $(\mathbb{R}, +, \cdot, 0, 1, <)$*](https://arxiv.org/abs/2604.03477),
+  arXiv:2604.03477.
+- A. J. Wilkie, *Model completeness results for expansions of the ordered field of real numbers
+  by restricted Pfaffian functions and the exponential function*, J. Amer. Math. Soc. 9 (1996),
+  1051–1094.
+-/
+
+namespace TransExponentialOMinimal
+
+open FirstOrder FirstOrder.Language Filter
+
+universe u v
+
+/--
+**Tarski–Seidenberg.** The real ordered field $\bar{\mathbb{R}}$ is o-minimal: its definable
+sets are the semialgebraic sets, and a semialgebraic subset of $\mathbb{R}$ is a finite union of
+points and open intervals.
+-/
+@[category research solved, AMS 3 14]
+theorem isOMinimal_real_orderedField : (Language.ring.sum Language.order).IsOMinimal ℝ := by
+  sorry
+
+/--
+**Wilkie's theorem.** The real exponential field
+$\mathbb{R}_{\exp} = (\mathbb{R}, +, \cdot, -, 0, 1, \le, \exp)$ is o-minimal.
+-/
+@[category research solved, AMS 3 12]
+theorem isOMinimal_realExp : Language.orderedExpField.IsOMinimal ℝ := by
+  sorry
+
+/--
+Is every o-minimal expansion of the real ordered field $\bar{\mathbb{R}}$ exponentially bounded?
+That is, given an o-minimal expansion of $\bar{\mathbb{R}}$ and a definable function
+$f : \mathbb{R} \to \mathbb{R}$, is there a compositional iterate $\exp_N$ of $\exp$ with
+$f(t) = O(\exp_N(t))$ as $t \to +\infty$?
+-/
+@[category research open, AMS 3 26]
+theorem oMinimal_expansion_isExponentiallyBounded :
+    answer(sorry) ↔ ∀ (L : FirstOrder.Language.{u, v}) [L.Structure ℝ] [L.IsOrdered]
+      (φ : Language.ring →ᴸ L) [φ.IsExpansionOn ℝ] [L.IsOMinimal ℝ],
+      L.IsExponentiallyBounded := by
+  sorry
+
+/--
+Does there exist an o-minimal expansion of the real ordered field $\bar{\mathbb{R}}$ with a
+definable trans-exponential function, i.e. a definable $f : \mathbb{R} \to \mathbb{R}$ such that
+for every $N$ we have $f(t) > \exp_N(t)$ for all sufficiently large $t$?
+
+This is the form of the question in Wikipedia's list. By Miller's growth dichotomy, an o-minimal
+expansion of $\bar{\mathbb{R}}$ that is not polynomially bounded defines $\exp$, and then by
+o-minimality it is not exponentially bounded if and only if it defines a trans-exponential
+function.
+-/
+@[category research open, AMS 3 26]
+theorem exists_oMinimal_expansion_transExponential :
+    answer(sorry) ↔ ∃ (L : FirstOrder.Language.{u, v}) (_ : L.Structure ℝ) (_ : L.IsOrdered)
+      (φ : Language.ring →ᴸ L) (_ : φ.IsExpansionOn ℝ) (_ : L.IsOMinimal ℝ) (f : ℝ → ℝ),
+      (Set.univ : Set ℝ).Definable₂ L f.graph ∧ ∀ N : ℕ, ∀ᶠ x in atTop, Real.exp^[N] x < f x := by
+  sorry
+
+end TransExponentialOMinimal

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -137,6 +137,9 @@ public import FormalConjecturesForMathlib.LinearAlgebra.AffineSpace.Simplex.Basi
 public import FormalConjecturesForMathlib.LinearAlgebra.GeneralLinearGroup
 public import FormalConjecturesForMathlib.LinearAlgebra.SpecialLinearGroup
 public import FormalConjecturesForMathlib.Logic.Equiv.Fin.Rotate
+public import FormalConjecturesForMathlib.ModelTheory.Decidability
+public import FormalConjecturesForMathlib.ModelTheory.Encoding
+public import FormalConjecturesForMathlib.ModelTheory.Real
 public import FormalConjecturesForMathlib.NumberTheory.AdditionChain
 public import FormalConjecturesForMathlib.NumberTheory.AdditiveComplement
 public import FormalConjecturesForMathlib.NumberTheory.AdditivelyComplete

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -139,6 +139,7 @@ public import FormalConjecturesForMathlib.LinearAlgebra.SpecialLinearGroup
 public import FormalConjecturesForMathlib.Logic.Equiv.Fin.Rotate
 public import FormalConjecturesForMathlib.ModelTheory.Decidability
 public import FormalConjecturesForMathlib.ModelTheory.Encoding
+public import FormalConjecturesForMathlib.ModelTheory.OMinimal
 public import FormalConjecturesForMathlib.ModelTheory.Real
 public import FormalConjecturesForMathlib.NumberTheory.AdditionChain
 public import FormalConjecturesForMathlib.NumberTheory.AdditiveComplement

--- a/FormalConjecturesForMathlib/ModelTheory/Decidability.lean
+++ b/FormalConjecturesForMathlib/ModelTheory/Decidability.lean
@@ -1,0 +1,114 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import FormalConjecturesForMathlib.ModelTheory.Encoding
+public import Mathlib.Computability.Partrec
+
+/-!
+# Recursive and decidable theories
+
+Mathlib's `FirstOrder.Language.Theory` is an arbitrary set of sentences, which need not be
+closed under logical consequence. Two computability notions are therefore distinct:
+
+- `T` is *recursive* if membership in `T` is computable: there is an algorithm which, given a
+  sentence `φ`, decides whether `φ ∈ T`. This is a property of the set of axioms.
+- `T` is *decidable* if the set of consequences `{φ | T ⊨ᵇ φ}` is recursive: there is an
+  algorithm which decides whether `φ` holds in every model of `T`. This only depends on the
+  consequences of `T`, so it is invariant under replacing `T` by a logically equivalent set of
+  axioms (`FirstOrder.Language.Theory.isDecidable_congr`).
+
+The two notions agree when `T` is closed under consequence, in particular for the complete
+theory `L.completeTheory M` of a structure `M`
+(`FirstOrder.Language.Theory.isDecidable_completeTheory_iff`).
+
+Both notions use the Gödel numbering of sentences from
+`FormalConjecturesForMathlib.ModelTheory.Encoding` and the notion of a computable function
+`ℕ → Bool` from Mathlib's computability library. As usual, they are relative to the chosen
+encoding of the symbols of `L`. For a language with finitely many symbols, all injective
+encodings of the symbols give the same notions.
+
+## Main declarations
+
+- `FirstOrder.Language.Theory.IsRecursive`: membership in the set of sentences is computable.
+- `FirstOrder.Language.Theory.IsDecidable`: the set of consequences is recursive.
+- `FirstOrder.Language.Theory.isDecidable_iff_isRecursive`: for a theory closed under
+  consequence, the two notions agree.
+-/
+
+@[expose] public section
+
+namespace FirstOrder.Language.Theory
+
+variable {L : Language} [Encodable (Σ n, L.Functions n)] [Encodable (Σ n, L.Relations n)]
+
+/-- A set of sentences `T` is *recursive* if there is a computable function `f : ℕ → Bool` such
+that, for every sentence `φ`, `f` returns `true` on the Gödel number of `φ` if and only if
+`φ ∈ T`. -/
+def IsRecursive (T : L.Theory) : Prop :=
+  ∃ f : ℕ → Bool, Computable f ∧ ∀ φ : L.Sentence, f (Encodable.encode φ) = true ↔ φ ∈ T
+
+/-- A theory `T` is *decidable* if the set of its consequences `{φ | T ⊨ᵇ φ}` is recursive:
+there is an algorithm which, given a sentence `φ`, decides whether `φ` holds in every model of
+`T`. -/
+def IsDecidable (T : L.Theory) : Prop :=
+  IsRecursive {φ | T ⊨ᵇ φ}
+
+variable {T T' : L.Theory}
+
+/-- The empty set of sentences is recursive. -/
+theorem isRecursive_empty : (∅ : L.Theory).IsRecursive :=
+  ⟨fun _ => false, Computable.const false, fun _ => by simp⟩
+
+/-- The set of all sentences is recursive. -/
+theorem isRecursive_univ : IsRecursive (Set.univ : L.Theory) :=
+  ⟨fun _ => true, Computable.const true, fun _ => by simp⟩
+
+/-- The complement of a recursive set of sentences is recursive. -/
+theorem IsRecursive.compl (hT : T.IsRecursive) : Tᶜ.IsRecursive := by
+  obtain ⟨f, hf, hfT⟩ := hT
+  refine ⟨fun n => !f n, ?_, fun φ => ?_⟩
+  · exact (hf.cond (Computable.const false) (Computable.const true)).of_eq fun n => by
+      cases f n <;> rfl
+  · have key : ∀ (b : Bool) (P : Prop), (b = true ↔ P) → ((!b) = true ↔ ¬P) := by
+      rintro b P h
+      cases b <;> simp_all
+    exact key _ _ (hfT φ)
+
+/-- Decidability only depends on the consequences of a theory. In particular, logically
+equivalent sets of axioms are decidable together. -/
+theorem isDecidable_congr (h : ∀ φ : L.Sentence, T ⊨ᵇ φ ↔ T' ⊨ᵇ φ) :
+    T.IsDecidable ↔ T'.IsDecidable := by
+  unfold IsDecidable
+  rw [show {φ : L.Sentence | T ⊨ᵇ φ} = {φ | T' ⊨ᵇ φ} from Set.ext h]
+
+/-- For a theory closed under consequence, decidability is the same as recursiveness. -/
+theorem isDecidable_iff_isRecursive (hT : ∀ φ : L.Sentence, T ⊨ᵇ φ → φ ∈ T) :
+    T.IsDecidable ↔ T.IsRecursive := by
+  unfold IsDecidable
+  rw [show {φ : L.Sentence | T ⊨ᵇ φ} = T from Set.ext fun φ => ⟨hT φ, models_sentence_of_mem⟩]
+
+/-- The complete theory of a structure `M` contains all its consequences, so it is decidable
+if and only if membership in it is computable. -/
+theorem isDecidable_completeTheory_iff (M : Type*) [L.Structure M] [Nonempty M] :
+    (L.completeTheory M).IsDecidable ↔ (L.completeTheory M).IsRecursive :=
+  isDecidable_iff_isRecursive fun _ h => mem_completeTheory.2 (h.realize_sentence M)
+
+/-- The inconsistent theory of all sentences is decidable. -/
+theorem isDecidable_univ : IsDecidable (Set.univ : L.Theory) :=
+  (isDecidable_iff_isRecursive fun φ _ => Set.mem_univ φ).2 isRecursive_univ
+
+end FirstOrder.Language.Theory

--- a/FormalConjecturesForMathlib/ModelTheory/Encoding.lean
+++ b/FormalConjecturesForMathlib/ModelTheory/Encoding.lean
@@ -1,0 +1,127 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.ModelTheory.Algebra.Ring.Basic
+public import Mathlib.ModelTheory.Encoding
+public import Mathlib.ModelTheory.Order
+
+/-!
+# Gödel numberings of first-order formulas
+
+Mathlib encodes the terms and the bounded formulas of a first-order language `L` as lists of
+symbols (`FirstOrder.Language.Term.listEncode` and
+`FirstOrder.Language.BoundedFormula.listEncode`), and derives from this an `Encodable`
+instance on terms. This file derives `Encodable` instances on bounded formulas, formulas and
+sentences in the same way. Given `Encodable` instances on the function symbols
+`Σ n, L.Functions n` and on the relation symbols `Σ n, L.Relations n`, every sentence `φ` of
+`L` gets a Gödel number `Encodable.encode φ : ℕ`.
+
+The file also provides `Encodable` instances on the symbols of `Language.ring`,
+`Language.order`, and of sums of languages.
+
+## Main declarations
+
+- `FirstOrder.Language.BoundedFormula.encodableSigma`: Gödel numbering of
+  `Σ n, L.BoundedFormula α n`.
+- `FirstOrder.Language.BoundedFormula.encodable`: Gödel numbering of `L.BoundedFormula α n`,
+  hence of `L.Formula α` and `L.Sentence`.
+
+## Implementation notes
+
+The numbering is the composition of Mathlib's list encoding of formulas with Mathlib's
+`Encodable` instance on lists and the given encodings of the symbols, so it is effective in the
+usual informal sense. For a language with finitely many symbols, any two injective encodings of
+the symbols yield Gödel numberings that are computably inter-translatable, so notions such as
+decidability of a theory do not depend on the choice made here. No `Primcodable` instance is
+provided; computability statements about theories are phrased on `ℕ` through `Encodable.encode`.
+-/
+
+@[expose] public section
+
+namespace FirstOrder.Language
+
+open Encodable
+
+variable {L : Language} {α : Type*}
+
+section Symbols
+
+/-- The function symbols of a sum of two languages are encodable when those of both summands
+are. -/
+instance sum.encodableFunctions {L' : Language} [Encodable (Σ n, L.Functions n)]
+    [Encodable (Σ n, L'.Functions n)] : Encodable (Σ n, (L.sum L').Functions n) :=
+  ofEquiv _ (Equiv.sigmaSumDistrib L.Functions L'.Functions)
+
+/-- The relation symbols of a sum of two languages are encodable when those of both summands
+are. -/
+instance sum.encodableRelations {L' : Language} [Encodable (Σ n, L.Relations n)]
+    [Encodable (Σ n, L'.Relations n)] : Encodable (Σ n, (L.sum L').Relations n) :=
+  ofEquiv _ (Equiv.sigmaSumDistrib L.Relations L'.Relations)
+
+/-- A relational language has no function symbols. -/
+instance IsRelational.encodableFunctions [L.IsRelational] : Encodable (Σ n, L.Functions n) :=
+  ⟨fun f => isEmptyElim f.2, fun _ => none, fun f => isEmptyElim f.2⟩
+
+/-- An algebraic language has no relation symbols. -/
+instance IsAlgebraic.encodableRelations [L.IsAlgebraic] : Encodable (Σ n, L.Relations n) :=
+  ⟨fun r => isEmptyElim r.2, fun _ => none, fun r => isEmptyElim r.2⟩
+
+/-- The function symbols `+`, `*`, `-`, `0`, `1` of the language of rings are encoded as
+`0`, `1`, `2`, `3`, `4`. -/
+instance ring.encodableFunctions : Encodable (Σ n, Language.ring.Functions n) :=
+  ofLeftInjection
+    (fun f => match f with
+      | ⟨_, .add⟩ => 0
+      | ⟨_, .mul⟩ => 1
+      | ⟨_, .neg⟩ => 2
+      | ⟨_, .zero⟩ => 3
+      | ⟨_, .one⟩ => 4)
+    (fun n => match n with
+      | 0 => some ⟨2, Ring.addFunc⟩
+      | 1 => some ⟨2, Ring.mulFunc⟩
+      | 2 => some ⟨1, Ring.negFunc⟩
+      | 3 => some ⟨0, Ring.zeroFunc⟩
+      | 4 => some ⟨0, Ring.oneFunc⟩
+      | _ => none)
+    (fun f => by rcases f with ⟨_, f⟩; cases f <;> rfl)
+
+/-- The unique relation symbol `≤` of the language of orders is encoded as `0`. -/
+instance order.encodableRelations : Encodable (Σ n, Language.order.Relations n) :=
+  ofLeftInjection (fun _ => (0 : ℕ)) (fun _ => some default) fun _ =>
+    congrArg some (Subsingleton.elim _ _)
+
+end Symbols
+
+namespace BoundedFormula
+
+variable [Encodable α] [Encodable (Σ n, L.Functions n)] [Encodable (Σ n, L.Relations n)]
+
+/-- The Gödel numbering of bounded formulas, obtained from the list encoding
+`BoundedFormula.encoding` and the `Encodable` instances on lists and on the symbols. -/
+instance encodableSigma : Encodable (Σ n, L.BoundedFormula α n) :=
+  ofLeftInjection BoundedFormula.encoding.encode BoundedFormula.encoding.decode
+    BoundedFormula.encoding.decode_encode
+
+/-- The Gödel numbering of bounded formulas with `n` bound variables, and in particular of
+formulas (`n = 0`) and sentences (`n = 0` and `α = Empty`). -/
+instance encodable (n : ℕ) : Encodable (L.BoundedFormula α n) :=
+  ofLeftInjection (fun φ => (⟨n, φ⟩ : Σ n, L.BoundedFormula α n))
+    (fun ψ => if h : ψ.1 = n then some (h ▸ ψ.2) else none) fun _ => dif_pos rfl
+
+end BoundedFormula
+
+end FirstOrder.Language

--- a/FormalConjecturesForMathlib/ModelTheory/OMinimal.lean
+++ b/FormalConjecturesForMathlib/ModelTheory/OMinimal.lean
@@ -1,0 +1,112 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.ModelTheory.Definability
+public import Mathlib.ModelTheory.Order
+
+/-!
+# O-minimal structures
+
+A structure `M` in a language `L` containing the order symbol `≤` is *o-minimal* if `≤` is
+interpreted as a linear order on `M` and every subset of `M` definable with parameters is a
+finite union of points and open intervals with endpoints in `M ∪ {-∞, +∞}`.
+
+*References:*
+- A. Pillay, C. Steinhorn, *Definable sets in ordered structures. I*,
+  Trans. Amer. Math. Soc. 295 (1986), 565–592.
+- L. van den Dries, *Tame topology and o-minimal structures*, London Mathematical Society
+  Lecture Note Series 248, Cambridge University Press, 1998.
+
+## Main declarations
+
+- `Set.IsPointOrOpenInterval`: a subset of a preorder is a singleton or an open interval,
+  possibly unbounded.
+- `FirstOrder.Language.IsOMinimal`: o-minimal structures.
+- `FirstOrder.Language.IsOMinimal.exists_finite_ordConnected`: in an o-minimal structure, every
+  definable subset is a finite union of order-connected sets.
+
+## Implementation notes
+
+Finite unions are expressed through `Set.Finite` on a set of subsets, rather than a `Finset`, so
+that no decidable equality on `Set M` is needed to write one down. The order is not required to
+be dense or to have no endpoints, following Pillay and Steinhorn.
+-/
+
+@[expose] public section
+
+namespace Set
+
+variable {M : Type*} [Preorder M]
+
+/-- A subset `s` of a preorder is a *point or an open interval* if it is a singleton `{a}` or one
+of the open intervals `Ioo a b`, `Iio b`, `Ioi a` and `univ`. -/
+def IsPointOrOpenInterval (s : Set M) : Prop :=
+  (∃ a, s = {a}) ∨ (∃ a b, s = Ioo a b) ∨ (∃ b, s = Iio b) ∨ (∃ a, s = Ioi a) ∨ s = univ
+
+theorem isPointOrOpenInterval_singleton (a : M) : ({a} : Set M).IsPointOrOpenInterval :=
+  Or.inl ⟨a, rfl⟩
+
+theorem isPointOrOpenInterval_Ioo (a b : M) : (Ioo a b).IsPointOrOpenInterval :=
+  Or.inr (Or.inl ⟨a, b, rfl⟩)
+
+theorem isPointOrOpenInterval_Iio (b : M) : (Iio b).IsPointOrOpenInterval :=
+  Or.inr (Or.inr (Or.inl ⟨b, rfl⟩))
+
+theorem isPointOrOpenInterval_Ioi (a : M) : (Ioi a).IsPointOrOpenInterval :=
+  Or.inr (Or.inr (Or.inr (Or.inl ⟨a, rfl⟩)))
+
+theorem isPointOrOpenInterval_univ : (univ : Set M).IsPointOrOpenInterval :=
+  Or.inr (Or.inr (Or.inr (Or.inr rfl)))
+
+/-- In a partial order, a point or an open interval is order-connected. -/
+theorem IsPointOrOpenInterval.ordConnected {M : Type*} [PartialOrder M] {s : Set M}
+    (hs : s.IsPointOrOpenInterval) : s.OrdConnected := by
+  rcases hs with ⟨a, rfl⟩ | ⟨a, b, rfl⟩ | ⟨b, rfl⟩ | ⟨a, rfl⟩ | rfl <;> infer_instance
+
+-- A closed ray is a finite union of points and open intervals, as o-minimality requires of every
+-- definable set.
+example {M : Type*} [PartialOrder M] (a : M) :
+    ∃ F : Set (Set M), F.Finite ∧ (∀ t ∈ F, t.IsPointOrOpenInterval) ∧ Ici a = ⋃₀ F := by
+  refine ⟨{{a}, Ioi a}, Set.toFinite _, ?_, ?_⟩
+  · simp [isPointOrOpenInterval_singleton, isPointOrOpenInterval_Ioi]
+  · rw [Set.sUnion_insert, Set.sUnion_singleton, Set.singleton_union, Set.Ioi_insert]
+
+end Set
+
+namespace FirstOrder.Language
+
+/-- An `L`-structure `M` on a linearly ordered set, where `L` contains the symbol `≤`, is
+*o-minimal* if `≤` is interpreted as the order of `M` and every subset of `M` definable with
+parameters is a finite union of points and open intervals.
+
+We do not require the order to be dense or to have no endpoints. -/
+class IsOMinimal (L : Language) (M : Type*) [LinearOrder M] [L.IsOrdered] [L.Structure M] :
+    Prop extends L.OrderedStructure M where
+  exists_finite_of_definable : ∀ s : Set M, (Set.univ : Set M).Definable₁ L s →
+    ∃ F : Set (Set M), F.Finite ∧ (∀ t ∈ F, t.IsPointOrOpenInterval) ∧ s = ⋃₀ F
+
+variable {L : Language} {M : Type*} [LinearOrder M] [L.IsOrdered] [L.Structure M]
+
+/-- In an o-minimal structure, every definable subset is a finite union of order-connected
+sets. -/
+theorem IsOMinimal.exists_finite_ordConnected [L.IsOMinimal M] {s : Set M}
+    (hs : (Set.univ : Set M).Definable₁ L s) :
+    ∃ F : Set (Set M), F.Finite ∧ (∀ t ∈ F, t.OrdConnected) ∧ s = ⋃₀ F := by
+  obtain ⟨F, hF, hF', rfl⟩ := IsOMinimal.exists_finite_of_definable s hs
+  exact ⟨F, hF, fun t ht => (hF' t ht).ordConnected, rfl⟩
+
+end FirstOrder.Language

--- a/FormalConjecturesForMathlib/ModelTheory/Real.lean
+++ b/FormalConjecturesForMathlib/ModelTheory/Real.lean
@@ -1,0 +1,102 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import FormalConjecturesForMathlib.ModelTheory.Encoding
+public import Mathlib.Analysis.SpecialFunctions.Exp
+
+/-!
+# Expansions of the real field
+
+This file makes `ℝ` a structure for the language of rings and for the language of orders. It
+defines the language `Language.exp` with a single unary function symbol `exp`, the language
+`Language.orderedExpField` of ordered exponential fields, and the *real exponential field*
+`(ℝ, +, *, -, 0, 1, ≤, exp)` as a structure for that language.
+
+## Main declarations
+
+- `FirstOrder.Language.exp`: the language with one unary function symbol `exp`.
+- `FirstOrder.Language.orderedExpField`: the language of ordered exponential fields.
+
+## Implementation notes
+
+Mathlib deliberately does not make `Ring.compatibleRingOfRing` or `orderStructure` instances,
+because for a general type `R` the round trip `Ring R → Language.ring.Structure R → Ring R`
+need not commute definitionally. Here they are declared as instances for the single type `ℝ`.
+Mathlib has no instance producing a `Ring` or `LE` structure from a first-order structure on a
+concrete type, so no such round trip arises.
+-/
+
+@[expose] public section
+
+namespace FirstOrder
+
+/-- The type of function symbols of `Language.exp`: a single unary symbol `exp`. -/
+inductive expFunc : ℕ → Type
+  | exp : expFunc 1
+  deriving DecidableEq
+
+namespace Language
+
+/-- The language with a single unary function symbol `exp` and no relation symbols. -/
+protected def exp : Language := ⟨expFunc, fun _ => Empty⟩
+  deriving IsAlgebraic
+
+/-- The language of ordered exponential fields: the language of rings, together with a unary
+function symbol `exp` and the order relation `≤`. -/
+protected abbrev orderedExpField : Language :=
+  Language.ring.sum (Language.exp.sum Language.order)
+
+/-- The language of ordered exponential fields contains the order symbol `≤`. -/
+instance orderedExpField.instIsOrdered : Language.orderedExpField.IsOrdered :=
+  ⟨Sum.inr leSymb⟩
+
+/-- The function symbol `exp` is encoded as `0`. -/
+instance exp.encodableFunctions : Encodable (Σ n, Language.exp.Functions n) :=
+  Encodable.ofLeftInjection (fun _ => (0 : ℕ)) (fun _ => some ⟨1, expFunc.exp⟩) fun f => by
+    rcases f with ⟨_, f⟩
+    cases f
+    rfl
+
+noncomputable section Real
+
+/-- `ℝ` as a structure for the language of rings, with the usual ring operations. -/
+instance compatibleRingReal : Ring.CompatibleRing ℝ := Ring.compatibleRingOfRing ℝ
+
+/-- `ℝ` as a structure for the language of orders, with `≤` interpreted as `≤`. -/
+instance orderStructureReal : Language.order.Structure ℝ := orderStructure ℝ
+
+instance orderOrderedStructureReal : Language.order.OrderedStructure ℝ := ⟨fun _ => Iff.rfl⟩
+
+/-- `ℝ` as a structure for `Language.exp`, with `exp` interpreted as the exponential function. -/
+instance expStructureReal : Language.exp.Structure ℝ where
+  funMap {n} f := match n, f with
+    | _, .exp => fun x => Real.exp (x 0)
+
+@[simp]
+theorem funMap_exp (x : Fin 1 → ℝ) :
+    Structure.funMap (L := Language.exp) expFunc.exp x = Real.exp (x 0) :=
+  rfl
+
+/-- In the real exponential field, `≤` is interpreted as `≤`. -/
+instance orderedExpFieldOrderedStructureReal : Language.orderedExpField.OrderedStructure ℝ :=
+  ⟨fun _ => Iff.rfl⟩
+
+end Real
+
+end Language
+
+end FirstOrder

--- a/FormalConjecturesForMathlib/ModelTheory/Real.lean
+++ b/FormalConjecturesForMathlib/ModelTheory/Real.lean
@@ -16,7 +16,9 @@ limitations under the License.
 module
 
 public import FormalConjecturesForMathlib.ModelTheory.Encoding
+public import Mathlib.Analysis.Asymptotics.Defs
 public import Mathlib.Analysis.SpecialFunctions.Exp
+public import Mathlib.ModelTheory.Definability
 
 /-!
 # Expansions of the real field
@@ -26,10 +28,21 @@ defines the language `Language.exp` with a single unary function symbol `exp`, t
 `Language.orderedExpField` of ordered exponential fields, and the *real exponential field*
 `(ℝ, +, *, -, 0, 1, ≤, exp)` as a structure for that language.
 
+It also defines when a structure on `ℝ` is *exponentially bounded*: every definable function
+`f : ℝ → ℝ` satisfies `f = O(exp^[N])` at `+∞` for some compositional iterate `exp^[N]` of the
+exponential function.
+
+*References:*
+- L. van den Dries, C. Miller, *Geometric categories and o-minimal structures*,
+  Duke Math. J. 84 (1996), 497–540. See 5.5 and the remark following it.
+
 ## Main declarations
 
 - `FirstOrder.Language.exp`: the language with one unary function symbol `exp`.
 - `FirstOrder.Language.orderedExpField`: the language of ordered exponential fields.
+- `FirstOrder.Language.IsExponentiallyBounded`: exponentially bounded structures on `ℝ`.
+- `FirstOrder.Language.IsExponentiallyBounded.of_expansion`: exponential boundedness passes to
+  reducts.
 
 ## Implementation notes
 
@@ -95,6 +108,16 @@ theorem funMap_exp (x : Fin 1 → ℝ) :
 instance orderedExpFieldOrderedStructureReal : Language.orderedExpField.OrderedStructure ℝ :=
   ⟨fun _ => Iff.rfl⟩
 
+open Asymptotics Filter
+
+variable (L : Language) [L.Structure ℝ]
+
+/-- A structure on `ℝ` is *exponentially bounded* if every function `f : ℝ → ℝ` definable with
+parameters is `O(exp^[N])` at `+∞` for some compositional iterate `exp^[N]` of the exponential
+function. -/
+def IsExponentiallyBounded : Prop :=
+  ∀ f : ℝ → ℝ, (Set.univ : Set ℝ).Definable₂ L f.graph → ∃ N : ℕ, f =O[atTop] Real.exp^[N]
+
 -- In the real exponential field, the symbol `exp` is interpreted as the exponential function.
 example (x : ℝ) :
     Structure.funMap (L := Language.orderedExpField) (Sum.inr (Sum.inl expFunc.exp)) ![x] =
@@ -115,6 +138,13 @@ example (x y : ℝ) :
 example : Encodable Language.orderedExpField.Sentence := inferInstance
 
 end Real
+
+/-- Exponential boundedness passes to reducts: if `L'` expands `L` on `ℝ` and `L'` is
+exponentially bounded, then so is `L`. -/
+theorem IsExponentiallyBounded.of_expansion {L L' : Language} [L.Structure ℝ] [L'.Structure ℝ]
+    (φ : L →ᴸ L') [φ.IsExpansionOn ℝ] (h : L'.IsExponentiallyBounded) :
+    L.IsExponentiallyBounded :=
+  fun f hf => h f (Set.Definable.map_expansion hf φ)
 
 end Language
 

--- a/FormalConjecturesForMathlib/ModelTheory/Real.lean
+++ b/FormalConjecturesForMathlib/ModelTheory/Real.lean
@@ -95,6 +95,25 @@ theorem funMap_exp (x : Fin 1 → ℝ) :
 instance orderedExpFieldOrderedStructureReal : Language.orderedExpField.OrderedStructure ℝ :=
   ⟨fun _ => Iff.rfl⟩
 
+-- In the real exponential field, the symbol `exp` is interpreted as the exponential function.
+example (x : ℝ) :
+    Structure.funMap (L := Language.orderedExpField) (Sum.inr (Sum.inl expFunc.exp)) ![x] =
+      Real.exp x :=
+  rfl
+
+-- In the real exponential field, the symbol `+` is interpreted as addition.
+example (x y : ℝ) :
+    Structure.funMap (L := Language.orderedExpField) (Sum.inl Ring.addFunc) ![x, y] = x + y :=
+  rfl
+
+-- In the real exponential field, the symbol `≤` is interpreted as the order of `ℝ`.
+example (x y : ℝ) :
+    Structure.RelMap (L := Language.orderedExpField) leSymb ![x, y] ↔ x ≤ y :=
+  Iff.rfl
+
+-- The Gödel numbering of sentences of `Language.orderedExpField` is found by instance resolution.
+example : Encodable Language.orderedExpField.Sentence := inferInstance
+
 end Real
 
 end Language


### PR DESCRIPTION
Fixes #5498

**Stacked on #5385**, which adds `FormalConjecturesForMathlib/ModelTheory/Real.lean`. Until that
merges, the diff below also shows #5385's files; the four files this PR adds are listed here.
Draft until #5385 lands.

Is every o-minimal expansion of the real ordered field $\bar{\mathbb{R}}$ exponentially bounded?
That is, is every definable $f : \mathbb{R} \to \mathbb{R}$ dominated by some compositional
iterate of $\exp$? Equivalently, by Miller's growth dichotomy, is there an o-minimal expansion of
$\bar{\mathbb{R}}$ with a definable trans-exponential function? Both forms are open. Wikipedia's
list of unsolved problems asks the trans-exponential form for an arbitrary o-minimal theory,
without naming the underlying field.

- `FormalConjecturesForMathlib/ModelTheory/OMinimal.lean` (new): `Set.IsPointOrOpenInterval`, a
  subset of a preorder that is a point or an open interval; `FirstOrder.Language.IsOMinimal`, an
  ordered structure whose definable subsets of the base type are finite unions of such sets; and
  `IsOMinimal.exists_finite_ordConnected`. Finite unions use `Set.Finite` on a set of subsets, so
  no decidable equality on `Set M` is needed. Following Pillay and Steinhorn, the order is not
  required to be dense or without endpoints.
- `FormalConjecturesForMathlib/ModelTheory/Real.lean`: adds
  `FirstOrder.Language.IsExponentiallyBounded` for structures on `ℝ`, and
  `IsExponentiallyBounded.of_expansion`, which passes it to reducts.
- `FormalConjectures/Wikipedia/TransExponentialOMinimal.lean` (new): Tarski–Seidenberg and
  Wilkie's theorem that $\bar{\mathbb{R}}$ and $\mathbb{R}_{\exp}$ are o-minimal
  (`research solved`), and the two open forms of the question (`research open`).

Formalisation notes:

- An expansion of $\bar{\mathbb{R}}$ is a structure on `ℝ` in a language `L` with the order
  symbol together with a language map `φ : Language.ring →ᴸ L` that is an expansion on `ℝ`.
  Requiring `≤` in the language loses no generality, since it is definable from `+` and `·`.
  The languages range over arbitrary universes.
- Domination is Mathlib's `IsBigO` along `atTop`, and the iterates are `Real.exp^[N]`.
- Definable means definable with parameters (`Set.Definable₁` and `Set.Definable₂` on
  `Set.univ`).

How I checked it:

- `lake --wfail build FormalConjecturesForMathlib FormalConjectures.Wikipedia.TransExponentialOMinimal`
  passes with no warnings. `ModelTheory/OMinimal.lean` contains no `sorry`.
- Statements read against van den Dries–Miller (Duke Math. J. 84 (1996), 5.5 and the remark
  following it), Miller's growth dichotomy (Proc. Amer. Math. Soc. 122 (1994), 257–259), Wilkie
  (J. Amer. Math. Soc. 9 (1996), 1051–1094), and Wikipedia's list of unsolved problems.

AI disclosure: this formalization was drafted with Claude Code, and reviewed by Codex and by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6KJQtpCKG5fs21rQhGCb6
