### PR TITLE
feat(Wikipedia): the isomorphism problem for Coxeter groups

### DIFF
--- a/FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean
+++ b/FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean
@@ -24,9 +24,8 @@ corresponding Coxeter groups are isomorphic?
 
 ## Main definitions
 
-* `FinCoxeterMatrix`: a Coxeter matrix of finite rank, `Σ n, CoxeterMatrix (Fin n)`.
-* `equivTable`: the bijection between `FinCoxeterMatrix` and Coxeter tables (`IsCoxeterTable`),
-  the lists of rows of Coxeter matrices. It gives `FinCoxeterMatrix` its `Primcodable` structure.
+* `ofTable L`: the Coxeter matrix presented by a list of rows `L : List (List ℕ)`. Every Coxeter
+  matrix of finite rank is presented by the list of its rows (`ofTable_surjective`).
 
 ## Main results
 
@@ -35,16 +34,14 @@ corresponding Coxeter groups are isomorphic?
 ## Implementation notes
 
 Decidability is expressed by `ComputablePred`, since classically every proposition is `Decidable`.
-This requires a `Primcodable` structure on `FinCoxeterMatrix`, obtained by encoding a Coxeter
-matrix by the list of its rows. Any encoding from which this list can be computed primitive
-recursively, and conversely, is primitive recursively isomorphic to this one, so the statement does
-not depend on this choice.
+The input therefore has to be a `Primcodable` type. Rather than encoding `Σ n, CoxeterMatrix (Fin n)`
+we take the input to be a list of rows `L : List (List ℕ)`, and read it as a Coxeter matrix of rank
+`L.length` by `ofTable`, which normalises the entries that would violate the axioms of a Coxeter
+matrix. Since `ofTable` is computable and surjective, and the list of rows of a Coxeter matrix is
+computable from it, deciding the predicate below is equivalent to deciding isomorphism of Coxeter
+groups from their Coxeter matrices, whichever reasonable encoding of the latter is chosen.
 
-Mathlib writes the entry $\infty$ of a Coxeter matrix as $0$. Restricting to matrices indexed by
-`Fin n` loses no generality, as reindexing does not change the isomorphism type of the Coxeter
-group (`CoxeterMatrix.reindexGroupEquiv`).
-
-## References
+Mathlib writes the entry $\infty$ of a Coxeter matrix as $0$.
 
 ## References
 
@@ -57,91 +54,35 @@ group (`CoxeterMatrix.reindexGroupEquiv`).
 
 namespace IsomorphismProblemOfCoxeterGroups
 
-open Primrec
+/-- The symmetrised $(i, j)$ entry of a table of natural numbers, missing entries counting
+as $0$. -/
+def entry (L : List (List ℕ)) (i j : ℕ) : ℕ :=
+  max ((L.getD i []).getD j 0) ((L.getD j []).getD i 0)
 
-/-- A Coxeter matrix of finite rank. -/
-abbrev FinCoxeterMatrix := Σ n : ℕ, CoxeterMatrix (Fin n)
+@[category API, AMS 20]
+theorem entry_comm (L : List (List ℕ)) (i j : ℕ) : entry L i j = entry L j i :=
+  max_comm _ _
 
-/- Bounded quantification is primitive recursive. -/
-@[category API, AMS 3]
-theorem foldr_decide_and {β : Type*} (p : β → Prop) [DecidablePred p] (l : List β) :
-    l.foldr (fun b s ↦ decide (p b ∧ s = true)) true = decide (∀ b ∈ l, p b) := by
-  induction l with
-  | nil => simp
-  | cons b l ih => rw [List.foldr_cons, ih]; simp
+/-- The Coxeter matrix of rank `L.length` presented by a list of rows `L`: its diagonal entries
+are $1$, and its off-diagonal entries are the symmetrised entries of `L`, with $1$ replaced
+by $0$. If `L` is the list of rows of a Coxeter matrix `M` then `ofTable L` is `M`, see
+`ofTable_surjective`. -/
+def ofTable (L : List (List ℕ)) : CoxeterMatrix (Fin L.length) where
+  M := Matrix.of fun i j ↦ if i = j then 1 else if entry L i j = 1 then 0 else entry L i j
+  isSymm := Matrix.IsSymm.ext fun i j ↦ by
+    rcases eq_or_ne i j with rfl | h
+    · rfl
+    · simp [h, h.symm, entry_comm L j i]
+  diagonal i := by simp
+  off_diagonal i j h h' := by
+    simp only [Matrix.of_apply, if_neg h] at h'
+    split_ifs at h' with hk
+    exact hk h'
 
