### PR TITLE
fix(ErdosProblems/1026): admissibleConstants quantifies over positive sequences

### DIFF
--- a/FormalConjectures/ErdosProblems/1026.lean
+++ b/FormalConjectures/ErdosProblems/1026.lean
@@ -45,15 +45,20 @@ def monotonicSubsequenceSums {n : ℕ} (x : Fin n → ℝ) : Set ℝ :=
   {S | ∃ I : Finset (Fin n), (MonotoneOn x ↑I ∨ AntitoneOn x ↑I) ∧ (∑ i ∈ I, x i) = S}
 
 /--
-The set of constants $c$ such that, for all sequences of $n$ distinct real numbers
+The set of constants $c$ such that, for all sequences of $n$ distinct positive real numbers
 $x_1,\ldots,x_n$,
 $$
 \max\left(\sum x_{i_r}\right) > (c-o(1))\frac{1}{\sqrt{n}}\sum x_i
 $$
 (where the maximum is taken over all monotonic subsequences).
+
+The source reduces to positive sequences. With signed sequences the condition is not a vanishing
+error term: for $\varepsilon > |c|$ and $x_i = -i$ the right-hand side is positive while every
+subsequence sum is nonpositive, so no constant would be admissible.
 -/
 def admissibleConstants : Set ℝ :=
   {c : ℝ | ∀ ε : ℝ, 0 < ε → ∀ᶠ n : ℕ in atTop, ∀ x : Fin n → ℝ, Function.Injective x →
+    (∀ i, 0 < x i) →
     ∃ S ∈ monotonicSubsequenceSums x, (c - ε) / Real.sqrt (n : ℝ) * (∑ i, x i) ≤ S}
 
 /--


### PR DESCRIPTION
**What changed**

- `admissibleConstants` requires `∀ i, 0 < x i` in addition to injectivity. The docstring records the source's reduction to positive sequences.

**Why**

With signed sequences the universal `ε` is not a vanishing error term. For any proposed `c`, take `ε = |c| + 1` and `x i = -(i + 1)`: every subsequence sum is nonpositive while `(c - ε) / √n * ∑ x` is positive, so no constant was admissible. Hence `admissibleConstants = ∅`, `erdos_1026` and `variants.lower_bound` were false, and `variants.upper_bound` held vacuously.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«1026»

/-! Certificates concerning the exact audited definitions or propositions. -/

namespace Counterexamples.Group3.Erdos1026
open _root_.Erdos1026 Filter

def negativeSeq (n : ℕ) (i : Fin n) : ℝ := -((i.val : ℝ) + 1)

lemma negativeSeq_injective (n : ℕ) : Function.Injective (negativeSeq n) := by
  intro i j h
  apply Fin.ext
  have h' : (i.val : ℝ) = (j.val : ℝ) := by
    dsimp [negativeSeq] at h
    linarith
  exact_mod_cast h'

lemma negativeSeq_neg (n : ℕ) (i : Fin n) : negativeSeq n i < 0 := by
  dsimp [negativeSeq]
  have : 0 ≤ (i.val : ℝ) := Nat.cast_nonneg _
  linarith

lemma negativeSeq_subseq_nonpos (n : ℕ) {S : ℝ}
    (hS : S ∈ monotonicSubsequenceSums (negativeSeq n)) : S ≤ 0 := by
  obtain ⟨I, _, rfl⟩ := hS
  exact Finset.sum_nonpos fun i _ => (negativeSeq_neg n i).le

lemma negativeSeq_sum_neg (n : ℕ) (hn : 0 < n) : (∑ i, negativeSeq n i) < 0 := by
  have h : (∑ i : Fin n, negativeSeq n i) < ∑ _i : Fin n, (0 : ℝ) := by
    apply Finset.sum_lt_sum
    · intro i _
      exact (negativeSeq_neg n i).le
    · exact ⟨⟨0, hn⟩, Finset.mem_univ _, negativeSeq_neg n _⟩
  simpa using h

lemma zero_mem_subseqSums {n : ℕ} (x : Fin n → ℝ) :
    0 ∈ monotonicSubsequenceSums x := by
  refine ⟨∅, Or.inl ?_, by simp⟩
  simp [MonotoneOn]

lemma admissibleConstants_empty : admissibleConstants = ∅ := by
  apply Set.eq_empty_iff_forall_notMem.mpr
  intro c hc
  have he : 0 < |c| + 1 := by positivity
  have hce : c - (|c| + 1) < 0 := by
    have := le_abs_self c
    linarith
  obtain ⟨n, hbound, hn⟩ := ((hc (|c| + 1) he).and (eventually_gt_atTop (0 : ℕ))).exists
  obtain ⟨S, hS, hle⟩ := hbound (negativeSeq n) (negativeSeq_injective n)
  have hsqrt : 0 < Real.sqrt (n : ℝ) := Real.sqrt_pos.mpr (by exact_mod_cast hn)
  have hpos : 0 < (c - (|c| + 1)) / Real.sqrt (n : ℝ) * ∑ i, negativeSeq n i :=
    mul_pos_of_neg_of_neg (div_neg_of_neg_of_pos hce hsqrt) (negativeSeq_sum_neg n hn)
  exact (not_lt_of_ge (hle.trans (negativeSeq_subseq_nonpos n hS))) hpos

theorem full_refutation : ¬ (type_of% _root_.Erdos1026.erdos_1026) := by
  rw [admissibleConstants_empty]
  simp [IsGreatest]

theorem lower_bound_refutation : ¬ (type_of% _root_.Erdos1026.erdos_1026.variants.lower_bound) := by
  rw [admissibleConstants_empty]
  simp

#print axioms full_refutation
#print axioms lower_bound_refutation
end Counterexamples.Group3.Erdos1026
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«1026»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/1026

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
