### PR TITLE
fix(OEIS/113010): ask whether another fixed point exists

### DIFF
--- a/FormalConjectures/OEIS/113010.lean
+++ b/FormalConjectures/OEIS/113010.lean
@@ -52,7 +52,7 @@ theorem a_4 : a 4 = 1 := by native_decide
 $n=1$ and $32$ are two fixed points. Are there any others?
 -/
 @[category research open, AMS 11]
-theorem conjecture : answer(sorry) ↔ ∀ n : ℕ, a n = n ∧ n > 0 → n = 1 ∨ n = 32 := by
+theorem conjecture : answer(sorry) ↔ ∃ n : ℕ, a n = n ∧ n ≠ 1 ∧ n ≠ 32 := by
   sorry
 
 end OeisA113010


### PR DESCRIPTION
**What changed**

- The right-hand side of `conjecture` is `∃ n, a n = n ∧ n ≠ 1 ∧ n ≠ 32`.

**Why**

The docstring asks "Are there any others?", but the statement said that `1` and `32` are the only positive fixed points. So `answer(True)` would have recorded a negative answer to the source's question. The `n > 0` guard is unnecessary: `a 0 = 1`, so `0` is not a fixed point.

**How I checked**

- `lake --wfail build 'FormalConjectures.OEIS.«113010»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/OEIS/113010

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
