### PR TITLE
fix(Other/VCDimConvex): ask the global VC_n question, whose answer is False

### DIFF
--- a/FormalConjectures/Other/VCDimConvex.lean
+++ b/FormalConjectures/Other/VCDimConvex.lean
@@ -73,10 +73,19 @@ $\mathrm{VC}_n$ dimension at most $d$. -/
 lemma exists_hasAddVCNDimAtMost_n_of_convex_rn_add_one (n : ℕ) (hn : 1 ≤ n) :
     ∃ d : ℕ, ∀ C : Set (Fin (n + 1) → ℝ), Convex ℝ C → HasAddVCNDimAtMost C n d := sorry
 
-/-- If $n \ge 2$, every convex set in $\mathbb R^{n + 1}$ has $\mathrm{VC}_n$ dimension at most 1.
--/
-@[category research open, AMS 5 52]
-lemma hasAddVCNDimAtMost_n_one_of_convex_rn_add_one {n : ℕ} (hn : 2 ≤ n) {C : Set (Fin (n + 1) → ℝ)}
-    (hC : Convex ℝ C) : HasAddVCNDimAtMost C n 1 := sorry
+/-- Is it true that, if $n \ge 2$, every convex set in $\mathbb R^{n + 1}$ has
+$\mathrm{VC}_n$ dimension at most 1?
+
+The answer is no: the counterexample to the $n = 2$ case recorded in
+`hasAddVCNDimAtMost_two_one_of_convex_r3` disproves the universal statement. -/
+@[category research solved, AMS 5 52]
+lemma hasAddVCNDimAtMost_n_one_of_convex_rn_add_one :
+    answer(False) ↔ ∀ {n : ℕ}, 2 ≤ n → ∀ {C : Set (EuclideanSpace ℝ (Fin (n + 1)))},
+      Convex ℝ C → HasAddVCNDimAtMost C n 1 := by
+  constructor
+  · simp
+  · intro h
+    exact hasAddVCNDimAtMost_two_one_of_convex_r3 fun {C} hC ↦
+      h (n := 2) (C := C) (by norm_num) hC
 
 end VCDimConvex


### PR DESCRIPTION
**What changed**

- `hasAddVCNDimAtMost_n_one_of_convex_rn_add_one` becomes the global question

```lean
@[category research solved, AMS 5 52]
lemma hasAddVCNDimAtMost_n_one_of_convex_rn_add_one :
    answer(False) ↔ ∀ {n : ℕ}, 2 ≤ n → ∀ {C : Set (EuclideanSpace ℝ (Fin (n + 1)))},
      Convex ℝ C → HasAddVCNDimAtMost C n 1
```

  with a complete proof.

**Why**

The previous form was parameterised by `n` and `C`, so it *asserted* the claim rather than asking
it, and no answer could be recorded. The claim is false already at `n = 2`: the immediately
preceding declaration `hasAddVCNDimAtMost_two_one_of_convex_r3` — `research solved`, with an
external Lean proof — is exactly its negation in `ℝ³`.

`EuclideanSpace ℝ (Fin (n + 1))` is used so the `n = 2` instance is definitionally the same
ambient space as that `ℝ³` counterexample. The proof introduces no new `sorry`.

This is not the trivial-answer case CONTRIBUTING excludes: `False` is forced by the neighbouring
solved counterexample, not chosen to make the slot fillable.


*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