-@[category API, AMS 3]
-theorem primrecPred_forall_mem_list {α β : Type*} [Primcodable α] [Primcodable β]
-    {f : α → List β} {R : α → β → Prop} [∀ a b, Decidable (R a b)]
-    (hf : Primrec f) (hR : PrimrecRel R) : PrimrecPred fun a ↦ ∀ b ∈ f a, R a b := by
-  obtain ⟨_, hR'⟩ := (hR.comp (α := α × β × Bool) fst (fst.comp snd)).and
-    (Primrec.eq.comp (snd.comp snd) (const true))
-  have hh : Primrec₂ fun (a : α) (p : β × Bool) ↦ decide (R a p.1 ∧ p.2 = true) := by
-    unfold Primrec₂
-    exact hR'.of_eq fun _ ↦ decide_eq_decide.mpr Iff.rfl
-  have h : Primrec fun a ↦ (f a).foldr (fun b s ↦ decide (R a b ∧ s = true)) true :=
-    list_foldr hf (const true) hh
-  exact ⟨inferInstance, h.of_eq fun a ↦
-    (foldr_decide_and (R a) (f a)).trans (decide_eq_decide.mpr Iff.rfl)⟩
-
-@[category API, AMS 3]
-theorem primrecPred_forall_lt {α : Type*} [Primcodable α] {f : α → ℕ} {R : α → ℕ → Prop}
-    [∀ a n, Decidable (R a n)] (hf : Primrec f) (hR : PrimrecRel R) :
-    PrimrecPred fun a ↦ ∀ n < f a, R a n :=
-  (primrecPred_forall_mem_list (list_range.comp hf) hR).of_eq fun _ ↦ by simp
-
-/- Coxeter tables. -/
-
-/-- The $(i, j)$ entry of a table of natural numbers, with default value $0$. -/
-def entry (L : List (List ℕ)) (i j : ℕ) : ℕ := (L.getD i []).getD j 0
-
-@[category API, AMS 3]
-theorem primrec_entry : Primrec fun p : List (List ℕ) × ℕ × ℕ ↦ entry p.1 p.2.1 p.2.2 :=
-  (list_getD 0).comp ((list_getD ([] : List ℕ)).comp fst (fst.comp snd)) (snd.comp snd)
-
-/-- A *Coxeter table* is a square symmetric table of natural numbers whose entries are equal to
-$1$ exactly on the diagonal. These are the lists of rows of Coxeter matrices of finite rank, see
-`equivTable`. -/
-def IsCoxeterTable (L : List (List ℕ)) : Prop :=
-  (∀ row ∈ L, row.length = L.length) ∧
-    ∀ i < L.length, ∀ j < L.length, entry L i j = entry L j i ∧ (i = j ↔ entry L i j = 1)
-
-instance : DecidablePred IsCoxeterTable := fun L ↦ by
-  unfold IsCoxeterTable
-  infer_instance
-
-@[category API, AMS 3]
-theorem primrecPred_isCoxeterTable : PrimrecPred IsCoxeterTable := by
-  have hsquare : PrimrecPred fun L : List (List ℕ) ↦ ∀ row ∈ L, row.length = L.length :=
-    primrecPred_forall_mem_list Primrec.id
-      (Primrec.eq.comp (list_length.comp snd) (list_length.comp fst))
-  have e₁ : Primrec fun r : (List (List ℕ) × ℕ) × ℕ ↦ entry r.1.1 r.1.2 r.2 :=
-    primrec_entry.comp ((fst.comp fst).pair ((snd.comp fst).pair snd))
-  have e₂ : Primrec fun r : (List (List ℕ) × ℕ) × ℕ ↦ entry r.1.1 r.2 r.1.2 :=
-    primrec_entry.comp ((fst.comp fst).pair (snd.pair (snd.comp fst)))
-  have hdiag : PrimrecPred fun r : (List (List ℕ) × ℕ) × ℕ ↦ r.1.2 = r.2 :=
-    Primrec.eq.comp (snd.comp fst) snd
-  have hone : PrimrecPred fun r : (List (List ℕ) × ℕ) × ℕ ↦ entry r.1.1 r.1.2 r.2 = 1 :=
-    Primrec.eq.comp e₁ (const 1)
-  have hbody : PrimrecRel fun (q : List (List ℕ) × ℕ) (j : ℕ) ↦
-      entry q.1 q.2 j = entry q.1 j q.2 ∧ (q.2 = j ↔ entry q.1 q.2 j = 1) :=
-    (Primrec.eq.comp e₁ e₂).and (((hdiag.and hone).or (hdiag.not.and hone.not)).of_eq
-      fun _ ↦ iff_iff_and_or_not_and_not.symm)
-  have hrow : PrimrecRel fun (L : List (List ℕ)) (i : ℕ) ↦ ∀ j < L.length,
-      entry L i j = entry L j i ∧ (i = j ↔ entry L i j = 1) :=
-    primrecPred_forall_lt (list_length.comp fst) hbody
-  exact hsquare.and (primrecPred_forall_lt list_length hrow)
-
-instance : Primcodable {L : List (List ℕ) // IsCoxeterTable L} :=
-  Primcodable.subtype primrecPred_isCoxeterTable
-
-
-/- Coxeter matrices of finite rank are in bijection with Coxeter tables. -/
-@[category API, AMS 3]
-theorem getD_ofFn {α : Type*} {n : ℕ} (g : Fin n → α) (d : α) (i : Fin n) :
-    (List.ofFn g).getD (i : ℕ) d = g i := by
-  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by simp), List.getElem_ofFn,
-    Option.getD_some]
+@[category API, AMS 20]
+theorem ofTable_apply (L : List (List ℕ)) (i j : Fin L.length) :
+    ofTable L i j = if i = j then 1 else if entry L i j = 1 then 0 else entry L i j :=
+  rfl
 
 /-- The list of rows of a Coxeter matrix of finite rank. -/
 def toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) : List (List ℕ) :=
