### PR TITLE
fix(ErdosProblems/507): minTriangleArea uses unsigned areas of all triples

### DIFF
--- a/FormalConjectures/ErdosProblems/507.lean
+++ b/FormalConjectures/ErdosProblems/507.lean
@@ -37,11 +37,13 @@ open scoped EuclideanGeometry
 namespace Erdos507
 
 /--
-The minimum area of a triangle determined by three distinct points in a set `S`.
+The minimum (unsigned) area of a triangle determined by three distinct points in a set `S`.
+Collinear triples count with area `0`. `EuclideanGeometry.triangle_area` is a signed area, so the
+absolute value is taken before the infimum.
 -/
 noncomputable def minTriangleArea (S : Finset ℝ²) : ℝ :=
-  sInf {EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) |
-    (t : Affine.Triangle ℝ ℝ²) (_ : ∀ i, t.points i ∈ S)}
+  sInf {abs (EuclideanGeometry.triangle_area (p 0) (p 1) (p 2)) |
+    (p : Fin 3 → ℝ²) (_ : Function.Injective p) (_ : ∀ i, p i ∈ S)}
 
 /--
 $\alpha(n)$ is the supremum of `minTriangleArea S` over all sets `S` of $n$ points in the unit disk.


### PR DESCRIPTION
**What changed**

- `minTriangleArea S` is the infimum of `|triangle_area (p 0) (p 1) (p 2)|` over injective `p : Fin 3 → ℝ²` with values in `S`. The docstring explains both changes.

**Why**

`EuclideanGeometry.triangle_area` is a signed area and `Affine.Triangle` admits both orientations, so the previous infimum was minus the largest triangle area of `S`; shrinking configurations then gives `α n = 0` for every `n`, which trivialises `erdos_507.equivalent`, `lower`, `upper` and makes `variants.lower_erdos` false. The Lean file below refutes `lower_erdos`. Independently, `Affine.Triangle` excludes collinear triples, whereas the minimum over three distinct points must count them with area `0`; the outer `¬ Collinear` condition in `α` only excludes sets lying on one line. Quantifying over injective triples fixes both.

This also repairs `GreensOpenProblems/77`, which uses `Erdos507.α`: with the signed definition its question side was provable with `o = 0`.

<details>
<summary>Lean counterexample (compiled with <code>lake --wfail build</code> against the current statement, standard axioms only)</summary>

