### PR TITLE
fix(ErdosProblems/392): the implication goes from the a_t ≤ n result to the main statement

### DIFF
--- a/FormalConjectures/ErdosProblems/392.lean
+++ b/FormalConjectures/ErdosProblems/392.lean
@@ -66,8 +66,8 @@ by pairing variables together, e.g. taking $a'_i = a_{2i-1}a_{2i}$ (and the lowe
 Stirling's approximation).
 -/
 @[category research solved, AMS 11]
-theorem erdos_392.variants.implication (h : type_of% erdos_392) :
-    type_of% erdos_392.variants.lower := by
+theorem erdos_392.variants.implication (h : type_of% erdos_392.variants.lower) :
+    type_of% erdos_392 := by
   sorry
 
 end Erdos392


### PR DESCRIPTION
**What changed**

- `erdos_392.variants.implication` assumes `type_of% erdos_392.variants.lower` and concludes `type_of% erdos_392`.

**Why**

Cambie's observation, quoted in the docstring, derives the asymptotic for factors bounded by `n²` from the one for factors bounded by `n`, by pairing consecutive factors (with Stirling for the lower bound). The statement had the converse implication.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«392»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/392

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
