### PR TITLE
fix(Wikipedia/RudinsConjecture): state uniqueness at N = GP_k + 1 ≥ 8

### DIFF
--- a/FormalConjectures/Wikipedia/RudinsConjecture.lean
+++ b/FormalConjectures/Wikipedia/RudinsConjecture.lean
@@ -108,12 +108,16 @@ theorem rudins_conjecture_strong (N : ℕ) (hN : 6 ≤ N) : Q N 24 1 = Qmax N :=
   sorry
 
 /--
-The strongest form of Rudin's conjecture also asserts *uniqueness*: for $N \ge 6$, any non-trivial
-arithmetic progression attaining the maximum $Q(N)$ has common difference $24$. (Its initial term
-is then forced by $\gcd(24, a) = 1$; the progression $24n + 1$ is the canonical representative.)
+The super-strong form of Rudin's conjecture, due to González-Jiménez and Xarles, also asserts
+*uniqueness* at the values $N = GP_k + 1 \ge 8$, where $GP_k = k(3k - 1)/2$ with $k \in \mathbb{Z}$
+is a generalized pentagonal number: any non-trivial arithmetic progression attaining the maximum
+$Q(N)$ has common difference $24$. (Its initial term is then forced by $\gcd(24, a) = 1$; the
+progression $24n + 1$ is the canonical representative.) Uniqueness fails at other values of $N$:
+for $N = 6$ the progression $120 n + 49$ also attains $Q(6) = 4$.
 -/
 @[category research open, AMS 11]
