### PR TITLE
fix(ErdosProblems/346): the golden-ratio limit fails for a lacunary counterexample

### DIFF
--- a/FormalConjectures/ErdosProblems/346.lean
+++ b/FormalConjectures/ErdosProblems/346.lean
@@ -32,9 +32,14 @@ open Filter Topology Set
 namespace Erdos346
 
 /-- Is it true that for every lacunary, strongly complete sequence `A` that is not complete whenever
-infinitely many terms are removed from it, `lim A (n + 1) / A n = (1 + √5) / 2`? -/
-@[category research open, AMS 11]
-theorem erdos_346 : answer(sorry) ↔ ∀ {A : ℕ → ℕ}, IsLacunary A → IsAddStronglyCompleteNatSeq A →
+infinitely many terms are removed from it, `lim A (n + 1) / A n = (1 + √5) / 2`?
+
+The answer is no. A counterexample recorded at [erdosproblems.com/346] has all successive ratios
+at least `6 / 5`, but has subsequences of successive ratios tending to two different limits,
+`(1 + √5) / 2` and `(1 + √5) / 2 + 1 / 4`.
+-/
+@[category research solved, AMS 11]
+theorem erdos_346 : answer(False) ↔ ∀ {A : ℕ → ℕ}, IsLacunary A → IsAddStronglyCompleteNatSeq A →
     (∀ B : Set ℕ, B ⊆ range A → B.Infinite → ¬ IsAddComplete (range A \ B)) →
     Tendsto (fun n => A (n + 1) / (A n : ℝ)) atTop (𝓝 ((1 + √5) / 2)) := by
   sorry


### PR DESCRIPTION
fixes [#5238](https://github.com/google-deepmind/formal-conjectures/issues/5238)

**What changed**

- `erdos_346` is `research solved` with `answer(False)`.
- The docstring records the counterexample.

**Why**

[erdosproblems.com/346](https://www.erdosproblems.com/346) records the problem as solved and states
the answer is negative: a sequence `A` with the required completeness properties was constructed
with `a_{n+1}/a_n ≥ 6/5` for all `n`, and an increasing sequence `N_j` with

```
a_{N_j}/a_{N_j-1} → φ        and        a_{N_j+1}/a_{N_j} → φ + 1/4
```

Two distinct subsequential limits means `a_{n+1}/a_n` does not converge, so the displayed limit
`(1+√5)/2` fails. The declaration is an `answer(sorry) ↔ ∀ …` question, so the counterexample gives
`answer(False)` directly.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
