### PR TITLE
fix(GreensOpenProblems/38): sign conditions in the growth-rate statements

### DIFF
--- a/FormalConjectures/GreensOpenProblems/38.lean
+++ b/FormalConjectures/GreensOpenProblems/38.lean
@@ -69,20 +69,22 @@ noncomputable def C₁ : ℝ := (367 : ℝ) ^ (5⁻¹ : ℝ)
 /-- The upper bound constant $C_2 \approx 3.3177$ from [La79]. -/
 noncomputable def C₂ : ℝ := (7 * Real.cos (Real.pi / 7)) / (1 + Real.cos (Real.pi / 7))
 
-/-- Can we improve the lower bound? -/
+/-- Can we improve the lower bound? The answer sequence must be eventually nonnegative, since
+`=O` compares norms. -/
 @[category research open, AMS 5 11]
 theorem green_38.lower :
     let ans := (answer(sorry) : ℕ → ℝ)
-    ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
+    (∀ᶠ n in atTop, 0 ≤ ans n) ∧ ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
     ∃ c > C₁, (fun n ↦ c ^ n) =O[atTop] ans := by
   sorry
 
-/-- Can we improve the best upper bound? -/
+/-- Can we improve the best upper bound? The base `c` must be positive, since `=O` compares
+norms. -/
 @[category research open, AMS 5 11]
 theorem green_38.upper :
     let ans := (answer(sorry) : ℕ → ℝ)
     LargestAdmissibleCardinality ≤ᶠ[atTop] ans ∧
-    ∃ c < C₂, ans =O[atTop] (fun n ↦ c ^ n) := by
+    ∃ c : ℝ, 0 < c ∧ c < C₂ ∧ ans =O[atTop] (fun n ↦ c ^ n) := by
   sorry
 
 /--
@@ -90,7 +92,7 @@ The current best lower bound is $(C_1 - o(1))^n \leqslant |A|$ where
 $C_1 = 367^{1/5} \approx 3.2578$ [Po20, Section 9.1]. -/
 @[category research solved, AMS 5 11]
 theorem green_38.variants.best_lower :
-    ∀ ε > 0, ∀ᶠ n in atTop, (C₁ - ε) ^ n ≤ LargestAdmissibleCardinality n := by
+    ∀ ε ∈ Set.Ioo (0 : ℝ) C₁, ∀ᶠ n in atTop, (C₁ - ε) ^ n ≤ LargestAdmissibleCardinality n := by
   sorry
 
 /-- The current best upper bound is $|A| \leqslant (C_2 + o(1))^n$ where


### PR DESCRIPTION
**What changed**

- `green_38.lower` requires the answer sequence to be eventually nonnegative.
- `green_38.upper` requires the exponential base `c` to be positive.
- `green_38.variants.best_lower` quantifies over `ε ∈ Set.Ioo 0 C₁`.

**Why**

`=O` compares norms, so negative sequences and negative bases satisfied the statements trivially: `ans n = -((C₁ + 1) ^ n)` proved `lower`, `ans n = 7 ^ n` with `c = -7` proved `upper` (the ambient space has `7 ^ n` elements), and `ε = C₁ + 8` refuted `best_lower` at every even `n`, since `(-8) ^ n = 8 ^ n > 7 ^ n`. The Lean file below contains all three.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.GreensOpenProblems.«38»
/-! Independent checks of Green 38, without using its sorry theorems. -/
open Filter Set Green38
open scoped Pointwise Asymptotics

namespace Counterexamples.Group3.Green38

lemma largest_nonneg (n : ℕ) : 0 ≤ LargestAdmissibleCardinality n := by
  exact Nat.cast_nonneg _

lemma largest_bound (n : ℕ) : LargestAdmissibleCardinality n ≤ (7 : ℝ) ^ n := by
  have h : sSup (ValidCardinalities n) ≤ 7 ^ n := by
    apply csSup_le ⟨0, green_38.test_zero_mem_validCardinalities⟩
    rintro _ ⟨A, _, rfl⟩
    calc A.card ≤ Fintype.card (𝔽₇ n) := A.card_le_univ
      _ = 7 ^ n := by simp
  unfold LargestAdmissibleCardinality
  exact_mod_cast h

lemma c1_pos : 0 < C₁ := by
  unfold C₁
  exact Real.rpow_pos_of_pos (by norm_num) _

lemma c2_pos : 0 < C₂ := by
  have hcos : 0 < Real.cos (Real.pi / 7) :=
    Real.cos_pos_of_mem_Ioo ⟨by linarith [Real.pi_pos], by linarith [Real.pi_pos]⟩
  unfold C₂
  positivity

-- A negative exponential is accepted as an "improved lower bound".
theorem trivial_lower :
    let ans := fun n : ℕ ↦ -(C₁ + 1) ^ n
    ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
    ∃ c > C₁, (fun n ↦ c ^ n) =O[atTop] ans := by
  dsimp only
  constructor
  · apply Filter.Eventually.of_forall
    intro n
    exact (neg_nonpos.mpr (pow_nonneg (by linarith [c1_pos]) n)).trans (largest_nonneg n)
  · exact ⟨C₁ + 1, by linarith, (Asymptotics.isBigO_refl _ _).neg_right⟩

-- The whole ambient-space bound is accepted as an "improved upper bound".
theorem trivial_upper :
    let ans := fun n : ℕ ↦ (7 : ℝ) ^ n
    LargestAdmissibleCardinality ≤ᶠ[atTop] ans ∧
    ∃ c < C₂, ans =O[atTop] (fun n ↦ c ^ n) := by
  dsimp only
  refine ⟨Filter.Eventually.of_forall largest_bound, (-7 : ℝ), by linarith [c2_pos], ?_⟩
  apply Asymptotics.isBigO_of_le
  intro n
  simp [norm_pow, norm_neg]

-- Epsilon may make the base negative with absolute value larger than 7.
theorem best_lower_is_false :
    ¬ (type_of% _root_.Green38.green_38.variants.best_lower) := by
  intro h
  obtain ⟨N, hN⟩ := eventually_atTop.1 (h (C₁ + 8) (by linarith [c1_pos]))
  have bad := (hN (2 * (N + 1)) (by omega)).trans (largest_bound _)
  have hbase : C₁ - (C₁ + 8) = (-8 : ℝ) := by ring
  rw [hbase, pow_mul (-8 : ℝ) 2, pow_mul (7 : ℝ) 2] at bad
  norm_num only [even_two, Even.neg_pow, Nat.reduceMul, Nat.reduceAdd, OfNat.ofNat, pow_two] at bad
  have strict : (49 : ℝ) ^ (N + 1) < (64 : ℝ) ^ (N + 1) :=
    pow_lt_pow_left₀ (by norm_num) (by norm_num) (by omega)
  exact (not_le_of_gt strict) bad

#print axioms trivial_lower
#print axioms trivial_upper
#print axioms best_lower_is_false

end Counterexamples.Group3.Green38
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.GreensOpenProblems.«38»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/GreensOpenProblems/38 (findings 1 to 3)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
