### PR TITLE
fix(OEIS/7468): the only-square claim also requires a 38 to be a square

### DIFF
--- a/FormalConjectures/OEIS/7468.lean
+++ b/FormalConjectures/OEIS/7468.lean
@@ -65,7 +65,7 @@ The only positive integer $n$ such that $a(n)$ is a perfect square is $n=38$.
 - Carlos Eduardo Olivieri, Mar 09 2015
 -/
 @[category research open, AMS 11]
-theorem conjecture (n : ℕ) (hn : 0 < n) (hsq : IsSquare (a n)) : n = 38 := by
+theorem conjecture (n : ℕ) (hn : 0 < n) : IsSquare (a n) ↔ n = 38 := by
   sorry
 
 end OeisA7468


### PR DESCRIPTION
**What changed**

- `conjecture` reads `IsSquare (a n) ↔ n = 38` instead of `IsSquare (a n) → n = 38`.

**Why**

The docstring states "The only positive integer `n` such that `a(n)` is a perfect square is
`n = 38`". That asserts two things: that `a(38)` is a square, and that no other positive index
gives one. The implication only encodes the second, and is satisfied vacuously by a sequence with
no square at all.

`a(38)` is indeed a square: row 38 runs over prime indices 703 to 740 and sums to
`207936 = 456²`. A direct scan of `n = 1 … 658` finds no other square, so the biconditional is
consistent with the data and remains open.

This PR does not add a Lean certificate for `a(38) = 207936`, which would require certifying the
38 relevant `Nat.nth Nat.Prime` values; both directions stay `sorry`, as before.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
