### PR TITLE
fix(ErdosProblems/592): countability guards the whole classification

### DIFF
--- a/FormalConjectures/ErdosProblems/592.lean
+++ b/FormalConjectures/ErdosProblems/592.lean
@@ -34,7 +34,7 @@ red/blue colouring of the edges of $K_α$ there is either a red $K_α$ or a blue
 -/
 @[category research open, AMS 3]
 theorem erdos_592 (β : Ordinal.{u}) : β.card ≤ ℵ₀ →
-    OrdinalCardinalRamsey (ω ^ β) (ω ^ β) 3 ↔ (answer(sorry) : Ordinal.{u} → Prop) β := by
+    (OrdinalCardinalRamsey (ω ^ β) (ω ^ β) 3 ↔ (answer(sorry) : Ordinal.{u} → Prop) β) := by
   sorry
 
 -- TODO(firsching): add condition by Galvin and Larson.


### PR DESCRIPTION
**What changed**

- `erdos_592` reads `β.card ≤ ℵ₀ → (OrdinalCardinalRamsey (ω ^ β) (ω ^ β) 3 ↔ answer β)`.

**Why**

Without the parentheses the statement elaborated as `(β.card ≤ ℵ₀ → R β) ↔ A β`, so every uncountable ordinal was required to satisfy the answer predicate regardless of its Ramsey property. The problem only asks to classify the countable ordinals.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«592»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/592

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