@@ -152,79 +93,52 @@ theorem length_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) : (toTable M).lengt
   List.length_ofFn
 
 @[category API, AMS 20]
+theorem getD_ofFn {α : Type*} {n : ℕ} (g : Fin n → α) (d : α) (i : Fin n) :
+    (List.ofFn g).getD (i : ℕ) d = g i := by
+  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by simp), List.getElem_ofFn,
+    Option.getD_some]
+
+@[category API, AMS 20]
 theorem entry_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) (i j : Fin n) :
     entry (toTable M) i j = M i j := by
-  simp only [entry, toTable, getD_ofFn]
+  simp [entry, toTable, M.symmetric j i]
 
 @[category API, AMS 20]
-theorem isCoxeterTable_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) :
-    IsCoxeterTable (toTable M) := by
-  refine ⟨fun row hrow ↦ ?_, fun i hi j hj ↦ ?_⟩
-  · simp only [toTable, List.mem_ofFn] at hrow
-    obtain ⟨k, rfl⟩ := hrow
-    simp [length_toTable]
-  · rw [length_toTable] at hi hj
-    rw [entry_toTable M ⟨i, hi⟩ ⟨j, hj⟩, entry_toTable M ⟨j, hj⟩ ⟨i, hi⟩]
-    refine ⟨M.symmetric _ _, fun h ↦ ?_, fun h ↦ ?_⟩
-    · subst h
-      exact M.diagonal _
-    · by_contra h'
-      exact M.off_diagonal _ _ (fun e ↦ h' (congrArg Fin.val e)) h
-
-/-- The Coxeter matrix whose list of rows is a given Coxeter table. -/
-def ofTable (L : List (List ℕ)) (hL : IsCoxeterTable L) : CoxeterMatrix (Fin L.length) where
-  M := Matrix.of fun i j ↦ entry L i j
-  isSymm := Matrix.IsSymm.ext fun i j ↦ (hL.2 j j.2 i i.2).1
-  diagonal i := (hL.2 i i.2 i i.2).2.mp rfl
-  off_diagonal i j h h' := h (Fin.ext ((hL.2 i i.2 j j.2).2.mpr h'))
-
-@[category API, AMS 20]
-theorem entry_ofTable (L : List (List ℕ)) (hL : IsCoxeterTable L) (i j : Fin L.length) :
-    ofTable L hL i j = entry L i j :=
-  rfl
-
-@[category API, AMS 20]
-theorem FinCoxeterMatrix.ext {m n : ℕ} (h : m = n) (X : CoxeterMatrix (Fin m))
-    (Y : CoxeterMatrix (Fin n)) (hXY : ∀ i j : Fin m, X i j = Y (Fin.cast h i) (Fin.cast h j)) :
-    (⟨m, X⟩ : FinCoxeterMatrix) = ⟨n, Y⟩ := by
+theorem sigma_mk_eq {m n : ℕ} (h : m = n) (X : CoxeterMatrix (Fin m)) (Y : CoxeterMatrix (Fin n))
+    (hXY : ∀ i j : Fin m, X i j = Y (Fin.cast h i) (Fin.cast h j)) :
+    (⟨m, X⟩ : Σ n, CoxeterMatrix (Fin n)) = ⟨n, Y⟩ := by
   subst h
   obtain ⟨X, _, _, _⟩ := X
   obtain ⟨Y, _, _, _⟩ := Y
   obtain rfl : X = Y := Matrix.ext fun i j ↦ hXY i j
   rfl
 
-/-- Coxeter matrices of finite rank are in bijection with Coxeter tables. -/
-def equivTable : FinCoxeterMatrix ≃ {L : List (List ℕ) // IsCoxeterTable L} where
-  toFun M := ⟨toTable M.2, isCoxeterTable_toTable M.2⟩
-  invFun L := ⟨L.1.length, ofTable L.1 L.2⟩
-  left_inv := by
-    rintro ⟨n, M⟩
-    exact FinCoxeterMatrix.ext (length_toTable M) _ _ fun i j ↦
-      entry_toTable M (Fin.cast (length_toTable M) i) (Fin.cast (length_toTable M) j)
-  right_inv := by
-    rintro ⟨L, hL⟩
-    refine Subtype.ext (List.ext_getElem (length_toTable _) fun i _ hi ↦ ?_)
-    replace hi : i < L.length := hi
-    have hrow : L[i].length = L.length := hL.1 _ (List.getElem_mem hi)
-    refine List.ext_getElem (by simp [toTable, hrow]) fun j _ hj ↦ ?_
-    replace hj : j < L[i].length := hj
-    simp [toTable, entry_ofTable, entry, List.getD_eq_getElem?_getD, hj]
-
-/-- A Coxeter matrix of finite rank is encoded by the list of its rows. -/
-instance : Primcodable FinCoxeterMatrix := Primcodable.ofEquiv _ equivTable
+/-- Every Coxeter matrix of finite rank is presented by a list of rows. -/
+@[category API, AMS 20]
+theorem ofTable_surjective :
+    Function.Surjective fun L : List (List ℕ) ↦ (⟨L.length, ofTable L⟩ : Σ n, CoxeterMatrix (Fin n)) := by
+  rintro ⟨n, M⟩
+  refine ⟨toTable M, sigma_mk_eq (length_toTable M) _ _ fun i j ↦ ?_⟩
+  rw [ofTable_apply]
+  rcases eq_or_ne i j with rfl | hij
+  · rw [if_pos rfl, M.diagonal]
+  · have hne : Fin.cast (length_toTable M) i ≠ Fin.cast (length_toTable M) j := by
+      simpa [Fin.ext_iff] using hij
+    have h₁ := entry_toTable M (Fin.cast (length_toTable M) i) (Fin.cast (length_toTable M) j)
+    simp only [Fin.val_cast] at h₁
+    rw [if_neg hij, h₁, if_neg (M.off_diagonal _ _ hne)]
 
 /--
 **The isomorphism problem for Coxeter groups.** Is there an algorithm which, given two Coxeter
 matrices $M$ and $M'$ of finite rank, decides whether the Coxeter groups $W(M)$ and $W(M')$ are
 isomorphic?
 
