### PR TITLE
fix(Wikipedia/Mahler32): Ω(3/2) > 1/2 implies Mahler's conjecture, not conversely

### DIFF
--- a/FormalConjectures/Wikipedia/Mahler32.lean
+++ b/FormalConjectures/Wikipedia/Mahler32.lean
@@ -39,10 +39,11 @@ noncomputable def Ω (α : ℝ) : ℝ :=
 theorem mahler_conjecture (x : ℝ) (hx : IsZNumber x) : False := by
   sorry
 
-/-- If Mahler's conjecture is true, i.e. there are no Z-numbers, then `Ω(3/2)` exceeds `1/2`. -/
+/-- Mahler's conjecture would follow if `Ω(3/2)` exceeded `1/2`: a Z-number `x` has all
+fractional parts `{x (3/2)^n}` below `1/2`, so `Ω(3/2) ≤ 1/2`. -/
 @[category textbook, AMS 11]
-theorem mahler_conjecture.variants.consequence (H : type_of% mahler_conjecture) :
-    1 / 2 < Ω (3 / 2) := by
+theorem mahler_conjecture.variants.consequence (H : 1 / 2 < Ω (3 / 2)) :
+    type_of% mahler_conjecture := by
   sorry
 
 /-- It is known that for all rational `p/q > 1` in lowest terms, we have `Ω(p/q) > 1/p`. -/


### PR DESCRIPTION
**What changed**

- `mahler_conjecture.variants.consequence` assumes `1 / 2 < Ω (3 / 2)` and concludes `type_of% mahler_conjecture`. The docstring gives the argument.

**Why**

The source says that Mahler's conjecture would follow if `Ω(3/2)` exceeded `1/2`. The statement had the implication the other way round: it derived the bound from the nonexistence of Z-numbers. The correct direction is elementary: a Z-number `x` has all fractional parts `{x (3/2)^n}` below `1/2`, so `Ω(3/2) ≤ 1/2`.

**How I checked**

- `lake --wfail build FormalConjectures.Wikipedia.Mahler32` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/Wikipedia/Mahler32 (finding 1)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
