### PR TITLE
fix(Mathoverflow/31809): ask for a pretriangulated category that is not triangulated

### DIFF
--- a/FormalConjectures/Mathoverflow/31809.lean
+++ b/FormalConjectures/Mathoverflow/31809.lean
@@ -30,7 +30,7 @@ open CategoryTheory Limits Category Preadditive Pretriangulated
 
 /-- Does there exist a category that is pretriangulated but not triangulated? -/
 @[category research open, AMS 18]
-theorem mathoverflow_31809 : answer(sorry) ↔ (∀ (C : Type*) [Category C] [Preadditive C]
+theorem mathoverflow_31809 : answer(sorry) ↔ ¬ (∀ (C : Type*) [Category C] [Preadditive C]
     [HasZeroObject C] [HasShift C ℤ] [∀ (n : ℤ), (shiftFunctor C n).Additive]
     [Pretriangulated C], IsTriangulated C) := by
   sorry


### PR DESCRIPTION
**What changed**

- The right-hand side of `mathoverflow_31809` is negated: it now says that not every pretriangulated category is triangulated.

**Why**

The question is whether a pretriangulated but not triangulated category exists. The previous right-hand side asserted that every pretriangulated category is triangulated, so `answer(True)` would have meant that no such example exists.

**How I checked**

- `lake --wfail build 'FormalConjectures.Mathoverflow.«31809»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Mathoverflow/31809

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
