### PR TITLE
fix(Wikipedia/ModularityConjecture): use period 1 in the q-expansion

### DIFF
--- a/FormalConjectures/Wikipedia/ModularityConjecture.lean
+++ b/FormalConjectures/Wikipedia/ModularityConjecture.lean
@@ -39,9 +39,11 @@ namespace ModularityConjecture
 open Complex CongruenceSubgroup ModularFormClass ModularityConjecture UpperHalfPlane
 open scoped Real ModularForm CongruenceSubgroup
 
-/-- The `n`-th Fourier coefficient of a modular form (around the cusp at infinity). -/
+/-- The `n`-th Fourier coefficient of a modular form (around the cusp at infinity), with respect to
+`q = exp (2 π i τ)`. The first argument of `qExpansion` is the period at infinity, which is `1` for
+`Γ₀(N)`, not the level `N`. -/
 noncomputable def modularFormAn (n : ℕ) {N : ℕ} {k : ℤ} (f : CuspForm (Gamma0 N) k) : ℂ :=
-  (qExpansion N f).coeff n
+  (qExpansion 1 f).coeff n
 
 local notation:73 "a_[" n:0 "]" f:72 => modularFormAn n f
 


### PR DESCRIPTION
**What changed**

- `modularFormAn n f` is `(qExpansion 1 f).coeff n`. The first argument of `UpperHalfPlane.qExpansion` is the period at infinity, which is `1` for `Γ₀(N)`, not the level `N`. The docstring says so.

**Why**

With `qExpansion N f`, the coefficients are taken with respect to `q = exp (2 π i τ / N)`. Every form on `Γ₀(N)` is `1`-periodic, so for `N > 1` the expansion is `(qExpansion 1 f).expand N` and the coefficient `a₁` is `0`, contradicting the normalisation in `IsNormalisedEigenform`; for `N = 1` the weight-`2` cusp form space is zero. So `modularityConjecture E` was false for every elliptic curve, and `modularity_conjecture` was refutable. The Lean file below does this.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.Wikipedia.ModularityConjecture

/-!
The written level N Fourier expansion has zero coefficient at 1 for N>1. The weight 2 level 1 cusp-form space is zero as well, so the written normalized-eigenform requirement fails for the explicit elliptic curve y²=x³−x.

Audited source: https://github.com/google-deepmind/formal-conjectures/blob/84063d69421173d491cdae299fe766d3cd66c37c/FormalConjectures/Wikipedia/ModularityConjecture.lean
-/

namespace Counterexamples.Group1.Modularity
open ModularityConjecture UpperHalfPlane CongruenceSubgroup
open scoped CongruenceSubgroup Real ModularForm MatrixGroups

lemma qParam_level_pow {N : ℕ} (hN : N ≠ 0) (z : ℂ) :
    Function.Periodic.qParam (N : ℝ) z ^ N = Function.Periodic.qParam 1 z := by
  simp only [Function.Periodic.qParam, Complex.ofReal_natCast, Complex.ofReal_one, div_one]
  rw [← Complex.exp_nat_mul]
  congr 1
  field_simp

lemma coeff_eq_expand {N : ℕ} (hN : 0 < N) {k : ℤ} (f : CuspForm (Gamma0 N) k) (m : ℕ) :
    modularFormAn m f = ((qExpansion 1 f).expand N hN.ne').coeff m := by
  have hper : (N : ℝ) ∈ (Gamma0 N : Subgroup (GL (Fin 2) ℝ)).strictPeriods := by
    simp only [strictPeriods_Gamma0]
    exact AddSubgroup.mem_zmultiples_iff.mpr ⟨N, by simp⟩
  unfold modularFormAn
  symm
  refine ModularFormClass.qExpansion_coeff_unique (f := f)
    (c := fun j ↦ ((qExpansion 1 f).expand N hN.ne').coeff j)
    (by exact_mod_cast hN) hper ?_ m
  intro τ
  let : Fact (IsCusp OnePoint.infty (Gamma0 N : Subgroup (GL (Fin 2) ℝ))) :=
    ⟨Subgroup.isCusp_of_mem_strictPeriods (h := 1) (by norm_num) (by simp)⟩
  have hsum := ModularForm.hasSum_qExpansion f (h := 1) (by norm_num) (by simp) τ
  have hi : Function.Injective (fun j : ℕ ↦ N * j) := mul_right_injective₀ hN.ne'
  apply (hi.hasSum_iff ?_).mp
  · simpa only [Function.comp_def, smul_eq_mul, PowerSeries.coeff_expand_mul,
        pow_mul, qParam_level_pow hN.ne'] using hsum
  · intro j hj
    have hNj : ¬ N ∣ j := by
      rintro ⟨d, rfl⟩
      exact hj ⟨d, rfl⟩
    simp [PowerSeries.coeff_expand_of_not_dvd, hNj]

lemma first_coeff_zero {N : ℕ} (hN : 1 < N) {k : ℤ} (f : CuspForm (Gamma0 N) k) :
    modularFormAn 1 f = 0 := by
  rw [coeff_eq_expand (by omega)]
  apply PowerSeries.coeff_expand_of_not_dvd
  simpa using (show N ≠ 1 by omega)

lemma gamma0_one_coe_eq_SL : (Gamma0 1 : Subgroup (GL (Fin 2) ℝ)) = 𝒮ℒ := by
  have h : Gamma0 1 = ⊤ := by
    ext γ
    simp [eq_iff_true_of_subsingleton]
  simp [h, MonoidHom.range_eq_map]

lemma level_one_weight_two_zero (f : CuspForm (Gamma0 1) 2) : f = 0 := by
  let g : CuspForm 𝒮ℒ 2 := f.copy f rfl gamma0_one_coe_eq_SL.symm
  have hg : g = 0 := rank_zero_iff_forall_zero.mp
    (CuspForm.rank_eq_zero_of_weight_lt_twelve (k := 2) (by norm_num)) g
  ext τ
  exact DFunLike.congr_fun hg τ

lemma no_normalised_eigenform {N : ℕ} (hN : 0 < N) (f : CuspForm (Gamma0 N) 2) :
    ¬ IsNormalisedEigenform f := by
  intro hf
  have ha : modularFormAn 1 f = 0 := by
    by_cases h1 : N = 1
    · subst N
      simp [level_one_weight_two_zero f, modularFormAn, UpperHalfPlane.qExpansion_zero]
    · exact first_coeff_zero (by omega) f
  exact zero_ne_one (ha.symm.trans hf.1)

lemma not_modularityConjecture (E : _root_.WeierstrassCurve ℚ) [E.IsElliptic] :
    ¬ modularityConjecture E := by
  rintro ⟨N, f, hf, _⟩
  exact no_normalised_eigenform N.pos f hf

/-- The rational elliptic curve y²=x³-x has nonzero discriminant 64. -/
def curve : _root_.WeierstrassCurve ℚ := ⟨0, 0, 0, -1, 0⟩
instance : curve.IsElliptic := by
  constructor
  norm_num [curve, _root_.WeierstrassCurve.Δ, _root_.WeierstrassCurve.b₂,
    _root_.WeierstrassCurve.b₄, _root_.WeierstrassCurve.b₆, _root_.WeierstrassCurve.b₈]

theorem refutes_original : ¬ (type_of% @ModularityConjecture.modularity_conjecture) := by
  intro h
  exact not_modularityConjecture curve (h curve)
#print axioms refutes_original

end Counterexamples.Group1.Modularity
```

</details>

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.ModularityConjecture` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/ModularityConjecture

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
