### PR TITLE
fix(ErdosProblems/694): extrema on nonempty totient fibres, identity for large x

### DIFF
--- a/FormalConjectures/ErdosProblems/694.lean
+++ b/FormalConjectures/ErdosProblems/694.lean
@@ -42,14 +42,19 @@ $$
 A Lean formalisation of the reduction exists, conditional on Mertens' product theorem and
 Linnik's theorem; see the
 [formal proof](https://github.com/Shashi456/erdos-formalizations/blob/main/Erdos/P694/Proof.lean).
+
+The extrema are only required on nonempty fibres of the totient (values such as $3$ have no
+preimage), and the identity is asked for sufficiently large $x$: at $x = 1$ the maximum is
+$f_\max(1) / f_\min(1) = 2$ while $\log \log 1 = 0$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_694 : ∀ᵉ (fmax : ℕ → ℕ) (fmin : ℕ → ℕ),
-      (∀ n, IsGreatest (Nat.totient ⁻¹' {n}) (fmax n)) →
-      (∀ n, IsLeast (Nat.totient ⁻¹' {n}) (fmin n)) →
+      (∀ n, (∃ m, Nat.totient m = n) → IsGreatest (Nat.totient ⁻¹' {n}) (fmax n)) →
+      (∀ n, (∃ m, Nat.totient m = n) → IsLeast (Nat.totient ⁻¹' {n}) (fmin n)) →
       ∃ o : ℕ → ℝ, Tendsto o atTop (𝓝 0) ∧
-        ∀ x : ℕ, sSup { (fmax n : ℝ) / fmin n | (n : ℕ) (_ : n ≤ x) (_ : ∃ m, Nat.totient m = n) } =
-          (exp eulerMascheroniConstant + o x) * log (log (x : ℝ)) := by
+        ∀ᶠ x : ℕ in atTop,
+          sSup { (fmax n : ℝ) / fmin n | (n : ℕ) (_ : n ≤ x) (_ : ∃ m, Nat.totient m = n) } =
+            (exp eulerMascheroniConstant + o x) * log (log (x : ℝ)) := by
   sorry
 
 /--


### PR DESCRIPTION
**What changed**

- The extrema hypotheses of `erdos_694` are only required for values `n` in the image of the totient.
- The asymptotic identity is asked for sufficiently large `x` (`∀ᶠ x in atTop`). The docstring explains both.

**Why**

`IsGreatest (Nat.totient ⁻¹' {3}) (fmax 3)` implies `Nat.totient (fmax 3) = 3`, which is impossible, so the old hypotheses were unsatisfiable and the theorem held vacuously; the Lean proof below derives the statement as written from this alone. Independently, at `x = 1` the maximum is `fmax 1 / fmin 1 = 2` while `log (log 1) = 0`, so the identity cannot hold for every `x` even with satisfiable hypotheses.

<details>
<summary>Lean proof of the statement as written (compiled with <code>lake --wfail build</code>, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«694»

/-! Certificates concerning the exact audited definitions or propositions. -/

namespace Counterexamples.Group3
namespace Erdos694
lemma no_totient_three (m : ℕ) : Nat.totient m ≠ 3 := by
  intro h
  have hm : 2 < m := by
    have := Nat.totient_le m
    omega
  have he := Nat.totient_even hm
  rw [h] at he
  norm_num at he

lemma no_global_fmax (fmax : ℕ → ℕ) :
    ¬ (∀ n, IsGreatest (Nat.totient ⁻¹' {n}) (fmax n)) := by
  intro h
  exact no_totient_three (fmax 3) (h 3).1

/-- No functions satisfy all hypotheses of the exact audited main theorem. -/
theorem full_trivial_proof : type_of% _root_.Erdos694.erdos_694 := by
  intro fmax _ hmax _
  exact (no_global_fmax fmax hmax).elim

#print axioms full_trivial_proof
end Erdos694
end Counterexamples.Group3
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«694»'` passes.

Related: the "Erdős 694 — empty totient fiber makes the wrapper vacuous" item in #4896.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/694 (findings 1 and 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
