### PR TITLE
fix(ErdosProblems/1): the distinct subset sums conjecture is false

### DIFF
--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -41,9 +41,13 @@ distinct for all $S\subseteq A$ then
 $$
   N \gg 2 ^ n.
 $$
+
+This conjecture is false. A machine-checked disproof constructs sum-distinct sets for which
+$N / 2^n$ tends to zero.
 -/
-@[category research open, AMS 5 11]
-theorem erdos_1 : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ) (_ : IsSumDistinctSet A N),
+@[category research solved, AMS 5 11, formal_proof using lean4 at
+  "https://github.com/tadamcz/erdos1/blob/0e395153306f34b3829d118b85bdd704136f2843/Erdos1/Resolutions/Erdos1_219usd_38h.lean#L2419"]
+theorem erdos_1 : ¬ ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ) (_ : IsSumDistinctSet A N),
     N ≠ 0 → C * 2 ^ A.card < N := by
   sorry
 
@@ -107,14 +111,107 @@ abbrev IsSumDistinctRealSet (A : Finset ℝ) (N : ℕ) : Prop :=
 A generalisation of the problem to sets $A \subseteq (0, N]$ of real numbers, such that the subset
 sums all differ by at least $1$ is proposed in [Er73] and [ErGr80].
 
+The positive statement is false: every natural-number counterexample to `erdos_1` embeds into
+`ℝ`, and distinct integer subset sums differ by at least one.
+
 [Er73] Erdős, P., _Problems and results on combinatorial number theory_. A survey of combinatorial theory (Proc. Internat. Sympos., Colorado State Univ., Fort Collins, Colo., 1971) (1973), 117-138.
 
 [ErGr80] Erdős, P. and Graham, R., _Old and new problems and results in combinatorial number theory_. Monographies de L'Enseignement Mathematique (1980).
 -/
-@[category research open, AMS 5 11]
-theorem erdos_1.variants.real : ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℝ)
+@[category research solved, AMS 5 11]
+theorem erdos_1.variants.real : ¬ ∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℝ)
     (_ : IsSumDistinctRealSet A N), N ≠ 0 → C * 2 ^ A.card < N := by
-  sorry
+  intro hreal
+  apply erdos_1
+  rcases hreal with ⟨C, hC, hreal⟩
+  refine ⟨C, hC, ?_⟩
+  intro N A hA hN
+  let e : ℕ ↪ ℝ := ⟨fun n => (n : ℝ), Nat.cast_injective⟩
+  let B : Finset ℝ := A.map e
+  have hB : IsSumDistinctRealSet B N := by
+    constructor
+    · intro x hx
+      change x ∈ B at hx
+      simp only [B, Finset.mem_map] at hx
+      rcases hx with ⟨n, hn, rfl⟩
+      have hnIcc := hA.1 hn
+      simp only [Finset.mem_Icc] at hnIcc
+      change (0 : ℝ) < (n : ℝ) ∧ (n : ℝ) ≤ (N : ℝ)
+      exact ⟨by exact_mod_cast hnIcc.1, by exact_mod_cast hnIcc.2⟩
+    · intro S₁ hS₁ S₂ hS₂ hne
+      change S₁ ∈ B.powerset at hS₁
+      change S₂ ∈ B.powerset at hS₂
+      have hS₁' : S₁ ⊆ B := Finset.mem_powerset.mp hS₁
+      have hS₂' : S₂ ⊆ B := Finset.mem_powerset.mp hS₂
+      let T₁ := S₁.preimage e (Set.injOn_of_injective e.injective)
+      let T₂ := S₂.preimage e (Set.injOn_of_injective e.injective)
+      have hm₁ : T₁.map e = S₁ := by
+        ext x
+        simp only [Finset.mem_map]
+        constructor
+        · rintro ⟨n, hn, rfl⟩
+          exact Finset.mem_preimage.mp hn
+        · intro hx
+          have hxB := hS₁' hx
+          simp only [B, Finset.mem_map] at hxB
+          rcases hxB with ⟨n, hn, rfl⟩
+          exact ⟨n, Finset.mem_preimage.mpr hx, rfl⟩
+      have hm₂ : T₂.map e = S₂ := by
+        ext x
+        simp only [Finset.mem_map]
+        constructor
+        · rintro ⟨n, hn, rfl⟩
+          exact Finset.mem_preimage.mp hn
+        · intro hx
+          have hxB := hS₂' hx
+          simp only [B, Finset.mem_map] at hxB
+          rcases hxB with ⟨n, hn, rfl⟩
+          exact ⟨n, Finset.mem_preimage.mpr hx, rfl⟩
+      have hT₁A : T₁ ⊆ A := by
+        intro n hn
+        have : e n ∈ S₁ := by
+          rw [← hm₁]
+          exact Finset.mem_map.mpr ⟨n, hn, rfl⟩
+        exact hS₁' this |> fun h => by simpa [B] using h
+      have hT₂A : T₂ ⊆ A := by
+        intro n hn
+        have : e n ∈ S₂ := by
+          rw [← hm₂]
+          exact Finset.mem_map.mpr ⟨n, hn, rfl⟩
+        exact hS₂' this |> fun h => by simpa [B] using h
+      have hTne : T₁ ≠ T₂ := by
+        intro heq
+        apply hne
+        rw [← hm₁, ← hm₂, heq]
+      have hsumne : T₁.sum id ≠ T₂.sum id := by
+        intro hsum
+        apply hTne
+        have hsubeq :
+            (⟨T₁, Finset.mem_powerset.mpr hT₁A⟩ : A.powerset) =
+              ⟨T₂, Finset.mem_powerset.mpr hT₂A⟩ := hA.2 hsum
+        exact congrArg Subtype.val hsubeq
+      rw [← hm₁, ← hm₂, Finset.sum_map, Finset.sum_map]
+      simp only [e, Function.Embedding.coeFn_mk, id_eq]
+      have hs₁ : (∑ n ∈ T₁, (n : ℝ)) = ((T₁.sum id : ℕ) : ℝ) := by
+        rw [Nat.cast_sum]
+        rfl
+      have hs₂ : (∑ n ∈ T₂, (n : ℝ)) = ((T₂.sum id : ℕ) : ℝ) := by
+        rw [Nat.cast_sum]
+        rfl
+      rw [hs₁, hs₂, Real.dist_eq]
+      rcases lt_or_gt_of_ne hsumne with hlt | hgt
+      · rw [abs_of_nonpos (sub_nonpos.mpr (by exact_mod_cast Nat.le_of_lt hlt))]
+        have hgap : T₁.sum id + 1 ≤ T₂.sum id := by omega
+        have hgapR : (((T₁.sum id + 1 : ℕ) : ℝ)) ≤ T₂.sum id := by exact_mod_cast hgap
+        norm_num at hgapR ⊢
+        linarith
+      · rw [abs_of_nonneg (sub_nonneg.mpr (by exact_mod_cast Nat.le_of_lt hgt))]
+        have hgap : T₂.sum id + 1 ≤ T₁.sum id := by omega
+        have hgapR : (((T₂.sum id + 1 : ℕ) : ℝ)) ≤ T₁.sum id := by exact_mod_cast hgap
+        norm_num at hgapR ⊢
+        linarith
+  have := hreal N B hB hN
+  simpa [B] using this
 
 /--
 The minimal value of $N$ such that there exists a sum-distinct set with three

