### PR TITLE
fix(ErdosProblems/74): the Erdos-Hajnal-Szemeredi question has a negative answer

### DIFF
--- a/FormalConjectures/ErdosProblems/74.lean
+++ b/FormalConjectures/ErdosProblems/74.lean
@@ -119,9 +119,13 @@ noncomputable def SimpleGraph.maxSubgraphEdgeDistToBipartite
 Let $f(n)\to \infty$ possibly very slowly.
 Is there a graph of infinite chromatic number such that every finite subgraph on $n$
 vertices can be made bipartite by deleting at most $f(n)$ edges?
+
+The answer is no. A machine-checked disproof constructs a function $f(n) \to \infty$ for which
+every graph satisfying this local deletion bound has finite chromatic number.
 -/
-@[category research open, AMS 5]
-theorem erdos_74 : answer(sorry) ↔ ∀ f : ℕ → ℕ, Tendsto f atTop atTop →
+@[category research solved, AMS 5, formal_proof using lean4 at
+  "https://github.com/tadamcz/erdos74/blob/e127ee587c7c91267eecdb3569443d2b0ad64b52/Erdos74/Resolutions/Erdos74_118usd_22h.lean#L2511"]
+theorem erdos_74 : answer(False) ↔ ∀ f : ℕ → ℕ, Tendsto f atTop atTop →
     (∃ (V : Type u) (G : SimpleGraph V), G.chromaticNumber = ⊤ ∧
     ∀ n, G.maxSubgraphEdgeDistToBipartite n ≤ f n) := by
   sorry


### PR DESCRIPTION
**What changed**

- `erdos_74` is `research solved` with `answer(False)` and a `formal_proof using lean4` attribute.

**Status and attribution**

[erdosproblems.com/74](https://www.erdosproblems.com/74) records this as **DISPROVED (LEAN)** —
"solved in the negative and the proof verified in Lean". The conjecture is due to Erdős, Hajnal
and Szemerédi [EHS82]. The page credits the negative answer to **GPT-6 Astra**, for
`f(n) ≍ log n / log log n`, noting that in fact such a graph must have chromatic number at most
`3`. Thomas Bloom has written a proof exposition on that page.

The Lean development is hosted at a pinned commit of
[`tadamcz/erdos74`](https://github.com/tadamcz/erdos74/blob/e127ee587c7c91267eecdb3569443d2b0ad64b52/Erdos74/Resolutions/Erdos74_118usd_22h.lean#L2511).

**Audit of the linked proof**

- No `sorry`, `axiom`, `native_decide`, `unsafe` or `implemented_by`.
- `SimpleGraph.edgeDistancesToBipartite`, `minEdgeDistToBipartite` and
  `maxSubgraphEdgeDistToBipartite` are **verbatim identical** to this file's definitions.
- The linked theorem is `¬ (∀ f : ℕ → ℕ, Tendsto f atTop atTop → ∃ V G, G.chromaticNumber = ⊤ ∧
  ∀ n, maxSubgraphEdgeDistToBipartite G n ≤ f n)`, which is exactly `answer(False)` for the
  right-hand side of this declaration.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-6 Astra** in the FrontierMath Erdős benchmark (Adamczewski and Bloom, 2026). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
