### PR TITLE
fix(Other/EquationalTheories_677_255): state 677 => 255 as one question

### DIFF
--- a/FormalConjectures/Other/EquationalTheories_677_255.lean
+++ b/FormalConjectures/Other/EquationalTheories_677_255.lean
@@ -53,24 +53,20 @@ theorem Finite.Equation255_not_implies_Equation677 :
   ⟨Fin 3, ⟨![![1, 2, 0], ![2, 0, 1], ![0, 1, 2]]⟩, Finite.intro (Fintype.equivFin _),
     fun x ↦ by fin_cases x <;> rfl, of_decide_eq_false rfl⟩
 
-/-- The negation of `Finite.Equation677_implies_Equation255`.
+/-- **Equational Theories, Problem 8.1.** Does Equation 677 imply Equation 255 in every finite
+magma? The project tentatively conjectures that the answer is no; a false answer is equivalent to
+the existence of a finite countermodel satisfying Equation 677 but not Equation 255.
 
-Probably this is true. It would be a stronger form of
-`Equation677_not_implies_Equation255`.
+This is deliberately a single `answer(sorry)` question rather than a pair of theorems. The
+existential countermodel and the universal implication are logical negations of each other, so
+declaring both as `theorem`s would assert a proposition and its negation simultaneously; the
+neutral form records the open problem without committing to either side.
 
-Discussion thread here:
+Discussion thread:
 https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/FINITE.3A.20677.20-.3E.20255 -/
 @[category research open, AMS 8]
-theorem Finite.Equation677_not_implies_Equation255 :
-    ∃ (G : Type) (_ : Magma G), Finite G ∧ Equation677 G ∧ ¬ Equation255 G := by
-  sorry
-
-/-- The negation of `Finite.Equation677_not_implies_Equation255`.
-
-Probably this is false. -/
-@[category research open, AMS 8]
-theorem Finite.Equation677_implies_Equation255 (G : Type) [Magma G] [Finite G]
-    (h : Equation677 G) : Equation255 G := by
+theorem Finite.Equation677_implies_Equation255 :
+    answer(sorry) ↔ ∀ (G : Type) (_ : Magma G), Finite G → Equation677 G → Equation255 G := by
   sorry
 
 end EquationalTheories_677_255

--- a/FormalConjectures/Other/EquationalTheories_677_255.lean
+++ b/FormalConjectures/Other/EquationalTheories_677_255.lean
@@ -57,10 +57,6 @@ theorem Finite.Equation255_not_implies_Equation677 :
 magma? The project tentatively conjectures that the answer is no; a false answer is equivalent to
 the existence of a finite countermodel satisfying Equation 677 but not Equation 255.
 
-This is deliberately a single `answer(sorry)` question rather than a pair of theorems. The
-existential countermodel and the universal implication are logical negations of each other, so
-declaring both as `theorem`s would assert a proposition and its negation simultaneously; the
-neutral form records the open problem without committing to either side.
 
 Discussion thread:
 https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/FINITE.3A.20677.20-.3E.20255 -/


### PR DESCRIPTION
**What changed**

- The two `research open` declarations `Finite.Equation677_not_implies_Equation255` and
  `Finite.Equation677_implies_Equation255` are replaced by a single neutral question:

```lean
@[category research open, AMS 8]
theorem Finite.Equation677_implies_Equation255 :
    answer(sorry) ↔ ∀ (G : Type) (_ : Magma G), Finite G → Equation677 G → Equation255 G
```

**Why**

The two statements were literal negations of one another, and both were declared as `theorem`s
with `sorry`. At least one of the two declarations was therefore necessarily false, and the file
asserted both at once.

The Equational Theories project poses this as a single open yes/no question — Problem 8.1 of
<https://teorth.github.io/equational_theories/paper.pdf> — and only tentatively conjectures a
negative answer. The `answer(sorry) ↔ …` form is this repository's idiom for that shape, and a
`False` answer is exactly the finite countermodel the removed declaration asked for.

The mathematics is untouched: the question is as open as it was.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