-Equivalently, is it decidable whether $W(M)$ has a subset $S$ such that $(W(M), S)$ is a Coxeter
-system of type $M'$?
+Coxeter matrices are given as lists of rows, see `ofTable` and `ofTable_surjective`.
 -/
 @[category research open, AMS 3 20]
 theorem isomorphism_problem_of_coxeter_groups :
-    answer(sorry) ↔ ComputablePred fun p : FinCoxeterMatrix × FinCoxeterMatrix ↦
-      Nonempty (p.1.2.Group ≃* p.2.2.Group) := by
+    answer(sorry) ↔ ComputablePred fun p : List (List ℕ) × List (List ℕ) ↦
+      Nonempty ((ofTable p.1).Group ≃* (ofTable p.2).Group) := by
   sorry
 
 end IsomorphismProblemOfCoxeterGroups

--- a/FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean
+++ b/FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean
@@ -1,0 +1,230 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The isomorphism problem for Coxeter groups
+
+Is there an algorithm which, given two Coxeter matrices of finite rank, decides whether the
+corresponding Coxeter groups are isomorphic?
+
+## Main definitions
+
+* `FinCoxeterMatrix`: a Coxeter matrix of finite rank, `Σ n, CoxeterMatrix (Fin n)`.
+* `equivTable`: the bijection between `FinCoxeterMatrix` and Coxeter tables (`IsCoxeterTable`),
+  the lists of rows of Coxeter matrices. It gives `FinCoxeterMatrix` its `Primcodable` structure.
+
+## Main results
+
+* `isomorphism_problem_of_coxeter_groups`: the isomorphism problem for Coxeter groups.
+
+## Implementation notes
+
+Decidability is expressed by `ComputablePred`, since classically every proposition is `Decidable`.
+This requires a `Primcodable` structure on `FinCoxeterMatrix`, obtained by encoding a Coxeter
+matrix by the list of its rows. Any encoding from which this list can be computed primitive
+recursively, and conversely, is primitive recursively isomorphic to this one, so the statement does
+not depend on this choice.
+
+Mathlib writes the entry $\infty$ of a Coxeter matrix as $0$. Restricting to matrices indexed by
+`Fin n` loses no generality, as reindexing does not change the isomorphism type of the Coxeter
+group (`CoxeterMatrix.reindexGroupEquiv`).
+
+## References
+
+## References
+
+* [B. Mühlherr, *The isomorphism problem for Coxeter groups*](https://doi.org/10.48550/arXiv.math/0506572),
+  Problem 1.
+* [Y. Santos Rego, P. Schwer, *The galaxy of Coxeter groups*](https://doi.org/10.1016/j.jalgebra.2023.12.006),
+  Section 3.2.
+* [Wikipedia, *Isomorphism problem of Coxeter groups*](https://en.wikipedia.org/wiki/Isomorphism_problem_of_Coxeter_groups)
+-/
+
+namespace IsomorphismProblemOfCoxeterGroups
+
+open Primrec
+
+/-- A Coxeter matrix of finite rank. -/
+abbrev FinCoxeterMatrix := Σ n : ℕ, CoxeterMatrix (Fin n)
+
+/- Bounded quantification is primitive recursive. -/
+@[category API, AMS 3]
+theorem foldr_decide_and {β : Type*} (p : β → Prop) [DecidablePred p] (l : List β) :
+    l.foldr (fun b s ↦ decide (p b ∧ s = true)) true = decide (∀ b ∈ l, p b) := by
+  induction l with
+  | nil => simp
+  | cons b l ih => rw [List.foldr_cons, ih]; simp
+
+@[category API, AMS 3]
+theorem primrecPred_forall_mem_list {α β : Type*} [Primcodable α] [Primcodable β]
+    {f : α → List β} {R : α → β → Prop} [∀ a b, Decidable (R a b)]
+    (hf : Primrec f) (hR : PrimrecRel R) : PrimrecPred fun a ↦ ∀ b ∈ f a, R a b := by
+  obtain ⟨_, hR'⟩ := (hR.comp (α := α × β × Bool) fst (fst.comp snd)).and
+    (Primrec.eq.comp (snd.comp snd) (const true))
+  have hh : Primrec₂ fun (a : α) (p : β × Bool) ↦ decide (R a p.1 ∧ p.2 = true) := by
+    unfold Primrec₂
+    exact hR'.of_eq fun _ ↦ decide_eq_decide.mpr Iff.rfl
+  have h : Primrec fun a ↦ (f a).foldr (fun b s ↦ decide (R a b ∧ s = true)) true :=
+    list_foldr hf (const true) hh
+  exact ⟨inferInstance, h.of_eq fun a ↦
+    (foldr_decide_and (R a) (f a)).trans (decide_eq_decide.mpr Iff.rfl)⟩
+
+@[category API, AMS 3]
+theorem primrecPred_forall_lt {α : Type*} [Primcodable α] {f : α → ℕ} {R : α → ℕ → Prop}
+    [∀ a n, Decidable (R a n)] (hf : Primrec f) (hR : PrimrecRel R) :
+    PrimrecPred fun a ↦ ∀ n < f a, R a n :=
+  (primrecPred_forall_mem_list (list_range.comp hf) hR).of_eq fun _ ↦ by simp
+
+/- Coxeter tables. -/
+
+/-- The $(i, j)$ entry of a table of natural numbers, with default value $0$. -/
+def entry (L : List (List ℕ)) (i j : ℕ) : ℕ := (L.getD i []).getD j 0
+
+@[category API, AMS 3]
+theorem primrec_entry : Primrec fun p : List (List ℕ) × ℕ × ℕ ↦ entry p.1 p.2.1 p.2.2 :=
+  (list_getD 0).comp ((list_getD ([] : List ℕ)).comp fst (fst.comp snd)) (snd.comp snd)
+
+/-- A *Coxeter table* is a square symmetric table of natural numbers whose entries are equal to
+$1$ exactly on the diagonal. These are the lists of rows of Coxeter matrices of finite rank, see
+`equivTable`. -/
+def IsCoxeterTable (L : List (List ℕ)) : Prop :=
+  (∀ row ∈ L, row.length = L.length) ∧
+    ∀ i < L.length, ∀ j < L.length, entry L i j = entry L j i ∧ (i = j ↔ entry L i j = 1)
+
+instance : DecidablePred IsCoxeterTable := fun L ↦ by
+  unfold IsCoxeterTable
+  infer_instance
+
+@[category API, AMS 3]
+theorem primrecPred_isCoxeterTable : PrimrecPred IsCoxeterTable := by
+  have hsquare : PrimrecPred fun L : List (List ℕ) ↦ ∀ row ∈ L, row.length = L.length :=
+    primrecPred_forall_mem_list Primrec.id
+      (Primrec.eq.comp (list_length.comp snd) (list_length.comp fst))
+  have e₁ : Primrec fun r : (List (List ℕ) × ℕ) × ℕ ↦ entry r.1.1 r.1.2 r.2 :=
+    primrec_entry.comp ((fst.comp fst).pair ((snd.comp fst).pair snd))
+  have e₂ : Primrec fun r : (List (List ℕ) × ℕ) × ℕ ↦ entry r.1.1 r.2 r.1.2 :=
+    primrec_entry.comp ((fst.comp fst).pair (snd.pair (snd.comp fst)))
+  have hdiag : PrimrecPred fun r : (List (List ℕ) × ℕ) × ℕ ↦ r.1.2 = r.2 :=
+    Primrec.eq.comp (snd.comp fst) snd
+  have hone : PrimrecPred fun r : (List (List ℕ) × ℕ) × ℕ ↦ entry r.1.1 r.1.2 r.2 = 1 :=
+    Primrec.eq.comp e₁ (const 1)
+  have hbody : PrimrecRel fun (q : List (List ℕ) × ℕ) (j : ℕ) ↦
+      entry q.1 q.2 j = entry q.1 j q.2 ∧ (q.2 = j ↔ entry q.1 q.2 j = 1) :=
+    (Primrec.eq.comp e₁ e₂).and (((hdiag.and hone).or (hdiag.not.and hone.not)).of_eq
+      fun _ ↦ iff_iff_and_or_not_and_not.symm)
+  have hrow : PrimrecRel fun (L : List (List ℕ)) (i : ℕ) ↦ ∀ j < L.length,
+      entry L i j = entry L j i ∧ (i = j ↔ entry L i j = 1) :=
+    primrecPred_forall_lt (list_length.comp fst) hbody
+  exact hsquare.and (primrecPred_forall_lt list_length hrow)
+
+instance : Primcodable {L : List (List ℕ) // IsCoxeterTable L} :=
+  Primcodable.subtype primrecPred_isCoxeterTable
+
+
+/- Coxeter matrices of finite rank are in bijection with Coxeter tables. -/
+@[category API, AMS 3]
+theorem getD_ofFn {α : Type*} {n : ℕ} (g : Fin n → α) (d : α) (i : Fin n) :
+    (List.ofFn g).getD (i : ℕ) d = g i := by
+  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by simp), List.getElem_ofFn,
+    Option.getD_some]
+
+/-- The list of rows of a Coxeter matrix of finite rank. -/
+def toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) : List (List ℕ) :=
+  List.ofFn fun i ↦ List.ofFn fun j ↦ M i j
+
+@[category API, AMS 20]
+theorem length_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) : (toTable M).length = n :=
+  List.length_ofFn
+
+@[category API, AMS 20]
+theorem entry_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) (i j : Fin n) :
+    entry (toTable M) i j = M i j := by
+  simp only [entry, toTable, getD_ofFn]
+
+@[category API, AMS 20]
+theorem isCoxeterTable_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) :
+    IsCoxeterTable (toTable M) := by
+  refine ⟨fun row hrow ↦ ?_, fun i hi j hj ↦ ?_⟩
+  · simp only [toTable, List.mem_ofFn] at hrow
+    obtain ⟨k, rfl⟩ := hrow
+    simp [length_toTable]
+  · rw [length_toTable] at hi hj
+    rw [entry_toTable M ⟨i, hi⟩ ⟨j, hj⟩, entry_toTable M ⟨j, hj⟩ ⟨i, hi⟩]
+    refine ⟨M.symmetric _ _, fun h ↦ ?_, fun h ↦ ?_⟩
+    · subst h
+      exact M.diagonal _
+    · by_contra h'
+      exact M.off_diagonal _ _ (fun e ↦ h' (congrArg Fin.val e)) h
+
+/-- The Coxeter matrix whose list of rows is a given Coxeter table. -/
+def ofTable (L : List (List ℕ)) (hL : IsCoxeterTable L) : CoxeterMatrix (Fin L.length) where
+  M := Matrix.of fun i j ↦ entry L i j
+  isSymm := Matrix.IsSymm.ext fun i j ↦ (hL.2 j j.2 i i.2).1
+  diagonal i := (hL.2 i i.2 i i.2).2.mp rfl
+  off_diagonal i j h h' := h (Fin.ext ((hL.2 i i.2 j j.2).2.mpr h'))
+
+@[category API, AMS 20]
+theorem entry_ofTable (L : List (List ℕ)) (hL : IsCoxeterTable L) (i j : Fin L.length) :
+    ofTable L hL i j = entry L i j :=
+  rfl
+
+@[category API, AMS 20]
+theorem FinCoxeterMatrix.ext {m n : ℕ} (h : m = n) (X : CoxeterMatrix (Fin m))
+    (Y : CoxeterMatrix (Fin n)) (hXY : ∀ i j : Fin m, X i j = Y (Fin.cast h i) (Fin.cast h j)) :
+    (⟨m, X⟩ : FinCoxeterMatrix) = ⟨n, Y⟩ := by
+  subst h
+  obtain ⟨X, _, _, _⟩ := X
+  obtain ⟨Y, _, _, _⟩ := Y
+  obtain rfl : X = Y := Matrix.ext fun i j ↦ hXY i j
+  rfl
+
+/-- Coxeter matrices of finite rank are in bijection with Coxeter tables. -/
+def equivTable : FinCoxeterMatrix ≃ {L : List (List ℕ) // IsCoxeterTable L} where
+  toFun M := ⟨toTable M.2, isCoxeterTable_toTable M.2⟩
+  invFun L := ⟨L.1.length, ofTable L.1 L.2⟩
+  left_inv := by
+    rintro ⟨n, M⟩
+    exact FinCoxeterMatrix.ext (length_toTable M) _ _ fun i j ↦
+      entry_toTable M (Fin.cast (length_toTable M) i) (Fin.cast (length_toTable M) j)
+  right_inv := by
+    rintro ⟨L, hL⟩
+    refine Subtype.ext (List.ext_getElem (length_toTable _) fun i _ hi ↦ ?_)
+    replace hi : i < L.length := hi
+    have hrow : L[i].length = L.length := hL.1 _ (List.getElem_mem hi)
+    refine List.ext_getElem (by simp [toTable, hrow]) fun j _ hj ↦ ?_
+    replace hj : j < L[i].length := hj
+    simp [toTable, entry_ofTable, entry, List.getD_eq_getElem?_getD, hj]
+
+/-- A Coxeter matrix of finite rank is encoded by the list of its rows. -/
+instance : Primcodable FinCoxeterMatrix := Primcodable.ofEquiv _ equivTable
+
+/--
+**The isomorphism problem for Coxeter groups.** Is there an algorithm which, given two Coxeter
+matrices $M$ and $M'$ of finite rank, decides whether the Coxeter groups $W(M)$ and $W(M')$ are
+isomorphic?
+
+Equivalently, is it decidable whether $W(M)$ has a subset $S$ such that $(W(M), S)$ is a Coxeter
+system of type $M'$?
+-/
+@[category research open, AMS 3 20]
+theorem isomorphism_problem_of_coxeter_groups :
+    answer(sorry) ↔ ComputablePred fun p : FinCoxeterMatrix × FinCoxeterMatrix ↦
+      Nonempty (p.1.2.Group ≃* p.2.2.Group) := by
+  sorry
+
+end IsomorphismProblemOfCoxeterGroups

