### PR TITLE
fix(ErdosProblems/940): ask for infinitely many unrepresentable integers

### DIFF
--- a/FormalConjectures/ErdosProblems/940.lean
+++ b/FormalConjectures/ErdosProblems/940.lean
@@ -67,13 +67,13 @@ theorem erdos_940.variants.three_cubes :
 
 
 /--
-Let $r \ge 3$. It is not known if all large integers are the sum of at most $r$-many
-$r$-powerful numbers.
+Let $r \ge 3$. Are there infinitely many integers which are not the sum of at most $r$-many
+$r$-powerful numbers?
 -/
 @[category research open, AMS 11]
 theorem erdos_940.variants.large_integers :
     answer(sorry) ↔
-    ∀ r ≥ 3, (∀ᶠ x in atTop, ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ x = S.sum) := by
+    ∀ r ≥ 3, ¬ (∀ᶠ x in atTop, ∃ (S : Multiset ℕ), S.card ≤ r ∧ (∀ s ∈ S, r.Full s) ∧ x = S.sum) := by
   sorry
 
 /--


### PR DESCRIPTION
**What changed**

- The right-hand side of `erdos_940.variants.large_integers` is `∀ r ≥ 3, ¬ (∀ᶠ x in atTop, …)`. The docstring quotes the source's question.

**Why**

[erdosproblems.com/940](https://www.erdosproblems.com/940) asks: "Are there infinitely many integers which are not the sum of at most `r` many `r`-powerful numbers?" The previous right-hand side asked instead whether all large integers are such sums, for every `r ≥ 3`; its negation is `∃ r ≥ 3, …`, which is not the source's universal question.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«940»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/940

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