-theorem rudins_conjecture_unique (N : ℕ) (hN : 6 ≤ N) (q a : ℕ)
+theorem rudins_conjecture_unique (N : ℕ) (hN : 8 ≤ N)
+    (hN' : ∃ k : ℤ, (N : ℤ) = k * (3 * k - 1) / 2 + 1) (q a : ℕ)
     (hqa : IsNontrivial q a) (hmax : Q N q a = Qmax N) : q = 24 := by
   sorry
 


### PR DESCRIPTION
fixes #4568

**What changed**

- `rudins_conjecture_unique` assumes `8 ≤ N` and `N = k (3k - 1) / 2 + 1` for some integer `k`, the values at which the super-strong form of González-Jiménez and Xarles asserts uniqueness. The docstring is rewritten accordingly.

**Why**

The statement asserted uniqueness of the common difference at every `N ≥ 6`, but at `N = 6` the progression `120 n + 49` contains the four squares `49, 169, 289, 529`, so it attains `Qmax 6 = 4` with `q ≠ 24`. The Lean file below refutes the statement as written. The [Wikipedia article](https://en.wikipedia.org/wiki/Rudin%27s_conjecture) states the super-strong form only for `N = GP_k + 1 ≥ 8`.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.Wikipedia.RudinsConjecture

/-! Certificates concerning the exact audited definitions or propositions. -/

namespace Counterexamples.Group3.Rudin
open RudinsConjecture Filter Asymptotics

def countQ (N q a : ℕ) : ℕ :=
  ((Finset.range N).filter fun n => IsSquare (q * n + a)).card

lemma Q_eq_countQ (N q a : ℕ) : Q N q a = countQ N q a := by
  classical
  have hs : {n : ℕ | n < N ∧ IsSquare (q * n + a)} =
      (↑((Finset.range N).filter fun n => IsSquare (q * n + a)) : Set ℕ) := by
    ext n
    simp
  rw [Q, hs, Set.ncard_coe_finset]
  rfl

lemma Q_le_N (N q a : ℕ) : Q N q a ≤ N := by
  rw [Q_eq_countQ]
  exact (Finset.card_filter_le _ _).trans_eq (Finset.card_range N)

lemma admissible_counts_bdd (N : ℕ) :
    BddAbove {m : ℕ | ∃ q a : ℕ, IsNontrivial q a ∧ Q N q a = m} := by
  refine ⟨N, ?_⟩
  rintro m ⟨q, a, _, rfl⟩
  exact Q_le_N N q a

lemma Qmax_attained (N : ℕ) :
    ∃ q a, IsNontrivial q a ∧ Q N q a = Qmax N := by
  exact Nat.sSup_mem (s := {m : ℕ | ∃ q a : ℕ, IsNontrivial q a ∧ Q N q a = m})
    ⟨Q N 24 1, 24, 1, isNontrivial_24_1, rfl⟩ (admissible_counts_bdd N)

lemma Q_le_Qmax (N q a : ℕ) (hqa : IsNontrivial q a) : Q N q a ≤ Qmax N := by
  exact le_csSup (admissible_counts_bdd N) ⟨q, a, hqa, rfl⟩

lemma square_gap_twentyfour (x : ℕ) (hx : IsSquare x)
    (hy : IsSquare (x + 24)) : x ≤ 25 := by
  obtain ⟨r, rfl⟩ := hx
  obtain ⟨s, hs⟩ := hy
  have hrs : r < s := by nlinarith
  have hgap : r + 2 ≤ s := by
    by_contra h
    have heq : s = r + 1 := by omega
    subst s
    have heq : 2 * r = 23 := by nlinarith
    omega
  have hb : r ≤ 5 := by nlinarith
  nlinarith

lemma step24_count_le_four (a : ℕ) (ha : 1 ≤ a) : Q 6 24 a ≤ 4 := by
  by_cases h : a ≤ 25
  · interval_cases a <;> rw [Q_eq_countQ] <;> decide +kernel
  · have hpair0 : ¬ (IsSquare a ∧ IsSquare (24 + a)) := by
      rintro ⟨h0,h1⟩
      exact h (square_gap_twentyfour a h0 (by simpa [Nat.add_comm] using h1))
    have hpair2 : ¬ (IsSquare (48 + a) ∧ IsSquare (72 + a)) := by
      rintro ⟨h0,h1⟩
      have h' := square_gap_twentyfour (48 + a) h0 (by convert h1 using 1; omega)
      omega
    have hpair4 : ¬ (IsSquare (96 + a) ∧ IsSquare (120 + a)) := by
      rintro ⟨h0,h1⟩
      have h' := square_gap_twentyfour (96 + a) h0 (by convert h1 using 1; omega)
      omega
    rw [Q_eq_countQ]
    simp only [countQ, Finset.card_eq_sum_ones, Finset.sum_filter]
    simp only [Finset.sum_range_succ, Finset.sum_range_zero]
    norm_num only at *
    split_ifs <;> simp_all

-- Disproof of the N=6 instance of the file's uniqueness statement.
-- Uses only proved API/test lemmas, not the sorry-bearing conjectures.
theorem not_unique_at_six :
    ¬ (∀ q a, IsNontrivial q a → Q 6 q a = Qmax 6 → q = 24) := by
  intro huniq
  obtain ⟨q, a, hqa, hmax⟩ := Qmax_attained 6
  have hq := huniq q a hqa hmax
  subst q
  have hu : Qmax 6 ≤ 4 := by
    rw [← hmax]
    exact step24_count_le_four a hqa.2.1
  have hl : 4 ≤ Qmax 6 := by
    simpa only [Q_six_twentyfour_one] using Q_le_Qmax 6 24 1 isNontrivial_24_1
  have hm : Qmax 6 = 4 := le_antisymm hu hl
  have hc : Q 6 120 49 = 4 := by rw [Q_eq_countQ]; decide +kernel
  have hn : IsNontrivial 120 49 := by unfold IsNontrivial; decide +kernel
  have h := huniq 120 49 hn (hc.trans hm.symm)
  norm_num at h

theorem not_rudins_conjecture_unique :
    ¬ (∀ N : ℕ, 6 ≤ N → ∀ q a : ℕ,
      IsNontrivial q a → Q N q a = Qmax N → q = 24) := by
  intro h
  exact not_unique_at_six (h 6 (by decide))

theorem full_refutation : ¬ (type_of% RudinsConjecture.rudins_conjecture_unique) :=
  not_rudins_conjecture_unique

#print axioms full_refutation
end Counterexamples.Group3.Rudin
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.RudinsConjecture` passes.
- `6` is not of the form `GP_k + 1` with `N ≥ 8`, so the counterexample no longer applies.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/RudinsConjecture

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
