### PR TITLE
fix(ErdosProblems/272): the main asymptotic follows from the Szabo bound

### DIFF
--- a/FormalConjectures/ErdosProblems/272.lean
+++ b/FormalConjectures/ErdosProblems/272.lean
@@ -40,16 +40,6 @@ noncomputable def maxArithInterCard (N : ℕ) : ℕ :=
   sSup {#A | (A : _) (_ : IsArithInterSet N A)}
 
 /--
-Let $N\geq 1$. What is the largest $t$ such that there are
-$A_1,\ldots,A_t\subseteq \{1,\ldots,N\}$ with $A_i\cap A_j$ a non-empty
-arithmetic progression for all $i\neq j$?
--/
-@[category research open, AMS 5]
-theorem erdos_272 :
-    (fun N ↦ (maxArithInterCard N : ℝ)) ~[atTop] (answer(sorry) : ℕ → ℝ) := by
-  sorry
-
-/--
 Simonovits and Sós have shown that $t\ll N^2$.
 -/
 @[category research solved, AMS 5]
@@ -67,6 +57,33 @@ theorem erdos_272.variants.szabo :
     (fun N ↦ (maxArithInterCard N - N ^ 2 / 2 : ℝ)) =O[atTop]
       fun N : ℕ ↦ N ^ ((5 : ℝ) /  3) * (Real.log N) ^ 3 := by
   sorry
+
+/--
+Let $N\geq 1$. What is the largest $t$ such that there are
+$A_1,\ldots,A_t\subseteq \{1,\ldots,N\}$ with $A_i\cap A_j$ a non-empty
+arithmetic progression for all $i\neq j$? Szabó's error estimate above implies the asymptotic
+$t \sim N^2/2$.
+-/
+@[category research solved, AMS 5]
+theorem erdos_272 :
+    (fun N ↦ (maxArithInterCard N : ℝ)) ~[atTop]
+      answer(fun N : ℕ ↦ (N : ℝ) ^ 2 / 2) := by
+  rw [Asymptotics.IsEquivalent]
+  apply erdos_272.variants.szabo.trans_isLittleO
+  have hlog : (fun x : ℝ ↦ Real.log x ^ (3 : ℝ)) =o[atTop]
+      (fun x : ℝ ↦ x ^ ((1 : ℝ) / 3)) :=
+    isLittleO_log_rpow_rpow_atTop 3 (by norm_num)
+  have hmul := (isBigO_refl (fun x : ℝ ↦ x ^ ((5 : ℝ) / 3)) atTop).mul_isLittleO hlog
+  have hnat := hmul.comp_tendsto tendsto_natCast_atTop_atTop
+  have hbase : (fun N : ℕ ↦ (N : ℝ) ^ ((5 : ℝ) / 3) * Real.log N ^ (3 : ℝ)) =o[atTop]
+      (fun N : ℕ ↦ (N : ℝ) ^ (2 : ℝ)) := by
+    apply (hnat.congr_left fun _ => rfl).congr_right
+    intro N
+    simp only [Function.comp_apply]
+    rw [← Real.rpow_add' (Nat.cast_nonneg N) (by norm_num : (5 / 3 : ℝ) + 1 / 3 ≠ 0)]
+    norm_num
+  have hfinal := hbase.const_mul_right (by norm_num : (1 / 2 : ℝ) ≠ 0)
+  simpa [div_eq_mul_inv, mul_comm] using hfinal
 
 /-- Szabo asks whether the maximal $t$ is given by
 $$


### PR DESCRIPTION
Addresses the "Erdős 272 — main asymptotic" item of #4927.

**What changed**

- `erdos_272` becomes `research solved` with `answer(fun N : ℕ ↦ (N : ℝ) ^ 2 / 2)` and a complete
  proof.
- It is moved below `erdos_272.variants.szabo`, which the proof uses.

**Why**

The already-`research solved` Szabó variant in this file states

```
maxArithInterCard N - N² / 2  =O[atTop]  N^(5/3) (log N)³
```

Since `log(x)³ = o(x^(1/3))`, multiplying by `x^(5/3)` gives `N^(5/3)(log N)³ = o(N²)`. Scaling by
`1/2` and applying `IsBigO.trans_isLittleO` yields an `o(N²/2)` error, i.e.
`maxArithInterCard N ~ N²/2`.

**Judgement call.** This settles the headline *as formalised*, which asks only for the asymptotic
equivalence. The sharper question Szabó actually poses — whether the error term is `O(N)` — is a
separate declaration in this file and stays `research open`. If you would rather the headline
capture that sharper form, the alternative is to strengthen the statement instead of marking it
solved; happy to switch.

This is not the trivial-answer case CONTRIBUTING excludes: the answer `N ↦ N²/2` is derived from
the recorded Szabó error term, not copied from the statement.


*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
