### PR TITLE
fix(OEIS/113271): a 4 is prime and a 5 = 135457 is not

### DIFF
--- a/FormalConjectures/OEIS/113271.lean
+++ b/FormalConjectures/OEIS/113271.lean
@@ -48,13 +48,32 @@ theorem a_3 : a 3 = 41 := by rfl
 @[category test, AMS 11]
 theorem a_4 : a 4 = 593 := by rfl
 
+@[category test, AMS 11]
+theorem a_4_prime : (a 4).Prime := by
+  rw [a_4]
+  norm_num
+
+/-- The next term from the defining formula and the official OEIS b-file. -/
+@[category test, AMS 11]
+theorem a_5 : a 5 = 135457 := by rfl
+
+/-- The term `a(5) = 135457 = 7 * 37 * 523` is composite. -/
+@[category test, AMS 11]
+theorem a_5_not_prime : ¬ (a 5).Prime := by
+  rw [a_5]
+  norm_num
+
 /--
-The smallest primes in this (always odd) sequence are $a(1) = 3$, $a(3) = 41$ and $a(5) = 543$.
-What is the next prime?
+The first prime terms in this (always odd) sequence are $a(1) = 3$, $a(3) = 41$, and
+$a(4) = 593$. What is the next prime?
+
+The OEIS comment currently says `$a(5) = 543$`, but this conflicts with its defining formula,
+b-file, and examples: the actual index-five term is the composite number `135457`. Consequently the
+search for the next prime must begin after index `4`, not after index `5`.
 -/
 @[category research open, AMS 11]
 theorem conjecture1 :
-  answer(sorry) = a (sInf {n : ℕ | 5 < n ∧ (a n).Prime}) := by
+  answer(sorry) = a (sInf {n : ℕ | 4 < n ∧ (a n).Prime}) := by
   sorry
 
 end OeisA113271


### PR DESCRIPTION
**What changed**

- The `conjecture1` search starts after index `4` instead of after index `5`.
- New `category test` theorems: `a_4_prime`, `a_5 : a 5 = 135457`, and `a_5_not_prime`.
- The docstring records the discrepancy with the OEIS comment.

**Why**

The docstring repeated the OEIS comment, "The smallest primes in this (always odd) sequence are
`a(1) = 3`, `a(3) = 41` and `a(5) = 543`", and the search was therefore restricted to `5 < n`.

That comment is inconsistent with the rest of the same OEIS entry. A113271's DATA section reads
`1, 3, 9, 41, 593, 135457, ...` and its EXAMPLE section reads `a(5) = 135457 = 1^32 + 2^16 + 4^8 +
8^4 + 16^2 + 32^1`. So `543` is neither the index-five term nor prime (`543 = 3 · 181`).

Recomputing from the file's own definition confirms the DATA: `a(4) = 593`, which **is** prime, and
`a(5) = 135457 = 7 · 37 · 523`, which is not. The genuine third prime is therefore `a(4)`, and the
old bound `5 < n` excluded it from the record while starting the search one index too late.

The question itself is unchanged and still open: no further prime occurs for `n ≤ 12`.

*AI assistance: this was found, and the Lean proof written, by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and proof were then independently re-derived and verified with Claude Opus 5 before submission.*
