### PR TITLE
fix(ErdosProblems/726): take the remainder in ℕ before casting

### DIFF
--- a/FormalConjectures/ErdosProblems/726.lean
+++ b/FormalConjectures/ErdosProblems/726.lean
@@ -37,12 +37,13 @@ $\sum_{p\leq n}1_{n\in (p/2,p)\pmod{p}}\frac{1}{p}\sim \frac{\log\log n}{2}$?
 A conjecture of Erdős, Graham, Ruzsa, and Straus [EGRS75].
 
 By $n\in (p/2,p)\pmod{p}$ we mean $n\equiv r\pmod{p}$ for some integer $r$ with $p/2<r<p$.
+The remainder `n % p` is computed in `ℕ` before casting to `ℝ`.
 -/
 @[category research open, AMS 11]
 theorem erdos_726 :
     answer(sorry) ↔
       (fun n : ℕ ↦ ∑ p ∈ (range (n + 1)).filter
-          (fun p : ℕ ↦ p.Prime ∧ (p : ℝ) / 2 < (n % p : ℝ)),
+          (fun p : ℕ ↦ p.Prime ∧ (p : ℝ) / 2 < ((n % p : ℕ) : ℝ)),
         (1 : ℝ) / (p : ℝ))
       ~[atTop] (fun n : ℕ ↦ Real.log (Real.log (n : ℝ)) / 2) := by
   sorry


### PR DESCRIPTION
**What changed**

- The filter predicate uses `((n % p : ℕ) : ℝ)`. The docstring says so.

**Why**

`(n % p : ℝ)` elaborated as the real-field remainder `(n : ℝ) % (p : ℝ)`, which is `0` in Mathlib's `Field.toEuclideanDomain`. So the filter `p / 2 < 0` was empty, the sum was identically `0`, and the asymptotic on the right-hand side was trivially false.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«726»

/-! Certificates concerning the exact audited definitions or propositions. -/

namespace Counterexamples.Group3.Erdos726
open Nat Filter Finset
open scoped Topology Asymptotics

noncomputable def originalSum (n : ℕ) : ℝ :=
  ∑ p ∈ (range (n + 1)).filter
      (fun p : ℕ ↦ p.Prime ∧ (p : ℝ) / 2 < (n % p : ℝ)),
    (1 : ℝ) / (p : ℝ)

-- Concrete distinction between real-field and natural-number remainder.
example : (5 % 3 : ℝ) = 0 := by norm_num
example : ((5 % 3 : ℕ) : ℝ) = 2 := by norm_num
example : ¬ ((3 : ℝ) / 2 < (5 % 3 : ℝ)) := by norm_num
example : (3 : ℝ) / 2 < ((5 % 3 : ℕ) : ℝ) := by norm_num

lemma real_remainder_zero (n p : ℕ) (hp : p.Prime) : (n % p : ℝ) = 0 := by
  have hp0 : (p : ℝ) ≠ 0 := by exact_mod_cast hp.ne_zero
  simp [Field.mod_eq, hp0]

lemma original_filter_empty (n : ℕ) :
    (range (n + 1)).filter
      (fun p : ℕ ↦ p.Prime ∧ (p : ℝ) / 2 < (n % p : ℝ)) = ∅ := by
  apply Finset.filter_eq_empty_iff.mpr
  intro p _ hp
  rw [real_remainder_zero n p hp.1] at hp
  have hnonneg : (0 : ℝ) ≤ (p : ℝ) / 2 := by positivity
  exact (not_lt_of_ge hnonneg) hp.2

lemma original_sum_zero (n : ℕ) : originalSum n = 0 := by
  simp only [originalSum, original_filter_empty, Finset.sum_empty]

lemma loglog_tendsto :
    Tendsto (fun n : ℕ ↦ Real.log (Real.log (n : ℝ))) atTop atTop :=
  Real.tendsto_log_atTop.comp
    (Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop)

lemma denominator_eventually_ne_zero :
    ∀ᶠ n : ℕ in atTop, Real.log (Real.log (n : ℝ)) / 2 ≠ 0 := by
  filter_upwards [loglog_tendsto.eventually_ne_atTop 0] with n hn
  exact div_ne_zero hn (by norm_num)

lemma original_asymptotic_false :
    ¬ (originalSum ~[atTop] (fun n : ℕ ↦ Real.log (Real.log (n : ℝ)) / 2)) := by
  intro h
  have hz : (fun n : ℕ ↦ Real.log (Real.log (n : ℝ)) / 2) ~[atTop] (0 : ℕ → ℝ) := by
    have hzero : originalSum = (0 : ℕ → ℝ) := funext original_sum_zero
    simpa only [hzero] using h.symm
  have heq := Asymptotics.isEquivalent_zero_iff_eventually_zero.mp hz
  obtain ⟨n, he, hn⟩ := (heq.and denominator_eventually_ne_zero).exists
  exact hn he

end Counterexamples.Group3.Erdos726
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«726»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/726

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
