### PR TITLE
fix(ErdosProblems/633): the classification of triangles is known

### DIFF
--- a/FormalConjectures/ErdosProblems/633.lean
+++ b/FormalConjectures/ErdosProblems/633.lean
@@ -22,6 +22,8 @@ import FormalConjecturesUtil
 * [erdosproblems.com/633](https://www.erdosproblems.com/633)
 * [So09] Soifer, Alexander, How Does One Cut a Triangle? I
 * [So09c] Soifer, Alexander, Is there anything beyond the solution?
+* [BLZ26] Beeson, Michael, Laczkovich, Miklós, and Zhang, Yan,
+  [*Solution of Erdős problem 633*](https://arxiv.org/abs/2604.03609).
 -/
 
 open Affine
@@ -69,8 +71,16 @@ lemma isCuttable_iff_isSquare_of_linearIndependent
     IsCuttable n T ↔ n ≠ 0 ∧ IsSquare n := by
   exact ⟨fun hT ↦ ⟨hT.ne_zero, sorry⟩, fun hn ↦ .of_isSquare hn.1 hn.2⟩
 
-/-- Which triangles can only be decomposed into a square number of congruent triangles? -/
-@[category research open, AMS 5 51]
+-- The complete classification is too involved to encode as the answer set here.
+set_option linter.style.category_answer false in
+/--
+Which triangles can only be decomposed into a square number of congruent triangles?
+
+Beeson, Laczkovich, and Zhang [BLZ26] classify the triangles that can be tiled only into a square
+number of congruent triangles, settling this problem. The classification is too involved to encode
+in the answer slot here, so the answer is left as `sorry` and the reference records the result.
+-/
+@[category research solved, AMS 5 51]
 lemma erdos_633 : T ∈ (answer(sorry) : Set <| Triangle ℝ ℝ²) ↔
     ∀ n, IsCuttable n T → IsSquare n := sorry
 


### PR DESCRIPTION
**What changed**

- `erdos_633` is `research solved`, with the answer slot left as `sorry` and a localised
  `linter.style.category_answer` suppression.
- Beeson–Laczkovich–Zhang added to the references.

**Why**

[arXiv:2604.03609](https://arxiv.org/abs/2604.03609), *Solution of Erdős Problem 633* by Michael
Beeson, Miklós Laczkovich and Yan X. Zhang: "We classify triangles that can be tiled only into a
square number of congruent triangles, settling Erdős Problem 633."
[erdosproblems.com/633](https://www.erdosproblems.com/633) likewise records the problem as solved.

The answer here is a *set* of similarity classes of triangles, and the classification is too
involved to encode in the answer slot, so it is left as `sorry`. This follows the existing pattern
in the repository for solved problems whose answer resists a compact closed form — see
`ErdosProblems/416.lean`, `975.lean`, `1119.lean`, `1175.lean` and
`WrittenOnTheWallII/GraphConjecture34.lean`, which use the same localised suppression.

If you would rather keep this `research open` until someone encodes the classification, that is a
reasonable alternative and I am happy to close this.

*AI assistance: this was found by an OpenAI Codex agent during a repository-wide sweep of open declarations. The statement and the cited sources were then independently re-checked and verified with Claude Opus 5 before submission.*
