### PR TITLE
fix(ErdosProblems/126): f n / log n does tend to infinity

### DIFF
--- a/FormalConjectures/ErdosProblems/126.lean
+++ b/FormalConjectures/ErdosProblems/126.lean
@@ -36,9 +36,12 @@ def IsMaximalAddFactorsCard (f : ℕ → ℕ) : Prop := ∀ n,
 Let $f(n)$ be maximal such that if $A\subseteq\mathbb{N}$ has $|A| = n$ then
 $\prod_{a\neq b\in A}(a + b)$ has at least $f(n)$ distinct prime factors.
 Is it true that $\frac{f(n)}{\log n} \to\infty$?
+
+The answer is yes, and a machine-checked proof is available.
 -/
-@[category research open, AMS 11]
-theorem erdos_126 : answer(sorry) ↔ ∀ (f : ℕ → ℕ), IsMaximalAddFactorsCard f →
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/tadamcz/erdos126/blob/2516785fe6bbc43e979cf6029c976d9f998a7fba/Erdos126/Resolutions/Erdos126_132usd_25h.lean#L3053"]
+theorem erdos_126 : answer(True) ↔ ∀ (f : ℕ → ℕ), IsMaximalAddFactorsCard f →
     Tendsto (fun n => f n / Real.log n) atTop atTop := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `erdos_126` is `research solved` with `answer(True)` and a `formal_proof using lean4` attribute.

**Status and attribution**

[erdosproblems.com/126](https://www.erdosproblems.com/126) records this as **PROVED (LEAN)** —
"solved in the affirmative and the proof verified in Lean". The problem goes back to Erdős and
Turán's first joint paper [ErTu34], who proved `log n ≪ f(n) ≪ n/log n`. The page credits the
proof to **GPT-6 Astra**, which in fact establishes the much stronger `f(n) ≫ n^{1/2}`; the
question asked only whether `f(n)/log n → ∞`.

The Lean development is hosted at a pinned commit of
[`tadamcz/erdos126`](https://github.com/tadamcz/erdos126/blob/2516785fe6bbc43e979cf6029c976d9f998a7fba/Erdos126/Resolutions/Erdos126_132usd_25h.lean#L3053).

**Audit of the linked proof**

- No `sorry`, `axiom`, `native_decide`, `unsafe` or `implemented_by`.
- Its `IsMaximalAddFactorsCard` is **verbatim identical** to this file's.
- The linked theorem is `∀ f, IsMaximalAddFactorsCard f → Tendsto (fun n => f n / Real.log n)
  atTop atTop`, exactly the right-hand side of this declaration, so `answer(True)`.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-6 Astra** in the FrontierMath Erdős benchmark (Adamczewski and Bloom, 2026). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
