### PR TITLE
fix(Wikipedia/Mersenne): reduce the New Mersenne Conjecture to odd primes

### DIFF
--- a/FormalConjectures/Wikipedia/Mersenne.lean
+++ b/FormalConjectures/Wikipedia/Mersenne.lean
@@ -78,14 +78,15 @@ theorem new_mersenne_conjecture (p : ℕ) (hp : Odd p) :
     NewMersenneConjectureStatement p := by
   sorry
 
-/-- It suffices to check this conjecture for primes -/
+/-- It suffices to check this conjecture for odd primes. The statement fails at `p = 2`:
+`mersenne 2 = 3` is prime and `2 = 2 ^ 0 + 1`, but `2` gives no Wagstaff prime. -/
 @[category textbook, AMS 11]
 theorem new_mersenne_conjecture_of_prime :
-    (∀ p, p.Prime → NewMersenneConjectureStatement p) →
+    (∀ p, p.Prime → Odd p → NewMersenneConjectureStatement p) →
     ∀ p, Odd p → NewMersenneConjectureStatement p := by
   intro H p hp_odd
   by_cases hp_prime : p.Prime
-  · exact H p hp_prime
+  · exact H p hp_prime hp_odd
   suffices ¬Nat.GivesWagstaffPrime p by
     have hF1 : ¬(mersenne p).Prime := fun h => hp_prime h.of_mersenne
     refine ⟨?_, ?_, ?_⟩ <;> grind


### PR DESCRIPTION
**What changed**

- The premise of `new_mersenne_conjecture_of_prime` quantifies over odd primes, and the proof passes `hp_odd` along. The docstring explains the `p = 2` case.

**Why**

`NewMersenneConjectureStatement 2` is false: `mersenne 2 = 3` is prime and `2 = 2 ^ 0 + 1`, but `2` gives no Wagstaff prime. So the premise `∀ p, p.Prime → NewMersenneConjectureStatement p` was impossible and the reduction theorem was vacuous. The Lean proof below derives the theorem as written from that alone.

<details>
<summary>Lean proof of the statement as written (compiled with <code>lake --wfail build</code>, standard axioms only)</summary>

```lean
import FormalConjectures.Wikipedia.Mersenne

/-! Certificates concerning the exact audited definitions or propositions. -/

namespace Counterexamples.Group3
namespace MersenneReduction
lemma special_two : Mersenne.Nat.IsSpecialForm 2 := by
  exact ⟨0, Or.inl (by norm_num)⟩

lemma not_wagstaff_two : ¬ Mersenne.Nat.GivesWagstaffPrime 2 := by
  norm_num [Mersenne.Nat.GivesWagstaffPrime]

lemma not_new_mersenne_two : ¬ Mersenne.NewMersenneConjectureStatement 2 := by
  intro h
  exact not_wagstaff_two (h.2.1 ⟨by norm_num [mersenne], special_two⟩)

lemma impossible_reduction_hypothesis :
    ¬ (∀ p : ℕ, p.Prime → Mersenne.NewMersenneConjectureStatement p) := by
  intro h
  exact not_new_mersenne_two (h 2 Nat.prime_two)

/-- The whole reduction theorem follows from its impossible premise. -/
theorem full_trivial_proof : type_of% Mersenne.new_mersenne_conjecture_of_prime := by
  intro h
  exact (impossible_reduction_hypothesis h).elim

#print axioms full_trivial_proof
end MersenneReduction
end Counterexamples.Group3
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.Mersenne` passes, including the existing proof with the extra hypothesis.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/Mersenne

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
