### PR TITLE
fix(ErdosProblems/421): a density-one sequence with distinct products exists

### DIFF
--- a/FormalConjectures/ErdosProblems/421.lean
+++ b/FormalConjectures/ErdosProblems/421.lean
@@ -19,7 +19,9 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 421
 
-*Reference:* [erdosproblems.com/421](https://www.erdosproblems.com/421)
+*References:*
+- [erdosproblems.com/421](https://www.erdosproblems.com/421)
+- [Pr26] Pratt, Kyle, [*Erdős Problem 421*](https://www.erdosproblems.com/static/421-Pratt.pdf).
 -/
 
 open Set
@@ -28,9 +30,12 @@ namespace Erdos421
 
 /--
 Is there a sequence $1 \le d_1 < d_2 < \dots$ with density 1 such that all products
-$\prod_{u \le i \le v} d_i$ are distinct? -/
-@[category research open, AMS 11]
-theorem erdos_421 : answer(sorry) ↔
+$\prod_{u \le i \le v} d_i$ are distinct?
+
+The answer is yes; see Pratt's proof [Pr26].
+-/
+@[category research solved, AMS 11]
+theorem erdos_421 : answer(True) ↔
     ∃ (d : ℕ → ℕ), StrictMono d ∧ 1 ≤ d 0 ∧ HasDensity (Set.range d) 1 ∧
     {(u, v) : ℕ × ℕ | u ≤ v}.InjOn fun (u, v) => ∏ i ∈ Finset.Icc u v, d i := by
   sorry


### PR DESCRIPTION
fixes [#5379](https://github.com/google-deepmind/formal-conjectures/issues/5379)

**What changed**

- `erdos_421` is `research solved` with `answer(True)`.
- Pratt's write-up added to the references.

**Why**

[erdosproblems.com/421](https://www.erdosproblems.com/421) records the problem as solved and states
plainly: "The answer is yes." A density-one sequence all of whose consecutive products
`∏_{u ≤ i ≤ v} d_i` are distinct does exist.

The page notes the provenance is "a little messy" — an approach sketched by Tao, fleshed out by
Chojecki, with full proofs claimed independently by several people — and that a simplified proof
exists. A write-up by Kyle Pratt is hosted on the problem page and is cited here.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
