### PR TITLE
feat(Paper): Nakayama conjectures

### DIFF
--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -197,9 +197,14 @@ The goal of this part is to define a version of duality in artinian algebra that
 variable {C: Type u} [Category.{v} C] [Abelian C]
 variable {M E : C} (u : M ⟶ E)
 
+/--
+ `u`is an essential extension of `M` if for every subobject `s` of `E` that is non zero the pullback wuth `u`is also non zero.
+-/
 def IsEssentialExtension : Prop :=
   ∀ s : Subobject E, IsZero (Subobject.underlying.obj s) ∨ ¬ IsZero (pullback u ((MonoOver.forget E).obj (Subobject.representative.obj s)).hom)
 
+/--
+An injective hull is an essential extension that is also injective.-/
 def IsInjectiveHull : Prop := Injective E ∧ IsEssentialExtension u
 
 variable (M)
@@ -215,7 +220,11 @@ noncomputable def injectiveHullHom [HasInjectiveHull M] : M ⟶ (injectiveHull M
 lemma IsInjectiveHullInjectiveHull [HasInjectiveHull M] : IsInjectiveHull (injectiveHullHom M) :=
   (HasInjectiveHull.existsInjHull (M := M)).choose_spec.choose_spec
 
+/--
+ From wikipedia: https://en.wikipedia.org/wiki/Injective_hull
 
+ In an AB5 actegory with enough injectives (in particular categories of modules over a ring), every object has an injective hull
+-/
 @[category API, AMS 16 18]
 instance [HasFilteredColimits C] [AB5 C] [EnoughInjectives C] : HasInjectiveHull M := by
   sorry

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -1,0 +1,100 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+open CategoryTheory Abelian Limits
+
+/-!
+# Strong Nakayama Conjecture
+*Reference:* [R.R. Colby and K.R. Fuller, A note on the Nakayama conjectures, Tsukuba J. Math. \textbf{14} (1990), no.~2, 343--352.](https://doi.org/10.21099/tkbjm/1496161457)
+
+# Generalized Nakayama Conjecture
+# Auslander-Reiten Conjecture
+*Reference:*
+[M. Auslander and I. Reiten, On a generalized version of the Nakayama conjecture, Proc. Amer. Math. Soc. 52 (1975), 69--74.](https://doi.org/10.1090/S0002-9939-1975-0389977-6)
+
+# Tachikawa Conjectures
+*Reference:* [H. Tachikawa, Quasi-Frobenius Rings and Generalizations: QF-3 and QF-1 Rings, Lecture Notes in Mathematics, vol. 351, Springer, Berlin–Heidelberg, 1973](https://doi.org/10.1007/BFb0060005)
+
+# Nakayama Conjecture
+*Reference:* [T. Nakayama, On algebras with complete homology. Abh. Math. Sem. Univ. Hamburg 22 (1958), 300–307.](https://doi.org/10.1007/BF02941960)
+-/
+
+universe u v w
+
+variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] {M : ModuleCat.{v} A} [Module.Finite A M.carrier]
+
+
+namespace NakayamaConjectures
+
+/--
+The Strong Nakayama Conjecture:
+Let A be a finite module over an aritinain ring. For any finitely generated A-module M with Ext^i(M,A) = 0 for any integer i ≥ 0 it follows that M = 0.
+-/
+@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
+theorem SNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) : IsZero M := by
+  sorry
+
+/--
+The Generalized Nakayama Conjecture:
+Let A be a finite-dimensional algebra. For any finitely generated A-module M with Ext^i(M,A) = 0 for any integer i \geq 0 it follows that M is not simple.
+-/
+@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
+theorem GNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) :
+    ¬ Simple M := by
+  sorry
+
+/--
+Auslander-Reiten-Conjecture - an equivalent formulation of GNC:
+Let A be a finite-dimensional algebra. For any finitely generated A-module M with Ext^i(M,M) = Ext^i(M,A) = 0 for any integer i \geq 0 it follows that M is projective.
+-/
+@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
+theorem ARC (_ : ∀ i > 0 ,
+        Subsingleton (Ext M (.of A A) i) ∧
+        Subsingleton (Ext M M i)) :
+        Projective M := by
+  sorry
+
+/--
+First Tachikawa Conjecture:
+Let A be a finite-dimensional algebra. If Ext^p(A^*,A) = 0 for any integer p > 0, then A is self-injective.
+-/
+@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
+theorem TC1 (_ : ∀ p > 0, ∀ (I : FGModuleCat A), (Injective I) →
+        Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) →
+        CategoryTheory.Injective (ModuleCat.of A A)) :
+        Injective (ModuleCat.of A A) := by
+    sorry
+
+/--
+Second Tachikawa Conjecture:
+Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer p > 0, it follows that M is projective.
+-/
+@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
+theorem TC2 (_ : Injective (ModuleCat.of A A)) (_ : ∀ p > 0,
+        Subsingleton (Ext M M p)) :
+        Projective (ModuleCat.of A M ) := by
+  sorry
+
+
+/-
+Nakayama Conjecture:
+Let A be a finite-dimensional algebra.
+-/
+
+
+end NakayamaConjectures

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -16,8 +16,6 @@ limitations under the License.
 
 import FormalConjecturesUtil
 
-open CategoryTheory Abelian Limits
-
 /-!
 # Strong Nakayama Conjecture
 *Reference:* [R.R. Colby and K.R. Fuller, A note on the Nakayama conjectures, Tsukuba J. Math. \textbf{14} (1990), no.~2, 343--352.](https://doi.org/10.21099/tkbjm/1496161457)
@@ -34,23 +32,30 @@ open CategoryTheory Abelian Limits
 *Reference:* [T. Nakayama, On algebras with complete homology. Abh. Math. Sem. Univ. Hamburg 22 (1958), 300–307.](https://doi.org/10.1007/BF02941960)
 -/
 
+open CategoryTheory Abelian Limits
+
 universe u v w
-
-/-
-Let `R`be an artinian ring, `A` an algebra of finite type and `M`a finitely generated module over `A`-/
-variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] {M : ModuleCat.{v} A} [Module.Finite A M.carrier]
-
 
 namespace NakayamaConjectures
 
+/-
+Let `R`be an artinian ring, `A` an algebra of finite type and `M`a finitely generated module over `A`-/
+variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
+
+abbrev SNCstatement := (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M
+
+include R in
 /--
 The Strong Nakayama Conjecture:
 If  Ext^i(M,A) = 0 for any integer `i ≥ 0` then M = 0.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem SNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) : IsZero M := by
+theorem SNC : SNCstatement M := by
   sorry
 
+abbrev GNCstatement := ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M
+
+include R in
 /--
 The Generalized Nakayama Conjecture:
 If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
@@ -58,10 +63,20 @@ If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
 Note that `Simple` here is in Finitely generated Modules but it is equivalent to being simple in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem GNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) :
-    ¬ Simple M := by
+theorem GNC : GNCstatement M := by
   sorry
 
+include R
+/--
+Reference: TODO
+-/
+@[category research solved, AMS 16 18]
+lemma SGNCImplGNC : (∀ M : ModuleCat A, Module.Finite A M → SNCstatement M) → (∀ M : ModuleCat A, Module.Finite A M → GNCstatement M) := by
+  sorry
+
+abbrev ARCstatement := ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsingleton (Ext M M i)) → Projective M
+
+include R in
 /--
 Auslander-Reiten-Conjecture - an equivalent formulation of GNC:
 If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
@@ -69,12 +84,24 @@ If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
 Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem ARC (_ : ∀ i > 0 ,
-        Subsingleton (Ext M (.of A A) i) ∧
-        Subsingleton (Ext M M i)) :
-        Projective M := by
+theorem ARC : ARCstatement M := by
   sorry
 
