### PR TITLE
fix(GreensOpenProblems/41): exists_better_bound follows from the Kravitz-Leng bound

### DIFF
--- a/FormalConjectures/GreensOpenProblems/41.lean
+++ b/FormalConjectures/GreensOpenProblems/41.lean
@@ -71,28 +71,42 @@ theorem green_41 :
   sorry
 
 /--
-Is there a better bound than the best-known bound from [KrLe25]?
-This is an existential version of the main problem that does not require providing the bound explicitly.
--/
-@[category research open, AMS 51 52]
-theorem green_41.variants.exists_better_bound : answer(sorry) ↔
-    ∃ C : ℝ, C > 0 ∧ ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀,
-      ∃ ans : ℝ, (minCopies ε : ℝ) ≤ ans ∧ ans < Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
-  sorry
-
-/-- Is $\varepsilon^{-C}$ rotations enough? -/
-@[category research open, AMS 51 52]
-theorem green_41.variants.polynomial_bound : answer(sorry) ↔
-    ∃ C : ℝ, ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀, (minCopies ε : ℝ) ≤ ε ^ (-C) := by
-  sorry
-
-/--
 [KrLe25] have established the first quantitative bound, showing via an analysis of [Ma15]'s method
 that $\exp\exp\exp(\varepsilon^{-C})$ rotations suffice.
 -/
 @[category research solved, AMS 51 52]
 theorem green_41.variants.kravitz_leng :
     ∃ C : ℝ, ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀, (minCopies ε : ℝ) ≤ Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
+  sorry
+
+/-- This existential statement is already implied by the [KrLe25] bound: increase its exponent
+constant and use the old bound as `ans`. Thus this formulation does not capture an asymptotic
+improvement over [KrLe25]. -/
+@[category research solved, AMS 51 52]
+theorem green_41.variants.exists_better_bound : answer(True) ↔
+    ∃ C : ℝ, C > 0 ∧ ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀,
+      ∃ ans : ℝ, (minCopies ε : ℝ) ≤ ans ∧ ans < Real.exp (Real.exp (Real.exp (ε ^ (-C)))) := by
+  rw [true_iff]
+  obtain ⟨C, ε₀, hε₀, hbound⟩ := green_41.variants.kravitz_leng
+  let C' := max C 0 + 1
+  refine ⟨C', by dsimp [C']; positivity, min ε₀ (1 / 2), by positivity, ?_⟩
+  intro ε hε
+  have hεpos : 0 < ε := hε.1
+  have hεhalf : ε ≤ 1 / 2 := hε.2.trans (min_le_right _ _)
+  have hεone : ε < 1 := hεhalf.trans_lt (by norm_num)
+  have hεold : ε ∈ Ioc 0 ε₀ := ⟨hεpos, hε.2.trans (min_le_left _ _)⟩
+  refine ⟨Real.exp (Real.exp (Real.exp (ε ^ (-C)))), hbound ε hεold, ?_⟩
+  apply Real.exp_lt_exp.mpr
+  apply Real.exp_lt_exp.mpr
+  apply Real.exp_lt_exp.mpr
+  apply Real.rpow_lt_rpow_of_exponent_gt hεpos hεone
+  dsimp [C']
+  linarith [le_max_left C 0]
+
+/-- Is $\varepsilon^{-C}$ rotations enough? -/
+@[category research open, AMS 51 52]
+theorem green_41.variants.polynomial_bound : answer(sorry) ↔
+    ∃ C : ℝ, ∃ ε₀ > 0, ∀ ε ∈ Ioc 0 ε₀, (minCopies ε : ℝ) ≤ ε ^ (-C) := by
   sorry
 
 end Green41


### PR DESCRIPTION
Related to #5005 — and directly relevant to the fix suggested there (see the note below).

**What changed**

- `green_41.variants.kravitz_leng` is moved above the variant that now depends on it.
- `green_41.variants.exists_better_bound` becomes `research solved` with `answer(True)` and a
  complete proof.
- Its docstring records that the formulation does not express an improvement over [KrLe25].

**Why**

The variant asks for some `ans` with `minCopies ε ≤ ans < exp³(ε^(-C))`, where `C` is
existentially quantified in the *same* statement. One may therefore take the Kravitz–Leng bound
itself as `ans` and simply enlarge the exponent. With `C' = max C 0 + 1 > C` and `0 < ε < 1`,

```
ε^(-C) < ε^(-C')
```

since `t ↦ ε^t` is strictly decreasing for `0 < ε < 1`; three applications of strict monotonicity
of `exp` give the required strict inequality. No asymptotic improvement is involved.

**Note for #5005.** That issue flags the headline `green_41` and suggests folding it into
`green_41.variants.exists_better_bound`, "which puts `∃ ans : ℝ` **inside** the `∀ ε`". That
alone is not sufficient: as shown here, the variant is already satisfied by the bound the
repository records. Capturing genuine improvement needs the comparison constant fixed *before*
`ans` is chosen — for instance quantifying over every `C` admissible for [KrLe25] and asking for a
bound below `exp³(ε^(-C))` for that same `C`. I have not included such a reformulation here, to
keep this PR to the one defect; happy to add it if you would prefer them together.

This is not the trivial-answer case CONTRIBUTING excludes: the answer is not the statement copied
into its own slot, but a consequence of the specific bound already recorded in this file, and the
proof is the content.


*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
