### PR TITLE
fix(GreensOpenProblems/38): the lower bound has been improved

### DIFF
--- a/FormalConjectures/GreensOpenProblems/38.lean
+++ b/FormalConjectures/GreensOpenProblems/38.lean
@@ -69,20 +69,22 @@ noncomputable def C₁ : ℝ := (367 : ℝ) ^ (5⁻¹ : ℝ)
 /-- The upper bound constant $C_2 \approx 3.3177$ from [La79]. -/
 noncomputable def C₂ : ℝ := (7 * Real.cos (Real.pi / 7)) / (1 + Real.cos (Real.pi / 7))
 
-/-- Can we improve the lower bound? -/
+/-- Can we improve the lower bound? The answer sequence must be eventually nonnegative, since
+`=O` compares norms. -/
 @[category research open, AMS 5 11]
 theorem green_38.lower :
     let ans := (answer(sorry) : ℕ → ℝ)
-    ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
+    (∀ᶠ n in atTop, 0 ≤ ans n) ∧ ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
     ∃ c > C₁, (fun n ↦ c ^ n) =O[atTop] ans := by
   sorry
 
-/-- Can we improve the best upper bound? -/
+/-- Can we improve the best upper bound? The base `c` must be positive, since `=O` compares
+norms. -/
 @[category research open, AMS 5 11]
 theorem green_38.upper :
     let ans := (answer(sorry) : ℕ → ℝ)
     LargestAdmissibleCardinality ≤ᶠ[atTop] ans ∧
-    ∃ c < C₂, ans =O[atTop] (fun n ↦ c ^ n) := by
+    ∃ c : ℝ, 0 < c ∧ c < C₂ ∧ ans =O[atTop] (fun n ↦ c ^ n) := by
   sorry
 
 /--
@@ -90,7 +92,7 @@ The current best lower bound is $(C_1 - o(1))^n \leqslant |A|$ where
 $C_1 = 367^{1/5} \approx 3.2578$ [Po20, Section 9.1]. -/
 @[category research solved, AMS 5 11]
 theorem green_38.variants.best_lower :
-    ∀ ε > 0, ∀ᶠ n in atTop, (C₁ - ε) ^ n ≤ LargestAdmissibleCardinality n := by
+    ∀ ε ∈ Set.Ioo (0 : ℝ) C₁, ∀ᶠ n in atTop, (C₁ - ε) ^ n ≤ LargestAdmissibleCardinality n := by
   sorry
 
 /-- The current best upper bound is $|A| \leqslant (C_2 + o(1))^n$ where

--- a/FormalConjectures/GreensOpenProblems/38.lean
+++ b/FormalConjectures/GreensOpenProblems/38.lean
@@ -25,6 +25,13 @@ import FormalConjecturesUtil
   IEEE Transactions on Information theory 25.1 (1979): 1-7.
 - [Po20] Polak, Sven. "New methods in coding theory: Error-correcting codes and the Shannon capacity."
   arXiv preprint arXiv:2005.02945 (2020).
+- [IRCR26] Itty, Nathaniel and Rosin, Christopher D. and Carstensen, Chase and Reichman, Daniel.
+  "Improved lower bounds for the Shannon capacity of odd cycles." arXiv:2607.21517 (2026).
+- [Ga26] Gao, Yu. "A recursive construction improving the lower bound on the Shannon capacity of
+  $C_7$." arXiv:2607.27869 (2026).
+- [BPZ26] Buys, Pjotr and Polak, Sven and Zuiddam, Jeroen. "Lean-verified lower bounds for the
+  Shannon capacity of odd cycles." arXiv:2607.29681 (2026). Lean formalisation:
+  https://github.com/spectra-research/shannon-capacity-lean
 -/
 
 open Filter Set
@@ -70,10 +77,18 @@ noncomputable def C₁ : ℝ := (367 : ℝ) ^ (5⁻¹ : ℝ)
 noncomputable def C₂ : ℝ := (7 * Real.cos (Real.pi / 7)) / (1 + Real.cos (Real.pi / 7))
 
 /-- Can we improve the lower bound? The answer sequence must be eventually nonnegative, since
