### PR TITLE
fix(ErdosProblems/1095): log g(k) ≍ k / log k is a Θ statement

### DIFF
--- a/FormalConjectures/ErdosProblems/1095.lean
+++ b/FormalConjectures/ErdosProblems/1095.lean
@@ -72,7 +72,8 @@ theorem erdos_1095.variants.lower_conjecture : ∃ c > 0, ∀ᶠ k in atTop, g k
 Sorenson, Sorenson, and Webster [SSWE20] give heuristic evidence that $\log g(k) \asymp \frac{k}{\log k}$.
 -/
 @[category research open, AMS 11]
-theorem erdos_1095.variants.log_equivalent : (fun k ↦ log (g k)) ~[atTop] (fun k ↦ k / log k) := by
+theorem erdos_1095.variants.log_equivalent :
+    (fun k ↦ log (g k)) =Θ[atTop] (fun k ↦ (k : ℝ) / log k) := by
   sorry
 
 end Erdos1095


### PR DESCRIPTION
**What changed**

- `erdos_1095.variants.log_equivalent` uses `=Θ[atTop]` instead of `~[atTop]`.

**Why**

The source's `≍` means bounded above and below by positive constant multiples. `~[atTop]` is asymptotic equivalence, which would impose the leading constant `1` on `log g(k) / (k / log k)`, a claim the heuristic does not make.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«1095»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/1095

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