+include R
+/--
+Reference: TODO
+-/
+@[category research solved, AMS 16 18]
+lemma GNCEquivARC : (∀ M : ModuleCat A, Module.Finite A M → GNCstatement M) ↔ (∀ M : ModuleCat A, Module.Finite A M → ARCstatement M) := by
+  sorry
+
+variable (A) in
+abbrev TC1statement := ( ∀ p > 0, ∀ (I : FGModuleCat A),
+  (Injective I) →
+  Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) → CategoryTheory.Injective (ModuleCat.of A A))
+  → Injective (ModuleCat.of A A)
+
+include R in
 /--
 First Tachikawa Conjecture:
 
@@ -82,32 +109,116 @@ If for any `p > 0` and `I` a finiyely generated module over `A` Ext^p(I,A)=0 the
 
 Note that there is an equivalent formulation :If Ext^p(A^*,A) = 0 for any integer `p > 0`, then A is self-injective.
 
-But A^* is defined as `A →ₗ[R] R` equiped with a structure of A module.
-- An instance is given by `LinearMap.instModuleDomMulActOfSMulCommClass`but in order to have a good universe, we need to have `R`and `A` leaving in the same universe.
-- In adition it's a module over `Aᵈᵐᵃ`wich is not `A`if `A`is not commutative.
-- Finaly in order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet availabla.
+But A^* is defined as `A →ₗ[R] R` equiped with a structure of A module.The instance of module is given by :
 
+instance : Module A (A →ₗ[R] R) := by
+  let m := LinearMap.instModuleDomMulActOfSMulCommClass (S := Aᵐᵒᵖ) (R := R) (σ₁₂ := RingHom.id R) (M' := R) (M:= A)
+  have : A ≃+* (Aᵐᵒᵖ)ᵈᵐᵃ := RingEquiv.opOp _
+  apply Module.compHom _ (this.toRingHom)
+
+If `R`is not a fild, in  order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet available in mathlib. We state this version of the conjecture.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem TC1 (_ : ∀ p > 0, ∀ (I : FGModuleCat A), (Injective I) →
-        Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) →
-        CategoryTheory.Injective (ModuleCat.of A A)) :
-        Injective (ModuleCat.of A A) := by
-    sorry
+theorem TC1 : TC1statement A := by
+  sorry
 
+abbrev TC2statement := (Injective (ModuleCat.of A A) → ∀ p > 0,
+  Subsingleton (Ext M M p)) → Projective (ModuleCat.of A M )
+
+include R in
 /--
 Second Tachikawa Conjecture:
 Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer `p > 0`, it follows that M is projective.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem TC2 (_ : Injective (ModuleCat.of A A)) (_ : ∀ p > 0,
-        Subsingleton (Ext M M p)) :
-        Projective (ModuleCat.of A M ) := by
+theorem TC2 : TC2statement M := by
   sorry
 
-/-
+variable (A) in
+abbrev NCstatement := (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, Projective <| I.cocomplex.X n) → Injective (ModuleCat.of A A )
+
+include R in
+/--
 Nakayama Conjecture:
-Let A be a finite-dimensional algebra.
+As in the First Tachikawa Conjecture there is an aquivalent formulation with the dual:
+
+for every finitely genretaed module `M` over `A` if for all ì > 0 Extî(M ⊕ A^*, M ⊕ A) = 0 then `M` is projective.
+
+We state the following version : if `A`has a projective-injective resolution then `A`is self injective.
 -/
+@[category research open, AMS 16 18]
+theorem NC : NCstatement A := by
+  sorry
 
 end NakayamaConjectures
+
+namespace NakayamaConjecturesOverFields
+
+variable {R : Type u} {A : Type v} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
+
+variable (R A) in
+abbrev dual := (A →ₗ[R] R)
+
+instance : Module A (dual R A) := by
+  have : A ≃+* (Aᵐᵒᵖ)ᵈᵐᵃ := RingEquiv.opOp _
+  apply Module.compHom _ (this.toRingHom)
+
+/--
+Gorenstein Symmetry Conjecture
+-/
+@[category research open, AMS 16 18]
+theorem GSC : injectiveDimension (ModuleCat.of A A) < ⊤ → projectiveDimension (ModuleCat.of A (dual R A)) < ⊤ := by
+  sorry
+
+/- in order to take Ext groups of dual R A with some other `ModuleCat.{v}` we need to have `R` and `A` leaving on the same universe-/
+variable {R A: Type u} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
+
+variable (R) in
+abbrev SNCdualStatement := IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i)
+
+/--
+SNC expressed with the dual
+-/
+@[category research open, AMS 16 18]
+theorem SNCdual : SNCdualStatement R M := by
+  sorry
+
+/--
+In this situation, SNCdual and SNC are equivalent,
+ref: TODO
+-/
+@[category research solved, AMS 16 18]
+lemma SNCEquiv : NakayamaConjectures.SNCstatement M ↔ SNCdualStatement R M := by sorry
+
+variable (R) in
+abbrev NCdualStatement := (∀ i > 0,
+  Subsingleton (Ext M M i) ∧
+  Subsingleton (Ext M (.of A A) i) ∧
+  Subsingleton (Ext (.of A (dual R A)) M i) ∧
+  Subsingleton (Ext ((.of A (dual R A))) (ModuleCat.of A A) i)) → Projective M
+
+/--
+NC expressed with the dual
+-/
+@[category research open, AMS 16 18]
+theorem NCdual : NCdualStatement R M := by
+  sorry
+
+/--
+In this situation, NCdual and NC are equivalent,
+ref: TODO
+-/
+@[category research solved, AMS 16 18]
+lemma NCEquiv : NakayamaConjectures.NCstatement A ↔ NCdualStatement R M := by sorry
+
+/--
+In this situation, NCdual is equivalent to the conjunction of the two Tachikawa's conjectures
+ref: TODO
+-/
+@[category research solved, AMS 16 18]
+lemma NCEquivTC1andTC2 :
+    NakayamaConjectures.TC1statement A ∧ (∀ M : ModuleCat A, NakayamaConjectures.TC2statement M) ↔ NCdualStatement R M := by
+  sorry
+
+
+end NakayamaConjecturesOverFields

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -42,7 +42,7 @@ namespace NakayamaConjectures
 Let `R`be an artinian ring, `A` an algebra of finite type and `M`a finitely generated module over `A`-/
 variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
 
-abbrev SNCstatement := (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M
+abbrev sNC_statement := (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M
 
 include R in
 /--
@@ -50,10 +50,10 @@ The Strong Nakayama Conjecture:
 If  Ext^i(M,A) = 0 for any integer `i ≥ 0` then M = 0.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem SNC : SNCstatement M := by
+theorem sNC : sNC_statement M := by
   sorry
 
-abbrev GNCstatement := ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M
+abbrev gNC_statement := ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M
 
 include R in
 /--
@@ -63,7 +63,7 @@ If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
 Note that `Simple` here is in Finitely generated Modules but it is equivalent to being simple in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem GNC : GNCstatement M := by
+theorem gNC : gNC_statement M := by
   sorry
 
 include R
@@ -71,20 +71,20 @@ include R
 Reference: TODO
 -/
 @[category research solved, AMS 16 18]
-lemma SGNCImplGNC : (∀ M : ModuleCat A, Module.Finite A M → SNCstatement M) → (∀ M : ModuleCat A, Module.Finite A M → GNCstatement M) := by
+lemma sGNC_impl_gNC : (∀ M : ModuleCat A, Module.Finite A M → sNC_statement M) → (∀ M : ModuleCat A, Module.Finite A M → gNC_statement M) := by
   sorry
 
-abbrev ARCstatement := ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsingleton (Ext M M i)) → Projective M
+abbrev aRC_statement := ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsingleton (Ext M M i)) → Projective M
 
 include R in
 /--
-Auslander-Reiten-Conjecture - an equivalent formulation of GNC:
+Auslander-Reiten-Conjecture - an equivalent formulation of gNC:
 If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
 
 Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem ARC : ARCstatement M := by
+theorem aRC : aRC_statement M := by
   sorry
 
 include R
@@ -92,11 +92,11 @@ include R
 Reference: TODO
 -/
 @[category research solved, AMS 16 18]