-`=O` compares norms. -/
-@[category research open, AMS 5 11]
+`=O` compares norms.
+
+Yes. Itty, Rosin, Carstensen and Reichman [IRCR26] found a valid set of size $134753$ in
+$\mathbb{F}_7^{10}$ (an independent set in the tenth strong power of $C_7$). Taking products
+gives valid sets of size $134753^{\lfloor n/10 \rfloor}$ in $\mathbb{F}_7^n$, see
+`green_38.variants.lower_itty_rosin_carstensen_reichman`, so the growth rate is at least
+$134753^{1/10} > 3.258020 > C_1$ (note $134753 > 367^2 = 134689$). Gao [Ga26] and then Buys,
+Polak and Zuiddam [BPZ26] improved the rate further, to $3.258789\ldots$ and $3.2588\ldots$
+respectively; the latter is formalised in Lean. The exact growth rate remains open. -/
+@[category research solved, AMS 5 11]
 theorem green_38.lower :
-    let ans := (answer(sorry) : ℕ → ℝ)
+    let ans := (answer(fun n : ℕ ↦ (134753 : ℝ) ^ (n / 10)) : ℕ → ℝ)
     (∀ᶠ n in atTop, 0 ≤ ans n) ∧ ans ≤ᶠ[atTop] LargestAdmissibleCardinality ∧
     ∃ c > C₁, (fun n ↦ c ^ n) =O[atTop] ans := by
   sorry
@@ -88,11 +103,21 @@ theorem green_38.upper :
   sorry
 
 /--
-The current best lower bound is $(C_1 - o(1))^n \leqslant |A|$ where
-$C_1 = 367^{1/5} \approx 3.2578$ [Po20, Section 9.1]. -/
+The lower bound $(C_1 - o(1))^n \leqslant |A|$ where $C_1 = 367^{1/5} \approx 3.2578$, from a
+valid set of size $367$ in $\mathbb{F}_7^5$ [Po20, Section 9.1]. This was the best known bound
+when Green's list was written; it has since been improved, see `green_38.lower`. -/
 @[category research solved, AMS 5 11]
 theorem green_38.variants.best_lower :
     ∀ ε ∈ Set.Ioo (0 : ℝ) C₁, ∀ᶠ n in atTop, (C₁ - ε) ^ n ≤ LargestAdmissibleCardinality n := by
+  sorry
+
+/--
+Itty, Rosin, Carstensen and Reichman [IRCR26] found a valid set of size $134753$ in
+$\mathbb{F}_7^{10}$. Products of copies of it, padded with zero coordinates, give
+$134753^{\lfloor n/10 \rfloor} \leqslant |A|$ in $\mathbb{F}_7^n$. -/
+@[category research solved, AMS 5 11]
+theorem green_38.variants.lower_itty_rosin_carstensen_reichman (n : ℕ) :
+    (134753 : ℝ) ^ (n / 10) ≤ LargestAdmissibleCardinality n := by
   sorry
 
 /-- The current best upper bound is $|A| \leqslant (C_2 + o(1))^n$ where


### PR DESCRIPTION
Follow-up to https://github.com/google-deepmind/formal-conjectures/pull/5511, which fixed the sign conditions.

- `green_38.lower` is `research solved` with the answer `fun n ↦ 134753 ^ (n / 10)`: Itty,
  Rosin, Carstensen and Reichman (arXiv:2607.21517) found a valid set of size 134753 in F_7^10,
  and products give the base 134753^(1/10) > 3.258020 > C₁ = 367^(1/5) (as 134753 > 367²).
  Gao (arXiv:2607.27869) and Buys, Polak and Zuiddam (arXiv:2607.29681, formalised in Lean)
  improved the rate further; the exact growth rate remains open.
- New `green_38.variants.lower_itty_rosin_carstensen_reichman` records the concrete bound
  134753^⌊n/10⌋ ≤ M(n).
- The docstring of `variants.best_lower` now describes Polak's bound as the best known when
  Green's list was written rather than the current best.
- References [IRCR26], [Ga26], [BPZ26] added.

identified by @tadamcz running an AI pipeline: https://tadamcz.com/fc-review-results/#/f/GreensOpenProblems/38