### PR TITLE
fix(GreensOpenProblems/42): Cohn–Elkies admissible functions are continuous

### DIFF
--- a/FormalConjectures/GreensOpenProblems/42.lean
+++ b/FormalConjectures/GreensOpenProblems/42.lean
@@ -50,11 +50,12 @@ noncomputable def fHat (f : V → ℝ) (t : V) : ℝ :=
   (𝓕 (fun x ↦ (f x : ℂ)) t).re
 
 /--
-Definition 2.1 from [CoEl03]: A function is admissible if both the function and its Fourier
-transform decay sufficiently fast.
+Definition 2.1 from [CoEl03]: A function is admissible if it is continuous and both the function
+and its Fourier transform decay sufficiently fast. Continuity is essential: changing `f` at a
+single point leaves `fHat f` unchanged, so without it every positive bound would be achievable.
 -/
 def CohnElkiesAdmissible (f : V → ℝ) : Prop :=
-  ∃ C > 0, ∃ δ > 0,
+  Continuous f ∧ ∃ C > 0, ∃ δ > 0,
     (∀ x : V, |f x| ≤ C / (1 + ‖x‖) ^ ((Module.finrank ℝ V : ℝ) + δ)) ∧
     (∀ t : V, |fHat f t| ≤ C / (1 + ‖t‖) ^ ((Module.finrank ℝ V : ℝ) + δ))
 


### PR DESCRIPTION
**What changed**

- `CohnElkiesAdmissible f` requires `Continuous f`, as in Definition 2.1 of [CoEl03]. The docstring says why.

**Why**

Without continuity, changing `f` at the single point `0` leaves `fHat f` unchanged and preserves every other scheme condition, so `f 0 / fHat f 0` can be made any positive number. The Lean file below proves `CohnElkiesOptimal 2 b ↔ 0 < b` for the previous definition, which makes `green_42` (and the dimension variants) trivial.

<details>
<summary>Lean proof of the statement as written (compiled with <code>lake --wfail build</code>, standard axioms only)</summary>

