### PR TITLE
fix(ErdosProblems/394): the logarithmic saving exponent is a real number

### DIFF
--- a/FormalConjectures/ErdosProblems/394.lean
+++ b/FormalConjectures/ErdosProblems/394.lean
@@ -65,7 +65,7 @@ Is it true that $\sum_{n\leq x}t_2(n)\ll \frac{x^2}{(\log x)^c}$ for some $c>0$?
 @[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/williamjblair/lean-proofs/blob/4f915a323443bfb1709a6805a013812016dca88a/starfleet/erdos-394/Research/FirstQuestion.lean"]
 theorem erdos_394.parts.i :
     answer(True) ↔
-      ∃ c > 0, (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊,
+      ∃ c > (0 : ℝ), (fun x ↦ ∑ n ∈ Icc 1 ⌊x⌋₊,
       (t 2 n : ℝ)) ≪ (fun x ↦ x ^ 2 / (Real.log x) ^ c) := by
   sorry
 


### PR DESCRIPTION
**What changed**

- In `erdos_394.parts.i`, `∃ c > 0` becomes `∃ c > (0 : ℝ)`.

**Why**

Without a type ascription the exponent `c` was inferred as a natural number, so the statement required a positive integer power of `log x`, which is `S₂(x) = O(x² / log x)`. The question asks for some positive real exponent, and the linked formal proof establishes the real-exponent statement with `c = 1/2048`; it does not certify the integer-exponent statement.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«394»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/394

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
