### PR TITLE
fix(ErdosProblems/36): Erdős's 1955 bound gives liminf ≥ 1/4

### DIFF
--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -261,7 +261,7 @@ by *Paul Erdős*, Riveon Lematematika 9, p.45-48,1955
 -/
 @[category textbook, AMS 5 11]
 theorem minimum_overlap.variants.lower.erdos_1955 :
-    (1 : ℝ) / 4 < atTop.liminf MinOverlapQuotient := by
+    (1 : ℝ) / 4 ≤ atTop.liminf MinOverlapQuotient := by
   sorry
 
 /--


### PR DESCRIPTION
**What changed**

- `minimum_overlap.variants.lower.erdos_1955` states `1 / 4 ≤ atTop.liminf MinOverlapQuotient`.

**Why**

The cited estimate is the finite-`n` bound `M(n) > n / 4`. Its limiting consequence is `1/4 ≤ liminf`; strict inequalities need not survive the limit. Later stronger results make the strict inequality true, but it is not what the 1955 paper proves, and the theorem is attributed to that paper.

**How I checked**

- `lake --wfail build 'FormalConjectures.ErdosProblems.«36»'` passes.

Identified by the fc-review audit: https://tadamcz.com/fc-review-results/#/f/ErdosProblems/36 (finding 1)

AI disclosure: drafted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
