### PR TITLE
fix(OEIS/167918): drop the existence hypothesis from conjecture1

### DIFF
--- a/FormalConjectures/OEIS/167918.lean
+++ b/FormalConjectures/OEIS/167918.lean
@@ -195,11 +195,11 @@ theorem a_4 : a 4 = 7 := by
 /--
 Conjecture: $f(n, k) = 2$ for infinitely many cases, where $k = a(n)$.
 
-We assume $a(n) \ne 0$ (i.e., that a suitable $k > n$ always exists), as `sInf` evaluates to $0$
-on an empty set.
+No hypothesis on the existence of $a(n)$ is needed: if no suitable $k > n$ exists then
+$a(n) = 0$ and $S(0) = 4 < 2 S(n)$, so such $n$ cannot be witnesses.
 -/
 @[category research open, AMS 11]
-theorem conjecture1 (M : ℕ) (ha : ∀ n > 0, a n ≠ 0) :
+theorem conjecture1 (M : ℕ) :
     ∃ n : ℕ, n ≥ M ∧ n > 0 ∧ S (a n) = 2 * S n := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `conjecture1` no longer assumes `∀ n > 0, a n ≠ 0`. The docstring explains why no hypothesis is needed.

**Why**

The hypothesis is equivalent to `∀ n > 0, ∃ k > n, S n ∣ S k`, a substantive assumption that OEIS does not make for the ratio-two conjecture. It is also unnecessary: if no suitable `k` exists then `a n = 0` and `S 0 = P 0 + P 1 = 4`, while `2 * S n ≥ 10` for positive `n`, so such `n` can never be a witness.

**How I checked**

- `lake --wfail build 'FormalConjectures.OEIS.«167918»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/OEIS/167918

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
