### PR TITLE
fix(GreensOpenProblems/19): the bounds follow from the solved value C = 4

### DIFF
--- a/FormalConjectures/GreensOpenProblems/19.lean
+++ b/FormalConjectures/GreensOpenProblems/19.lean
@@ -80,15 +80,16 @@ This question has been resolved by [FSS20], showing that $C = 4$.
 theorem green_19 : C = 4 := by
   sorry
 
-/-- [Ma21] showed that $3.13 \leq C$. -/
-@[category research open, AMS 5 11]
+/-- [Ma21] showed that $3.13 \leq C$. This also follows from `green_19`. -/
+@[category research solved, AMS 5 11]
 theorem green_19.lower : C >= 3.13 := by
-  sorry
+  rw [green_19]
+  norm_num
 
-/-- [Ma21] showed that $C \leq 4$. -/
-@[category research open, AMS 5 11]
+/-- [Ma21] showed that $C \leq 4$. This also follows from `green_19`. -/
+@[category research solved, AMS 5 11]
 theorem green_19.upper : C <= 4 := by
-  sorry
+  rw [green_19]
 
 /- TODO(jeangud): in [FSS20] they mention that the corresponding question for squares
 $(x, y), (x, y + d), (x + d, y), (x + d, y + d)$ is wide open (and here it is not even clear that


### PR DESCRIPTION
Addresses the "Green 19 — `lower` and `upper`" item of #4927.

**What changed**

- `green_19.lower` and `green_19.upper` become `research solved`, proved from the
  already-`research solved` `green_19 : C = 4` via `rw [green_19]` (plus `norm_num` for the
  numeric comparison).

**Why**

[Ma21]'s bounds `3.13 ≤ C` and `C ≤ 4` were tagged `research open`, but the same file already
records the exact value `C = 4` as solved, which implies both.

Both proofs are two lines and derive from the file's own solved value; no new mathematics is
claimed.


*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
