### PR TITLE
fix(ErdosProblems/263): state Koizumi's theorem with a nondecreasing sequence

### DIFF
--- a/FormalConjectures/ErdosProblems/263.lean
+++ b/FormalConjectures/ErdosProblems/263.lean
@@ -47,6 +47,16 @@ def IsIrrationalitySequence (a : ℕ → ℕ) : Prop :=
       atTop.Tendsto (fun n : ℕ => (a n : ℝ) / (b n : ℝ)) (𝓝 1) →
       Irrational (∑' n, 1 / (b n : ℝ)))
 
+/-- The nondecreasing version of `IsIrrationalitySequence`, as used by Koizumi [Ko25]: the sequence
+is positive and nondecreasing, and every positive sequence asymptotic to it has irrational
+reciprocal sum. -/
+def IsWeakIrrationalitySequence (a : ℕ → ℕ) : Prop :=
+  (∀ n : ℕ, a n > 0) ∧
+    Monotone a ∧
+    (∀ b : ℕ → ℕ, (∀ n : ℕ, b n > 0) ∧
+      atTop.Tendsto (fun n : ℕ => (a n : ℝ) / (b n : ℝ)) (𝓝 1) →
+      Irrational (∑' n, 1 / (b n : ℝ)))
+
 /--
 Is $a_n = 2^{2^n}$ an irrationality sequence in the above sense?
 -/
@@ -115,14 +125,17 @@ theorem erdos_263.variants.super_doubly_exponential (a: ℕ -> ℕ)
 
 /--
 Koizumi [Ko25] showed that $a_n = \lfloor \alpha^{2^n} \rfloor$ is an irrationality sequence
-for all but countably many $\alpha > 1$.
+for all but countably many $\alpha > 1$, in the nondecreasing sense `IsWeakIrrationalitySequence`.
+The strictly increasing predicate would fail on the whole interval $1 < \alpha < 4/3$, where
+$a_0 = a_1 = 1$.
 
 [Ko25] Koizumi, J., Irrationality of the reciprocal sum of doubly exponential sequences,
        arXiv:2504.05933 (2025).
 -/
 @[category research solved, AMS 11]
 theorem erdos_263.variants.doubly_exponential_all_but_countable :
-    ∀ᶠ (α : ℝ) in .cocountable, α > 1 → IsIrrationalitySequence (fun n : ℕ => ⌊α ^ 2 ^ n⌋₊) := by
+    ∀ᶠ (α : ℝ) in .cocountable, α > 1 →
+      IsWeakIrrationalitySequence (fun n : ℕ => ⌊α ^ 2 ^ n⌋₊) := by
   sorry
 
 end Erdos263

--- a/FormalConjectures/ErdosProblems/263.lean
+++ b/FormalConjectures/ErdosProblems/263.lean
@@ -124,6 +124,22 @@ theorem erdos_263.variants.super_doubly_exponential (a: ℕ -> ℕ)
   sorry
 
 /--
+The same folklore result with the growth hypothesis stated as an eventual lower bound
+$a_{n+1} \geq c\, a_n^{2+\varepsilon}$. Unlike the real-valued `liminf` in
+`erdos_263.variants.super_doubly_exponential`, this form also covers sequences such as
+$a_n = 2^{(n+1)!}$, for which the ratio $a_{n+1} / a_n^{2+\varepsilon}$ tends to $+\infty$ and the
+real `liminf` defaults to $0$.
+-/
+@[category research solved, AMS 11]
+theorem erdos_263.variants.super_doubly_exponential_eventual (a : ℕ → ℕ)
+    (ha : ∀ n : ℕ, a n > 0)
+    (ha' : StrictMono a)
+    (ha'' : ∃ ε c : ℝ, 0 < ε ∧ 0 < c ∧
+      ∀ᶠ n in atTop, c * (a n : ℝ) ^ (2 + ε) ≤ (a (n + 1) : ℝ)) :
+    IsIrrationalitySequence a := by
+  sorry
+
+/--
 Koizumi [Ko25] showed that $a_n = \lfloor \alpha^{2^n} \rfloor$ is an irrationality sequence
 for all but countably many $\alpha > 1$, in the nondecreasing sense `IsWeakIrrationalitySequence`.
 The strictly increasing predicate would fail on the whole interval $1 < \alpha < 4/3$, where


### PR DESCRIPTION
**What changed**

- New predicate `IsWeakIrrationalitySequence`, the nondecreasing version of `IsIrrationalitySequence` (positivity, `Monotone`, and the same universal irrationality condition).
- `erdos_263.variants.doubly_exponential_all_but_countable` uses it. The docstring explains why.

**Why**

The variant asserted `IsIrrationalitySequence (fun n => ⌊α ^ 2 ^ n⌋₊)` for all but countably many `α > 1`, but that predicate contains `StrictMono`. For every `α` in the uncountable interval `1 < α < 4/3` the first two terms are both `1`, so the statement was false. Koizumi's theorem is stated for nondecreasing sequences.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«263»
import Mathlib.Analysis.Real.Cardinality

/-!
For every real α in the uncountable interval (1,4/3), the first two floored double-exponential terms are both 1. The required strict monotonicity fails on an uncountable set, refuting the complete cocountable variant.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/ErdosProblems/263.lean
-/
namespace Counterexamples.Group1.Erdos263
open Filter
open scoped Topology
-- Every alpha in this nonempty open interval fails StrictMono at 0 < 1.
theorem floor_not_strictMono {α : ℝ} (hα : α ∈ Set.Ioo (1 : ℝ) (4/3)) :
    ¬ StrictMono (fun n : ℕ => ⌊α ^ 2 ^ n⌋₊) := by
  have hpos : 0 ≤ α := by linarith [hα.1]
  have hsq : α ^ 2 < 2 := by
    have hmul := mul_pos (show 0 < (4/3 : ℝ) - α by linarith [hα.2])
      (show 0 < (4/3 : ℝ) + α by linarith [hα.1])
    nlinarith
  have h0 : ⌊α⌋₊ = 1 := (Nat.floor_eq_iff hpos).mpr (by
    constructor <;> norm_num <;> linarith [hα.1, hα.2])
  have h1 : ⌊α ^ 2⌋₊ = 1 := (Nat.floor_eq_iff (sq_nonneg α)).mpr (by
    simpa only [Nat.cast_one, one_add_one_eq_two] using
      (show (1 : ℝ) ≤ α ^ 2 ∧ α ^ 2 < 2 from
        ⟨by nlinarith [hα.1, sq_nonneg (α - 1)], hsq⟩))
  intro h
  have hh := h (show (0 : ℕ) < 1 by omega)
  norm_num [h0, h1] at hh

-- Kernel-check a concrete small input too.
example : ⌊((6/5 : ℝ) ^ 2 ^ (0 : ℕ))⌋₊ = 1 ∧
    ⌊((6/5 : ℝ) ^ 2 ^ (1 : ℕ))⌋₊ = 1 := by norm_num

-- This refutes the entire cocountable theorem, not just one allowed exception.
theorem not_countable_variant :
    ¬ (∀ᶠ (α : ℝ) in Filter.cocountable, α > 1 →
      Erdos263.IsIrrationalitySequence (fun n : ℕ => ⌊α ^ 2 ^ n⌋₊)) := by
  intro h
  have hc : {α : ℝ | ¬ (α > 1 →
      Erdos263.IsIrrationalitySequence (fun n : ℕ => ⌊α ^ 2 ^ n⌋₊))}.Countable :=
    Filter.mem_cocountable.mp h
  have hi : (Set.Ioo (1 : ℝ) (4/3)).Countable := hc.mono (by
    intro α hα hgood
    exact floor_not_strictMono hα (hgood hα.1).2.1)
  have := Cardinal.Real.Ioo_countable_iff.mp hi
  norm_num at this

/-- The exact cocountable statement fails on the uncountable interval (1,4/3). -/
theorem refutes_original :
    ¬ (type_of% @Erdos263.erdos_263.variants.doubly_exponential_all_but_countable) :=
  not_countable_variant
#print axioms refutes_original

end Counterexamples.Group1.Erdos263
```

</details>

**Also in this PR (after review)**

The audit also reports that `erdos_263.variants.super_doubly_exponential` uses a real-valued `liminf`, which excludes the `+∞` case of the source. Following review, that statement and its `formal_proof` link are kept unchanged, and a second variant `erdos_263.variants.super_doubly_exponential_eventual` states the hypothesis as an eventual lower bound `∃ ε c, 0 < ε ∧ 0 < c ∧ ∀ᶠ n in atTop, c * a n ^ (2 + ε) ≤ a (n + 1)`, which covers sequences such as `2 ^ (n + 1)!` whose ratio tends to `+∞`.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«263»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/263 (finding 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

