### PR TITLE
fix(OEIS/24356): the only-zero claim also requires a 4 = 0

### DIFF
--- a/FormalConjectures/OEIS/24356.lean
+++ b/FormalConjectures/OEIS/24356.lean
@@ -49,10 +49,37 @@ theorem a_2 : a 2 = 1 := by
   simp [a, Matrix.det_fin_two, Nat.nth_prime_zero_eq_two,
     Nat.nth_prime_one_eq_three, Nat.nth_prime_two_eq_five]
 
+/-- Value of the sequence `a` at 4. This records the zero whose uniqueness is conjectured below. -/
+@[category test, AMS 11]
+theorem a_4 : a 4 = 0 := by
+  unfold a
+  have hp13 : Nat.Prime 13 := by decide
+  have hp17 : Nat.Prime 17 := by decide
+  have h5 : Nat.nth Nat.Prime 5 = 13 := Nat.nth_count hp13
+  have h6 : Nat.nth Nat.Prime 6 = 17 := Nat.nth_count hp17
+  have hM :
+      (Matrix.of fun (i j : Fin 4) ↦ (Nat.nth Nat.Prime (i.val + j.val) : ℤ)) =
+        !![(2 : ℤ), 3, 5, 7; 3, 5, 7, 11; 5, 7, 11, 13; 7, 11, 13, 17] := by
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Nat.nth_prime_zero_eq_two, Nat.nth_prime_one_eq_three,
+        Nat.nth_prime_two_eq_five, Nat.nth_prime_three_eq_seven,
+        Nat.nth_prime_four_eq_eleven, h5, h6]
+  rw [hM]
+  apply Matrix.det_eq_zero_of_mulVec_eq_zero_of_mem_nonZeroDivisors
+    (v := ![(6 : ℤ), -3, -2, 1]) (i := 0)
+  · decide
+  · norm_num [nonZeroDivisors]
+
 /--
-"I conjecture that $a(4)$ is the only zero. - _Jon Perry_, Mar 22 2004"-/
+"I conjecture that $a(4)$ is the only zero. - _Jon Perry_, Mar 22 2004"
+
+Stated as a biconditional: the claim that $a(4)$ is *the only* zero asserts both that $a(4) = 0$
+and that no other index vanishes. A bare implication `a n = 0 → n = 4` would be satisfied
+vacuously by a sequence with no zero at all. The existence direction is certified by `a_4`; the
+uniqueness direction is the open part. -/
 @[category research open, AMS 11 15]
-theorem conjecture : ∀ n : ℕ, a n = 0 → n = 4 := by
+theorem conjecture : ∀ n : ℕ, a n = 0 ↔ n = 4 := by
   sorry
 
 end OeisA24356


### PR DESCRIPTION
**What changed**

- `conjecture` becomes `∀ n : ℕ, a n = 0 ↔ n = 4` (previously `a n = 0 → n = 4`).
- New `category test` theorem `a_4 : a 4 = 0` certifies the existence direction.

**Why**

The OEIS comment is *"I conjecture that a(4) is the only zero"*, which asserts both that `a 4 = 0`
and that nothing else vanishes. The implication alone does not say a zero exists — a sequence that
never vanishes satisfies it vacuously.

`a_4` is a kernel-reduced computation, not `native_decide`. The `4 × 4` Hankel matrix is

```
 2  3  5  7
 3  5  7 11
 5  7 11 13
 7 11 13 17
```

(using `Nat.nth_count` for the entries 13 and 17), and singularity is witnessed by the explicit
null vector `(6, -3, -2, 1)`.

The uniqueness direction remains `research open`.

*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
