### PR TITLE
fix(ErdosProblems/316): test partitions into at most n parts

### DIFF
--- a/FormalConjectures/ErdosProblems/316.lean
+++ b/FormalConjectures/ErdosProblems/316.lean
@@ -74,11 +74,14 @@ This is not true in general, as shown by Sándor [Sa97], who observed that the p
 $120$ form a counterexample. More generally, Sándor shows that for any $n\geq 2$ there exists a
 finite set $A\subseteq \mathbb{N}\backslash\{1\}$ with $\sum_{k\in A}\frac{1}{k} < n$ and no
 partition into $n$ parts each of which has $\sum_{k\in A_i}\frac{1}{k}<1$.
+
+A `Finpartition` has no empty parts, so partitions into at most $n$ parts are tested. Testing
+exactly $n$ parts would let the singleton $\{2\}$ satisfy the statement vacuously.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_316.variants.generalized (n : ℕ) (hn : 2 ≤ n) : ∃ A : Finset ℕ,
     A.Nonempty ∧ 0 ∉ A ∧ 1 ∉ A ∧ ∑ k ∈ A, (1 / k : ℚ) < n ∧ ∀ P : Finpartition A,
-    P.parts.card = n → ∃ p ∈ P.parts, 1 ≤ ∑ n ∈ p, (1 / n : ℚ) := by
+    P.parts.card ≤ n → ∃ p ∈ P.parts, 1 ≤ ∑ n ∈ p, (1 / n : ℚ) := by
   sorry
 
 end Erdos316


### PR DESCRIPTION
**What changed**

- `erdos_316.variants.generalized` quantifies over partitions with `P.parts.card ≤ n` instead of `= n`. The docstring says why.

**Why**

Mathlib's `Finpartition` has no empty parts, so `P.parts.card = n` only tests partitions into exactly `n` nonempty parts. The singleton `A = {2}` then satisfies the whole statement for every `n ≥ 2`: it has reciprocal sum `1/2 < n` and no partition into `n ≥ 2` parts, so the implication is vacuous. The Lean proof below establishes the statement as written from this witness. Testing at most `n` nonempty parts is the same as `n` indexed parts with empty parts allowed.

<details>
<summary>Lean proof of the statement as written (compiled with <code>lake --wfail build</code>, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«316»

/-!
The singleton set {2} makes the required partitions into at least two nonempty pieces impossible, giving a trivial proof of the complete written existence statement.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/ErdosProblems/316.lean
-/
namespace Counterexamples.Group1.Erdos316
theorem generalized_vacuous (n : ℕ) (hn : 2 ≤ n) : ∃ A : Finset ℕ,
    A.Nonempty ∧ 0 ∉ A ∧ 1 ∉ A ∧ ∑ k ∈ A, (1 / k : ℚ) < n ∧ ∀ P : Finpartition A,
    P.parts.card = n → ∃ p ∈ P.parts, 1 ≤ ∑ k ∈ p, (1 / k : ℚ) := by
  refine ⟨{2}, by simp, by simp, by simp, ?_, ?_⟩
  · have hnq : (2 : ℚ) ≤ n := by exact_mod_cast hn
    norm_num
    linarith
  · intro P hP
    have hcard := P.card_parts_le_card
    simp only [Finset.card_singleton] at hcard
    omega

/-- The exact generalized theorem has the singleton/vacuous-partition proof. -/
theorem trivial_original : type_of% @Erdos316.erdos_316.variants.generalized := generalized_vacuous
#print axioms trivial_original

end Counterexamples.Group1.Erdos316
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«316»'` passes.
- `{2}` has the one-part partition, whose only part has reciprocal sum `1/2 < 1`, so it no longer satisfies the statement.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/316

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