```lean
import FormalConjectures.ErdosProblems.«507»

namespace Counterexamples.Group1.Erdos507
open Asymptotics Filter Topology
open scoped EuclideanGeometry Pointwise
lemma area_swap (a b c : ℝ²) :
    EuclideanGeometry.triangle_area b a c = -EuclideanGeometry.triangle_area a b c := by
  unfold EuclideanGeometry.triangle_area
  rw [Orientation.areaForm_swap, neg_div]

lemma minTriangleArea_nonpos (S : Finset ℝ²) : Erdos507.minTriangleArea S ≤ 0 := by
  let T : Set ℝ := {EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) |
    (t : Affine.Triangle ℝ ℝ²) (_ : ∀ i, t.points i ∈ S)}
  change sInf T ≤ 0
  obtain hT | ⟨x, hx⟩ := T.eq_empty_or_nonempty
  · simp [hT]
  rcases hx with ⟨t, ht, rfl⟩
  by_cases h : EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) ≤ 0
  · exact Real.sInf_nonpos' ⟨_, ⟨t, ht, rfl⟩, h⟩
  let u := t.reindex (Equiv.swap 0 1)
  apply Real.sInf_nonpos'
  refine ⟨_, ⟨u, ?_, rfl⟩, ?_⟩
  · intro i
    exact ht _
  · change EuclideanGeometry.triangle_area (t.points 1) (t.points 0) (t.points 2) ≤ 0
    rw [area_swap]
    exact neg_nonpos.mpr (le_of_lt (lt_of_not_ge h))

lemma alpha_nonpos (n : ℕ) : Erdos507.α n ≤ 0 := by
  apply Real.sSup_nonpos
  rintro x ⟨S, _, rfl⟩
  exact minTriangleArea_nonpos S

lemma area_smul (r : ℝ) (a b c : ℝ²) :
    EuclideanGeometry.triangle_area (r • a) (r • b) (r • c) =
      r^2 * EuclideanGeometry.triangle_area a b c := by
  simp only [EuclideanGeometry.triangle_area, vsub_eq_sub, ← smul_sub,
    map_smul, LinearMap.smul_apply, smul_eq_mul]
  ring

noncomputable def scaleTriangle (r : ℝ) (hr : r ≠ 0) (t : Affine.Triangle ℝ ℝ²) :
    Affine.Triangle ℝ ℝ² :=
  ⟨fun i => r • t.points i, by
    exact (t.independent.smul (a := Units.mk0 r hr))⟩

lemma minTriangleArea_smul (r : ℝ) (hr : r ≠ 0) (S : Finset ℝ²) :
    Erdos507.minTriangleArea (S.image (fun x => r • x)) = r^2 * Erdos507.minTriangleArea S := by
  classical
  let T : Set ℝ := {EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) |
    (t : Affine.Triangle ℝ ℝ²) (_ : ∀ i, t.points i ∈ S)}
  have he : {EuclideanGeometry.triangle_area (t.points 0) (t.points 1) (t.points 2) |
      (t : Affine.Triangle ℝ ℝ²) (_ : ∀ i, t.points i ∈ S.image (fun x => r • x))} =
      (fun x => r^2*x) '' T := by
    ext a
    constructor
    · rintro ⟨t, ht, rfl⟩
      let u := scaleTriangle r⁻¹ (inv_ne_zero hr) t
      refine ⟨_, ⟨u, ?_, rfl⟩, ?_⟩
      · intro i
        obtain ⟨p,hp,heq⟩ := Finset.mem_image.mp (ht i)
        change r⁻¹ • t.points i ∈ S
        rw [← heq]
        simpa [smul_smul, hr] using hp
      · change r^2 * EuclideanGeometry.triangle_area
          (r⁻¹ • t.points 0) (r⁻¹ • t.points 1) (r⁻¹ • t.points 2) = _
        rw [area_smul, ← mul_assoc, ← mul_pow]
        simp [hr]
    · rintro ⟨_,⟨t,ht,rfl⟩,rfl⟩
      refine ⟨scaleTriangle r hr t, ?_, ?_⟩
      · intro i
        exact Finset.mem_image.mpr ⟨t.points i, ht i, rfl⟩
      · exact area_smul r _ _ _
  unfold Erdos507.minTriangleArea
  rw [he]
  exact Real.sInf_smul_of_nonneg (sq_nonneg r) T

lemma collinear_smul_image (s : Set ℝ²) (h : Collinear ℝ s) (r : ℝ) :
    Collinear ℝ ((fun x => r • x) '' s) := by
  obtain ⟨p₀,v,hv⟩ := (collinear_iff_exists_forall_eq_smul_vadd s).mp h
  apply (collinear_iff_exists_forall_eq_smul_vadd _).mpr
  refine ⟨r • p₀, r • v, ?_⟩
  rintro _ ⟨p,hp,rfl⟩
  obtain ⟨a, rfl⟩ := hv p hp
  exact ⟨a, by simp [smul_add, smul_smul, mul_comm]⟩

lemma admissible_smul {n : ℕ} (S : Finset ℝ²)
    (hS : S.card = n ∧ ↑S ⊆ Metric.closedBall (0 : ℝ²) 1 ∧ ¬ Collinear ℝ (S : Set ℝ²))
    (r : ℝ) (hr : 0 < r) (hr1 : r ≤ 1) :
    let U := S.image (fun x => r • x)
    U.card = n ∧ ↑U ⊆ Metric.closedBall (0 : ℝ²) 1 ∧ ¬ Collinear ℝ (U : Set ℝ²) := by
  classical
  dsimp only
  refine ⟨?_, ?_, ?_⟩
  · rw [Finset.card_image_of_injective, hS.1]
    exact smul_right_injective ℝ² (ne_of_gt hr)
  · intro p hp
    obtain ⟨q,hq,rfl⟩ := Finset.mem_image.mp hp
    have hq' : ‖q‖ ≤ 1 := by simpa using hS.2.1 hq
    simp only [Metric.mem_closedBall, dist_zero_right, norm_smul, Real.norm_eq_abs, abs_of_pos hr]
    exact (mul_le_mul_of_nonneg_left hq' hr.le).trans (by simpa using hr1)
  · intro hc
    have hinv := collinear_smul_image _ hc r⁻¹
    apply hS.2.2
    apply Collinear.subset _ hinv
    intro p hp
    exact ⟨r • p, Finset.mem_image.mpr ⟨p,hp,rfl⟩, by simp [smul_smul, ne_of_gt hr]⟩

lemma alpha_zero (n : ℕ) : Erdos507.α n = 0 := by
  classical
  apply le_antisymm (alpha_nonpos n)
  let F : Set (Finset ℝ²) := {S | S.card = n ∧ ↑S ⊆ Metric.closedBall (0 : ℝ²) 1 ∧
    ¬ Collinear ℝ (S : Set ℝ²)}
  obtain hF | ⟨S,hS⟩ := F.eq_empty_or_nonempty
  · change 0 ≤ sSup (Erdos507.minTriangleArea '' F)
    simp [hF]
  have hb : BddAbove (Erdos507.minTriangleArea '' F) := by
    refine ⟨0, ?_⟩
    rintro _ ⟨U,_,rfl⟩
    exact minTriangleArea_nonpos U
  have ht : Tendsto (fun k : ℕ => (1/((k:ℝ)+1))^2 * Erdos507.minTriangleArea S)
      atTop (𝓝 0) := by
    convert (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)).pow 2 |>.mul_const
      (Erdos507.minTriangleArea S) using 1; norm_num
  apply le_of_tendsto ht
  apply Filter.Eventually.of_forall
  intro k
  have hr : 0 < 1/((k:ℝ)+1) := by positivity
  have hr1 : 1/((k:ℝ)+1) ≤ 1 := by
    rw [div_le_iff₀ (by positivity)]
    simp
  rw [← minTriangleArea_smul _ (ne_of_gt hr) S]
  exact le_csSup hb ⟨_, admissible_smul S hS _ hr hr1, rfl⟩

lemma alpha_eq_zero_function : Erdos507.α = (fun _ => 0) := funext alpha_zero

lemma lower_erdos_false : ¬ (Erdos507.α ≫ (fun n => 1 / (n : ℝ)^2)) := by
  rw [alpha_eq_zero_function, isBigO_zero_right_iff]
  intro h
  obtain ⟨N,hN⟩ := eventually_atTop.mp h
  have he := hN (N+1) (by omega)
  have hn : ((N+1 : ℕ) : ℝ) ≠ 0 := by positivity
  have hp : (1:ℝ) / ((N+1 : ℕ) : ℝ)^2 ≠ 0 := div_ne_zero one_ne_zero (pow_ne_zero _ hn)
  exact hp he

theorem refutes_original_lower : ¬ (type_of% @Erdos507.erdos_507.variants.lower_erdos) :=
  lower_erdos_false
#print axioms refutes_original_lower

end Counterexamples.Group1.Erdos507
```

