### PR TITLE
fix(Wikipedia/Bloch): a schlicht disk is the image of an open subdomain

### DIFF
--- a/FormalConjectures/Wikipedia/Bloch.lean
+++ b/FormalConjectures/Wikipedia/Bloch.lean
@@ -34,16 +34,23 @@ import FormalConjecturesUtil
   Equations 54 (2009), no. 10, 951–955.
 - [MathWorld](https://mathworld.wolfram.com/BlochConstant.html)
 - [Bhowmik–Sen](https://www.cambridge.org/core/journals/canadian-mathematical-bulletin/article/improved-bloch-and-landau-constants-for-meromorphic-functions/FD465D1F2CEF7E8C62AFF16C3E89B7B4)
+- [Re2008] Rettinger, R. ["Bloch's constant is computable."](https://jucs.org/jucs_14_6/blochs_constant_is_computable/jucs_14_06_0896_0907_rettinger.pdf)
+  Journal of Universal Computer Science 14 (2008), 896–907. In particular, a schlicht disk is the
+  image of a subdomain under a biholomorphic restriction.
 -/
 open scoped Topology ENNReal
 open Metric Set Filter
 namespace Bloch
 
-/-- The **Bloch radius** $B_f$ of a function $f$ is the supremum of radii of univalent disks in the
-image of the unit disk under $f$. Takes values in `ℝ≥0∞` so that functions whose image contains
-arbitrarily large univalent disks correctly get radius `⊤` rather than `0`. -/
+/-- The **Bloch radius** $B_f$ of a function $f$ is the supremum of radii of schlicht disks in the
+image of the unit disk under $f$: the restriction of `f` maps an open subdomain injectively and
+onto the disk. Requiring an open subdomain and equality of the image is essential; mere containment
+would allow an arbitrary set-theoretic choice of one preimage per point. Takes values in `ℝ≥0∞` so
+that functions whose image contains arbitrarily large schlicht disks correctly get radius `⊤`
+rather than `0`. -/
 noncomputable def blochRadius (f : ℂ → ℂ) : ℝ≥0∞ :=
-  sSup (ENNReal.ofReal '' {r : ℝ | ∃ S ⊆ ball (0 : ℂ) 1, ∃ x, ball x r ⊆ f '' S ∧ InjOn f S})
+  sSup (ENNReal.ofReal '' {r : ℝ | ∃ S, IsOpen S ∧ S ⊆ ball (0 : ℂ) 1 ∧
+    ∃ x, f '' S = ball x r ∧ InjOn f S})
 
 @[category API, AMS 30]
 lemma zero_le_blochRadius (f : ℂ → ℂ) : 0 ≤ blochRadius f := zero_le
@@ -95,16 +102,16 @@ lemma blochRadius_id_eq_one : blochRadius id = 1 := by
   apply le_antisymm
   · -- blochRadius id ≤ 1: every valid radius r satisfies r ≤ 1
     apply sSup_le
-    rintro _ ⟨r, ⟨S, hS, x, hball, -⟩, rfl⟩
+    rintro _ ⟨r, ⟨S, -, hS, x, hball, -⟩, rfl⟩
     simp only [image_id] at hball
     by_cases hpos : 0 < r
     · exact (ENNReal.ofReal_le_ofReal
-        (radius_le_of_ball_subset_ball (𝕜 := ℂ) hpos (hball.trans hS))).trans
+        (radius_le_of_ball_subset_ball (𝕜 := ℂ) hpos (hball ▸ hS))).trans
         (by simp [ENNReal.ofReal_one])
     · exact (ENNReal.ofReal_of_nonpos (by linarith)).le.trans zero_le
   · -- 1 ≤ blochRadius id: ball 0 1 ⊆ id '' ball 0 1
     rw [show (1 : ℝ≥0∞) = ENNReal.ofReal 1 from by simp]
-    exact le_sSup ⟨1, ⟨ball (0 : ℂ) 1, Subset.rfl, 0, by simp⟩, rfl⟩
+    exact le_sSup ⟨1, ⟨ball (0 : ℂ) 1, isOpen_ball, Subset.rfl, 0, by simp⟩, rfl⟩
 
 /-- The **Landau radius** $L_f$ of a function $f$ is the supremum of radii of disks contained in
 the image of the unit disk under $f$. Takes values in `ℝ≥0∞` so that functions with unbounded
@@ -116,7 +123,7 @@ noncomputable def landauRadius (f : ℂ → ℂ) : ℝ≥0∞ :=
 unit disk with $f'(0) = 1$ has a schlicht (univalent) disk of that radius in its image. -/
 noncomputable def blochConstant : ℝ :=
   sSup {B : ℝ | ∀ f : ℂ → ℂ, DifferentiableOn ℂ f (ball 0 1) → deriv f 0 = 1 →
-    ∃ S ⊆ ball 0 1, ∃ x, ball x B ⊆ f '' S ∧ InjOn f S}
+    ∃ S, IsOpen S ∧ S ⊆ ball 0 1 ∧ ∃ x, f '' S = ball x B ∧ InjOn f S}
 
 /-- It is proved in [CP96] that the Bloch constant is bounded below by
 $\sqrt{3}/4 + 2 \times 10^{-4}$ -/
@@ -145,7 +152,8 @@ holomorphic function on the unit disk with $f'(0) = 1$ has a schlicht disk of th
 image. -/
 noncomputable def univalentBlochConstant : ℝ :=
   sSup {B : ℝ | ∀ f : ℂ → ℂ, InjOn f (ball 0 1) → DifferentiableOn ℂ f (ball 0 1) →
-    deriv f 0 = 1 → ∃ S ⊆ ball 0 1, ∃ x, ball x B ⊆ f '' S ∧ InjOn f S}
+    deriv f 0 = 1 → ∃ S, IsOpen S ∧ S ⊆ ball 0 1 ∧
+      ∃ x, f '' S = ball x B ∧ InjOn f S}
 
 /-- It is proved in [Skin2009] that the Univalent Bloch constant is bounded below by $0.5708858$. -/
 @[category research solved, AMS 30]