```lean
import FormalConjectures.GreensOpenProblems.«42»
/-! A concrete easy starting function for the missing-continuity counterexample. -/
open Real Complex MeasureTheory Filter
open scoped EuclideanGeometry FourierTransform
set_option maxHeartbeats 600000

namespace Counterexamples.Group3.Green42

noncomputable def gauss (a : ℝ) (x : ℝ^2) : ℝ := Real.exp (-a * ‖x‖ ^ 2)
noncomputable def base (x : ℝ^2) : ℝ := 4 * gauss 2 x - gauss 1 x

lemma cast_gauss (a : ℝ) : (fun x : ℝ^2 => (gauss a x : ℂ)) =
    fun x => Complex.exp (-(a : ℂ) * (‖x‖ : ℂ) ^ 2) := by
  funext x
  simp [gauss]

lemma integrable_gauss_cast (a : ℝ) (ha : 0 < a) :
    Integrable (fun x : ℝ^2 => (gauss a x : ℂ)) := by
  rw [cast_gauss]
  simpa using GaussianFourier.integrable_cexp_neg_mul_sq_norm_add
    (V := ℝ^2) (b := (a : ℂ)) (by simpa using ha) 0 0

lemma fHat_gauss (a : ℝ) (ha : 0 < a) (t : ℝ^2) :
    Green42.fHat (gauss a) t = π / a * Real.exp (-π ^ 2 * ‖t‖ ^ 2 / a) := by
  unfold Green42.fHat
  rw [cast_gauss, fourier_gaussian_innerProductSpace (by simpa using ha)]
  norm_num
  simp [← Complex.ofReal_pow, ← Complex.ofReal_mul, ← Complex.ofReal_neg,
    ← Complex.ofReal_div, ← Complex.ofReal_exp]

lemma fourier_add_integrable (f g : ℝ^2 → ℂ) (hf : Integrable f) (hg : Integrable g) :
    𝓕 (f + g) = 𝓕 f + 𝓕 g := by
  exact VectorFourier.fourierIntegral_add (by fun_prop)
    (by change Continuous (fun p : (ℝ^2) × (ℝ^2) => inner ℝ p.1 p.2); fun_prop) hf hg

lemma fourier_const_smul (f : ℝ^2 → ℂ) (c : ℂ) : 𝓕 (c • f) = c • 𝓕 f := by
  exact VectorFourier.fourierIntegral_const_smul _ _ _ _ _

lemma fHat_add (f g : ℝ^2 → ℝ)
    (hf : Integrable (fun x => (f x : ℂ))) (hg : Integrable (fun x => (g x : ℂ))) (t : ℝ^2) :
    Green42.fHat (fun x => f x + g x) t = Green42.fHat f t + Green42.fHat g t := by
  have hcast : (fun x => ((f x + g x : ℝ) : ℂ)) =
      (fun x => (f x : ℂ)) + (fun x => (g x : ℂ)) := by ext x; simp
  unfold Green42.fHat
  rw [hcast, fourier_add_integrable _ _ hf hg]
  simp

lemma fHat_mul (f : ℝ^2 → ℝ) (a : ℝ) (t : ℝ^2) :
    Green42.fHat (fun x => a * f x) t = a * Green42.fHat f t := by
  have hcast : (fun x => ((a * f x : ℝ) : ℂ)) = (a : ℂ) • (fun x => (f x : ℂ)) := by
    ext x; simp
  unfold Green42.fHat
  rw [hcast, fourier_const_smul]
  simp [smul_eq_mul]

lemma fHat_base (t : ℝ^2) : Green42.fHat base t =
    2 * π * gauss (π ^ 2 / 2) t - π * gauss (π ^ 2) t := by
  have hf := integrable_gauss_cast 2 (by norm_num)
  have hg := integrable_gauss_cast 1 (by norm_num)
  have hbase : base = fun x => 4 * gauss 2 x + (-1) * gauss 1 x := by
    funext x; simp [base, sub_eq_add_neg]
  rw [hbase, fHat_add, fHat_mul, fHat_mul, fHat_gauss 2 (by norm_num),
    fHat_gauss 1 (by norm_num)]
  · simp only [gauss]
    have he : -π ^ 2 * ‖t‖ ^ 2 / 2 = -(π ^ 2 / 2) * ‖t‖ ^ 2 := by ring
    rw [he]
    ring
  · simpa using hf.const_mul (4 : ℂ)
  · simpa using hg.const_mul (-1 : ℂ)

lemma gauss_pos (a : ℝ) (x : ℝ^2) : 0 < gauss a x := Real.exp_pos _

lemma gauss_le_gauss {a b : ℝ} (hab : a ≤ b) (x : ℝ^2) : gauss b x ≤ gauss a x := by
  apply Real.exp_le_exp.mpr
  nlinarith [sq_nonneg ‖x‖]

lemma basic_gaussian_decay {r : ℝ} (hr : 0 ≤ r) :
    Real.exp (-r^2) ≤ 8 / (1 + r)^4 := by
  have hquad := Real.quadratic_le_exp_of_nonneg (sq_nonneg r)
  have h2 : (1 + r)^2 ≤ 2 * (1 + r^2) := by nlinarith [sq_nonneg (1 - r)]
  have h4 : ((1 + r)^2)^2 ≤ (2 * (1 + r^2))^2 :=
    (sq_le_sq₀ (by positivity) (by positivity)).mpr h2
  apply (le_div_iff₀ (pow_pos (by linarith) 4)).mpr
  rw [Real.exp_neg]
  apply (inv_mul_le_iff₀ (Real.exp_pos _)).mpr
  nlinarith

lemma gauss_decay {a : ℝ} (ha : 1 ≤ a) (x : ℝ^2) :
    gauss a x ≤ 8 / (1 + ‖x‖)^4 := by
  have h := gauss_le_gauss ha x
  exact h.trans (by simpa [gauss] using basic_gaussian_decay (norm_nonneg x))

lemma base_nonpos (x : ℝ^2) (hx : 2 ≤ ‖x‖) : base x ≤ 0 := by
  have hu : 4 ≤ ‖x‖^2 := by nlinarith
  have he : 4 ≤ Real.exp (‖x‖^2) := by
    have := Real.add_one_le_exp (‖x‖^2)
    linarith
  have hsmall : 4 * Real.exp (-‖x‖^2) ≤ 1 := by
    rw [Real.exp_neg, ← div_eq_mul_inv]
    exact (div_le_one (Real.exp_pos _)).mpr he
  have hmul := mul_le_mul_of_nonneg_right hsmall (Real.exp_pos (-‖x‖^2)).le
  have hexp : Real.exp (-2 * ‖x‖^2) = Real.exp (-‖x‖^2) * Real.exp (-‖x‖^2) := by
    rw [← Real.exp_add]
    congr 1
    ring
  simp only [base, gauss, neg_one_mul]
  rw [hexp]
  nlinarith

#print axioms fHat_base
#print axioms basic_gaussian_decay
end Counterexamples.Group3.Green42

namespace Counterexamples.Group3.Green42

lemma base_admissible : Green42.CohnElkiesAdmissible base := by
  have hp : 1 ≤ π^2 / 2 := by nlinarith [Real.pi_gt_three]
  have hpp : 1 ≤ π^2 := by linarith
  refine ⟨128, by norm_num, 2, by norm_num, ?_, ?_⟩
  · intro x
    norm_num
    have hg1 := gauss_decay (by norm_num : (1 : ℝ) ≤ 1) x
    have hg2 := gauss_decay (by norm_num : (1 : ℝ) ≤ 2) x
    have hbound : |base x| ≤ 4 * gauss 2 x + gauss 1 x := by
      simpa [base, abs_of_pos (gauss_pos 2 x), abs_of_pos (gauss_pos 1 x)] using
        abs_sub (4 * gauss 2 x) (gauss 1 x)
    have hD : 0 < (1 + ‖x‖)^4 := by positivity
    calc
      |base x| ≤ 4 * gauss 2 x + gauss 1 x := hbound
      _ ≤ 4 * (8 / (1 + ‖x‖)^4) + 8 / (1 + ‖x‖)^4 := by linarith
      _ = 40 / (1 + ‖x‖)^4 := by ring
      _ ≤ 128 / (1 + ‖x‖)^4 := div_le_div_of_nonneg_right (by norm_num) hD.le
  · intro t
    norm_num
    have hg1 := gauss_decay hp t
    have hg2 := gauss_decay hpp t
    have hbound : |Green42.fHat base t| ≤
        2 * π * gauss (π^2 / 2) t + π * gauss (π^2) t := by
      rw [fHat_base]
      have hA := mul_pos (mul_pos (show (0 : ℝ) < 2 by norm_num) Real.pi_pos)
        (gauss_pos (π^2 / 2) t)
      have hB := mul_pos Real.pi_pos (gauss_pos (π^2) t)
      exact abs_le.mpr ⟨by linarith, by linarith⟩
    have hD : 0 < (1 + ‖t‖)^4 := by positivity
    calc
      |Green42.fHat base t| ≤ 2 * π * gauss (π^2 / 2) t + π * gauss (π^2) t := hbound
      _ ≤ 2 * π * (8 / (1 + ‖t‖)^4) + π * (8 / (1 + ‖t‖)^4) := by
        nlinarith [Real.pi_pos]
      _ = (24 * π) / (1 + ‖t‖)^4 := by ring
      _ ≤ 128 / (1 + ‖t‖)^4 :=
        div_le_div_of_nonneg_right (by linarith [Real.pi_lt_four]) hD.le

lemma base_satisfies_scheme : Green42.SatisfiesCohnElkiesScheme base := by
  refine ⟨base_admissible, ?_, base_nonpos, ?_, ?_, ?_⟩
  · intro x y hxy
    simp [base, gauss, hxy]
  · intro t
    rw [fHat_base]
    have h := gauss_le_gauss (by nlinarith [sq_nonneg π] : π^2 / 2 ≤ π^2) t
    have hpos := gauss_pos (π^2 / 2) t
    nlinarith [Real.pi_pos]
  · simp [fHat_base, gauss]
    linarith [Real.pi_pos]
  · norm_num [base, gauss]

#print axioms base_satisfies_scheme
end Counterexamples.Group3.Green42

namespace Counterexamples.Group3.Green42

noncomputable def atOrigin (f : ℝ^2 → ℝ) (a : ℝ) : ℝ^2 → ℝ :=
  Function.update f 0 a

@[simp] lemma atOrigin_zero (f : ℝ^2 → ℝ) (a : ℝ) : atOrigin f a 0 = a := by
  classical
  simp [atOrigin]

lemma atOrigin_ne (f : ℝ^2 → ℝ) (a : ℝ) {x : ℝ^2} (hx : x ≠ 0) :
    atOrigin f a x = f x := by
  classical
  simp [atOrigin, hx]

lemma fHat_atOrigin (f : ℝ^2 → ℝ) (a : ℝ) :
    Green42.fHat (atOrigin f a) = Green42.fHat f := by
  funext t
  unfold Green42.fHat
  congr 1
  apply Real.fourier_congr_ae
  filter_upwards [Measure.ae_ne (volume : Measure (ℝ^2)) 0] with x hx
  rw [atOrigin_ne f a hx]

lemma admissible_atOrigin (f : ℝ^2 → ℝ) (a : ℝ)
    (hf : Green42.CohnElkiesAdmissible f) :
    Green42.CohnElkiesAdmissible (atOrigin f a) := by
  rcases hf with ⟨C, hC, δ, hδ, hf, hhat⟩
  refine ⟨C + |a|, by positivity, δ, hδ, ?_, ?_⟩
  · intro x
    by_cases hx : x = 0
    · subst x
      simpa using (show |a| ≤ C + |a| by linarith)
    · rw [atOrigin_ne f a hx]
      exact (hf x).trans (div_le_div_of_nonneg_right (le_add_of_nonneg_right (abs_nonneg a))
        (le_of_lt (Real.rpow_pos_of_pos (by positivity) _)))
  · intro t
    rw [fHat_atOrigin]
    exact (hhat t).trans (div_le_div_of_nonneg_right (le_add_of_nonneg_right (abs_nonneg a))
      (le_of_lt (Real.rpow_pos_of_pos (by positivity) _)))

lemma scheme_atOrigin (f : ℝ^2 → ℝ) {a : ℝ} (ha : 0 < a)
    (hf : Green42.SatisfiesCohnElkiesScheme f) :
    Green42.SatisfiesCohnElkiesScheme (atOrigin f a) := by
  rcases hf with ⟨hadm, hrad, hspace, hfreq, hfreq0, _⟩
  refine ⟨admissible_atOrigin f a hadm, ?_, ?_, ?_, ?_, by simp [ha]⟩
  · intro x y hxy
    by_cases hx : x = 0
    · subst x
      have hy : y = 0 := norm_eq_zero.mp (by simpa using hxy.symm)
      simp [hy]
    · have hy : y ≠ 0 := by
        intro h; subst y; apply hx; simpa using hxy
      rw [atOrigin_ne f a hx, atOrigin_ne f a hy]
      exact hrad x y hxy
  · intro x hx
    have hx0 : x ≠ 0 := by intro h; subst x; norm_num at hx
    rw [atOrigin_ne f a hx0]
    exact hspace x hx
  · simpa [fHat_atOrigin] using hfreq
  · simpa [fHat_atOrigin] using hfreq0

lemma any_positive_bound (f : ℝ^2 → ℝ) (hf : Green42.SatisfiesCohnElkiesScheme f)
    {b : ℝ} (hb : 0 < b) : Green42.CohnElkiesOptimal 2 b := by
  refine ⟨atOrigin f (b * Green42.fHat f 0),
    scheme_atOrigin f (mul_pos hb hf.2.2.2.2.1) hf, ?_⟩
  simp only [atOrigin_zero, fHat_atOrigin]
  exact mul_div_cancel_right₀ b (ne_of_gt hf.2.2.2.2.1)

/-- The omitted regularity permits every positive claimed density bound. -/
theorem all_positive_bounds (b : ℝ) (hb : 0 < b) : _root_.Green42.CohnElkiesOptimal 2 b :=
  any_positive_bound base base_satisfies_scheme hb

/-- A concrete accepted density far below the classical packing density. -/
theorem implausible_density : _root_.Green42.CohnElkiesOptimal 2 (1 / 1000) :=
  all_positive_bounds _ (by norm_num)

#print axioms all_positive_bounds
#print axioms implausible_density
end Counterexamples.Group3.Green42
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.GreensOpenProblems.«42»'` passes.
- The witness modifies a Gaussian combination at one point, so it is not continuous.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/GreensOpenProblems/42

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