--- a/FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean
+++ b/FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean
@@ -24,8 +24,9 @@ corresponding Coxeter groups are isomorphic?
 
 ## Main definitions
 
-* `ofTable L`: the Coxeter matrix presented by a list of rows `L : List (List ℕ)`. Every Coxeter
-  matrix of finite rank is presented by the list of its rows (`ofTable_surjective`).
+* `ofTable L`: the Coxeter matrix presented by a list of rows `L : List (List ℕ)`.
+* `toTable M`: the list of rows of a Coxeter matrix `M` of finite rank. It presents `M`, see
+  `ofTable_toTable`.
 
 ## Main results
 
@@ -33,13 +34,14 @@ corresponding Coxeter groups are isomorphic?
 
 ## Implementation notes
 
-Decidability is expressed by `ComputablePred`, since classically every proposition is `Decidable`.
-The input therefore has to be a `Primcodable` type. Rather than encoding `Σ n, CoxeterMatrix (Fin n)`
-we take the input to be a list of rows `L : List (List ℕ)`, and read it as a Coxeter matrix of rank
-`L.length` by `ofTable`, which normalises the entries that would violate the axioms of a Coxeter
-matrix. Since `ofTable` is computable and surjective, and the list of rows of a Coxeter matrix is
-computable from it, deciding the predicate below is equivalent to deciding isomorphism of Coxeter
-groups from their Coxeter matrices, whichever reasonable encoding of the latter is chosen.
+Decidability is expressed by `ComputablePred`, since classically every proposition is
+`Decidable`. The input therefore has to be a `Primcodable` type. Rather than encoding
+`Σ n, CoxeterMatrix (Fin n)`, we take the input to be a list of rows `L : List (List ℕ)` and
+read it as a Coxeter matrix of rank `L.length` by `ofTable`, which normalises the entries that
+would violate the axioms of a Coxeter matrix. Since `ofTable` is computable and surjective
+(`ofTable_surjective`) and `toTable` computes the rows of a Coxeter matrix back, deciding the
+predicate below is equivalent to deciding isomorphism of Coxeter groups from their Coxeter
+matrices, whichever reasonable encoding of the latter is chosen.
 
 Mathlib writes the entry $\infty$ of a Coxeter matrix as $0$.
 
