### PR TITLE
fix(OEIS/1818): both Sun permanent conjectures are proved

### DIFF
--- a/FormalConjectures/OEIS/1818.lean
+++ b/FormalConjectures/OEIS/1818.lean
@@ -23,6 +23,8 @@ Squares of double factorials: $a(n) = ((2n-1)!!)^2 = (1 \cdot 3 \cdot 5 \cdots (
 
 *References:*
 - [A001818](https://oeis.org/A001818)
+- [She, Sun, Xia, *A novel permanent identity with applications*, Theorem 1.3(ii)](https://arxiv.org/abs/2208.12167)
+- [Yang, Zhang, *Sun-type determinant and permanent congruences*, Proposition 17](https://arxiv.org/abs/2605.19502)
 -/
 
 namespace OeisA1818
@@ -69,7 +71,7 @@ matrix $[m(j,k)]_{j,k=1..2n}$ coincides with $a(n) = ((2n-1)!!)^2$, where $m(j,k
 $(1+\zeta^{j-k})/(1-\zeta^{j-k})$ if $j \neq k$, and $1$ otherwise.
 - Zhi-Wei Sun, Dec 21 2021
 -/
-@[category research open, AMS 11 15]
+@[category research solved, AMS 11 15]
 theorem conjecture1 (n : ℕ) (hn : 1 ≤ n) :
     ∀ (ζ : ℂ), IsPrimitiveRoot ζ (2 * n) →
       Matrix.permanent (fun (i j : Fin (2 * n)) =>
@@ -86,7 +88,7 @@ $[f(j,k)]_{j,k=1..p-1}$ is congruent to $a((p-1)/2) = ((p-2)!!)^2 \pmod{p^2}$,
 where $f(j,k)$ is $(j+k)/(j-k)$ if $j \neq k$, and $f(j,k) = 1$ otherwise.
 - Zhi-Wei Sun, Dec 22 2021
 -/
-@[category research open, AMS 11 15]
+@[category research solved, AMS 11 15]
 theorem conjecture2 {p : ℕ} (hp : p.Prime) (h_odd : p ≠ 2) :
     let N : ℕ := p - 1
     let R := ZMod (p ^ 2)


### PR DESCRIPTION
**What changed**

- `conjecture1` and `conjecture2` are `research solved`.
- Both papers added to the reference list.

**conjecture1** — She, Sun and Xia, *A novel permanent identity with applications*,
[arXiv:2208.12167](https://arxiv.org/abs/2208.12167), Theorem 1.3(ii):

> Let `n > 1` be an integer, and let `ζ` be a primitive `n`th root of unity. Set
> `c_{j,k} = (1+ζ^{j-k})/(1-ζ^{j-k})` if `j ≠ k`, and `1` if `j = k`.
> If `n` is even, then `per[c_{j,k}]_{1≤j,k≤n} = ((n-1)!!)²`.

Taking `n = 2m` gives exactly this file's statement: the `2m × 2m` permanent equals
`((2m-1)!!)² = a m`. The paper records that this part "was first conjectured by the second
author", i.e. Zhi-Wei Sun, matching the attribution in the docstring.

**conjecture2** — Yang and Zhang, *Sun-type determinant and permanent congruences*,
[arXiv:2605.19502](https://arxiv.org/abs/2605.19502), Proposition 17:

> For every odd prime `p`, `per(I_{p-1} + R_p) ≡ ((p-2)!!)² (mod p²)`.

`I_{p-1} + R_p` is the `(p-1) × (p-1)` matrix with `1` on the diagonal and `(j+k)/(j-k)` off it —
this file's `fEntry` — and `((p-2)!!)² = a ((p-1)/2)`. Their proof combines She–Sun–Xia's permanent
identity with their own Cauchy permanent congruence and Morley's congruence.

Both declarations keep their literature-backed `sorry`, as is usual in this repository for results
whose proofs are not formalised.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
