### PR TITLE
fix(Wikipedia/Kakeya): require positive dimension in kakeya_finite

### DIFF
--- a/FormalConjectures/Wikipedia/Kakeya.lean
+++ b/FormalConjectures/Wikipedia/Kakeya.lean
@@ -94,12 +94,14 @@ The finite field Kakeya conjecture asserts that any Kakeya set in `𝔽_qⁿ` ha
 least `c_n · qⁿ` for some constant `c_n` depending only on `n`.
 This was first proved by Dvir [Dv08]. The best known bound to date, due to Bukh and Chao [BuCh21],
 establishes that any Kakeya set in `𝔽_qⁿ` has size at least `qⁿ / (2 - 1/q)^(n - 1)`.
+The dimension is positive, as in `kakeya_set_conjecture`; for `n = 0` the empty set is a Kakeya
+set and the bound would read `1 ≤ 0`.
 
 [Dv08] Dvir, Z., _On the size of Kakeya sets in finite fields_. Journal of the American Mathematical Society 22 (2009), no. 4, 1093–1097.
 [BuCh21] Bukh, B. and Chao, T.-W., _Sharp density bounds on the finite field Kakeya problem_. Discrete Analysis 26 (2021), 9 pp.
 -/
 @[category research solved, AMS 52]
-theorem kakeya_finite {F : Type*} [Field F] [Fintype F] {n : ℕ}
+theorem kakeya_finite {F : Type*} [Field F] [Fintype F] {n : ℕ} (hn : 0 < n)
     (K : Finset (Fin n → F)) (hK : IsKakeyaFinite K) :
     card F ^ n / (2 - 1 / card F : ℚ) ^ (n - 1) ≤ K.card := by
   sorry


### PR DESCRIPTION
**What changed**

- `kakeya_finite` assumes `0 < n`, as `kakeya_set_conjecture` already does. The docstring says why.

**Why**

For `n = 0` the empty set is a Kakeya set in `Fin 0 → F` (there are no nonzero directions), and with natural subtraction the bound reads `1 ≤ 0`. So the theorem was false at `n = 0`.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.Wikipedia.Kakeya

/-!
In dimension zero over ZMod2 there are no nonzero directions, so the empty set satisfies the Kakeya condition while violating the stated lower bound 1.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/Wikipedia/Kakeya.lean
-/
namespace Counterexamples.Group1.Kakeya
-- No nonzero directions exist in dimension zero.
theorem finite_zero_empty :
    Kakeya.IsKakeyaFinite (∅ : Finset (Fin 0 → ZMod 2)) := by
  intro v hv
  exact (hv (Subsingleton.elim _ _)).elim

-- The claimed lower bound is 1, but the empty set has cardinality 0.
theorem finite_zero_counterexample :
    ∃ K : Finset (Fin 0 → ZMod 2), Kakeya.IsKakeyaFinite K ∧
      ¬ (Fintype.card (ZMod 2) ^ (0 : ℕ) /
        (2 - 1 / Fintype.card (ZMod 2) : ℚ) ^ ((0 : ℕ) - 1) ≤ K.card) := by
  exact ⟨∅, finite_zero_empty, by norm_num⟩

/-- Refutes the full original finite-field theorem at dimension zero over ZMod 2. -/
theorem refutes_original : ¬ (type_of% @Kakeya.kakeya_finite.{0}) := by
  intro h
  have hh := h (F := ZMod 2) (n := 0) ∅ finite_zero_empty
  norm_num at hh
#print axioms refutes_original

end Counterexamples.Group1.Kakeya
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.Kakeya` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/Kakeya

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