@@ -54,56 +56,57 @@ Mathlib writes the entry $\infty$ of a Coxeter matrix as $0$.
 
 namespace IsomorphismProblemOfCoxeterGroups
 
+@[category API, AMS 5]
+theorem getD_ofFn {α : Type*} {n : ℕ} (g : Fin n → α) (d : α) (i : Fin n) :
+    (List.ofFn g).getD (i : ℕ) d = g i := by
+  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by simp), List.getElem_ofFn,
+    Option.getD_some]
+
 /-- The symmetrised $(i, j)$ entry of a table of natural numbers, missing entries counting
 as $0$. -/
-def entry (L : List (List ℕ)) (i j : ℕ) : ℕ :=
+def tableEntry (L : List (List ℕ)) (i j : ℕ) : ℕ :=
   max ((L.getD i []).getD j 0) ((L.getD j []).getD i 0)
 
-@[category API, AMS 20]
-theorem entry_comm (L : List (List ℕ)) (i j : ℕ) : entry L i j = entry L j i :=
+@[category API, AMS 5]
+theorem tableEntry_comm (L : List (List ℕ)) (i j : ℕ) : tableEntry L i j = tableEntry L j i :=
   max_comm _ _
 
 /-- The Coxeter matrix of rank `L.length` presented by a list of rows `L`: its diagonal entries
 are $1$, and its off-diagonal entries are the symmetrised entries of `L`, with $1$ replaced
