### PR TITLE
fix(OEIS/167918): ask whether the ratio is bounded, state existence

### DIFF
--- a/FormalConjectures/OEIS/167918.lean
+++ b/FormalConjectures/OEIS/167918.lean
@@ -195,11 +195,11 @@ theorem a_4 : a 4 = 7 := by
 /--
 Conjecture: $f(n, k) = 2$ for infinitely many cases, where $k = a(n)$.
 
-We assume $a(n) \ne 0$ (i.e., that a suitable $k > n$ always exists), as `sInf` evaluates to $0$
-on an empty set.
+No hypothesis on the existence of $a(n)$ is needed: if no suitable $k > n$ exists then
+$a(n) = 0$ and $S(0) = 4 < 2 S(n)$, so such $n$ cannot be witnesses.
 -/
 @[category research open, AMS 11]
-theorem conjecture1 (M : ℕ) (ha : ∀ n > 0, a n ≠ 0) :
+theorem conjecture1 (M : ℕ) :
     ∃ n : ℕ, n ≥ M ∧ n > 0 ∧ S (a n) = 2 * S n := by
   sorry
 

--- a/FormalConjectures/OEIS/167918.lean
+++ b/FormalConjectures/OEIS/167918.lean
@@ -193,6 +193,14 @@ theorem a_4 : a 4 = 7 := by
   rw [ha4, h_least.csInf_eq]
 
 /--
+Conjecture: the sequence is infinite, that is, for every $n \geq 1$ there is some $k > n$
+with $S(n) \mid S(k)$, so that $a(n)$ is defined.
+-/
+@[category research open, AMS 11]
+theorem conjecture_infinite : ∀ n > 0, ∃ k > n, S n ∣ S k := by
+  sorry
+
+/--
 Conjecture: $f(n, k) = 2$ for infinitely many cases, where $k = a(n)$.
 
 No hypothesis on the existence of $a(n)$ is needed: if no suitable $k > n$ exists then
@@ -204,14 +212,14 @@ theorem conjecture1 (M : ℕ) :
   sorry
 
 /--
-Open problem: Whether the ratio $f(n, k)$ is bounded, where $k = a(n)$.
+Open problem: is the ratio $f(n, k)$ bounded, where $k = a(n)$?
 
-We assume $a(n) \ne 0$ (i.e., that a suitable $k > n$ always exists), as `sInf` evaluates to $0$
-on an empty set.
+No hypothesis on the existence of $a(n)$ is needed: if no suitable $k > n$ exists then
+$a(n) = 0$ and $S(0) / S(n) = 4 / S(n) = 0$ for $n > 0$, so such $n$ do not affect boundedness.
+When $a(n) \neq 0$ we have $S(n) \mid S(a(n))$ by definition, so the division is exact.
 -/
 @[category research open, AMS 11]
-theorem conjecture2 (ha : ∀ n > 0, a n ≠ 0) :
-    ∃ C : ℕ, ∀ n : ℕ, n > 0 → S (a n) / S n ≤ C := by
+theorem conjecture2 : answer(sorry) ↔ ∃ C : ℕ, ∀ n : ℕ, n > 0 → S (a n) / S n ≤ C := by
   sorry
 
 


### PR DESCRIPTION
Follow-up to https://github.com/google-deepmind/formal-conjectures/pull/5529, which dropped the existence hypothesis from `conjecture1`.

- `conjecture2` is now `answer(sorry) ↔ ∃ C, ∀ n > 0, S (a n) / S n ≤ C`. OEIS comment (5a)
  asks whether f(n,k) is bounded; it does not conjecture a bound. The hypothesis
  `∀ n > 0, a n ≠ 0` is dropped for the same reason as in `conjecture1`: an undefined index
  contributes the quotient S 0 / S n = 4 / S n = 0, so it does not affect boundedness, whereas
  with the hypothesis a single undefined index made the statement vacuous.
- New `conjecture_infinite : ∀ n > 0, ∃ k > n, S n ∣ S k`, OEIS comment (1) ("the sequence is
  infinite"), which is exactly what the dropped hypothesis was assuming.

identified by @tadamcz running an AI pipeline: https://tadamcz.com/fc-review-results/#/f/OEIS/167918