-lemma GNCEquivARC : (∀ M : ModuleCat A, Module.Finite A M → GNCstatement M) ↔ (∀ M : ModuleCat A, Module.Finite A M → ARCstatement M) := by
+lemma gNC_equiv_aRC : (∀ M : ModuleCat A, Module.Finite A M → gNC_statement M) ↔ (∀ M : ModuleCat A, Module.Finite A M → aRC_statement M) := by
   sorry
 
 variable (A) in
-abbrev TC1statement := ( ∀ p > 0, ∀ (I : FGModuleCat A),
+abbrev tC1_statement := ( ∀ p > 0, ∀ (I : FGModuleCat A),
   (Injective I) →
   Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) → CategoryTheory.Injective (ModuleCat.of A A))
   → Injective (ModuleCat.of A A)
@@ -119,10 +119,10 @@ instance : Module A (A →ₗ[R] R) := by
 If `R`is not a fild, in  order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet available in mathlib. We state this version of the conjecture.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem TC1 : TC1statement A := by
+theorem tC1 : tC1_statement A := by
   sorry
 
-abbrev TC2statement := (Injective (ModuleCat.of A A) → ∀ p > 0,
+abbrev tC2_statement := (Injective (ModuleCat.of A A) → ∀ p > 0,
   Subsingleton (Ext M M p)) → Projective (ModuleCat.of A M )
 
 include R in
@@ -131,11 +131,11 @@ Second Tachikawa Conjecture:
 Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer `p > 0`, it follows that M is projective.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem TC2 : TC2statement M := by
+theorem tC2 : tC2_statement M := by
   sorry
 
 variable (A) in
-abbrev NCstatement := (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, Projective <| I.cocomplex.X n) → Injective (ModuleCat.of A A )
+abbrev nC_statement := (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, Projective <| I.cocomplex.X n) → Injective (ModuleCat.of A A )
 
 include R in
 /--
@@ -147,7 +147,7 @@ for every finitely genretaed module `M` over `A` if for all ì > 0 Extî(M ⊕ A
 We state the following version : if `A`has a projective-injective resolution then `A`is self injective.
 -/
 @[category research open, AMS 16 18]
-theorem NC : NCstatement A := by
+theorem nC : nC_statement A := by
   sorry
 
 end NakayamaConjectures
@@ -174,24 +174,24 @@ theorem GSC : injectiveDimension (ModuleCat.of A A) < ⊤ → projectiveDimensio
 variable {R A: Type u} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
 
 variable (R) in
-abbrev SNCdualStatement := IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i)
+abbrev sNC_with_dual_statement := IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i)
 
 /--
-SNC expressed with the dual
+sNC expressed with the dual
 -/
 @[category research open, AMS 16 18]
-theorem SNCdual : SNCdualStatement R M := by
+theorem sNC_dual : sNC_with_dual_statement R M := by
   sorry
 
 /--
-In this situation, SNCdual and SNC are equivalent,
+In this situation, sNCdual and sNC are equivalent,
 ref: TODO
 -/
 @[category research solved, AMS 16 18]
-lemma SNCEquiv : NakayamaConjectures.SNCstatement M ↔ SNCdualStatement R M := by sorry
+lemma sNC_equiv : NakayamaConjectures.sNC_statement M ↔ sNC_with_dual_statement R M := by sorry
 
 variable (R) in
