### PR TITLE
fix(ErdosProblems/1048): require a positive root radius

### DIFF
--- a/FormalConjectures/ErdosProblems/1048.lean
+++ b/FormalConjectures/ErdosProblems/1048.lean
@@ -38,7 +38,7 @@ def openLevelSet (f : Polynomial ℂ) : Set ℂ :=
 
 /--
 If $f\in \mathbb{C}[x]$ is a monic polynomial with all roots satisfying
-$\lvert z\rvert \leq r$ for some $r<2$, then must
+$\lvert z\rvert \leq r$ for some $0 < r < 2$, then must
 $$\{ z: \lvert f(z)\rvert <1\}$$
 have a connected component with diameter $>2-r$?
 
@@ -50,7 +50,7 @@ $\to 0$ as $n\to \infty$.
 -/
 @[category research solved, AMS 30, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos1048.lean"]
 theorem erdos_1048 : answer(False) ↔
-    ∀ (r : ℝ) (f : ℂ[X]), r < 2 → f.Monic → f.degree ≥ 1 → (∀ z ∈ f.roots, ‖z‖ ≤ r) →
+    ∀ (r : ℝ) (f : ℂ[X]), 0 < r → r < 2 → f.Monic → f.degree ≥ 1 → (∀ z ∈ f.roots, ‖z‖ ≤ r) →
       ∃ z ∈ openLevelSet f, ENNReal.ofReal (2 - r) <
         Metric.ediam (connectedComponentIn (openLevelSet f) z) := by
   sorry


### PR DESCRIPTION
**What changed**

- `erdos_1048` assumes `0 < r`. The docstring says `0 < r < 2`.

**Why**

With `r = 0` and `f = X` every hypothesis held: the only root is `0`, and the open sublevel set is the unit disc, whose diameter is exactly `2`, not `> 2`. So the recorded negative answer had a degenerate proof unrelated to Pommerenke's construction, which is the case excluded by the Erdős–Herzog–Piranian question. The Lean file below refutes the question side with this witness.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«1048»

/-! Certificates concerning the exact audited definitions or propositions. -/

namespace Counterexamples.Group3.Erdos1048
open Polynomial _root_.Erdos1043 _root_.Erdos1048

lemma component_diam_X_le_two (z : ℂ) :
    Metric.ediam (connectedComponentIn (openLevelSet (X : ℂ[X])) z) ≤ 2 := by
  apply le_trans (Metric.ediam_mono (connectedComponentIn_subset _ _))
  apply Metric.ediam_le
  intro x hx y hy
  have hx' : ‖x‖ < 1 := by simpa [openLevelSet] using hx
  have hy' : ‖y‖ < 1 := by simpa [openLevelSet] using hy
  rw [edist_dist]
  calc
    ENNReal.ofReal (dist x y) ≤ ENNReal.ofReal (2 : ℝ) := by
      apply ENNReal.ofReal_le_ofReal
      calc
        dist x y = ‖x - y‖ := dist_eq_norm _ _
        _ ≤ ‖x‖ + ‖y‖ := norm_sub_le _ _
        _ ≤ 2 := by linarith
    _ = 2 := by norm_num

-- This uses no assertion from the problem file: r = 0, f = X suffices.
theorem main_as_written_has_zero_radius_counterexample :
    ¬ (∀ (r : ℝ) (f : ℂ[X]), r < 2 → f.Monic → f.degree ≥ 1 →
        (∀ z ∈ f.roots, ‖z‖ ≤ r) →
        ∃ z ∈ openLevelSet f, ENNReal.ofReal (2 - r) <
          Metric.ediam (connectedComponentIn (openLevelSet f) z)) := by
  intro h
  obtain ⟨z, _, hd⟩ := h 0 X (by norm_num) monic_X (by simp) (by simp)
  norm_num at hd
  exact not_lt_of_ge (component_diam_X_le_two z) hd

end Counterexamples.Group3.Erdos1048
```

</details>

**Reviewer note**

The `formal_proof` link (Pommerenke's `X ^ n - (3/2) ^ n`, with `r = 3/2 > 0`) refutes the corrected statement by the same construction, but its literal theorem is about the previous formulation. An alternative fix, closer to [EHP58], is the strict root bound `‖z‖ < r`.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«1048»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/1048

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
