### PR TITLE
fix(OptimizationConstants/1a): take the supremum over the source's interval

### DIFF
--- a/FormalConjectures/OptimizationConstants/1a.lean
+++ b/FormalConjectures/OptimizationConstants/1a.lean
@@ -32,10 +32,13 @@ namespace Constant1a
 /-- **Tao's Optimization constant 1a / An autocorrelation constant related to Sidon sets**:
 The biggest real number satisfying a certain inequality about (auto)convolutions
 and $L^2$-norms of functions.
-This number is related to the maximal size of Sidon sets in additive combinatorics. -/
+This number is related to the maximal size of Sidon sets in additive combinatorics.
+
+The supremum is taken over $-1/2 \le t \le 1/2$, matching the source. This is the range where
+the autoconvolution of a function supported in $[-1/4, 1/4]$ can be nonzero. -/
 noncomputable def C1a : ℝ :=
   sSup {C : ℝ | ∀ ⦃f : ℝ → ℝ⦄, 0 ≤ f →  C * (∫ x in (- 1 / 4)..(1 / 4), f x) ^ 2
-    ≤ sSup {∫ x, f (t - x) * f x | t ∈ Icc (1 / 2 : ℝ) 1}}
+    ≤ sSup {∫ x, f (t - x) * f x | t ∈ Icc (- 1 / 2 : ℝ) (1 / 2)}}
 
 /-- The best known lower bound, proven by Matolcsi-Vinuesa in [M2010]-/
 @[category research solved, AMS 5 11 26]


### PR DESCRIPTION
Addresses the first item of #4896, "Optimization Constant C1a — integration interval".

**What changed**

- `C1a` takes its inner supremum over `t ∈ Icc (-1/2) (1/2)` instead of `t ∈ Icc (1/2) 1`.
- The docstring records the interval and why it is the right one.

Nothing else in the file is touched; no category changes.

**Why**

The [source page](https://teorth.github.io/optimizationproblems/constants/1a.html) defines `C1a` as
the largest constant with

```
max_{-1/2 ≤ t ≤ 1/2} ∫_ℝ f(t-x) f(x) dx  ≥  C1a (∫_{-1/4}^{1/4} f(x) dx)²
```

for all non-negative `f : ℝ → ℝ`. The repository had `1/2 ≤ t ≤ 1`.

This is not a harmless change of variables — it makes the constant collapse. Take `f` to be the
indicator of `[-1/4, 1/4]`. Then `f(t-x) f(x) ≠ 0` forces `x ∈ [-1/4, 1/4] ∩ [t-1/4, t+1/4]`, which
for `t ≥ 1/2` is empty except for the single point `x = 1/4` at `t = 1/2`. So the inner supremum is
`0`, while `∫_{-1/4}^{1/4} f = 1/2`, and the defining condition becomes `C · 1/4 ≤ 0`, i.e. `C ≤ 0`.
Conversely every `C ≤ 0` satisfies it, since the inner supremum is a supremum of non-negative
values. Hence the set is `(-∞, 0]` and the old `C1a` is `0`.

That makes the file's own `c1a_lower_bound : 1.2748 ≤ C1a`, marked `research solved`, false. With
the source interval the constant is the intended one and that bound is correct again.

I have not formalised the collapse argument above — it needs the a.e. vanishing of the product —
so this PR is the statement repair only. Happy to add it if you would like it in the file.

**Separately** (not changed here): relative to the source's current tables, `c1a_lower_bound`
(`1.2748`, [MV2009]) and `c1a_upper_bound` (`1.5029`) are both behind — the page now lists
`1.292` [PBV2026] and `1.502862` [T2026]. That is a different change and I did not want to bundle
it; happy to open it separately if useful.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