--- a/FormalConjectures/ErdosProblems/1.lean
+++ b/FormalConjectures/ErdosProblems/1.lean
@@ -112,7 +112,7 @@ A generalisation of the problem to sets $A \subseteq (0, N]$ of real numbers, su
 sums all differ by at least $1$ is proposed in [Er73] and [ErGr80].
 
 The positive statement is false: every natural-number counterexample to `erdos_1` embeds into
-`ℝ`, and distinct integer subset sums differ by at least one.
+$\mathbb{R}$, and distinct integer subset sums differ by at least one.
 
 [Er73] Erdős, P., _Problems and results on combinatorial number theory_. A survey of combinatorial theory (Proc. Internat. Sympos., Colorado State Univ., Fort Collins, Colo., 1971) (1973), 117-138.
 


### PR DESCRIPTION
**What changed**

- `erdos_1` is `research solved`, restated as the negation of the original claim, with a
  `formal_proof using lean4` attribute.
- `erdos_1.variants.real` is `research solved`, likewise restated, with a complete Lean reduction
  to `erdos_1` (no new `sorry`).

**Status and attribution**

[erdosproblems.com/1](https://www.erdosproblems.com/1) records this as **DISPROVED (LEAN)** — its
tag for "solved in the negative and the proof verified in Lean". The page credits the disproof to
**GPT-6 Astra**, which showed that for any `ε > 0` there are arbitrarily large `n` with
`N ≤ ε·2^n`. Since Erdős asked for `N ≫ 2^n`, no positive constant survives, so the existential
form in this file is false.

The Lean development is hosted at a pinned commit of
[`tadamcz/erdos1`](https://github.com/tadamcz/erdos1/blob/0e395153306f34b3829d118b85bdd704136f2843/Erdos1/Resolutions/Erdos1_219usd_38h.lean#L2419).

**Audit of the linked proof**

- The file contains no `sorry`, no `axiom`, no `native_decide`, no `unsafe`, no `implemented_by`.
- Its `IsSumDistinctSet` is **verbatim identical** to this file's, and the linked theorem is
  literally `¬ (∃ C > (0 : ℝ), ∀ (N : ℕ) (A : Finset ℕ) (_ : IsSumDistinctSet A N), N ≠ 0 →
  C * 2 ^ A.card < N)` — the exact negation of the statement here. Its own docstring says so.

**The real variant** is proved here rather than linked: map a natural counterexample into `ℝ` by
the cast embedding; distinct integer subset sums differ by at least `1`, which supplies the real
separation hypothesis, so a real bound would give an integer bound.

**Note on overlap.** Open PR #4382 also touches this file, but adds a `formal_proof` link to
`erdos_1.variants.lb_strong`, a different declaration. No semantic conflict, though the two may
need a trivial rebase.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-6 Astra** in the FrontierMath Erdős benchmark (Adamczewski and Bloom, 2026). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