@@ -158,14 +166,14 @@ function, which is $1$. This is the best upper bound we know according to [Optim
 theorem univalentBlochConstant_upper_bound : univalentBlochConstant ≤ 1 := by
   apply csSup_le
   · -- the set is nonempty: 0 is in it (ball x 0 = ∅ ⊆ anything)
-    exact ⟨0, fun f _ _ _ => ⟨∅, empty_subset _, 0, by simp⟩⟩
+    exact ⟨0, fun f _ _ _ => ⟨∅, isOpen_empty, empty_subset _, 0, by simp⟩⟩
   · -- every B in the set is ≤ 1
     intro B hB
     have h := hB id (injOn_id _) differentiableOn_id (by simp)
-    rcases h with ⟨S, hS, x, hball, -⟩
+    rcases h with ⟨S, -, hS, x, hball, -⟩
     simp only [image_id] at hball
     by_cases hpos : (0 : ℝ) < B
-    · exact radius_le_of_ball_subset_ball (𝕜 := ℂ) hpos (hball.trans hS)
+    · exact radius_le_of_ball_subset_ball (𝕜 := ℂ) hpos (hball ▸ hS)
     · linarith
 
 /-- The **Landau constant** $L$ is the largest radius such that every holomorphic function on the


### PR DESCRIPTION
Closes #5222.

**What changed**

- `blochRadius`, `blochConstant` and `univalentBlochConstant` now require the schlicht disk to be
  the image of an **open** subdomain under an injective restriction, with equality of images:
  `∃ S, IsOpen S ∧ S ⊆ ball 0 1 ∧ ∃ x, f '' S = ball x B ∧ InjOn f S`.
- The existing proofs `blochRadius_id_eq_one` and `univalentBlochConstant_upper_bound` are adapted
  to the stronger definition.
- Added Rettinger, *Bloch's constant is computable*, J.UCS 14 (2008), as a reference for the
  intended definition.

**Why**

The old clause required only `ball x B ⊆ f '' S` for an arbitrary subset `S`. With no openness
condition, a set-theoretic section of `f` (one preimage per point, via choice) satisfies it, so
`InjOn f S` was vacuous and the Bloch condition collapsed onto the Landau condition.

That collapse is not heuristic. Against the definitions currently on `main`, this compiles:

```lean
theorem blochConstant_eq_landauConstant : blochConstant = landauConstant
```

which contradicts the file's own data: its cited Landau lower bound exceeds `1/2`, whereas the
Ahlfors–Grunsky Bloch value is ≈ `0.47186`.

`IsConnected S` is not additionally required: for non-constant holomorphic `f`, `IsOpen S`,
`InjOn f S` and `f '' S = ball x B` already force `S` connected — otherwise the open mapping
theorem would split the ball into two disjoint nonempty open sets.

The exact-value declarations stay `research open`. This is a semantic repair, not a resolution.

*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
