### PR TITLE
fix(ErdosProblems/958): ask the classification for all sufficiently large n

### DIFF
--- a/FormalConjectures/ErdosProblems/958.lean
+++ b/FormalConjectures/ErdosProblems/958.lean
@@ -54,10 +54,14 @@ Erdős conjectured that the answer is no, and other such configurations exist.
 
 This was proved by Clemen, Dumitrescu, and Liu [CDL25], who observed that equidistant points on a
 short circular arc on a circle of radius $1$, together with the centre, are also an example.
+
+The classification is asked for all sufficiently large $n$. Small exceptions such as
+$\{(0,0), (1,0), (0,1), (0,-1)\}$ were known to Erdős, so the negative answer asserts
+counterexamples of arbitrarily large size, as in [CDL25].
 -/
-@[category research solved, AMS 5 52, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos958.lean"]
+@[category research solved, AMS 5 52]
 theorem erdos_958 : answer(False) ↔
-    ∀ (n : ℕ) (A : Finset ℝ²), #A = n →
+    ∃ N : ℕ, ∀ n ≥ N, ∀ A : Finset ℝ², #A = n →
       ((#(distanceSet A) = n - 1 ∧
             (distanceSet A).image (distanceMultiplicity A) = Finset.Icc 1 (n - 1)) →
         (IsEquidistantOnLine A ∨ IsEquidistantOnCircle A)) := by


### PR DESCRIPTION
**What changed**

- The right-hand side of `erdos_958` reads `∃ N, ∀ n ≥ N, …` instead of `∀ n, …`. The docstring explains the small exceptions.
- The `formal_proof` attribute is removed: the linked proof exhibits the four-point exception, which no longer refutes the corrected statement.

**Why**

The four-point set `{(0,0), (1,0), (0,1), (0,-1)}` has distances `1, √2, 2` with multiplicities `3, 2, 1` and lies on neither a line nor a circle, so the universal statement was refuted by a single small configuration. Such exceptions were known when Erdős posed the problem; the negative answer of Clemen, Dumitrescu and Liu asserts counterexamples of arbitrarily large size.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«958»

/-! Small exact geometric examples for the independent review of Erdős Problem 958. -/

open Finset EuclideanGeometry Erdos958

namespace Counterexamples.Group3.Erdos958

abbrev pt (x y : ℝ) : ℝ² := !₂[x, y]

noncomputable def fourPoints : Finset ℝ² :=
  {pt 0 0, pt 1 0, pt 0 1, pt 0 (-1)}

lemma fourPoints_card : #fourPoints = 4 := by
  norm_num [fourPoints, pt, (WithLp.toLp_injective 2).eq_iff]

lemma offDiag_filter (A : Finset ℝ²) :
    A.offDiag = (A ×ˢ A).filter (fun p => p.1 ≠ p.2) := by
  classical
  ext p
  simp [Finset.mem_offDiag, and_assoc]

@[simp] lemma one_ne_sqrt_two : (1 : ℝ) ≠ Real.sqrt 2 := by
  intro h
  have hs := Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
  rw [← h] at hs
  norm_num at hs

@[simp] lemma two_ne_sqrt_two : (2 : ℝ) ≠ Real.sqrt 2 := by
  intro h
  have hs := Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
  rw [← h] at hs
  norm_num at hs

lemma fourPoints_distances : distanceSet fourPoints = {1, Real.sqrt 2, 2} := by
  classical
  norm_num [distanceSet, offDiag_filter, fourPoints, pt,
    Finset.product_eq_biUnion, Finset.filter_insert, Finset.filter_singleton, (WithLp.toLp_injective 2).eq_iff,
    EuclideanSpace.dist_eq, Real.dist_eq]
  ext d
  simp [or_comm, or_left_comm]

lemma fourPoints_mult_one : distanceMultiplicity fourPoints 1 = 3 := by
  classical
  norm_num [distanceMultiplicity, offDiag_filter, fourPoints, pt,
    Finset.product_eq_biUnion, Finset.filter_insert, Finset.filter_singleton, (WithLp.toLp_injective 2).eq_iff,
    EuclideanSpace.dist_eq, Real.dist_eq]

lemma fourPoints_mult_sqrt_two : distanceMultiplicity fourPoints (Real.sqrt 2) = 2 := by
  classical
  norm_num [distanceMultiplicity, offDiag_filter, fourPoints, pt,
    Finset.product_eq_biUnion, Finset.filter_insert, Finset.filter_singleton, (WithLp.toLp_injective 2).eq_iff,
    EuclideanSpace.dist_eq, Real.dist_eq]

lemma fourPoints_mult_two : distanceMultiplicity fourPoints 2 = 1 := by
  classical
  norm_num [distanceMultiplicity, offDiag_filter, fourPoints, pt,
    Finset.product_eq_biUnion, Finset.filter_insert, Finset.filter_singleton, (WithLp.toLp_injective 2).eq_iff,
    EuclideanSpace.dist_eq, Real.dist_eq]

lemma fourPoints_profile :
    #(distanceSet fourPoints) = #fourPoints - 1 ∧
      (distanceSet fourPoints).image (distanceMultiplicity fourPoints) =
        Icc 1 (#fourPoints - 1) := by
  classical
  rw [fourPoints_card, fourPoints_distances]
  constructor
  · norm_num [Ne.symm one_ne_sqrt_two, Ne.symm two_ne_sqrt_two]
  · simp only [image_insert, image_singleton, fourPoints_mult_one,
      fourPoints_mult_sqrt_two, fourPoints_mult_two]
    decide

lemma fourPoints_not_line : ¬ IsEquidistantOnLine fourPoints := by
  rintro ⟨a, v, _, h⟩
  have rep : ∀ p ∈ fourPoints, ∃ i < #fourPoints, p = a + (i : ℝ) • v := by
    intro p hp
    have hp' : p ∈ (fourPoints : Set ℝ²) := hp
    rw [h] at hp'
    exact hp'
  obtain ⟨i, _, ei⟩ := rep (pt 0 0) (by simp [fourPoints])
  obtain ⟨j, _, ej⟩ := rep (pt 1 0) (by simp [fourPoints])
  obtain ⟨k, _, ek⟩ := rep (pt 0 1) (by simp [fourPoints])
  have ei0 := congrArg (fun x : ℝ² => x 0) ei
  have ei1 := congrArg (fun x : ℝ² => x 1) ei
  have ej0 := congrArg (fun x : ℝ² => x 0) ej
  have ek0 := congrArg (fun x : ℝ² => x 0) ek
  have ek1 := congrArg (fun x : ℝ² => x 1) ek
  norm_num [pt] at ei0 ei1 ej0 ek0 ek1
  have hv0 : v 0 ≠ 0 := by
    intro hz
    rw [hz] at ei0 ej0
    linarith
  have hik : (i : ℝ) = (k : ℝ) := by
    apply (mul_left_inj' hv0).mp
    linarith
  rw [hik] at ei1
  linarith

lemma fourPoints_not_circle : ¬ IsEquidistantOnCircle fourPoints := by
  rintro ⟨c, r, θ, α, hr, _, h⟩
  have hsphere : ∀ p ∈ fourPoints, dist p c = r := by
    intro p hp
    have hp' : p ∈ (fourPoints : Set ℝ²) := hp
    rw [h] at hp'
    obtain ⟨i, _, heq⟩ := hp'
    rw [heq]
    simp [dist_eq_norm, norm_smul, abs_of_pos hr, EuclideanSpace.norm_eq]
  have h0 := hsphere (pt 0 0) (by simp [fourPoints])
  have h1 := hsphere (pt 0 1) (by simp [fourPoints])
  have h2 := hsphere (pt 0 (-1)) (by simp [fourPoints])
  norm_num [EuclideanSpace.dist_eq, pt, Real.dist_eq,
    Real.sqrt_eq_iff_mul_self_eq_of_pos hr] at h0 h1 h2
  nlinarith

-- This proves the current theorem's exact type using four points only, without its sorry.
theorem fourPoints_refutes_current_statement :
    False ↔ ∀ (n : ℕ) (A : Finset ℝ²), #A = n →
      (#(distanceSet A) = n - 1 ∧
        (distanceSet A).image (distanceMultiplicity A) = Icc 1 (n - 1)) →
      (IsEquidistantOnLine A ∨ IsEquidistantOnCircle A) := by
  rw [false_iff]
  intro h
  rcases h #fourPoints fourPoints rfl fourPoints_profile with hl | hc
  · exact fourPoints_not_line hl
  · exact fourPoints_not_circle hc

#print axioms fourPoints_refutes_current_statement

end Counterexamples.Group3.Erdos958
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«958»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/958

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