-by $0$. If `L` is the list of rows of a Coxeter matrix `M` then `ofTable L` is `M`, see
-`ofTable_surjective`. -/
+by $0$. -/
 def ofTable (L : List (List ℕ)) : CoxeterMatrix (Fin L.length) where
-  M := Matrix.of fun i j ↦ if i = j then 1 else if entry L i j = 1 then 0 else entry L i j
+  M := Matrix.of fun i j ↦
+    if i = j then 1 else if tableEntry L i j = 1 then 0 else tableEntry L i j
   isSymm := Matrix.IsSymm.ext fun i j ↦ by
     rcases eq_or_ne i j with rfl | h
     · rfl
-    · simp [h, h.symm, entry_comm L j i]
+    · simp [h, h.symm, tableEntry_comm L j i]
   diagonal i := by simp
   off_diagonal i j h h' := by
     simp only [Matrix.of_apply, if_neg h] at h'
     split_ifs at h' with hk
     exact hk h'
 
-@[category API, AMS 20]
+@[simp, category API, AMS 20]
 theorem ofTable_apply (L : List (List ℕ)) (i j : Fin L.length) :
-    ofTable L i j = if i = j then 1 else if entry L i j = 1 then 0 else entry L i j :=
+    ofTable L i j =
+      if i = j then 1 else if tableEntry L i j = 1 then 0 else tableEntry L i j :=
   rfl
 
 /-- The list of rows of a Coxeter matrix of finite rank. -/
 def toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) : List (List ℕ) :=
   List.ofFn fun i ↦ List.ofFn fun j ↦ M i j
 
