### PR TITLE
fix(ErdosProblems/386): let k vary with n

### DIFF
--- a/FormalConjectures/ErdosProblems/386.lean
+++ b/FormalConjectures/ErdosProblems/386.lean
@@ -27,12 +27,13 @@ namespace Erdos386
 open Nat
 
 /--
-There is a $k$, such that $2 \le k \le n - 2$ and
-$\binom{n}{k}$ can be the product of consecutive primes infinitely often?
+Let $2 \le k \le n - 2$. Can $\binom{n}{k}$ be the product of consecutive primes infinitely
+often? Here $k$ may vary with $n$: the question asks for infinitely many admissible binomial
+coefficients, not for a single $k$ that works infinitely often.
 -/
 @[category research open, AMS 11]
 theorem erdos_386 :
-    answer(sorry) ↔ ∃ k ≥ 2, ∃ᶠ n in .atTop,
+    answer(sorry) ↔ ∃ᶠ n in .atTop, ∃ k ≥ 2,
       k ≤ n - 2 ∧ ∃ p q : ℕ, n.choose k = ∏ i ∈ .Ico p q, nth Nat.Prime i := by
     sorry
 


### PR DESCRIPTION
**What changed**

- In `erdos_386`, `∃ k ≥ 2` is moved inside `∃ᶠ n in atTop`. The docstring follows the source's wording.

**Why**

The source asks whether `binom(n, k)` with `2 ≤ k ≤ n - 2` is a product of consecutive primes infinitely often, with `k` allowed to depend on `n`. The previous quantifier order asked for one fixed `k` with infinitely many `n`, which excludes an infinite family of solutions with unbounded `k` but finitely many solutions per `k`.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«386»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/386

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
