### PR TITLE
fix(Wikipedia/InvariantSubspaceProblem): the finite-dimensional case needs a normed space

### DIFF
--- a/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
+++ b/FormalConjectures/Wikipedia/InvariantSubspaceProblem.lean
@@ -48,12 +48,15 @@ theorem Invariant_subspace_problem [InnerProductSpace ℂ H] [TopologicalSpace.S
   sorry
 
 /--
-Every (bounded) linear operator `T : H → H` on a finite-dimensional linear space `H` of dimension
+Every (bounded) linear operator `T : H → H` on a finite-dimensional normed space `H` of dimension
 at least 2 has a non-trivial (closed) `T`-invariant subspace. This can be solved using the Jordan
 normal form, which is
-[not yet in mathlib](https://leanprover-community.github.io/undergrad_todo.html). -/
+[not yet in mathlib](https://leanprover-community.github.io/undergrad_todo.html).
+
+`H` is a complex normed space: with a bare `Module ℂ H` unrelated to the norm, finite-dimensional
+subspaces need not be closed, and the statement fails already in complex dimension `2`. -/
 @[category research solved, AMS 47]
-theorem Invariant_subspace_problem_finite_dimensional [Module ℂ H] (h : FiniteDimensional ℂ H)
+theorem Invariant_subspace_problem_finite_dimensional [NormedSpace ℂ H] (h : FiniteDimensional ℂ H)
     (hdim : 2 ≤ Module.rank ℂ H) (T : H →L[ℂ] H) : Nonempty (ClosedInvariantSubspace T) := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `Invariant_subspace_problem_finite_dimensional` assumes `[NormedSpace ℂ H]` instead of `[Module ℂ H]`. The docstring explains why.

**Why**

`[Module ℂ H]` does not relate the complex scalar action to the norm of `H`, so finite-dimensional subspaces need not be closed. Transport the complex structure of `ℂ × ℂ` to the ordinary normed group `ℝ` along a `ℚ`-linear equivalence: this is a complex module of rank `2`, `T = 0` is continuous and linear, but every nonzero complex submodule contains `ℚ x` for some real `x ≠ 0` and is dense, so there is no non-trivial closed invariant subspace. The Lean file below refutes the statement as written.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.Wikipedia.InvariantSubspaceProblem
/-! A counterexample to the finite-dimensional statement without scalar/norm compatibility. -/
noncomputable section
namespace Counterexamples.Group2.InvariantSubspace
open InvariantSubspaceProblem Cardinal

/-- With any abstract complex-module structure on the ordinary additive reals,
every nonzero closed complex submodule is all of the reals. -/
theorem closed_real_submodule_eq_top [Module ℂ ℝ] (W : Submodule ℂ ℝ)
    (hc : IsClosed (W : Set ℝ)) (hb : W ≠ ⊥) : W = ⊤ := by
  obtain ⟨x, hx, hx0⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hb
  have hall (r : ℝ) : r * x ∈ W := by
    refine Rat.denseRange_cast.induction_on (p := fun a : ℝ => a * x ∈ W) r ?_ ?_
    · exact hc.preimage (continuous_id.mul continuous_const)
    · intro q
      have hq : (q : ℝ) • x ∈ W :=
        (ratCast_smul_eq ℂ ℝ q x) ▸ W.smul_mem (q : ℂ) hx
      simpa only [smul_eq_mul] using hq
  apply Submodule.eq_top_iff'.mpr
  intro y
  simpa [hx0] using hall (y / x)

/-- The additive groups of R and C^2 have the same rational dimension. -/
def rationalEquiv : ℝ ≃ₗ[ℚ] (ℂ × ℂ) :=
  LinearEquiv.ofRankEq _ _ (by
    rw [Real.rank_rat_real, rank_prod', Complex.rank_rat_complex]
    simp)

/-- Transport the complex-vector-space structure, but NOT the usual norm on R. -/
abbrev exoticModule : Module ℂ ℝ := rationalEquiv.toAddEquiv.module ℂ
attribute [local instance] exoticModule

def complexEquiv : ℝ ≃ₗ[ℂ] (ℂ × ℂ) :=
  rationalEquiv.toAddEquiv.linearEquiv ℂ

theorem exotic_finite : FiniteDimensional ℂ ℝ :=
  FiniteDimensional.of_injective complexEquiv.toLinearMap complexEquiv.injective

theorem exotic_rank : Module.rank ℂ ℝ = 2 := by
  rw [complexEquiv.rank_eq, rank_prod']
  norm_num

theorem exotic_no_subspace (T : ℝ →L[ℂ] ℝ) : IsEmpty (ClosedInvariantSubspace T) := by
  constructor
  intro W
  exact W.ne_top (closed_real_submodule_eq_top W.toSubspace W.is_closed W.ne_bot)

/-- All the actual hypotheses are satisfied, already with rank exactly 2 and T = 0. -/
theorem finite_dimensional_counterexample :
    ∃ (m : Module ℂ ℝ),
      letI := m
      FiniteDimensional ℂ ℝ ∧ 2 ≤ Module.rank ℂ ℝ ∧
        IsEmpty (ClosedInvariantSubspace (0 : ℝ →L[ℂ] ℝ)) := by
  refine ⟨exoticModule, exotic_finite, ?_, exotic_no_subspace 0⟩
  exact exotic_rank.ge

/-- This refutes precisely the original finite-dimensional statement, without invoking it. -/
theorem finite_dimensional_statement_false :
    ¬ (∀ (H : Type) [NormedAddCommGroup H] [Module ℂ H],
      FiniteDimensional ℂ H → 2 ≤ Module.rank ℂ H →
      ∀ T : H →L[ℂ] H, Nonempty (ClosedInvariantSubspace T)) := by
  intro h
  obtain ⟨W⟩ := h ℝ exotic_finite exotic_rank.ge 0
  exact (exotic_no_subspace 0).false W

theorem refutes : ¬ (type_of% (@InvariantSubspaceProblem.Invariant_subspace_problem_finite_dimensional.{0})) := by
  intro h
  obtain ⟨W⟩ := @h ℝ _ exoticModule exotic_finite exotic_rank.ge 0
  exact (exotic_no_subspace 0).false W
#print axioms refutes
end Counterexamples.Group2.InvariantSubspace
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.InvariantSubspaceProblem` passes.
- In a finite-dimensional normed space every subspace is closed, so the transported module is excluded.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/InvariantSubspaceProblem

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
