### PR TITLE
Formalize supplementary statements for Erdős Problem 873 and mark the all-scale conjecture as solved

### DIFF
--- a/FormalConjectures/ErdosProblems/873.lean
+++ b/FormalConjectures/ErdosProblems/873.lean
@@ -39,4 +39,40 @@ theorem erdos_873 : answer(sorry) ↔ ∀ᵉ (a : ℕ → ℕ) (ε > (0 : ℝ)),
     ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal := by
   sorry
 
+/-!
+## Statements following the original question
+
+The paper states (2), (3), and then conjectures an all-X strengthening of (3).
+-/
+
+/-- The upper bound (2). -/
+@[category research solved, AMS 11]
+theorem erdos_873.variants.triple_upper_bound :
+    ∃ C : ℝ, 0 < C ∧
+      ∀ (a : ℕ → ℕ), 0 < a 0 → StrictMono a →
+        ∀ᶠ X : ℝ in Filter.atTop,
+          (F a X 3 : EReal) ≤
+            (C * X ^ (1 / 3 : ℝ) * Real.log X).toEReal := by
+  sorry
+
+/-- The infinitely-often lower bound (3). -/
+@[category research solved, AMS 11]
+theorem erdos_873.variants.triple_lower_bound_infinitely_often :
+    ∃ (a : ℕ → ℕ) (c : ℝ),
+      0 < a 0 ∧ StrictMono a ∧ 0 < c ∧
+        ∀ X₀ : ℝ, ∃ X > X₀,
+          (c * X ^ (1 / 3 : ℝ) * Real.log X).toEReal ≤ (F a X 3 : EReal) := by
+  sorry
+
+/-- The proposed all-X strengthening of (3). -/
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/KitaKen1/erdos-873-lean/blob/44cbf183239517795522bd3f18124b08c095cc6d/lean/Erdos873Final.lean#L17-L24"]
+theorem erdos_873.variants.supplement_all_scale :
+    answer(False) ↔
+      ∃ (a : ℕ → ℕ) (c : ℝ),
+        0 < a 0 ∧ StrictMono a ∧ 0 < c ∧
+          ∀ X : ℝ, 0 < X →
+            (c * X ^ (1 / 3 : ℝ) * Real.log X).toEReal ≤ (F a X 3 : EReal) := by
+  sorry
+
 end Erdos873

--- a/FormalConjectures/ErdosProblems/873.lean
+++ b/FormalConjectures/ErdosProblems/873.lean
@@ -39,7 +39,7 @@ theorem erdos_873 : answer(sorry) ↔ ∀ᵉ (a : ℕ → ℕ) (ε > (0 : ℝ)),
     ∃ k, ∀ X > 0, F a X k < (X^ε).toEReal := by
   sorry
 
-/-!
+/-
 ## Statements following the original question
 
 The paper states (2), (3), and then conjectures an all-X strengthening of (3).


### PR DESCRIPTION
This PR makes two contributions concerning the three supplementary items stated in the original paper for Erdős Problem 873:

1. It formalizes all three supplementary items in Lean.
2. Two of the three, (2) and (3), were already solved. For the remaining open item—the all-scale conjecture stated after (3)—this PR provides a Lean proof of a negative answer, changing its status from open to solved.

Sources:
- Original paper: https://hrj.episciences.org/125
- Erdős Problem 873: https://www.erdosproblems.com/873

The original `erdos_873` statement remains unchanged and open. The negative answer to the supplementary all-scale conjecture is formalized as `answer(False)`.

The Lean formalization was prepared by [KitaKen1 (Kenta Kitamura)](https://github.com/KitaKen1).

The external proof establishes the exact target theorem:

```lean
theorem erdos_873.variants.supplement_all_scale :
    answer(False) ↔
      ∃ (a : ℕ → ℕ) (c : ℝ),
        0 < a 0 ∧ StrictMono a ∧ 0 < c ∧
          ∀ X : ℝ, 0 < X →
            (c * X ^ (1 / 3 : ℝ) * Real.log X).toEReal ≤ (F a X 3 : EReal)
```

Proof: https://github.com/KitaKen1/erdos-873-lean/blob/44cbf183239517795522bd3f18124b08c095cc6d/lean/Erdos873Final.lean#L17-L24

Repository: https://github.com/KitaKen1/erdos-873-lean

Lean4Web: https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2FKitaKen1%2Ferdos-873-lean%2F44cbf183239517795522bd3f18124b08c095cc6d%2Flean4web%2FErdos873Lean4Web.lean

`#print axioms erdos_873.variants.supplement_all_scale` reports only `propext`, `Classical.choice`, and `Quot.sound`; there is no `sorryAx` or project-specific mathematical axiom.

AI Usage Disclosure: This formalization was developed with assistance from ChatGPT and OpenAI Codex, using GPT-6 (Astra).