### PR TITLE
feat(ErdosProblems): Add lean sources from plby's github repo for Erdos Problems.

### DIFF
--- a/FormalConjectures/ErdosProblems/119.lean
+++ b/FormalConjectures/ErdosProblems/119.lean
@@ -69,7 +69,7 @@ This is Problem 4.1 in [Ha74] where it is attributed to Erdős.
 The weaker conjecture that $\limsup M_n=\infty$ was proved by Wagner [Wa80], who show that there is
 some $c>0$ with $M_n>(\log n)^c$ infinitely often.
 -/
-@[category research solved, AMS 30]
+@[category research solved, AMS 30, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos119.lean#L1759"]
 theorem erdos_119.parts.i :
     answer(True) ↔ ∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
       atTop.limsup (fun n => (M z n : EReal)) = ⊤ := by
@@ -81,7 +81,7 @@ Is it true that there exists $c > 0$ such that for infinitely many $n$ we have $
 The second question was answered by Beck [Be91], who proved that there exists some $c>0$ such that
 $\max_{n\leq N} M_n > N^c$.
 -/
-@[category research solved, AMS 30]
+@[category research solved, AMS 30, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos119.lean#L1712"]
 theorem erdos_119.parts.ii :
     answer(True) ↔ ∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
       ∃ (c : ℝ) (hc : c > 0), Infinite {n : ℕ | M z n > n ^ c} := by
@@ -94,7 +94,7 @@ The \$100 prize was offered for the third question in [Er97f]. This was resolved
 Korsky (see the proof claims), who proved that $\sum_{k\leq n}M_k \gg \frac{n^{5/4}}{\sqrt{\log n}}$
 (and hence for infinitely many $n$ we have $M_n> n^{1/4-o(1)}$).
 -/
-@[category research solved, AMS 30]
+@[category research solved, AMS 30, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos119.lean#L1687"]
 theorem erdos_119.parts.iii :
     answer(True) ↔ ∀ (z : ℕ → ℂ) (hz : ∀ i : ℕ, ‖z i‖ = 1),
       ∃ (c : ℝ) (hc : c > 0), ∀ᶠ n in atTop,

--- a/FormalConjectures/ErdosProblems/253.lean
+++ b/FormalConjectures/ErdosProblems/253.lean
@@ -38,7 +38,7 @@ $\frac{a_{i+1}}{a_i} \to 1$. If every arithmetic progression contains infinitely
 integers which are the sum of distinct $a_i$ then every sufficiently large integer is
 the sum of distinct $a_i$.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos253.lean#L699"]
 theorem erdos_253 : ¬ ∀ a : ℕ → ℕ, 0 < a 0 →
     RepresentsAPs a → (Filter.atTop.Tendsto (fun n ↦ (a <| n + 1 : ℝ) / a n) (𝓝 1)) →
       subsetSums (Set.range a) ∈ Filter.cofinite := by

--- a/FormalConjectures/ErdosProblems/277.lean
+++ b/FormalConjectures/ErdosProblems/277.lean
@@ -35,7 +35,7 @@ covering system whose moduli all divide $n$?
 
 This was answered affirmatively by Haight [Ha79].
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos277.lean#L1294"]
 theorem erdos_277 :
    answer(True) ↔ ∀ c : ℝ, ∃ n : ℕ, (σ 1 n : ℝ) > c * n ∧
       ∀ (m : StrictCoveringSystem ℤ), ∃ i, (n : ℤ) ∉ m.moduli i  := by

--- a/FormalConjectures/ErdosProblems/358.lean
+++ b/FormalConjectures/ErdosProblems/358.lean
@@ -70,7 +70,7 @@ Is there such an $A$ for which $f(n)\to \infty$ as $n\to \infty$?
 
 Tao [Ta26] constructed such a sequence with $f(n) \gg \log n$ for all sufficiently large $n$.
 -/
-@[category research solved, AMS 5 11]
+@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos358.lean#L9111"]
 theorem erdos_358.parts.i :
     answer(True) ↔ ∃ A, StrictMono A ∧ atTop.Tendsto (f A) atTop := by
   sorry
@@ -82,7 +82,7 @@ Is there an $A$ such that $f(n)\geq 2$ for all large $n$?
 
 This also follows from Tao's construction with $f(n) \gg \log n$ [Ta26].
 -/
-@[category research solved, AMS 5 11]
+@[category research solved, AMS 5 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos358.lean#L9115"]
 theorem erdos_358.parts.ii :
     answer(True) ↔ ∃ A, StrictMono A ∧ ∀ᶠ n in atTop, 2 ≤ f A n := by
   sorry

--- a/FormalConjectures/ErdosProblems/480.lean
+++ b/FormalConjectures/ErdosProblems/480.lean
@@ -32,7 +32,7 @@ Is it true that
 $$\inf_n \liminf_{m\to \infty} n \lvert x_{m+n}-x_m\rvert\leq 5^{-1/2}\approx 0.447?$$
 A conjecture of Newman.
 -/
-@[category research solved, AMS 11]
+@[category research solved, AMS 11, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos480.lean#L973"]
 theorem erdos_480 : answer(True) ↔ ∀ (x : ℕ → ℝ), (∀ n, x n ∈ Set.Icc 0 1) →
     ⨅ (n : ℕ+), atTop.liminf (fun m => (n : ℕ) * |x (m + (n : ℕ)) - x m|) ≤ 1 / √5 := by
   sorry

--- a/FormalConjectures/ErdosProblems/498.lean
+++ b/FormalConjectures/ErdosProblems/498.lean
@@ -46,7 +46,7 @@ arbitrary Hilbert spaces [Kl70].
 
 See also [395].
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos498.lean#L2006"]
 theorem erdos_498 : answer(True) ↔
     ∀ (n : ℕ) (z : Fin n → ℂ), (∀ i, 1 ≤ ‖z i‖) → ∀ c : ℂ,
       {ε : Fin n → ℤ | (∀ i, ε i = -1 ∨ ε i = 1) ∧

--- a/FormalConjectures/ErdosProblems/590.lean
+++ b/FormalConjectures/ErdosProblems/590.lean
@@ -36,7 +36,7 @@ universe u
 Let $α$ be the infinite ordinal $\omega^{\omega}$. It was proved by Chang [Ch72] that any red/blue
 colouring of the edges of $K_α$ there is either a red $K_α$ or a blue $K_3$.
 -/
-@[category research solved, AMS 3]
+@[category research solved, AMS 3, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos590.lean#L7928"]
 theorem erdos_590 : OrdinalCardinalRamsey (ω ^ ω) (ω ^ ω) 3 := by
   sorry
 

--- a/FormalConjectures/ErdosProblems/594.lean
+++ b/FormalConjectures/ErdosProblems/594.lean
@@ -48,7 +48,7 @@ if and only if it admits no proper colouring with countably many colours; this i
 encoded as `IsEmpty (G.Coloring ℕ)`. The conclusion states that there is some
 $N$ such that for every $k \geq N$ the graph contains a cycle of odd length $2k + 1$.
 -/
-@[category research solved, AMS 3 5]
+@[category research solved, AMS 3 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos594.lean#L907"]
 theorem erdos_594 : answer(True) ↔
     ∀ (V : Type) (G : SimpleGraph V), IsEmpty (G.Coloring ℕ) →
       ∃ N : ℕ, ∀ k : ℕ, N ≤ k →

--- a/FormalConjectures/ErdosProblems/613.lean
+++ b/FormalConjectures/ErdosProblems/613.lean
@@ -29,7 +29,7 @@ namespace Erdos613
 Let $n \geq 3$ and $G$ be a graph with $\binom{2n+1}{2} - \binom{n}{2} - 1$ edges.
 Must $G$ be the union of a bipartite graph and a graph with maximum degree less than $n$?
 -/
-@[category research solved, AMS 5]
+@[category research solved, AMS 5, formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos613.lean#L1170"]
 theorem erdos_613 :
     answer(False) ↔
       ∀ n ≥ 3, ∀ (V : Type*) [Fintype V] (G : SimpleGraph V), [DecidableRel G.Adj] →


### PR DESCRIPTION
Add 12 commit-pinned formal_proof links to verified proofs in plby/lean-proofs, including all three parts of problem 119 and both parts of problem 358. These links appear on the website and resolve the corresponding “solved” versus “formally solved” status mismatches.

- Fixes #5122 — Erdős Problem 119
- Fixes #5128 — Erdős Problem 253
- Fixes #5130 — Erdős Problem 277
- Fixes #5132 — Erdős Problem 358
- Fixes #5135 — Erdős Problem 480
- Fixes #4701 — Erdős Problem 498
- Fixes #5138 — Erdős Problem 590
- Fixes #5139 — Erdős Problem 594
- Fixes #4049 — Erdős Problem 613