### PR TITLE
Bsd minimal discriminant

### DIFF
--- a/FormalConjectures/Millenium/BSD.lean
+++ b/FormalConjectures/Millenium/BSD.lean
@@ -39,19 +39,6 @@ import FormalConjecturesUtil
   [Birch and Swinnerton-Dyer](https://tadamcz.com/autoformalization-results/#/p/wp-birch-and-swinnerton-dyer-conjecture)
 -/
 
-namespace WeierstrassCurve
-
-open NumberField IsDedekindDomain in
-/-- The minimal discriminant ideal of an elliptic curve over a number field is the product of
-the local minimal discriminant ideals `v.asIdeal ^ W.minimalDiscriminantExponent v` over
-all nonzero prime ideals `v` of its ring of integers. Only finitely many exponents are nonzero.
-See [LMFDB](https://www.lmfdb.org/knowledge/show/ec.minimal_discriminant). -/
-noncomputable def minimalDiscriminantIdeal {K : Type*} [Field K] [NumberField K]
-    (W : WeierstrassCurve K) [W.IsElliptic] : Ideal (𝓞 K) :=
-  ∏ᶠ v : HeightOneSpectrum (𝓞 K), v.asIdeal ^ W.minimalDiscriminantExponent v
-
-end WeierstrassCurve
-
 namespace BSD
 
 open scoped Topology

--- a/FormalConjectures/Millenium/BSD.lean
+++ b/FormalConjectures/Millenium/BSD.lean
@@ -39,6 +39,19 @@ import FormalConjecturesUtil
   [Birch and Swinnerton-Dyer](https://tadamcz.com/autoformalization-results/#/p/wp-birch-and-swinnerton-dyer-conjecture)
 -/
 
+namespace WeierstrassCurve
+
+open NumberField IsDedekindDomain in
+/-- The minimal discriminant ideal of an elliptic curve over a number field is the product of
+the local minimal discriminant ideals `v.asIdeal ^ W.minimalDiscriminantExponent v` over
+all nonzero prime ideals `v` of its ring of integers. Only finitely many exponents are nonzero.
+See [LMFDB](https://www.lmfdb.org/knowledge/show/ec.minimal_discriminant). -/
+noncomputable def minimalDiscriminantIdeal {K : Type*} [Field K] [NumberField K]
+    (W : WeierstrassCurve K) [W.IsElliptic] : Ideal (𝓞 K) :=
+  ∏ᶠ v : HeightOneSpectrum (𝓞 K), v.asIdeal ^ W.minimalDiscriminantExponent v
+
+end WeierstrassCurve
+
 namespace BSD
 
 open scoped Topology

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -27,6 +27,7 @@ public import FormalConjecturesForMathlib.Algebra.Polynomial.Basic
 public import FormalConjecturesForMathlib.Algebra.Polynomial.HasseDeriv
 public import FormalConjecturesForMathlib.Algebra.Powerfree
 public import FormalConjecturesForMathlib.Algebra.QuadraticAlgebra.Instances
+public import FormalConjecturesForMathlib.AlgebraicGeometry.EllipticCurve.MinimalDiscriminant
 public import FormalConjecturesForMathlib.AlgebraicGeometry.ProjectiveSpace
 public import FormalConjecturesForMathlib.AlgebraicGeometry.VectorBundle
 public import FormalConjecturesForMathlib.Analysis.Asymptotics.Basic

--- a/FormalConjecturesForMathlib/AlgebraicGeometry/EllipticCurve/MinimalDiscriminant.lean
+++ b/FormalConjecturesForMathlib/AlgebraicGeometry/EllipticCurve/MinimalDiscriminant.lean
@@ -1,0 +1,50 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
+
+/-!
+# Minimal discriminants of elliptic curves over number fields
+
+The local exponents cutting out the minimal discriminant ideal of an elliptic curve over a
+number field.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], Section VIII.8.
+-/
+
+@[expose] public section
+
+namespace WeierstrassCurve
+
+open NumberField IsDedekindDomain
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-- The exponent of `v` in the minimal discriminant ideal of `W`: the normalized additive
+valuation of the discriminant of a minimal model over the `v`-adic integers.
+A vanishing discriminant has valuation `⊤`, which `toNat` sends to `0`, so this is only
+meaningful for elliptic `W`. -/
+noncomputable def minimalDiscriminantExponent (W : WeierstrassCurve K)
+    (v : HeightOneSpectrum (𝓞 K)) : ℕ :=
+  (IsDiscreteValuationRing.addVal (v.adicCompletionIntegers K)
+    (((W⁄(v.adicCompletion K)).minimal (v.adicCompletionIntegers K)).integralModel
+      (v.adicCompletionIntegers K)).Δ).toNat
+
+end WeierstrassCurve

--- a/FormalConjecturesForMathlib/AlgebraicGeometry/EllipticCurve/MinimalDiscriminant.lean
+++ b/FormalConjecturesForMathlib/AlgebraicGeometry/EllipticCurve/MinimalDiscriminant.lean
@@ -15,14 +15,15 @@ limitations under the License.
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Finprod
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
 public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 
 /-!
 # Minimal discriminants of elliptic curves over number fields
 
-The local exponents cutting out the minimal discriminant ideal of an elliptic curve over a
-number field.
+The minimal discriminant ideal of an elliptic curve over a number field, together with the
+local exponents cutting it out.
 
 ## References
 
@@ -46,5 +47,13 @@ noncomputable def minimalDiscriminantExponent (W : WeierstrassCurve K)
   (IsDiscreteValuationRing.addVal (v.adicCompletionIntegers K)
     (((W⁄(v.adicCompletion K)).minimal (v.adicCompletionIntegers K)).integralModel
       (v.adicCompletionIntegers K)).Δ).toNat
+
+/-- The minimal discriminant ideal of an elliptic curve over a number field is the product of
+the local minimal discriminant ideals `v.asIdeal ^ W.minimalDiscriminantExponent v` over
+all nonzero prime ideals `v` of its ring of integers. Only finitely many exponents are nonzero.
+See [LMFDB](https://www.lmfdb.org/knowledge/show/ec.minimal_discriminant). -/
+noncomputable def minimalDiscriminantIdeal (W : WeierstrassCurve K) [W.IsElliptic] :
+    Ideal (𝓞 K) :=
+  ∏ᶠ v : HeightOneSpectrum (𝓞 K), v.asIdeal ^ W.minimalDiscriminantExponent v
 
 end WeierstrassCurve

--- a/FormalConjecturesForMathlib/AlgebraicGeometry/EllipticCurve/MinimalDiscriminant.lean
+++ b/FormalConjecturesForMathlib/AlgebraicGeometry/EllipticCurve/MinimalDiscriminant.lean
@@ -38,21 +38,20 @@ open NumberField IsDedekindDomain
 
 variable {K : Type*} [Field K] [NumberField K]
 
-/-- The exponent of `v` in the minimal discriminant ideal of `W`: the normalized additive
-valuation of the discriminant of a minimal model over the `v`-adic integers.
-A vanishing discriminant has valuation `⊤`, which `toNat` sends to `0`, so this is only
+/-- The exponent of `v` in the minimal discriminant ideal of `W`: the natural number `n` such that
+the discriminant of a minimal model over the `v`-adic completion has valuation `exp (-n)`.
+A vanishing discriminant has valuation `0`, whose `log` is `0`, so this is only
 meaningful for elliptic `W`. -/
 noncomputable def minimalDiscriminantExponent (W : WeierstrassCurve K)
     (v : HeightOneSpectrum (𝓞 K)) : ℕ :=
-  (IsDiscreteValuationRing.addVal (v.adicCompletionIntegers K)
-    (((W⁄(v.adicCompletion K)).minimal (v.adicCompletionIntegers K)).integralModel
-      (v.adicCompletionIntegers K)).Δ).toNat
+  (-WithZero.log ((IsDiscreteValuationRing.maximalIdeal (v.adicCompletionIntegers K)).valuation
+    (v.adicCompletion K) ((W⁄(v.adicCompletion K)).minimal (v.adicCompletionIntegers K)).Δ)).toNat
 
 /-- The minimal discriminant ideal of an elliptic curve over a number field is the product of
 the local minimal discriminant ideals `v.asIdeal ^ W.minimalDiscriminantExponent v` over
 all nonzero prime ideals `v` of its ring of integers. Only finitely many exponents are nonzero.
 See [LMFDB](https://www.lmfdb.org/knowledge/show/ec.minimal_discriminant). -/
-noncomputable def minimalDiscriminantIdeal (W : WeierstrassCurve K) [W.IsElliptic] :
+noncomputable def minimalDiscriminantIdeal (W : WeierstrassCurve K) :
     Ideal (𝓞 K) :=
   ∏ᶠ v : HeightOneSpectrum (𝓞 K), v.asIdeal ^ W.minimalDiscriminantExponent v
 


### PR DESCRIPTION
supersedes #5345 ; pared down to bare minimum we need

re @Multramate comment:

> Don't use assVal --- it will be deprecated soon. Do we really need IsElliptic? What happens if you remove it?

this was not done because i'm confused, what should it be instead? one could use `ℤᵐ⁰`-valued `HeightOneSpectrum.valuation` you use in `Reduction.lean`, but getting from there
to a `ℕ` exponent goes via `WithZero.unzero`, which needs Δ ≠ 0 — so it would
bring `IsElliptic` back as a hypothesis.