### PR TITLE
fix(Wikipedia/SteinerSystem): count only nontrivial Steiner systems

### DIFF
--- a/FormalConjectures/Wikipedia/SteinerSystem.lean
+++ b/FormalConjectures/Wikipedia/SteinerSystem.lean
@@ -260,10 +260,13 @@ $S(4, k, n)$ systems exist (for any fixed $k > 4$). The proof is nonconstructive
 
 Explicit examples include $S(4, 5, 11)$ (the unique system, related to the Mathieu
 group $M_{11}$) and $S(4, 7, 23)$ (related to the Mathieu group $M_{23}$).
+
+Only nontrivial systems with $4 < k < n$ are counted: for every $n$ the single block
+$\{1, \dots, n\}$ is an $S(4, n, n)$, and all $4$-subsets of an $n$-set form an $S(4, 4, n)$.
 -/
 @[category research solved, AMS 5]
 theorem infinitely_many_steiner_t4 :
-    ∃ S : Set (Σ k n : ℕ, S(4, k, n)), S.Infinite := by
+    {s : Σ k n : ℕ, S(4, k, n) | 4 < s.1 ∧ s.1 < s.2.1}.Infinite := by
   sorry
 
 /--
@@ -276,12 +279,15 @@ systems exist. The proof is nonconstructive.
 
 Only two explicit examples are known: $S(5, 6, 12)$ and $S(5, 8, 24)$, both Witt
 designs related to the Mathieu groups $M_{12}$ and $M_{24}$ respectively.
+
+Only nontrivial systems with $5 < k < n$ are counted, for the same reason as in
+`infinitely_many_steiner_t4`.
 No Steiner system with $t \geq 6$ has been explicitly constructed, though Keevash's
 result guarantees their existence nonconstructively as well.
 -/
 @[category research solved, AMS 5]
 theorem infinitely_many_steiner_t5 :
-    ∃ S : Set (Σ k n : ℕ, S(5, k, n)), S.Infinite := by
+    {s : Σ k n : ℕ, S(5, k, n) | 5 < s.1 ∧ s.1 < s.2.1}.Infinite := by
   sorry
 
 end SteinerSystems


### PR DESCRIPTION
**What changed**

- `infinitely_many_steiner_t4` and `infinitely_many_steiner_t5` state that the set of nontrivial systems, `t < k < n`, is infinite. The docstrings explain the exclusion.

**Why**

The previous statements `∃ S : Set (Σ k n, S(t, k, n)), S.Infinite` counted trivial systems: for every `n` the single block `{1, …, n}` is an `S(t, n, n)`, and all `t`-subsets form an `S(t, t, n)`, so both statements followed without Keevash's theorem. The Lean proofs below establish them as written.

<details>
<summary>Lean proof of the statement as written (compiled with <code>lake --wfail build</code>, standard axioms only)</summary>

```lean
import FormalConjectures.Wikipedia.SteinerSystem

namespace Counterexamples.Group1.Steiner
open SteinerSystems
def fullBlock (t n : ℕ) : SteinerSystem t n n where
  blocks := {Finset.univ}
  block_card := by simp
  cover_unique := by
    intro R hR
    change (({Finset.univ} : Finset (Finset (Fin n))).filter (R ⊆ ·)).card = 1
    rw [Finset.filter_singleton]
    simp

theorem trivial_infinitude (t : ℕ) : ∃ S : Set (Σ k n : ℕ, SteinerSystem t k n), S.Infinite := by
  let f : ℕ → (Σ k n : ℕ, SteinerSystem t k n) := fun n => ⟨n, n, fullBlock t n⟩
  refine ⟨Set.range f, Set.infinite_range_of_injective ?_⟩
  intro m n h
  exact congrArg Sigma.fst h

theorem trivial_original_t4 : type_of% @SteinerSystems.infinitely_many_steiner_t4 :=
  trivial_infinitude 4

theorem trivial_original_t5 : type_of% @SteinerSystems.infinitely_many_steiner_t5 :=
  trivial_infinitude 5
#print axioms trivial_original_t4
#print axioms trivial_original_t5

end Counterexamples.Group1.Steiner
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.SteinerSystem` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/SteinerSystem (findings 1 and 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