</details>

<details>
<summary>Lean proof of the Green 77 question side under the previous definition (standard axioms only)</summary>

```lean
import FormalConjectures.GreensOpenProblems.«77»

/-! Check the signed-area extremal function using only definitions and proved lemmas. -/

open Erdos507 Filter Topology EuclideanGeometry
open scoped EuclideanGeometry

namespace Counterexamples.Group2.Green77

private def triVals (S : Finset ℝ²) : Set ℝ :=
  {triangle_area (t.points 0) (t.points 1) (t.points 2) |
    (t : Affine.Triangle ℝ ℝ²) (_ : ∀ i, t.points i ∈ S)}

private theorem triVals_finite (S : Finset ℝ²) : (triVals S).Finite := by
  have hf : (Set.univ.pi (fun _ : Fin 3 => (S : Set ℝ²))).Finite :=
    Set.Finite.pi (fun _ => S.finite_toSet)
  refine (hf.image (fun p : Fin 3 → ℝ² => triangle_area (p 0) (p 1) (p 2))).subset ?_
  rintro x ⟨t, ht, rfl⟩
  exact ⟨t.points, by simpa using ht, rfl⟩

private theorem area_swap (a b c : ℝ²) :
    triangle_area b a c = -triangle_area a b c := by
  simp only [triangle_area]
  rw [Orientation.areaForm_swap (x := b -ᵥ c) (y := a -ᵥ c)]
  ring

 theorem minTriangleArea_nonpos (S : Finset ℝ²) : minTriangleArea S ≤ 0 := by
  classical
  change sInf (triVals S) ≤ 0
  by_cases h : (triVals S).Nonempty
  · obtain ⟨x, t, ht, rfl⟩ := h
    have ha := csInf_le (triVals_finite S).bddBelow
      (show triangle_area (t.points 0) (t.points 1) (t.points 2) ∈ triVals S from ⟨t, ht, rfl⟩)
    let u := t.reindex (Equiv.swap 0 1)
    have hu : -triangle_area (t.points 0) (t.points 1) (t.points 2) ∈ triVals S := by
      refine ⟨u, fun i => ht _, ?_⟩
      have hs : (Equiv.swap (0 : Fin 3) 1) 2 = 2 := by decide
      simpa [u, Affine.Simplex.reindex, hs] using area_swap (t.points 0) (t.points 1) (t.points 2)
    have hb := csInf_le (triVals_finite S).bddBelow hu
    linarith
  · rw [Set.not_nonempty_iff_eq_empty.mp h, Real.sInf_empty]

 theorem alpha_nonpos (n : ℕ) : α n ≤ 0 := by
  apply Real.sSup_nonpos
  rintro x ⟨S, _, rfl⟩
  exact minTriangleArea_nonpos S

private theorem area_abs_bound {a b c : ℝ²} {r : ℝ} (hr : 0 ≤ r)
    (ha : ‖a‖ ≤ r) (hb : ‖b‖ ≤ r) (hc : ‖c‖ ≤ r) :
    |triangle_area a b c| ≤ 2 * r ^ 2 := by
  have h1 : ‖a - c‖ ≤ 2 * r := (norm_sub_le a c).trans (by linarith)
  have h2 : ‖b - c‖ ≤ 2 * r := (norm_sub_le b c).trans (by linarith)
  have hm : ‖a - c‖ * ‖b - c‖ ≤ (2 * r) * (2 * r) :=
    mul_le_mul h1 h2 (norm_nonneg _) (by linarith)
  have h := (Orientation.abs_areaForm_le (positiveOrientation : Orientation ℝ ℝ² (Fin 2))
    (a - c) (b - c)).trans hm
  change |positiveOrientation.areaForm (a - c) (b - c) / 2| ≤ 2 * r ^ 2
  rw [abs_div, abs_of_pos (by norm_num : (0 : ℝ) < 2)]
  nlinarith

private theorem minTriangleArea_lower_bound (S : Finset ℝ²) {r : ℝ} (hr : 0 ≤ r)
    (hS : ∀ p ∈ S, ‖p‖ ≤ r) : -(2 * r ^ 2) ≤ minTriangleArea S := by
  apply Real.le_sInf
  · rintro x ⟨t, ht, rfl⟩
    exact (abs_le.mp (area_abs_bound hr (hS _ (ht 0)) (hS _ (ht 1)) (hS _ (ht 2)))).1
  · nlinarith [sq_nonneg r]

private theorem collinear_linear_image (f : ℝ² →ₗ[ℝ] ℝ²) {S : Set ℝ²}
    (h : Collinear ℝ S) : Collinear ℝ (f '' S) := by
  rw [collinear_iff_exists_forall_eq_smul_vadd] at h ⊢
  obtain ⟨p₀, v, h⟩ := h
  refine ⟨f p₀, f v, ?_⟩
  rintro _ ⟨p, hp, rfl⟩
  obtain ⟨t, ht⟩ := h p hp
  refine ⟨t, ?_⟩
  simpa only [vadd_eq_add, map_add, map_smul] using congrArg f ht

 theorem alpha_eq_zero (n : ℕ) : α n = 0 := by
  classical
  apply le_antisymm (alpha_nonpos n)
  let A : Set (Finset ℝ²) := {S | S.card = n ∧
    (S : Set ℝ²) ⊆ Metric.closedBall (0 : ℝ²) 1 ∧ ¬ Collinear ℝ (S : Set ℝ²)}
  by_cases hA : A.Nonempty
  · obtain ⟨S, hS⟩ := hA
    have hbdd : BddAbove (minTriangleArea '' A) := by
      refine ⟨0, ?_⟩
      rintro x ⟨T, _, rfl⟩
      exact minTriangleArea_nonpos T
    have hnear : ∀ r : ℝ, 0 < r → r ≤ 1 → -(2 * r ^ 2) ≤ α n := by
      intro r hr hr1
      let e : ℝ² ≃ₗ[ℝ] ℝ² := LinearEquiv.smulOfNeZero ℝ ℝ² r hr.ne'
      let T : Finset ℝ² := S.image e
      have hTnorm : ∀ p ∈ T, ‖p‖ ≤ r := by
        rintro p hp
        obtain ⟨q, hq, rfl⟩ := Finset.mem_image.mp hp
        change ‖r • q‖ ≤ r
        rw [norm_smul, Real.norm_eq_abs, abs_of_pos hr]
        have hq' : ‖q‖ ≤ 1 := by
          simpa [Metric.mem_closedBall, dist_zero_right] using hS.2.1 hq
        nlinarith
      have hT : T ∈ A := by
        refine ⟨?_, ?_, ?_⟩
        · calc
            T.card = S.card := Finset.card_image_of_injective _ e.injective
            _ = n := hS.1
        · intro p hp
          simpa [Metric.mem_closedBall, dist_zero_right] using (hTnorm p hp).trans hr1
        · intro hc
          have hc' := collinear_linear_image e.symm.toLinearMap hc
          have he : e.symm.toLinearMap '' (T : Set ℝ²) = (S : Set ℝ²) := by
            simp [T, Finset.coe_image, Set.image_image]
          rw [he] at hc'
          exact hS.2.2 hc'
      exact (minTriangleArea_lower_bound T hr.le hTnorm).trans
        (le_csSup hbdd (show minTriangleArea T ∈ minTriangleArea '' A from ⟨T, hT, rfl⟩))
    by_contra! hn
    let r : ℝ := min 1 (-α n / 4)
    have hr : 0 < r := lt_min (by norm_num) (by linarith)
    have hr1 : r ≤ 1 := min_le_left _ _
    have hrα : r ≤ -α n / 4 := min_le_right _ _
    have h := hnear r hr hr1
    nlinarith [mul_nonneg hr.le (sub_nonneg.mpr hr1)]
  · have he : A = ∅ := Set.not_nonempty_iff_eq_empty.mp hA
    change 0 ≤ sSup (minTriangleArea '' A)
    rw [he, Set.image_empty, Real.sSup_empty]

 theorem green_rhs : ∃ (o : ℕ → ℝ), Tendsto o atTop (𝓝 0) ∧
    α ≪ fun n ↦ n ^ (-2 + o n) := by
  refine ⟨fun _ => 0, tendsto_const_nhds, ?_⟩
  have h : α = fun _ => 0 := funext alpha_eq_zero
  rw [h]
  exact Asymptotics.isBigO_zero _ _

end Counterexamples.Group2.Green77
```

</details>

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«507»' 'FormalConjectures.GreensOpenProblems.«77»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/507 (findings 1 and 2) and https://tadamcz.com/fc-review-results/#/f/GreensOpenProblems/77 (findings 1 and 2)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