-@[category API, AMS 20]
+@[simp, category API, AMS 20]
 theorem length_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) : (toTable M).length = n :=
   List.length_ofFn
 
-@[category API, AMS 20]
-theorem getD_ofFn {α : Type*} {n : ℕ} (g : Fin n → α) (d : α) (i : Fin n) :
-    (List.ofFn g).getD (i : ℕ) d = g i := by
-  rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by simp), List.getElem_ofFn,
-    Option.getD_some]
+@[simp, category API, AMS 20]
+theorem tableEntry_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) (i j : Fin n) :
+    tableEntry (toTable M) i j = M i j := by
+  simp only [tableEntry, toTable, getD_ofFn, M.symmetric j i, max_self]
 
-@[category API, AMS 20]
-theorem entry_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) (i j : Fin n) :
-    entry (toTable M) i j = M i j := by
-  simp [entry, toTable, M.symmetric j i]
-
-@[category API, AMS 20]
+@[category API, AMS 5]
 theorem sigma_mk_eq {m n : ℕ} (h : m = n) (X : CoxeterMatrix (Fin m)) (Y : CoxeterMatrix (Fin n))
     (hXY : ∀ i j : Fin m, X i j = Y (Fin.cast h i) (Fin.cast h j)) :
     (⟨m, X⟩ : Σ n, CoxeterMatrix (Fin n)) = ⟨n, Y⟩ := by
@@ -113,20 +116,26 @@ theorem sigma_mk_eq {m n : ℕ} (h : m = n) (X : CoxeterMatrix (Fin m)) (Y : Cox
   obtain rfl : X = Y := Matrix.ext fun i j ↦ hXY i j
   rfl
 
-/-- Every Coxeter matrix of finite rank is presented by a list of rows. -/
+/-- The list of rows of a Coxeter matrix of finite rank presents that matrix. -/
 @[category API, AMS 20]
-theorem ofTable_surjective :
-    Function.Surjective fun L : List (List ℕ) ↦ (⟨L.length, ofTable L⟩ : Σ n, CoxeterMatrix (Fin n)) := by
-  rintro ⟨n, M⟩
-  refine ⟨toTable M, sigma_mk_eq (length_toTable M) _ _ fun i j ↦ ?_⟩
+theorem ofTable_toTable {n : ℕ} (M : CoxeterMatrix (Fin n)) :
+    (⟨(toTable M).length, ofTable (toTable M)⟩ : Σ n, CoxeterMatrix (Fin n)) = ⟨n, M⟩ := by
+  refine sigma_mk_eq (length_toTable M) _ _ fun i j ↦ ?_
   rw [ofTable_apply]
   rcases eq_or_ne i j with rfl | hij
   · rw [if_pos rfl, M.diagonal]
   · have hne : Fin.cast (length_toTable M) i ≠ Fin.cast (length_toTable M) j := by
       simpa [Fin.ext_iff] using hij
-    have h₁ := entry_toTable M (Fin.cast (length_toTable M) i) (Fin.cast (length_toTable M) j)
+    have h₁ :=
+      tableEntry_toTable M (Fin.cast (length_toTable M) i) (Fin.cast (length_toTable M) j)
     simp only [Fin.val_cast] at h₁
     rw [if_neg hij, h₁, if_neg (M.off_diagonal _ _ hne)]
+
+/-- Every Coxeter matrix of finite rank is presented by a list of rows. -/
+@[category API, AMS 20]
+theorem ofTable_surjective : Function.Surjective
+    fun L : List (List ℕ) ↦ (⟨L.length, ofTable L⟩ : Σ n, CoxeterMatrix (Fin n)) :=
+  fun ⟨_, M⟩ ↦ ⟨toTable M, ofTable_toTable M⟩
 
 /--
 **The isomorphism problem for Coxeter groups.** Is there an algorithm which, given two Coxeter


### PR DESCRIPTION
Adds `FormalConjectures/Wikipedia/IsomorphismProblemOfCoxeterGroups.lean`.

> Is there an algorithm deciding whether two Coxeter groups of finite rank are isomorphic as abstract groups?

Stating this with `ComputablePred` requires a `Primcodable` input type, which `Σ n, CoxeterMatrix (Fin n)` is not. The predicate therefore takes a pair of Coxeter matrices written out as lists of rows, and `ofTable` reads a list of rows back as a Coxeter matrix. `ofTable` accepts any list, patching entries that would break the Coxeter axioms, so no validity subtype is needed. It is computable and hits every finite-rank Coxeter matrix (`ofTable_surjective`), and `toTable` computes the rows back (`ofTable_toTable`), so deciding this predicate is the same problem as deciding isomorphism from the matrices themselves.

Inspired by https://tadamcz.com/autoformalization-results/#/p/wp-isomorphism-problem-of-coxeter-groups?q=isom

I now realised that this PR was open #2175 doing the same thing.