-abbrev NCdualStatement := (∀ i > 0,
+abbrev nC_with_dual_statement := (∀ i > 0,
   Subsingleton (Ext M M i) ∧
   Subsingleton (Ext M (.of A A) i) ∧
   Subsingleton (Ext (.of A (dual R A)) M i) ∧
@@ -201,23 +201,23 @@ abbrev NCdualStatement := (∀ i > 0,
 NC expressed with the dual
 -/
 @[category research open, AMS 16 18]
-theorem NCdual : NCdualStatement R M := by
+theorem nC_with_dual : nC_with_dual_statement R M := by
   sorry
 
 /--
-In this situation, NCdual and NC are equivalent,
+In this situation, nCdual and nC are equivalent,
 ref: TODO
 -/
 @[category research solved, AMS 16 18]
-lemma NCEquiv : NakayamaConjectures.NCstatement A ↔ NCdualStatement R M := by sorry
+lemma nC_equiv : NakayamaConjectures.nC_statement A ↔ nC_with_dual_statement R M := by sorry
 
 /--
-In this situation, NCdual is equivalent to the conjunction of the two Tachikawa's conjectures
+In this situation, nCdual is equivalent to the conjunction of the two Tachikawa's conjectures
 ref: TODO
 -/
 @[category research solved, AMS 16 18]
-lemma NCEquivTC1andTC2 :
-    NakayamaConjectures.TC1statement A ∧ (∀ M : ModuleCat A, NakayamaConjectures.TC2statement M) ↔ NCdualStatement R M := by
+lemma nC_equiv_tC1_and_tC2 :
+    NakayamaConjectures.tC1_statement A ∧ (∀ M : ModuleCat A, NakayamaConjectures.tC2_statement M) ↔ nC_with_dual_statement R M := by
   sorry
 
 

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -17,188 +17,243 @@ limitations under the License.
 import FormalConjecturesUtil
 
 /-!
-# Strong Nakayama Conjecture
-*Reference:* [R.R. Colby and K.R. Fuller, A note on the Nakayama conjectures, Tsukuba J. Math. \textbf{14} (1990), no.~2, 343--352.](https://doi.org/10.21099/tkbjm/1496161457)
+# The Nakayama Conjectures
 
-# Generalized Nakayama Conjecture
-# Auslander-Reiten Conjecture
-*Reference:*
-[M. Auslander and I. Reiten, On a generalized version of the Nakayama conjecture, Proc. Amer. Math. Soc. 52 (1975), 69--74.](https://doi.org/10.1090/S0002-9939-1975-0389977-6)
+Let $R$ be a commutative Artinian ring and let $A$ be an Artin $R$-algebra, that is, an
+$R$-algebra which is finitely generated as an $R$-module.
+All modules are assumed to be finitely generated left $A$-modules.
+The algebra $A$ is called *self-injective* if it is injective as a left module over itself.
 
-# Tachikawa Conjectures
-*Reference:* [H. Tachikawa, Quasi-Frobenius Rings and Generalizations: QF-3 and QF-1 Rings, Lecture Notes in Mathematics, vol. 351, Springer, Berlin–Heidelberg, 1973](https://doi.org/10.1007/BFb0060005)
+This file collects the Nakayama Conjecture together with the family of homological conjectures
+surrounding it.
 
-# Nakayama Conjecture
-*Reference:* [T. Nakayama, On algebras with complete homology. Abh. Math. Sem. Univ. Hamburg 22 (1958), 300–307.](https://doi.org/10.1007/BF02941960)
+* The **Nakayama Conjecture**: if $A$ has an injective resolution all of whose terms are
+  projective, then $A$ is self-injective.
+* The **Generalized Nakayama Conjecture**: a module $M$ with
+  $\operatorname{Ext}^i_A(M, A) = 0$ for all $i \geq 0$ is not simple.
+* The **Strong Nakayama Conjecture**: a module $M$ with
+  $\operatorname{Ext}^i_A(M, A) = 0$ for all $i \geq 0$ is zero.
+* The **Auslander-Reiten Conjecture**: a module $M$ with
+  $\operatorname{Ext}^i_A(M, M) = \operatorname{Ext}^i_A(M, A) = 0$ for all $i > 0$ is
+  projective. This conjecture has a separate entry.
+* The **first Tachikawa Conjecture**: if $\operatorname{Ext}^i_A(I, A) = 0$ for all $i > 0$
+  and all injective $I$, then $A$ is self-injective.
+* The **second Tachikawa Conjecture**: if $A$ is self-injective, then a module $M$ with
+  $\operatorname{Ext}^i_A(M, M) = 0$ for all $i > 0$ is projective.
+
+The implications between them are
+$$
+\mathrm{snc} \implies \mathrm{gnc} \iff \mathrm{arc} \implies \mathrm{nc}
+\iff \mathrm{tc1} \wedge \mathrm{tc2}.
+$$
+
+*References:*
+
+The Strong Nakayama Conjecture was formulated by R. R. Colby and K. R. Fuller,
+[A note on the Nakayama conjectures, Tsukuba J. Math. 14 (1990), no. 2, 343-352](https://doi.org/10.21099/tkbjm/1496161457),
+where it is also shown to imply the Generalized Nakayama Conjecture.
+
+The Generalized Nakayama Conjecture and its equivalence with the Auslander-Reiten Conjecture are
+due to M. Auslander and I. Reiten,
+[On a generalized version of the Nakayama conjecture, Proc. Amer. Math. Soc. 52 (1975), 69-74](https://doi.org/10.1090/S0002-9939-1975-0389977-6).
+
+The Nakayama Conjecture was formulated by T. Nakayama in
+[On algebras with complete homology, Abh. Math. Sem. Univ. Hamburg 22 (1958), 300-307](https://doi.org/10.1007/BF02941960).
+
+The two Tachikawa Conjectures, and the fact that together they are equivalent to the Nakayama
+Conjecture, appear in H. Tachikawa,
+[Quasi-Frobenius Rings and Generalizations: QF-3 and QF-1 Rings, Lecture Notes in Mathematics, vol. 351, Springer, Berlin-Heidelberg, 1973](https://doi.org/10.1007/BFb0060005).
 -/
 
 open CategoryTheory Abelian Limits
 
-universe u v w
+universe u v
 
 namespace NakayamaConjectures
 
-/-
-Let $R$ be an artinian ring, $A$ an algebra of finite type and $M$ a finitely generated module over $A$-/
-variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
-
+/- Let `R` be a commutative Artinian ring, `A` an Artin `R`-algebra and `M` a finitely generated
+`A`-module. -/
+variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A]
+  [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
 
 include R in
 /--
-The Strong Nakayama Conjecture :
+The **Strong Nakayama Conjecture**: For any finitely generated $A$-module $M$
 $$
-\operatorname{Ext}^1_A(M,A) = 0
-\quad \Longrightarrow  \quad
+\operatorname{Ext}^i_A(M, A) = 0 \quad \text{for all } i \geq 0,
+\quad \Longrightarrow \quad
 M = 0
 $$
 -/
-@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem sNC : (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M := by
+@[category research open, AMS 16 18]
+theorem snc : (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M := by
   sorry
 
 include R in
 /--
-The Generalized Nakayama Conjecture :
-If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
-
-Note that `Simple` here is in Finitely generated Modules but it is equivalent to being simple in Modules.
--/
-@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem gNC : ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M := by
-  sorry
-
-include R
-/--
-Reference : TODO
--/
-@[category research solved, AMS 16 18]
-lemma sGNC_impl_gNC : type_of% (sNC (R := R) (A := A)) → type_of% (gNC (R := R) (A:= A)) := by
-  sorry
-
-include R in
-/--
-Auslander-Reiten-Conjecture - an equivalent formulation of gNC :
-If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
-
-Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
--/
-@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem aRC : ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsingleton (Ext M M i)) → Projective M := by
-  sorry
-
-include R
-/--
-Reference: TODO
--/
-@[category research solved, AMS 16 18]
-lemma gNC_equiv_aRC : type_of% (gNC (R := R) (A := A)) ↔ type_of% (aRC (R := R) (A := A)) := by
-  sorry
-
-include R in
-/--
-First Tachikawa Conjecture:
-
-If for any `p > 0` and `I` a finiyely generated module over `A` Ext^p(I,A)=0 thent `A`is self injective (injective as a left module over itself).
-
-Note that there is an equivalent formulation :If Ext^p(A^*,A) = 0 for any integer `p > 0`, then A is self-injective.
-
-A^* is defined as `A →ₗ[R] R` equiped with a structure of A module. But if `R`is not a field, in  order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet available in mathlib. We state this version of the conjecture. at then end of the file.
--/
-@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem tC1 : ( ∀ p > 0, ∀ (I : FGModuleCat A),
-  (Injective I) →
-  Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) → CategoryTheory.Injective (ModuleCat.of A A))
-  → Injective (ModuleCat.of A A)
- := by
-  sorry
-
-include R in
-/--
-Second Tachikawa Conjecture :
-Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer `p > 0`, it follows that M is projective.
--/
-@[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem tC2 : (Injective (ModuleCat.of A A) → ∀ p > 0,
-  Subsingleton (Ext M M p)) → Projective (ModuleCat.of A M ) := by
-  sorry
-
-include R in
-/--
-Nakayama Conjecture :
-As in the First Tachikawa Conjecture there is an aquivalent formulation with the dual :
-
-for every finitely genretaed module `M` over `A` if for all ì > 0 Extî(M ⊕ A^*, M ⊕ A) = 0 then `M` is projective.
-
-We state the following version : if `A`has a projective-injective resolution then `A`is self injective.
+The **Generalized Nakayama Conjecture**:
+For any finitely generated $A$-module $M$
+$$
+\operatorname{Ext}^i_A(M, A) = 0 \quad \text{for all } i \geq 0,
+\quad \Longrightarrow \quad
+M \text{ is not simple}.
+$$
 -/
 @[category research open, AMS 16 18]
-theorem nC : (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, Projective <| I.cocomplex.X n) → Injective (ModuleCat.of A A ) := by
+theorem gnc : (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M := by
   sorry
 
+include R in
 /--
-In this situation, nC is equivalent to the conjunction of the two Tachikawa's conjectures
-ref : TODO
+The Strong Nakayama Conjecture implies the Generalized Nakayama Conjecture.
 -/
-@[category research solved, AMS 16 18]
-lemma nC_equiv_tC1_and_tC2 :
-    type_of% (tC1 (R := R) (A := A) ) ∧ type_of% (tC2 (R := R) (A := A)) ↔ type_of% (nC (R := R) (A := A)) := by
+@[category API, AMS 16 18]
+lemma snc_imp_gnc : type_of% (snc (R := R) (A := A)) → type_of% (gnc (R := R) (A := A)) := by
+  sorry
+
+
+/-
+The **Auslander-Reiten Conjecture**:
+For any finitely generated $A$-module $M$
+$$
+\operatorname{Ext}^i_A(M, A) = \operatorname{Ext}^i_A(M, M) = 0 \quad \text{for all } i > 0,
+\quad \Longrightarrow \quad
+M \text{ is projective}.
+$$
+Once PR #5440 is merged, the equivalence can be stated as
+
+@[category API, AMS 16 18]
+lemma gnc_iff_arc : type_of% (gnc (R := R) (A := A)) ↔
+    type_of% (ArtinAlgebra.auslander_reiten (R := R) (A := A)) := by
+  sorry
+-/
+
+include R in
+/--
+The **first Tachikawa Conjecture**: if
+$$
+\operatorname{Ext}^p_A(I, A) = 0 \quad \text{for all } p > 0 \text{ and all injective } I,
+$$
+then $A$ is self-injective.
+
+Injectivity of `I` is taken in the category of finitely generated $A$-modules, where it agrees
+with injectivity as an $A$-module because $A$ is an Artin algebra. Every such `I` is a direct
+summand of a finite direct sum of copies of $A^*$, so this is the usual formulation, which asks
+only for the vanishing of $\operatorname{Ext}^p_A(A^*, A)$.
+-/
+@[category research open, AMS 16 18]
+theorem tc1 : (∀ p > 0, ∀ I : FGModuleCat A, Injective I →
+    Subsingleton (Ext (.of A I.carrier) (ModuleCat.of A A) p)) →
+    Injective (ModuleCat.of A A) := by
+  sorry
+
+include R in
+/--
+The **second Tachikawa Conjecture**: if $A$ is self-injective and
+$$
+\operatorname{Ext}^i_A(M, M) = 0 \quad \text{for all } i > 0,
+$$
+then $M$ is projective.
+-/
+@[category research open, AMS 16 18]
+theorem tc2 : Injective (ModuleCat.of A A) → (∀ p > 0, Subsingleton (Ext M M p)) →
+    Projective M := by
+  sorry
+
+include R in
+/--
+The **Nakayama Conjecture**: if $A$ admits an injective resolution
+$$
+0 \to A \to I^0 \to I^1 \to \cdots
+$$
+in which every $I^n$ is projective, then $A$ is self-injective.
+
+The conjecture is usually stated for the minimal injective resolution of $A$. The two forms
+agree, because the minimal injective resolution is a direct summand of any injective resolution
+and a direct summand of a projective module is projective.
+-/
+@[category research open, AMS 16 18]
+theorem nc : (∃ I : InjectiveResolution (ModuleCat.of A A),
+    ∀ n, Projective (I.cocomplex.X n)) → Injective (ModuleCat.of A A) := by
+  sorry
+
+include R in
+/--
+The Nakayama Conjecture is equivalent to the conjunction of the two Tachikawa Conjectures.
+-/
+@[category API, AMS 16 18]
+lemma tc1_and_tc2_iff_nc :
+    type_of% (tc1 (R := R) (A := A)) ∧ type_of% (tc2 (R := R) (A := A)) ↔
+      type_of% (nc (R := R) (A := A)) := by
   sorry
 
 end NakayamaConjectures
 
+/- ## The dual formulations over a field
+
+Over a base field `k` the duality of an Artin algebra is the ordinary linear dual
+`(-)^* = Hom_k(-, k)`, so the conjectures take their customary form. -/
+
 namespace NakayamaConjecturesOverFields
 
-variable {R : Type u} {A : Type v} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
+/- Let `k` be a field, `A` a finite dimensional `k`-algebra and `M` a finitely generated
+`A`-module. -/
+variable {k : Type u} {A : Type v} [Field k] [Ring A] [Algebra k A] [Module.Finite k A]
+  (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
 
-variable (R A) in
-abbrev dual := (A →ₗ[R] R)
+variable (k A) in
+/-- The dual $A^* = \operatorname{Hom}_k(A, k)$ of `A`. -/
+abbrev dual := A →ₗ[k] k
 
-instance : Module A (dual R A) := by
+/-- `A^*` is a left `A`-module, obtained by transporting its right `A`-module structure along
+the isomorphism between `A` and the opposite of its opposite. -/
+instance : Module A (dual k A) := by
   have : A ≃+* (Aᵐᵒᵖ)ᵈᵐᵃ := RingEquiv.opOp _
   apply Module.compHom _ (this.toRingHom)
 
+variable {k A : Type u} [Field k] [Ring A] [Algebra k A] [Module.Finite k A] (M : ModuleCat A)
+  [Module.Finite A M.carrier]
+
 /--
-Gorenstein Symmetry Conjecture
+The Strong Nakayama Conjecture for finite-dimensional algebras in terms of the dual:
+For any finitely generated $A$-module $M$
+$$
+\operatorname{Ext}^i_A(A^*, M) = 0 \quad \text{for all } i \geq 0,
+\quad \Longrightarrow \quad
+M = 0
+$$
 -/
 @[category research open, AMS 16 18]
-theorem gSC : injectiveDimension (ModuleCat.of A A) < ⊤ → projectiveDimension (ModuleCat.of A (dual R A)) < ⊤ := by
+theorem snc_with_dual : IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual k A)) M i) := by
   sorry
 
-/- in order to take Ext groups of dual R A with some other `ModuleCat.{v}` we need to have `R` and `A` leaving on the same universe-/
-variable {R A : Type u} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
-
-/--
-sNC expressed with the dual
--/
-@[category research open, AMS 16 18]
-theorem sNC_with_dual : IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i) := by
-  sorry
-
-/--
-In this situation, sNC_with_dual and sNC are equivalent,
-ref : TODO
--/
-@[category research solved, AMS 16 18]
-lemma sNC_equiv : type_of% (NakayamaConjectures.sNC (R := R) (A := A)) ↔ type_of% (sNC_with_dual (R := R) (A := A)) := by sorry
-
-
-/--
-nC expressed with the dual
--/
-@[category research open, AMS 16 18]
-theorem nC_with_dual : (∀ i > 0,
-  Subsingleton (Ext M M i) ∧
-  Subsingleton (Ext M (.of A A) i) ∧
-  Subsingleton (Ext (.of A (dual R A)) M i) ∧
-  Subsingleton (Ext ((.of A (dual R A))) (ModuleCat.of A A) i)) → Projective M := by
+/-- Over a field the two formulations of the Strong Nakayama Conjecture agree. -/
+@[category API, AMS 16 18]
+lemma snc_iff_snc_with_dual :
+    type_of% (NakayamaConjectures.snc (R := k) (A := A)) ↔
+      type_of% (snc_with_dual (k := k) (A := A)) := by
   sorry
 
 /--
-In this situation, nCdual and nC are equivalent,
-ref : TODO
+The Nakayama Conjecture in terms of the dual: if
+$$
+\operatorname{Ext}^i_A(M \oplus A^*, M \oplus A) = 0 \quad \text{for all } i > 0,
+$$
+then $M$ is projective.
 -/
-@[category research solved, AMS 16 18]
-lemma nC_equiv : type_of% (NakayamaConjectures.nC (R := R) (A := A)) ↔ type_of% (nC_with_dual (R:= R) M) := by sorry
+@[category research open, AMS 16 18]
+theorem nc_with_dual : (∀ i > 0,
+    Subsingleton (Ext M M i) ∧
+    Subsingleton (Ext M (.of A A) i) ∧
+    Subsingleton (Ext (.of A (dual k A)) M i) ∧
+    Subsingleton (Ext (.of A (dual k A)) (ModuleCat.of A A) i)) → Projective M := by
+  sorry
 
+/-- Over a field the two formulations of the Nakayama Conjecture agree. -/
+@[category API, AMS 16 18]
+lemma nc_iff_nc_with_dual :
+    type_of% (NakayamaConjectures.nc (R := k) (A := A)) ↔
+      type_of% (nc_with_dual (k := k) (A := A)) := by
+  sorry
 
 end NakayamaConjecturesOverFields

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -36,6 +36,8 @@ open CategoryTheory Abelian Limits
 
 universe u v w
 
+/-
+Let `R`be an artinian ring, `A` an algebra of finite type and `M`a finitely generated module over `A`-/
 variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] {M : ModuleCat.{v} A} [Module.Finite A M.carrier]
 
 
@@ -43,7 +45,7 @@ namespace NakayamaConjectures
 
 /--
 The Strong Nakayama Conjecture:
-Let A be a finite module over an aritinain ring. For any finitely generated A-module M with Ext^i(M,A) = 0 for any integer i ≥ 0 it follows that M = 0.
+If  Ext^i(M,A) = 0 for any integer `i ≥ 0` then M = 0.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem SNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) : IsZero M := by
@@ -51,7 +53,9 @@ theorem SNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) : IsZero M := by
 
 /--
 The Generalized Nakayama Conjecture:
-Let A be a finite-dimensional algebra. For any finitely generated A-module M with Ext^i(M,A) = 0 for any integer i \geq 0 it follows that M is not simple.
+If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
+
+Note that `Simple` here is in Finitely generated Modules but it is equivalent to being simple in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem GNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) :
@@ -60,7 +64,9 @@ theorem GNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) :
 
 /--
 Auslander-Reiten-Conjecture - an equivalent formulation of GNC:
-Let A be a finite-dimensional algebra. For any finitely generated A-module M with Ext^i(M,M) = Ext^i(M,A) = 0 for any integer i \geq 0 it follows that M is projective.
+If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i ≥ 0` then `M` is projective.
+
+Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem ARC (_ : ∀ i > 0 ,
@@ -71,7 +77,16 @@ theorem ARC (_ : ∀ i > 0 ,
 
 /--
 First Tachikawa Conjecture:
-Let A be a finite-dimensional algebra. If Ext^p(A^*,A) = 0 for any integer p > 0, then A is self-injective.
+
+If for any `p ≥ 0` and `I` a finiyely generated module over `A` Ext^p(I,A)=0 thent `A`is self injective (injective as a left module over itself).
+
+Note that there is an equivalent formulation :If Ext^p(A^*,A) = 0 for any integer `p > 0`, then A is self-injective.
+
+But A^* is defined as `A →ₗ[R] R` equiped with a structure of A module.
+- An instance is given by `LinearMap.instModuleDomMulActOfSMulCommClass`but in order to have a good universe, we need to have `R`and `A` leaving in the same universe.
+- In adition it's a module over `Aᵈᵐᵃ`wich is not `A`if `A`is not commutative.
+- Finaly in order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet availabla.
+
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem TC1 (_ : ∀ p > 0, ∀ (I : FGModuleCat A), (Injective I) →
@@ -82,7 +97,7 @@ theorem TC1 (_ : ∀ p > 0, ∀ (I : FGModuleCat A), (Injective I) →
 
 /--
 Second Tachikawa Conjecture:
-Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer p > 0, it follows that M is projective.
+Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer `p > 0`, it follows that M is projective.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem TC2 (_ : Injective (ModuleCat.of A A)) (_ : ∀ p > 0,
@@ -90,11 +105,9 @@ theorem TC2 (_ : Injective (ModuleCat.of A A)) (_ : ∀ p > 0,
         Projective (ModuleCat.of A M ) := by
   sorry
 
-
 /-
 Nakayama Conjecture:
 Let A be a finite-dimensional algebra.
 -/
-
 
 end NakayamaConjectures

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -42,10 +42,8 @@ namespace NakayamaConjectures
 Let $R$ be an artinian ring, $A$ an algebra of finite type and $M$ a finitely generated module over $A$-/
 variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
 
-abbrev sNC_statement := (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M
 
 include R in
-
 /--
 The Strong Nakayama Conjecture :
 $$
@@ -55,10 +53,8 @@ M = 0
 $$
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem sNC : sNC_statement M := by
+theorem sNC : (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M := by
   sorry
-
-abbrev gNC_statement := ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M
 
 include R in
 /--
@@ -68,7 +64,7 @@ If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
 Note that `Simple` here is in Finitely generated Modules but it is equivalent to being simple in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem gNC : gNC_statement M := by
+theorem gNC : ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ Simple M := by
   sorry
 
 include R
@@ -76,10 +72,8 @@ include R
 Reference : TODO
 -/
 @[category research solved, AMS 16 18]
-lemma sGNC_impl_gNC : (∀ M : ModuleCat A, Module.Finite A M → sNC_statement M) → (∀ M : ModuleCat A, Module.Finite A M → gNC_statement M) := by
+lemma sGNC_impl_gNC : type_of% (sNC (R := R) (A := A)) → type_of% (gNC (R := R) (A:= A)) := by
   sorry
-
-abbrev aRC_statement := ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsingleton (Ext M M i)) → Projective M
 
 include R in
 /--
@@ -89,7 +83,7 @@ If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
 Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem aRC : aRC_statement M := by
+theorem aRC : ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsingleton (Ext M M i)) → Projective M := by
   sorry
 
 include R
@@ -97,14 +91,8 @@ include R
 Reference: TODO
 -/
 @[category research solved, AMS 16 18]
-lemma gNC_equiv_aRC : (∀ M : ModuleCat A, Module.Finite A M → gNC_statement M) ↔ (∀ M : ModuleCat A, Module.Finite A M → aRC_statement M) := by
+lemma gNC_equiv_aRC : type_of% (gNC (R := R) (A := A)) ↔ type_of% (aRC (R := R) (A := A)) := by
   sorry
-
-variable (A) in
-abbrev tC1_statement := ( ∀ p > 0, ∀ (I : FGModuleCat A),
-  (Injective I) →
-  Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) → CategoryTheory.Injective (ModuleCat.of A A))
-  → Injective (ModuleCat.of A A)
 
 include R in
 /--
@@ -117,11 +105,12 @@ Note that there is an equivalent formulation :If Ext^p(A^*,A) = 0 for any intege
 A^* is defined as `A →ₗ[R] R` equiped with a structure of A module. But if `R`is not a field, in  order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet available in mathlib. We state this version of the conjecture. at then end of the file.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem tC1 : tC1_statement A := by
+theorem tC1 : ( ∀ p > 0, ∀ (I : FGModuleCat A),
+  (Injective I) →
+  Subsingleton (Ext ((.of A I.carrier)) (ModuleCat.of A A) p) → CategoryTheory.Injective (ModuleCat.of A A))
+  → Injective (ModuleCat.of A A)
+ := by
   sorry
-
-abbrev tC2_statement := (Injective (ModuleCat.of A A) → ∀ p > 0,
-  Subsingleton (Ext M M p)) → Projective (ModuleCat.of A M )
 
 include R in
 /--
@@ -129,11 +118,9 @@ Second Tachikawa Conjecture :
 Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer `p > 0`, it follows that M is projective.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
-theorem tC2 : tC2_statement M := by
+theorem tC2 : (Injective (ModuleCat.of A A) → ∀ p > 0,
+  Subsingleton (Ext M M p)) → Projective (ModuleCat.of A M ) := by
   sorry
-
-variable (A) in
-abbrev nC_statement := (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, Projective <| I.cocomplex.X n) → Injective (ModuleCat.of A A )
 
 include R in
 /--
@@ -145,7 +132,16 @@ for every finitely genretaed module `M` over `A` if for all ì > 0 Extî(M ⊕ A
 We state the following version : if `A`has a projective-injective resolution then `A`is self injective.
 -/
 @[category research open, AMS 16 18]
-theorem nC : nC_statement A := by
+theorem nC : (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, Projective <| I.cocomplex.X n) → Injective (ModuleCat.of A A ) := by
+  sorry
+
+/--
+In this situation, nC is equivalent to the conjunction of the two Tachikawa's conjectures
+ref : TODO
+-/
+@[category research solved, AMS 16 18]
+lemma nC_equiv_tC1_and_tC2 :
+    type_of% (tC1 (R := R) (A := A) ) ∧ type_of% (tC2 (R := R) (A := A)) ↔ type_of% (nC (R := R) (A := A)) := by
   sorry
 
 end NakayamaConjectures
@@ -165,41 +161,36 @@ instance : Module A (dual R A) := by
 Gorenstein Symmetry Conjecture
 -/
 @[category research open, AMS 16 18]
-theorem GSC : injectiveDimension (ModuleCat.of A A) < ⊤ → projectiveDimension (ModuleCat.of A (dual R A)) < ⊤ := by
+theorem gSC : injectiveDimension (ModuleCat.of A A) < ⊤ → projectiveDimension (ModuleCat.of A (dual R A)) < ⊤ := by
   sorry
 
 /- in order to take Ext groups of dual R A with some other `ModuleCat.{v}` we need to have `R` and `A` leaving on the same universe-/
 variable {R A : Type u} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
 
-variable (R) in
-abbrev sNC_with_dual_statement := IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i)
-
 /--
 sNC expressed with the dual
 -/
 @[category research open, AMS 16 18]
-theorem sNC_dual : sNC_with_dual_statement R M := by
+theorem sNC_with_dual : IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i) := by
   sorry
 
 /--
-In this situation, sNCdual and sNC are equivalent,
+In this situation, sNC_with_dual and sNC are equivalent,
 ref : TODO
 -/
 @[category research solved, AMS 16 18]
-lemma sNC_equiv : NakayamaConjectures.sNC_statement M ↔ sNC_with_dual_statement R M := by sorry
+lemma sNC_equiv : type_of% (NakayamaConjectures.sNC (R := R) (A := A)) ↔ type_of% (sNC_with_dual (R := R) (A := A)) := by sorry
 
-variable (R) in
-abbrev nC_with_dual_statement := (∀ i > 0,
+
+/--
+nC expressed with the dual
+-/
+@[category research open, AMS 16 18]
+theorem nC_with_dual : (∀ i > 0,
   Subsingleton (Ext M M i) ∧
   Subsingleton (Ext M (.of A A) i) ∧
   Subsingleton (Ext (.of A (dual R A)) M i) ∧
-  Subsingleton (Ext ((.of A (dual R A))) (ModuleCat.of A A) i)) → Projective M
-
-/--
-NC expressed with the dual
--/
-@[category research open, AMS 16 18]
-theorem nC_with_dual : nC_with_dual_statement R M := by
+  Subsingleton (Ext ((.of A (dual R A))) (ModuleCat.of A A) i)) → Projective M := by
   sorry
 
 /--
@@ -207,16 +198,7 @@ In this situation, nCdual and nC are equivalent,
 ref : TODO
 -/
 @[category research solved, AMS 16 18]
-lemma nC_equiv : NakayamaConjectures.nC_statement A ↔ nC_with_dual_statement R M := by sorry
-
-/--
-In this situation, nCdual is equivalent to the conjunction of the two Tachikawa's conjectures
-ref : TODO
--/
-@[category research solved, AMS 16 18]
-lemma nC_equiv_tC1_and_tC2 :
-    NakayamaConjectures.tC1_statement A ∧ (∀ M : ModuleCat A, NakayamaConjectures.tC2_statement M) ↔ nC_with_dual_statement R M := by
-  sorry
+lemma nC_equiv : type_of% (NakayamaConjectures.nC (R := R) (A := A)) ↔ type_of% (nC_with_dual (R:= R) M) := by sorry
 
 
 end NakayamaConjecturesOverFields

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -183,8 +183,8 @@ The Nakayama Conjecture is equivalent to the conjunction of the two Tachikawa Co
 -/
 @[category API, AMS 16 18]
 lemma tc1_and_tc2_iff_nc :
-    type_of% (tc1 (R := R) (A := A)) ∧ type_of% (tc2 (R := R) (A := A)) ↔
-      type_of% (nc (R := R) (A := A)) := by
+    (type_of% @tc1 ∧ type_of% @tc2) ↔
+      type_of% @nc := by
   sorry
 
 end NakayamaConjectures

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -189,30 +189,65 @@ lemma tc1_and_tc2_iff_nc :
 
 end NakayamaConjectures
 
-/- ## The dual formulations over a field
+namespace Abelian
+/-
+The goal of this part is to define a version of duality in artinian algebra that does not require R to be a field.
+-/
 
-Over a base field `k` the duality of an Artin algebra is the ordinary linear dual
-`(-)^* = Hom_k(-, k)`, so the conjectures take their customary form. -/
+variable {C: Type u} [Category.{v} C] [Abelian C]
+variable {M E : C} (u : M ⟶ E)
 
-namespace NakayamaConjecturesOverFields
+def IsEssentialExtension : Prop :=
+  ∀ s : Subobject E, IsZero (Subobject.underlying.obj s) ∨ ¬ IsZero (pullback u ((MonoOver.forget E).obj (Subobject.representative.obj s)).hom)
 
-/- Let `k` be a field, `A` a finite dimensional `k`-algebra and `M` a finitely generated
-`A`-module. -/
-variable {k : Type u} {A : Type v} [Field k] [Ring A] [Algebra k A] [Module.Finite k A]
-  (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
+def IsInjectiveHull : Prop := Injective E ∧ IsEssentialExtension u
 
-variable (k A) in
-/-- The dual $A^* = \operatorname{Hom}_k(A, k)$ of `A`. -/
-abbrev dual := A →ₗ[k] k
+variable (M)
+
+class HasInjectiveHull : Prop where
+  existsInjHull : ∃ E : C, ∃ u : M ⟶ E, IsInjectiveHull u
+
+noncomputable def injectiveHull [HasInjectiveHull M] : C := (HasInjectiveHull.existsInjHull (M := M)).choose
+
+noncomputable def injectiveHullHom [HasInjectiveHull M] : M ⟶ (injectiveHull M) := (HasInjectiveHull.existsInjHull (M := M)).choose_spec.choose
+
+@[category API, AMS 18]
+lemma IsInjectiveHullInjectiveHull [HasInjectiveHull M] : IsInjectiveHull (injectiveHullHom M) :=
+  (HasInjectiveHull.existsInjHull (M := M)).choose_spec.choose_spec
+
+
+@[category API, AMS 16 18]
+instance [HasFilteredColimits C] [AB5 C] [EnoughInjectives C] : HasInjectiveHull M := by
+  sorry
+
+end Abelian
+
+/- ## The dual formulations
+
+There are variants of some of the previous conjectures that make usage of the dual of an artinian algebra.
+
+Over a base field `k` the duality of an Artin algebra is the ordinary linear dual `(-)^* = Hom_k(-, k)`, (equiped with a structure of `A`module) so the conjectures take their customary form.
+
+in the general case, the dual of `A` is `Hom_k(-, E(R/ Jacobson(R))`) (equiped with a structure of `A`module) with `E`being the injective enveloppe, defined in the previous section.
+
+In order to keep `A`and `A^*`as `A`-modules in the same universe (wich is necessary to state the conjecture) we need (excpet for the definition of the dual ) to restrict to the case where `A`and `R`lives in the same universe. For that reason it remains uselfull to keep the previous version of the conjecture.
+
+-/
+
+namespace NakayamaConjecturesWithDuals
+
+variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
+
+variable (R A) in
+abbrev dual := A →ₗ[R] (Abelian.injectiveHull (ModuleCat.of R (R ⧸ ((⊤:Ideal R).jacobson)))).carrier
 
 /-- `A^*` is a left `A`-module, obtained by transporting its right `A`-module structure along
 the isomorphism between `A` and the opposite of its opposite. -/
-instance : Module A (dual k A) := by
+noncomputable instance : Module A (dual R A) := by
   have : A ≃+* (Aᵐᵒᵖ)ᵈᵐᵃ := RingEquiv.opOp _
   apply Module.compHom _ (this.toRingHom)
 
-variable {k A : Type u} [Field k] [Ring A] [Algebra k A] [Module.Finite k A] (M : ModuleCat A)
-  [Module.Finite A M.carrier]
+variable {R A : Type u} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
 
 /--
 The Strong Nakayama Conjecture for finite-dimensional algebras in terms of the dual:
@@ -224,14 +259,14 @@ M = 0
 $$
 -/
 @[category research open, AMS 16 18]
-theorem snc_with_dual : IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual k A)) M i) := by
+theorem snc_with_dual : IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A)) M i) := by
   sorry
 
-/-- Over a field the two formulations of the Strong Nakayama Conjecture agree. -/
+/-- The two formulations of the Strong Nakayama Conjecture agree. -/
 @[category API, AMS 16 18]
 lemma snc_iff_snc_with_dual :
-    type_of% (NakayamaConjectures.snc (R := k) (A := A)) ↔
-      type_of% (snc_with_dual (k := k) (A := A)) := by
+    type_of% (NakayamaConjectures.snc (R := R) (A := A)) ↔
+      type_of% (snc_with_dual (R:= R) (A := A)) := by
   sorry
 
 /--
@@ -245,15 +280,15 @@ then $M$ is projective.
 theorem nc_with_dual : (∀ i > 0,
     Subsingleton (Ext M M i) ∧
     Subsingleton (Ext M (.of A A) i) ∧
-    Subsingleton (Ext (.of A (dual k A)) M i) ∧
-    Subsingleton (Ext (.of A (dual k A)) (ModuleCat.of A A) i)) → Projective M := by
+    Subsingleton (Ext (.of A (dual R A)) M i) ∧
+    Subsingleton (Ext (.of A (dual R A)) (ModuleCat.of A A) i)) → Projective M := by
   sorry
 
-/-- Over a field the two formulations of the Nakayama Conjecture agree. -/
+/-- The two formulations of the Nakayama Conjecture agree. -/
 @[category API, AMS 16 18]
 lemma nc_iff_nc_with_dual :
-    type_of% (NakayamaConjectures.nc (R := k) (A := A)) ↔
-      type_of% (nc_with_dual (k := k) (A := A)) := by
+    type_of% (NakayamaConjectures.nc (R := R) (A := A)) ↔
+      type_of% (nc_with_dual (R := R) (A := A)) := by
   sorry
 
-end NakayamaConjecturesOverFields
+end NakayamaConjecturesWithDuals

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -64,7 +64,7 @@ theorem GNC (_ : ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) :
 
 /--
 Auslander-Reiten-Conjecture - an equivalent formulation of GNC:
-If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i ≥ 0` then `M` is projective.
+If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
 
 Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
 -/
@@ -78,7 +78,7 @@ theorem ARC (_ : ∀ i > 0 ,
 /--
 First Tachikawa Conjecture:
 
-If for any `p ≥ 0` and `I` a finiyely generated module over `A` Ext^p(I,A)=0 thent `A`is self injective (injective as a left module over itself).
+If for any `p > 0` and `I` a finiyely generated module over `A` Ext^p(I,A)=0 thent `A`is self injective (injective as a left module over itself).
 
 Note that there is an equivalent formulation :If Ext^p(A^*,A) = 0 for any integer `p > 0`, then A is self-injective.
 

--- a/FormalConjectures/Paper/NakayamaConjectures.lean
+++ b/FormalConjectures/Paper/NakayamaConjectures.lean
@@ -39,15 +39,20 @@ universe u v w
 namespace NakayamaConjectures
 
 /-
-Let `R`be an artinian ring, `A` an algebra of finite type and `M`a finitely generated module over `A`-/
+Let $R$ be an artinian ring, $A$ an algebra of finite type and $M$ a finitely generated module over $A$-/
 variable {R : Type u} {A : Type v} [CommRing R] [IsArtinianRing R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat.{v} A) [Module.Finite A M.carrier]
 
 abbrev sNC_statement := (∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → IsZero M
 
 include R in
+
 /--
-The Strong Nakayama Conjecture:
-If  Ext^i(M,A) = 0 for any integer `i ≥ 0` then M = 0.
+The Strong Nakayama Conjecture :
+$$
+\operatorname{Ext}^1_A(M,A) = 0
+\quad \Longrightarrow  \quad
+M = 0
+$$
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem sNC : sNC_statement M := by
@@ -57,7 +62,7 @@ abbrev gNC_statement := ( ∀ i : ℕ, Subsingleton (Ext M (.of A A) i)) → ¬ 
 
 include R in
 /--
-The Generalized Nakayama Conjecture:
+The Generalized Nakayama Conjecture :
 If Ext^i(M,A) = 0 for any integer `i ≥ 0` then M is not simple.
 
 Note that `Simple` here is in Finitely generated Modules but it is equivalent to being simple in Modules.
@@ -68,7 +73,7 @@ theorem gNC : gNC_statement M := by
 
 include R
 /--
-Reference: TODO
+Reference : TODO
 -/
 @[category research solved, AMS 16 18]
 lemma sGNC_impl_gNC : (∀ M : ModuleCat A, Module.Finite A M → sNC_statement M) → (∀ M : ModuleCat A, Module.Finite A M → gNC_statement M) := by
@@ -78,7 +83,7 @@ abbrev aRC_statement := ( ∀ i > 0 , Subsingleton (Ext M (.of A A) i) ∧ Subsi
 
 include R in
 /--
-Auslander-Reiten-Conjecture - an equivalent formulation of gNC:
+Auslander-Reiten-Conjecture - an equivalent formulation of gNC :
 If Ext^i(M,M) = Ext^i(M,A) = 0 for any integer `i > 0` then `M` is projective.
 
 Note that `Projective` here is in Finitely generated Modules but it is equivalent to being projective in Modules.
@@ -109,14 +114,7 @@ If for any `p > 0` and `I` a finiyely generated module over `A` Ext^p(I,A)=0 the
 
 Note that there is an equivalent formulation :If Ext^p(A^*,A) = 0 for any integer `p > 0`, then A is self-injective.
 
-But A^* is defined as `A →ₗ[R] R` equiped with a structure of A module.The instance of module is given by :
-
-instance : Module A (A →ₗ[R] R) := by
-  let m := LinearMap.instModuleDomMulActOfSMulCommClass (S := Aᵐᵒᵖ) (R := R) (σ₁₂ := RingHom.id R) (M' := R) (M:= A)
-  have : A ≃+* (Aᵐᵒᵖ)ᵈᵐᵃ := RingEquiv.opOp _
-  apply Module.compHom _ (this.toRingHom)
-
-If `R`is not a fild, in  order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet available in mathlib. We state this version of the conjecture.
+A^* is defined as `A →ₗ[R] R` equiped with a structure of A module. But if `R`is not a field, in  order to get the right definition it may be necessary to replace `R` by some kind of injective enveloppe of `R` not yet available in mathlib. We state this version of the conjecture. at then end of the file.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
 theorem tC1 : tC1_statement A := by
@@ -127,7 +125,7 @@ abbrev tC2_statement := (Injective (ModuleCat.of A A) → ∀ p > 0,
 
 include R in
 /--
-Second Tachikawa Conjecture:
+Second Tachikawa Conjecture :
 Let A be a finite-dimensional, self-injective algebra. For any A-module M with Ext^p(M,M) = 0 for any integer `p > 0`, it follows that M is projective.
 -/
 @[category research open, AMS 16 18] /- Associative rings and algebras + Category theory; homological algebra -/
@@ -139,8 +137,8 @@ abbrev nC_statement := (∃ I : InjectiveResolution (ModuleCat.of A A ), ∀ n, 
 
 include R in
 /--
-Nakayama Conjecture:
-As in the First Tachikawa Conjecture there is an aquivalent formulation with the dual:
+Nakayama Conjecture :
+As in the First Tachikawa Conjecture there is an aquivalent formulation with the dual :
 
 for every finitely genretaed module `M` over `A` if for all ì > 0 Extî(M ⊕ A^*, M ⊕ A) = 0 then `M` is projective.
 
@@ -171,7 +169,7 @@ theorem GSC : injectiveDimension (ModuleCat.of A A) < ⊤ → projectiveDimensio
   sorry
 
 /- in order to take Ext groups of dual R A with some other `ModuleCat.{v}` we need to have `R` and `A` leaving on the same universe-/
-variable {R A: Type u} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
+variable {R A : Type u} [Field R] [Ring A] [Algebra R A] [Module.Finite R A] (M : ModuleCat A) [Module.Finite A M.carrier]
 
 variable (R) in
 abbrev sNC_with_dual_statement := IsZero M ∨ ∃ i, ¬ Subsingleton (Ext (.of A (dual R A )) M i)
@@ -185,7 +183,7 @@ theorem sNC_dual : sNC_with_dual_statement R M := by
 
 /--
 In this situation, sNCdual and sNC are equivalent,
-ref: TODO
+ref : TODO
 -/
 @[category research solved, AMS 16 18]
 lemma sNC_equiv : NakayamaConjectures.sNC_statement M ↔ sNC_with_dual_statement R M := by sorry
@@ -206,14 +204,14 @@ theorem nC_with_dual : nC_with_dual_statement R M := by
 
 /--
 In this situation, nCdual and nC are equivalent,
-ref: TODO
+ref : TODO
 -/
 @[category research solved, AMS 16 18]
 lemma nC_equiv : NakayamaConjectures.nC_statement A ↔ nC_with_dual_statement R M := by sorry
 
 /--
 In this situation, nCdual is equivalent to the conjunction of the two Tachikawa's conjectures
-ref: TODO
+ref : TODO
 -/
 @[category research solved, AMS 16 18]
 lemma nC_equiv_tC1_and_tC2 :


### PR DESCRIPTION
This file collects the Nakayama Conjecture together with the family of homological conjectures
surrounding it.

Let $R$ be a commutative Artinian ring and let $A$ be an Artin $R$-algebra, that is, an
$R$-algebra which is finitely generated as an $R$-module.
All modules are assumed to be finitely generated left $A$-modules.
The algebra $A$ is called *self-injective* if it is injective as a left module over itself.

if $A$ has an injective resolution all of whose terms are projective, then $A$ is self-injective

Co-authored-by: Wassilij Gnedin (@wgnedin)
