### PR TITLE
fix(Wikipedia/Sendov): mark Sendov's conjecture solved with a formal proof

### DIFF
--- a/FormalConjectures/Wikipedia/Sendov.lean
+++ b/FormalConjectures/Wikipedia/Sendov.lean
@@ -19,7 +19,12 @@ import FormalConjecturesUtil
 /-!
 # Sendov's conjecture
 
-*Reference:* [Wikipedia](https://en.wikipedia.org/wiki/Sendov%27s_conjecture)
+*References:*
+- [Wikipedia](https://en.wikipedia.org/wiki/Sendov%27s_conjecture)
+- Lech Mazur, *A Computer-Assisted Proof of Sendov's Conjecture*,
+  [ProofAtlas, August 5, 2026](https://www.proofatlas.ai/papers/sendov-conjecture/SENDOV_CONJECTURE_PROOF_AUGUST_5_2026.pdf).
+- Terence Tao, [*A digestion of the proof of Sendov's conjecture*](https://terrytao.wordpress.com/2026/08/12/a-digestion-of-the-proof-of-sendovs-conjecture/).
+- [Tao's Lean formalization of the digested proof](https://github.com/teorth/sendov).
 
 Tags: Sendov Conjecture, Ilieff's Conjecture.
 
@@ -48,7 +53,9 @@ def Nat.SatisfiesSendovConjecture (n : ℕ) : Prop :=
 $$f(z)=(z-r_{1})\cdots (z-r_{n}),\qquad (n\geq 2)$$
 with all roots $r_1, ..., r_n$ inside the closed unit disk $|z| ≤ 1$, each of the $n$ roots is at a
 distance no more than $1$ from at least one critical point. -/
-@[category research open, AMS 12 30 52]
+@[category research solved, AMS 12 30 52,
+  formal_proof using lean4 at
+    "https://github.com/teorth/sendov/blob/1ddea92d89f951a0a7cbbffa6c267cf7e6640b1d/Sendov/Conjecture.lean#L156-L167"]
 theorem sendov_conjecture (n : ℕ) (hn : 2 ≤ n) : n.SatisfiesSendovConjecture := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `sendov_conjecture` is `research solved`, with a `formal_proof using lean4` attribute pointing at
  a pinned commit of Tao's Lean development.
- The reference list gains Mazur's manuscript, Tao's write-up, and the formalization repository.

**Background**

Lech Mazur gave a [computer-assisted proof of Sendov's
conjecture](https://www.proofatlas.ai/papers/sendov-conjecture/SENDOV_CONJECTURE_PROOF_AUGUST_5_2026.pdf)
(5 August 2026). Terence Tao then [digested the
argument](https://terrytao.wordpress.com/2026/08/12/a-digestion-of-the-proof-of-sendovs-conjecture/)
into a shorter human-readable proof and formalised it in Lean 4 at
[teorth/sendov](https://github.com/teorth/sendov).

**Audit of the linked proof** (pinned commit `1ddea92d`)

- The `Sendov` library contains no `sorry`, no project `axiom`, no `native_decide`, no `unsafe`
  and no `implemented_by`. The only `sorry`s in the repository are in `Challenge.lean`, a separate
  library target that nothing in `Sendov` imports.
- The project ships its own audit script, `scripts/axioms.lean`, which `#print axioms` on
  `Sendov.sendov` and each of its main dependencies, requiring `propext`, `Classical.choice` and
  `Quot.sound` only.
- The pinned line range is the theorem itself, not a landing page.

**Statement match**

The external theorem is

```lean
theorem sendov {n : ℕ} (hn : 2 ≤ n) {p : ℂ[X]} (hdeg : p.natDegree = n)
    (hroots : ∀ w ∈ p.roots, ‖w‖ ≤ 1) {a : ℂ} (hpa : p.eval a = 0) :
    ∃ ζ : ℂ, (derivative p).eval ζ = 0 ∧ ‖ζ - a‖ ≤ 1
```

against this file's `∀ n, 2 ≤ n → n.SatisfiesSendovConjecture`. They agree:

- `p.natDegree = n` with `n ≥ 2` forces `p ≠ 0`, so `∀ w ∈ p.roots, ‖w‖ ≤ 1` and
  `p.rootSet ℂ ⊆ closedBall 0 1` are the same condition, and `z ∈ f.rootSet ℂ` matches
  `p.eval a = 0`.
- `natDegree p' = n - 1 ≥ 1`, so `p' ≠ 0` and a `ζ` with `p'.eval ζ = 0` really lies in
  `p'.rootSet ℂ`; hence `Metric.infDist z (f.derivative.rootSet ℂ) ≤ ‖ζ - z‖ ≤ 1`.
- Repeated roots are unproblematic: `rootSet` is the support of the root multiset, and the
  conclusion is about distance to that set.

The `research open` variants further down the file (degree ≤ 9, and the real-coefficient case) are
left untouched.

*AI assistance: the status change was identified by an OpenAI Codex agent during a repository-wide sweep. The linked Lean development is Terence Tao's own formalisation of his digest of Mazur's proof, not model-generated. The statement match and the `sorry`/axiom audit were carried out with Claude Opus 5.*
