### PR TITLE
fix(ErdosProblems/756): require m ≥ 1 in bhowmick_general

### DIFF
--- a/FormalConjectures/ErdosProblems/756.lean
+++ b/FormalConjectures/ErdosProblems/756.lean
@@ -67,11 +67,12 @@ theorem erdos_756.variants.bhowmick (n : ℕ) :
   sorry
 
 /--
-More generally, they construct, for any $m$ and large $n$, a set of $n$ points such that
+More generally, they construct, for any positive integer $m$ and large $n$, a set of $n$ points
+such that
 $\lfloor \frac{n}{2(m+1)}\rfloor$ distances occur at least $n+m$ times.
 -/
 @[category research solved, AMS 52]
-theorem erdos_756.variants.bhowmick_general (m : ℕ) :
+theorem erdos_756.variants.bhowmick_general (m : ℕ) (hm : 1 ≤ m) :
     ∀ᶠ n : ℕ in atTop, ∃ A : Finset ℝ², A.card = n ∧
       n / (2 * (m + 1)) ≤ (richDistances A (n + m)).card := by
   sorry


### PR DESCRIPTION
**What changed**

- `erdos_756.variants.bhowmick_general` assumes `1 ≤ m`. The docstring says "positive integer".

**Why**

At `m = 0` the statement asks, for all large `n`, for `⌊n/2⌋` distances each occurring at least `n` times. For even `n = 2t` this needs `2t²` distinct pairs, but `n` points have only `t(2t - 1)` pairs, so the eventual statement was false.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«756»

namespace Counterexamples.Group1.Erdos756
open Filter
open scoped EuclideanGeometry Asymptotics BigOperators
open _root_.Erdos756
lemma pair_bound (A : Finset ℝ²) (k : ℕ) :
    (richDistances A k).card * (2 * k) ≤ A.card * A.card - A.card := by
  classical
  have hlow (d : ℝ) (hd : d ∈ richDistances A k) :
      2 * k ≤ (A.offDiag.filter (fun p => dist p.1 p.2 = d)).card := by
    have h : k ≤ distanceMultiplicity A d := (Finset.mem_filter.mp hd).2
    simpa only [Nat.mul_comm] using
      (Nat.le_div_iff_mul_le (by decide : 0 < 2)).mp h
  calc
    (richDistances A k).card * (2 * k) = ∑ _d ∈ richDistances A k, 2 * k := by simp
    _ ≤ ∑ d ∈ richDistances A k,
        (A.offDiag.filter (fun p => dist p.1 p.2 = d)).card :=
      Finset.sum_le_sum hlow
    _ = (A.offDiag.filter (fun p => dist p.1 p.2 ∈ richDistances A k)).card :=
      Finset.sum_card_fiberwise_eq_card_filter A.offDiag (richDistances A k)
        (fun p => dist p.1 p.2)
    _ ≤ A.offDiag.card := Finset.card_filter_le _ _
    _ = A.card * A.card - A.card := Finset.offDiag_card A

lemma even_obstruction (t : ℕ) (ht : 0 < t) :
    ¬ ∃ A : Finset ℝ², A.card = 2 * t ∧
      (2 * t) / 2 ≤ (richDistances A (2 * t)).card := by
  rintro ⟨A, hA, hr⟩
  have hb := pair_bound A (2 * t)
  rw [hA] at hb
  have hr' : t ≤ (richDistances A (2 * t)).card := by simpa using hr
  have hmul := Nat.mul_le_mul_right (2 * (2 * t)) hr'
  have hstrict : (2 * t) * (2 * t) - 2 * t < (2 * t) * (2 * t) :=
    Nat.sub_lt (by positivity) (by positivity)
  nlinarith

lemma not_general_zero :
    ¬ (∀ᶠ n : ℕ in atTop, ∃ A : Finset ℝ², A.card = n ∧
      n / (2 * (0 + 1)) ≤ (richDistances A (n + 0)).card) := by
  intro h
  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp h
  apply even_obstruction (N + 1) (by omega)
  simpa using hN (2 * (N + 1)) (by omega)

lemma not_general_statement :
    ¬ (∀ m : ℕ, ∀ᶠ n : ℕ in atTop, ∃ A : Finset ℝ², A.card = n ∧
      n / (2 * (m + 1)) ≤ (richDistances A (n + m)).card) := by
  intro h
  exact not_general_zero (h 0)

theorem refutes_original : ¬ (type_of% @Erdos756.erdos_756.variants.bhowmick_general) :=
  not_general_statement
#print axioms refutes_original

end Counterexamples.Group1.Erdos756
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«756»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/756

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
