### PR TITLE
feat(Paper): Deligne's conjecture on special values for GL1/ℚ

### DIFF
--- a/FormalConjectures/Paper/SpecialValues.lean
+++ b/FormalConjectures/Paper/SpecialValues.lean
@@ -33,7 +33,7 @@ namespace Deligne
 
 open Complex ZMod
 
-/-- A Deligne package with respect to a parameter `M : Ω` is the tuple `(L, E, w, γ, c, σ)` where
+/-- A Deligne package with respect to a parameter `M : 𝓜` is the tuple `(L, E, w, γ, c, σ)` where
 - `L` : L-function;
 - `E` : algebraic subfield of ℂ containing L-values;
 - `w` : weight with respect to which the functional equation of `L` is expressed;
@@ -43,100 +43,100 @@ open Complex ZMod
 This contains the data required to state Deligne's conjecture for `M`. While Deligne's conjecture
 is traditionally stated for motives in the literature, we lack a formal definition of a motive.
 Moreover, this allows one to state the conjecture in potentially non-motivic cases. -/
-structure Pkg (Ω : Type*) where
+structure Pkg (𝓜 : Type*) where
   /-- The analytic `L`-function `L(M, s)`. -/
-  L : Ω → ℂ → ℂ
+  L : 𝓜 → ℂ → ℂ
   /-- The value field `E(M)`. -/
-  valueField : Ω → IntermediateField ℚ ℂ
+  valueField : 𝓜 → IntermediateField ℚ ℂ
   /-- The weight `w(M)`: the functional equation exchanges `s` and `w(M) + 1 - s`. -/
-  weight : Ω → ℤ
+  weight : 𝓜 → ℤ
   /-- The shifts of the archimedean Gamma factor, `∏ a, Γℝ(s + a)` with `a` ranging over
   `gammaShifts M` with multiplicity. -/
-  gammaShifts : Ω → Multiset ℤ
+  gammaShifts : 𝓜 → Multiset ℤ
   /-- Deligne's period `c⁺(M(n))`. -/
-  period : Ω → ℤ → ℂ
+  period : 𝓜 → ℤ → ℂ
   /-- The Galois action `σ ↦ (M ↦ Mᵟ)`. -/
-  galoisAction : Gal(ℂ/ℚ) →* Equiv.Perm Ω
+  galoisAction : Gal(ℂ/ℚ) →* Equiv.Perm 𝓜
   /-- Conjugate inputs have the same weight. -/
-  weight_galoisAction (σ : Gal(ℂ/ℚ)) (M : Ω) : weight (galoisAction σ M) = weight M
+  weight_galoisAction (σ : Gal(ℂ/ℚ)) (M : 𝓜) : weight (galoisAction σ M) = weight M
   /-- Conjugate inputs have the same Hodge numbers. -/
-  gammaShifts_galoisAction (σ : Gal(ℂ/ℚ)) (M : Ω) :
+  gammaShifts_galoisAction (σ : Gal(ℂ/ℚ)) (M : 𝓜) :
     gammaShifts (galoisAction σ M) = gammaShifts M
   /-- The coefficient field transports along the action. -/
-  valueField_galoisAction (σ : Gal(ℂ/ℚ)) (M : Ω) :
+  valueField_galoisAction (σ : Gal(ℂ/ℚ)) (M : 𝓜) :
     valueField (galoisAction σ M) = (valueField M).map σ
   /-- The coefficient field is algebraic over `ℚ`. -/
-  valueField_isAlgebraic (M : Ω) {x : ℂ} (hx : x ∈ valueField M) : IsAlgebraic ℚ x
+  valueField_isAlgebraic (M : 𝓜) {x : ℂ} (hx : x ∈ valueField M) : IsAlgebraic ℚ x
   /-- Prevents trivial junk case `· / 0 = 0 ∈ valueField`. -/
-  period_ne_zero' (M : Ω) (n : ℤ)
+  period_ne_zero' (M : 𝓜) (n : ℤ)
     (h₁ : ∀ a ∈ gammaShifts M, Odd (n + a) ∨ 0 < n + a)
     (h₂ : ∀ a ∈ gammaShifts M, Odd (weight M + 1 - n + a) ∨ 0 < weight M + 1 - n + a) :
     period M n ≠ 0
 
 namespace Pkg
 
-variable {Ω : Type*} {F : Pkg Ω}
+variable {𝓜 : Type*} {F : Pkg 𝓜} (M : 𝓜)
 
 /-- The gamma factor of the package is the product of `Γ(s + a)`, where `a` are given by the
 multiset of integer shifts defined in the package.-/
-noncomputable def gammaFactor (M : Ω) (s : ℂ) : ℂ := prodGammaℝ (F.gammaShifts M) s
+noncomputable def gammaFactor (s : ℂ) : ℂ := prodGammaℝ (F.gammaShifts M) s
 
 /-- An integer `n` is critical for `M` if the gamma factor has pole neither at `n` nor at
 `weight + 1 - n`. -/
-def IsCritical (M : Ω) (n : ℤ) : Prop :=
+def IsCritical (n : ℤ) : Prop :=
   0 ≤ meromorphicOrderAt (F.gammaFactor M) (n : ℂ) ∧
     0 ≤ meromorphicOrderAt (F.gammaFactor M) ((F.weight M + 1 - n : ℤ) : ℂ)
 
 @[category API, AMS 11 14]
-lemma isCritical_iff (M : Ω) (n : ℤ) :
+lemma isCritical_iff (n : ℤ) :
     F.IsCritical M n ↔ (∀ a ∈ F.gammaShifts M, Odd (n + a) ∨ 0 < n + a) ∧
       ∀ a ∈ F.gammaShifts M, Odd (F.weight M + 1 - n + a) ∨ 0 < F.weight M + 1 - n + a := by
   have hgf : F.gammaFactor M = prodGammaℝ (F.gammaShifts M) := rfl
   simp only [IsCritical, hgf, meromorphicOrderAt_prodGammaℝ_intCast_nonneg_iff]
 
 @[category API, AMS 11 14]
-lemma period_ne_zero (M : Ω) (n : ℤ) (h : F.IsCritical M n) : F.period M n ≠ 0 :=
+lemma period_ne_zero (n : ℤ) (h : F.IsCritical M n) : F.period M n ≠ 0 :=
   F.period_ne_zero' M n ((isCritical_iff M n).1 h).1 ((isCritical_iff M n).1 h).2
 
 /-- The normalised critical value `L(M, n) / c⁺(M, n)`. -/
-noncomputable def normalizedValue (M : Ω) (n : ℤ) : ℂ := F.L M n / F.period M n
+noncomputable def normalizedValue (n : ℤ) : ℂ := F.L M n / F.period M n
 
 /-- The package is arithmetic if the normalized critical values are in the value field. -/
-def IsArithmetic (M : Ω) : Prop := ∀ (n : ℤ), F.IsCritical M n →
+def IsArithmetic : Prop := ∀ (n : ℤ), F.IsCritical M n →
   F.normalizedValue M n ∈ F.valueField M
 
 /-- The packages is equivariant if the normalized critical values are equivariant under the
 Galois action. -/
-def IsEquivariant (M : Ω) : Prop :=
+def IsEquivariant : Prop :=
   ∀ (σ : Gal(ℂ/ℚ)) (n : ℤ), F.IsCritical M n →
     σ (F.normalizedValue M n) = F.normalizedValue (F.galoisAction σ M) n
 
 /-- Deligne's conjecture for `(L, E, w, γ, c, σ)` consists of arithmeticity and
 equivariance. -/
-abbrev Conjecture (M : Ω) : Prop := F.IsArithmetic M ∧ F.IsEquivariant M
+abbrev Conjecture : Prop := F.IsArithmetic M ∧ F.IsEquivariant M
 
 @[category API, AMS 11 14]
-lemma isCritical_galoisAction_iff (σ : Gal(ℂ/ℚ)) (M : Ω) (n : ℤ) :
+lemma isCritical_galoisAction_iff (σ : Gal(ℂ/ℚ)) (n : ℤ) :
     F.IsCritical (F.galoisAction σ M) n ↔ F.IsCritical M n := by
   simp only [isCritical_iff, gammaShifts_galoisAction, weight_galoisAction]
 
 section trivial_cases
 
-/- Some cases are trivial, either mathematically or by the choice of formalization of `Pkg`. -/
+variable {M}
 
+/- Some cases are trivial, either mathematically or by the choice of formalization of `Pkg`. -/
 
 /-- Empty critical set: if `M` has no critical integers, then the formal conjecture is vacuously
 true. This occurs in nature, for example the Dedekind zeta function of an imaginary
 quadratic field has no critical integers [Ne99]. -/
 @[category test, AMS 11 14]
-theorem conjecture_of_forall_not_isCritical {F : Pkg Ω} {M : Ω}
-    (h : ∀ n : ℤ, ¬ F.IsCritical M n) : F.Conjecture M :=
+theorem conjecture_of_forall_not_isCritical (h : ∀ n : ℤ, ¬ F.IsCritical M n) : F.Conjecture M :=
   ⟨fun n hn ↦ absurd hn (h n), fun _ n hn ↦ absurd hn (h n)⟩
 
 /-- Vanishing L-function: if the L-function vanishes at the critical points on the Galois orbit
 of `M`, then the formal conjecture is trivially true. -/
 @[category test, AMS 11 14]
-theorem conjecture_of_L_eq_zero {F : Pkg Ω} {M : Ω}
+theorem conjecture_of_L_eq_zero
     (h : ∀ (σ : Gal(ℂ/ℚ)) (n : ℤ), F.IsCritical M n → F.L (F.galoisAction σ M) n = 0) :
     F.Conjecture M := by
   have hM : ∀ n, F.IsCritical M n → F.L M n = 0 := fun n hn ↦ by simpa using h 1 n hn
@@ -147,13 +147,13 @@ theorem conjecture_of_L_eq_zero {F : Pkg Ω} {M : Ω}
 /-- Trivial period: if on the Galois orbit of `M`, the supplied period is some rescaling of the
 `L`-function. at critical integers, then the formal conjecture is trivially true. -/
 @[category test, AMS 11 14]
-theorem conjecture_of_period_eq_mul_L {F : Pkg Ω} {M : Ω} (e : ℤ → F.valueField M)
+theorem conjecture_of_period_eq_mul_L (e : ℤ → F.valueField M)
     (h : ∀ (σ : Gal(ℂ/ℚ)) (n : ℤ), F.IsCritical M n →
       F.period (F.galoisAction σ M) n = σ (e n) * F.L (F.galoisAction σ M) n) :
     F.Conjecture M := by
   have hL (σ : Gal(ℂ/ℚ)) (n : ℤ) (hn : F.IsCritical M n) :
       F.L (F.galoisAction σ M) n ≠ 0 := right_ne_zero_of_mul <|
-    h σ n hn ▸ F.period_ne_zero _ n ((F.isCritical_galoisAction_iff σ M n).2 hn)
+    h σ n hn ▸ F.period_ne_zero _ n ((F.isCritical_galoisAction_iff M σ n).2 hn)
   have hval (σ : Gal(ℂ/ℚ)) (n : ℤ) (hn : F.IsCritical M n) :
       F.normalizedValue (F.galoisAction σ M) n = (σ (e n))⁻¹ := by
     rw [normalizedValue, h σ n hn, mul_comm, ← div_div, div_self (hL σ n hn), one_div]

--- a/FormalConjectures/Paper/SpecialValues.lean
+++ b/FormalConjectures/Paper/SpecialValues.lean
@@ -1,0 +1,257 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjecturesUtil
+
+/-!
+# Special values of $L$-functions
+
+*References:*
+- [De79] P. Deligne, *Valeurs de fonctions L et périodes d'intégrales*, in Automorphic Forms,
+  Representations and L-functions (Corvallis 1977), Proc. Sympos. Pure Math. 33, Part 2,
+  AMS (1979), 313-346. States the conjecture (Conj. 2.8) and the critical integers (§1.3);
+  the Dirichlet character case is §6.
+- [Wa97] L. Washington, Introduction to Cyclotomic Fields, 2nd ed., GTM 83, Springer (1997),
+  Ch. 4. Generalized Bernoulli numbers and the values at non-positive integers.
+- [Ne99] J. Neukirch, Algebraic Number Theory, Springer (1999), Ch. VII §2. The Gamma factor
+  of a Dirichlet L-function, with shift 0 or 1 according to the parity of the character.
+-/
+
+namespace Deligne
+
+open Complex ZMod
+
+/-- A Deligne package with respect to a parameter `M : Ω` is the tuple `(L, E, w, γ, c, σ)` where
+- `L` : L-function;
+- `E` : algebraic subfield of ℂ containing L-values;
+- `w` : weight with respect to which the functional equation of `L` is expressed;
+- `γ` : gamma factors of the completed L-function;
+- `c` : period;
+- `σ` : Galois action on `M`.
+This contains the data required to state Deligne's conjecture for `M`. While Deligne's conjecture
+is traditionally stated for motives in the literature, we lack a formal definition of a motive.
+Moreover, this allows one to state the conjecture in potentially non-motivic cases. -/
+structure Pkg (Ω : Type*) where
+  /-- The analytic `L`-function `L(M, s)`. -/
+  L : Ω → ℂ → ℂ
+  /-- The value field `E(M)`. -/
+  valueField : Ω → IntermediateField ℚ ℂ
+  /-- The weight `w(M)`: the functional equation exchanges `s` and `w(M) + 1 - s`. -/
+  weight : Ω → ℤ
+  /-- The shifts of the archimedean Gamma factor, `∏ a, Γℝ(s + a)` with `a` ranging over
+  `gammaShifts M` with multiplicity. -/
+  gammaShifts : Ω → Multiset ℤ
+  /-- Deligne's period `c⁺(M(n))`. -/
+  period : Ω → ℤ → ℂ
+  /-- The Galois action `σ ↦ (M ↦ Mᵟ)`. -/
+  galoisAction : Gal(ℂ/ℚ) →* Equiv.Perm Ω
+  /-- Conjugate inputs have the same weight. -/
+  weight_galoisAction (σ : Gal(ℂ/ℚ)) (M : Ω) : weight (galoisAction σ M) = weight M
+  /-- Conjugate inputs have the same Hodge numbers. -/
+  gammaShifts_galoisAction (σ : Gal(ℂ/ℚ)) (M : Ω) :
+    gammaShifts (galoisAction σ M) = gammaShifts M
+  /-- The coefficient field transports along the action. -/
+  valueField_galoisAction (σ : Gal(ℂ/ℚ)) (M : Ω) :
+    valueField (galoisAction σ M) = (valueField M).map σ
+  /-- The coefficient field is algebraic over `ℚ`. -/
+  valueField_isAlgebraic (M : Ω) {x : ℂ} (hx : x ∈ valueField M) : IsAlgebraic ℚ x
+  /-- Prevents trivial junk case `· / 0 = 0 ∈ valueField`. -/
+  period_ne_zero' (M : Ω) (n : ℤ)
+    (h₁ : ∀ a ∈ gammaShifts M, Odd (n + a) ∨ 0 < n + a)
+    (h₂ : ∀ a ∈ gammaShifts M, Odd (weight M + 1 - n + a) ∨ 0 < weight M + 1 - n + a) :
+    period M n ≠ 0
+
+namespace Pkg
+
+variable {Ω : Type*} {F : Pkg Ω}
+
+/-- The gamma factor of the package is the product of `Γ(s + a)`, where `a` are given by the
+multiset of integer shifts defined in the package.-/
+noncomputable def gammaFactor (M : Ω) (s : ℂ) : ℂ := prodGammaℝ (F.gammaShifts M) s
+
+/-- An integer `n` is critical for `M` if the gamma factor has pole neither at `n` nor at
+`weight + 1 - n`. -/
+def IsCritical (M : Ω) (n : ℤ) : Prop :=
+  0 ≤ meromorphicOrderAt (F.gammaFactor M) (n : ℂ) ∧
+    0 ≤ meromorphicOrderAt (F.gammaFactor M) ((F.weight M + 1 - n : ℤ) : ℂ)
+
+@[category API, AMS 11 14]
+lemma isCritical_iff (M : Ω) (n : ℤ) :
+    F.IsCritical M n ↔ (∀ a ∈ F.gammaShifts M, Odd (n + a) ∨ 0 < n + a) ∧
+      ∀ a ∈ F.gammaShifts M, Odd (F.weight M + 1 - n + a) ∨ 0 < F.weight M + 1 - n + a := by
+  have hgf : F.gammaFactor M = prodGammaℝ (F.gammaShifts M) := rfl
+  simp only [IsCritical, hgf, meromorphicOrderAt_prodGammaℝ_intCast_nonneg_iff]
+
+@[category API, AMS 11 14]
+lemma period_ne_zero (M : Ω) (n : ℤ) (h : F.IsCritical M n) : F.period M n ≠ 0 :=
+  F.period_ne_zero' M n ((isCritical_iff M n).1 h).1 ((isCritical_iff M n).1 h).2
+
+/-- The normalised critical value `L(M, n) / c⁺(M, n)`. -/
+noncomputable def normalizedValue (M : Ω) (n : ℤ) : ℂ := F.L M n / F.period M n
+
+/-- The package is arithmetic if the normalized critical values are in the value field. -/
+def IsArithmetic (M : Ω) : Prop := ∀ (n : ℤ), F.IsCritical M n →
+  F.normalizedValue M n ∈ F.valueField M
+
+/-- The packages is equivariant if the normalized critical values are equivariant under the
+Galois action. -/
+def IsEquivariant (M : Ω) : Prop :=
+  ∀ (σ : Gal(ℂ/ℚ)) (n : ℤ), F.IsCritical M n →
+    σ (F.normalizedValue M n) = F.normalizedValue (F.galoisAction σ M) n
+
+/-- Deligne's conjecture for `(L, E, w, γ, c, σ)` consists of arithmeticity and
+equivariance. -/
+abbrev Conjecture (M : Ω) : Prop := F.IsArithmetic M ∧ F.IsEquivariant M
+
+@[category API, AMS 11 14]
+lemma isCritical_galoisAction_iff (σ : Gal(ℂ/ℚ)) (M : Ω) (n : ℤ) :
+    F.IsCritical (F.galoisAction σ M) n ↔ F.IsCritical M n := by
+  simp only [isCritical_iff, gammaShifts_galoisAction, weight_galoisAction]
+
+section trivial_cases
+
+/- Some cases are trivial, either mathematically or by the choice of formalization of `Pkg`. -/
+
+
+/-- Empty critical set: if `M` has no critical integers, then the formal conjecture is vacuously
+true. This occurs in nature, for example the Dedekind zeta function of an imaginary
+quadratic field has no critical integers [Ne99]. -/
+@[category test, AMS 11 14]
+theorem conjecture_of_forall_not_isCritical {F : Pkg Ω} {M : Ω}
+    (h : ∀ n : ℤ, ¬ F.IsCritical M n) : F.Conjecture M :=
+  ⟨fun n hn ↦ absurd hn (h n), fun _ n hn ↦ absurd hn (h n)⟩
+
+/-- Vanishing L-function: if the L-function vanishes at the critical points on the Galois orbit
+of `M`, then the formal conjecture is trivially true. -/
+@[category test, AMS 11 14]
+theorem conjecture_of_L_eq_zero {F : Pkg Ω} {M : Ω}
+    (h : ∀ (σ : Gal(ℂ/ℚ)) (n : ℤ), F.IsCritical M n → F.L (F.galoisAction σ M) n = 0) :
+    F.Conjecture M := by
+  have hM : ∀ n, F.IsCritical M n → F.L M n = 0 := fun n hn ↦ by simpa using h 1 n hn
+  refine ⟨fun n hn ↦ ?_, fun σ n hn ↦ ?_⟩
+  · simp [normalizedValue, hM n hn]
+  · simp [normalizedValue, hM n hn, h σ n hn]
+
+/-- Trivial period: if on the Galois orbit of `M`, the supplied period is some rescaling of the
+`L`-function. at critical integers, then the formal conjecture is trivially true. -/
+@[category test, AMS 11 14]
+theorem conjecture_of_period_eq_mul_L {F : Pkg Ω} {M : Ω} (e : ℤ → F.valueField M)
+    (h : ∀ (σ : Gal(ℂ/ℚ)) (n : ℤ), F.IsCritical M n →
+      F.period (F.galoisAction σ M) n = σ (e n) * F.L (F.galoisAction σ M) n) :
+    F.Conjecture M := by
+  have hL (σ : Gal(ℂ/ℚ)) (n : ℤ) (hn : F.IsCritical M n) :
+      F.L (F.galoisAction σ M) n ≠ 0 := right_ne_zero_of_mul <|
+    h σ n hn ▸ F.period_ne_zero _ n ((F.isCritical_galoisAction_iff σ M n).2 hn)
+  have hval (σ : Gal(ℂ/ℚ)) (n : ℤ) (hn : F.IsCritical M n) :
+      F.normalizedValue (F.galoisAction σ M) n = (σ (e n))⁻¹ := by
+    rw [normalizedValue, h σ n hn, mul_comm, ← div_div, div_self (hL σ n hn), one_div]
+  have hM (n : ℤ) (hn : F.IsCritical M n) : F.normalizedValue M n = (e n : ℂ)⁻¹ := by
+    simpa using hval 1 n hn
+  exact ⟨fun n hn ↦ hM n hn ▸ inv_mem (e n).2, fun σ n hn ↦ by rw [hM n hn, hval σ n hn, map_inv₀]⟩
+
+end trivial_cases
+
+end Pkg
+
+namespace GL1
+
+variable {N : ℕ} (χ : DirichletCharacter ℂ N)
+
+/-- The field `ℚ(χ)` generated by the values of a Dirichlet character. -/
+noncomputable abbrev valueField : IntermediateField ℚ ℂ := .adjoin ℚ (Set.range χ)
+
+/-- The Galois conjugate `χ ^ σ = σ ∘ χ` of a Dirichlet character. -/
+noncomputable abbrev galoisConj (σ : Gal(ℂ/ℚ)) :
+    DirichletCharacter ℂ N := χ.ringHomComp (σ : ℂ →+* ℂ)
+
+@[simp, category API, AMS 11 14]
+lemma galoisConj_apply (σ : Gal(ℂ/ℚ)) (a : ZMod N) :
+    galoisConj χ σ a = σ (χ a) := rfl
+
+@[simp, category API, AMS 11 14]
+lemma coe_galoisConj (σ : Gal(ℂ/ℚ)) : ⇑(galoisConj χ σ) = σ ∘ χ := rfl
+
+/-- Galois conjugation preserves the parity of a Dirichlet character: `σ` fixes `1`, so
+`χ ^ σ (-1) = 1` exactly when `χ (-1) = 1`. -/
+@[simp, category API, AMS 11 14]
+lemma even_galoisConj (σ : Gal(ℂ/ℚ)) : (galoisConj χ σ).Even ↔ χ.Even := by
+  simp only [DirichletCharacter.Even, galoisConj_apply]
+  exact ⟨fun h ↦ σ.injective (by rw [map_one]; exact h), fun h ↦ by rw [h, map_one]⟩
+
+variable {χ} in
+@[category API, AMS 11 14]
+lemma isPrimitive_galoisConj [NeZero N] (σ : Gal(ℂ/ℚ)) (hχ : χ.IsPrimitive) :
+    (galoisConj χ σ).IsPrimitive := hχ.ringHomComp σ.injective
+
+@[category API, AMS 11 14]
+lemma valueField_galoisConj (σ : Gal(ℂ/ℚ)) (χ : DirichletCharacter ℂ N) :
+    valueField (galoisConj χ σ) = (valueField χ).map σ := by
+  rw [valueField, valueField, coe_galoisConj, Set.range_comp, IntermediateField.adjoin_map,
+    AlgEquiv.coe_toAlgHom]
+
+/-- Deligne's period `c⁺(M(χ)(n))`: the Gauss sum of `χ` times `(2πi) ^ n` for `n ≥ 1`, and `1`
+for `n ≤ 0`. -/
+noncomputable def period [NeZero N] (χ : DirichletCharacter ℂ N) (n : ℤ) : ℂ :=
+  if 1 ≤ n then gaussSum χ stdAddChar * (2 * (Real.pi : ℂ) * I) ^ n else 1
+
+@[category API, AMS 11 14]
+lemma period_ne_zero [NeZero N] {χ : DirichletCharacter ℂ N} (hχ : χ.IsPrimitive) (n : ℤ) :
+    period χ n ≠ 0 := by
+  rw [period]
+  split
+  · exact mul_ne_zero hχ.gaussSum_ne_zero (zpow_ne_zero _ (by simp [Real.pi_ne_zero, I_ne_zero]))
+  · exact one_ne_zero
+
+/-- Galois conjugation as a permutation of the primitive Dirichlet characters modulo `N`. -/
+noncomputable def galoisAction [NeZero N] :
+    Gal(ℂ/ℚ) →* Equiv.Perm {χ : DirichletCharacter ℂ N // χ.IsPrimitive} where
+  toFun σ := {
+      toFun χ := ⟨galoisConj χ.1 σ, isPrimitive_galoisConj σ χ.2⟩
+      invFun χ := ⟨galoisConj χ.1 σ⁻¹, isPrimitive_galoisConj σ⁻¹ χ.2⟩
+      left_inv χ := by ext; simp
+      right_inv χ := by ext; simp
+  }
+  map_one' := by ext; simp
+  map_mul' σ τ := by ext; simp
+
+/-- The Deligne family of primitive Dirichlet characters modulo `N`. -/
+noncomputable def pkg (N : ℕ) [NeZero N] :
+    Pkg {χ : DirichletCharacter ℂ N // χ.IsPrimitive} where
+  L χ := DirichletCharacter.LFunction χ.1
+  valueField χ := valueField χ.1
+  weight _ := 0
+  gammaShifts χ := if χ.1.Even then {0} else {1}
+  period χ n := period χ.1 n
+  galoisAction := galoisAction
+  weight_galoisAction _ _ := rfl
+  gammaShifts_galoisAction σ χ := by simp [galoisAction]
+  valueField_isAlgebraic χ x hx :=
+    IntermediateField.isAlgebraic_iff.mp <|
+      ((IntermediateField.isAlgebraic_adjoin_iff_isAlgebraic ℚ ℂ).mpr
+        (by rintro _ ⟨a, rfl⟩; exact χ.1.isAlgebraic_apply a)).isAlgebraic ⟨x, hx⟩
+  valueField_galoisAction σ χ := valueField_galoisConj σ χ.1
+  period_ne_zero' χ n _ _ := period_ne_zero χ.2 n
+
+/-- Deligne's conjecture for the critical values of Dirichlet L-functions:
+`L(n, χ) / c(n, χ) ∈ ℚ(χ)` where `c(n, χ) = 1` if `n ≤ 0` and `c(n, χ) = G(χ)(2πi)ⁿ` if `1 ≤ n`. -/
+@[category textbook, AMS 11 14, formal_proof using lean4 at
+  "https://github.com/smmercuri/special-values/blob/e533378e0c16693103f8b7cd75aed33d2c6b2d33/SpecialValues/Deligne/GL1/Statement.lean#L166"]
+theorem conjecture {N : ℕ} [NeZero N] {χ : DirichletCharacter ℂ N} (h : χ.IsPrimitive) :
+    (pkg N).Conjecture ⟨χ, h⟩ := by
+  sorry
+
+end GL1
+
+end Deligne

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -36,6 +36,7 @@ public import FormalConjecturesForMathlib.Analysis.HasGaps
 public import FormalConjecturesForMathlib.Analysis.Matrix.Spectrum
 public import FormalConjecturesForMathlib.Analysis.Real.Cardinality
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.AdditiveCharacter
+public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Gamma.Deligne
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Log.Basic
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.NthRoot
 public import FormalConjecturesForMathlib.Combinatorics.AP.Basic

--- a/FormalConjecturesForMathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
+++ b/FormalConjecturesForMathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
@@ -1,0 +1,165 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Gamma.Deligne
+public import Mathlib.Analysis.Meromorphic.Order
+
+@[expose] public section
+
+/-!
+# Products of Deligne's Archimedean Gamma factors
+
+We study `Complex.prodGammaℝ N s = ∏ a ∈ N, Γℝ (s + a)` for a multiset `N` of integer shifts,
+the shape of the Archimedean factor of a motivic L-function. The main results are that it is
+meromorphic with no zeros of its own (`meromorphicOrderAt_prodGammaℝ_nonpos`), and the
+characterisation `meromorphicOrderAt_prodGammaℝ_intCast_nonneg_iff` of the integers at which it
+is regular, which are the critical integers in the sense of Deligne.
+-/
+
+namespace Complex
+
+/-- At an integer, `Gammaℝ` vanishes exactly at the non-positive even ones, equivalently where
+it has a pole. -/
+lemma Gammaℝ_intCast_eq_zero_iff {m : ℤ} : Gammaℝ (m : ℂ) = 0 ↔ m ≤ 0 ∧ Even m := by
+  rw [Gammaℝ_eq_zero_iff, Int.even_iff]
+  refine ⟨fun ⟨j, hj⟩ ↦ ?_, fun ⟨h₁, h₂⟩ ↦ ⟨(-m / 2).toNat, ?_⟩⟩
+  · have hm : m = -(2 * (j : ℤ)) := by exact_mod_cast hj
+    lia
+  · exact_mod_cast (by lia : m = -(2 * ((-m / 2).toNat : ℤ)))
+
+/-- `Complex.prodGammaℝ` is the product of Deligne Archimedean Gamma factors with arguments
+shifted by integers, possibly with repetition. -/
+noncomputable def prodGammaℝ (N : Multiset ℤ) (s : ℂ) : ℂ :=
+  (N.map fun a : ℤ ↦ Gammaℝ (s + a)).prod
+
+lemma analyticOnNhd_inv_Gammaℝ_add (a : ℂ) :
+    AnalyticOnNhd ℂ (fun z ↦ (Gammaℝ (z + a))⁻¹) Set.univ :=
+  (differentiable_Gammaℝ_inv.comp (differentiable_id.add_const a)).differentiableOn.analyticOnNhd
+    isOpen_univ
+
+lemma analyticAt_inv_Gammaℝ_add (a s : ℂ) :
+    AnalyticAt ℂ (fun z ↦ (Gammaℝ (z + a))⁻¹) s :=
+  analyticOnNhd_inv_Gammaℝ_add a s (Set.mem_univ s)
+
+/-- A shifted `Gammaℝ` is meromorphic everywhere: it is the inverse of an entire function. -/
+lemma meromorphicAt_Gammaℝ_add (a s : ℂ) : MeromorphicAt (fun z ↦ Gammaℝ (z + a)) s := by
+  have : (fun z ↦ Gammaℝ (z + a)) = (fun z ↦ (Gammaℝ (z + a))⁻¹)⁻¹ := by funext; simp
+  exact this ▸ (analyticAt_inv_Gammaℝ_add a s).meromorphicAt.inv
+
+/-- `Gammaℝ⁻¹` is entire and takes the value `1` at `1`, so by the identity theorem it does not
+vanish identically near any point and its analytic order there is finite. -/
+lemma analyticOrderAt_inv_Gammaℝ_add_ne_top (a s : ℂ) :
+    analyticOrderAt (fun z ↦ (Gammaℝ (z + a))⁻¹) s ≠ ⊤ := by
+  intro h
+  have hev : (fun z ↦ (Gammaℝ (z + a))⁻¹) =ᶠ[nhds s] 0 := by
+    filter_upwards [analyticOrderAt_eq_top.mp h] with z hz using hz
+  have hzero := (analyticOnNhd_inv_Gammaℝ_add a).eqOn_zero_of_preconnected_of_eventuallyEq_zero
+    isPreconnected_univ (Set.mem_univ s) hev
+  have h₁ := hzero (Set.mem_univ (1 - a))
+  simp only [Pi.zero_apply, show (1 - a) + a = 1 by ring, Gammaℝ_one, inv_one] at h₁
+  exact one_ne_zero h₁
+
+/-- The order of a shifted `Gammaℝ` at any point is `-n` for a natural number `n`, and `n = 0`
+exactly when the value is nonzero. `Gammaℝ` is the inverse of an entire function, so it has no
+zeros of its own: every point is either a regular point or a pole. -/
+theorem meromorphicOrderAt_Gammaℝ_add_eq_neg (a s : ℂ) :
+    ∃ n : ℕ, meromorphicOrderAt (fun z ↦ Gammaℝ (z + a)) s = ((-n : ℤ) : WithTop ℤ) ∧
+      (Gammaℝ (s + a) = 0 ↔ n ≠ 0) := by
+  have hg : AnalyticAt ℂ (fun z ↦ (Gammaℝ (z + a))⁻¹) s := analyticAt_inv_Gammaℝ_add a s
+  obtain ⟨n, hn⟩ := ENat.ne_top_iff_exists.mp (analyticOrderAt_inv_Gammaℝ_add_ne_top a s)
+  refine ⟨n, ?_, ?_⟩
+  · have : (fun z ↦ Gammaℝ (z + a)) = (fun z ↦ (Gammaℝ (z + a))⁻¹)⁻¹ := by funext; simp
+    simp [this, meromorphicOrderAt_inv, hg.meromorphicOrderAt_eq, ← hn]
+  · simp [← inv_eq_zero, ← hg.analyticOrderAt_ne_zero, ← hn]
+
+/-- `Gammaℝ (s + a)` is only ever zero when it has a pole. -/
+theorem meromorphicOrderAt_Gammaℝ_add_neg_iff {a s : ℂ} :
+    meromorphicOrderAt (fun z ↦ Gammaℝ (z + a)) s < 0 ↔ Gammaℝ (s + a) = 0 := by
+  obtain ⟨n, hord, hzero⟩ := meromorphicOrderAt_Gammaℝ_add_eq_neg a s
+  rw [hord, hzero, show (0 : WithTop ℤ) = ((0 : ℤ) : WithTop ℤ) from rfl, WithTop.coe_lt_coe]
+  lia
+
+/-- A shifted `Gammaℝ` never has a zero, so its order is at most `0` everywhere. -/
+lemma meromorphicOrderAt_Gammaℝ_add_nonpos (a s : ℂ) :
+    meromorphicOrderAt (fun z ↦ Gammaℝ (z + a)) s ≤ 0 := by
+  obtain ⟨n, hord, -⟩ := meromorphicOrderAt_Gammaℝ_add_eq_neg a s
+  rw [hord, show (0 : WithTop ℤ) = ((0 : ℤ) : WithTop ℤ) from rfl, WithTop.coe_le_coe]
+  lia
+
+@[simp]
+lemma prodGammaℝ_zero : prodGammaℝ 0 = fun _ ↦ 1 := by
+  funext; simp [prodGammaℝ]
+
+lemma prodGammaℝ_cons (a : ℤ) (N : Multiset ℤ) :
+    prodGammaℝ (a ::ₘ N) = (fun z ↦ Gammaℝ (z + a)) * prodGammaℝ N := by
+  funext; simp [prodGammaℝ]
+
+lemma meromorphicAt_prodGammaℝ (N : Multiset ℤ) (s : ℂ) :
+    MeromorphicAt (prodGammaℝ N) s := by
+  induction N using Multiset.induction with
+  | empty => exact prodGammaℝ_zero ▸ analyticAt_const.meromorphicAt
+  | cons a t ih => exact prodGammaℝ_cons a t ▸ (meromorphicAt_Gammaℝ_add _ s).mul ih
+
+lemma meromorphicOrderAt_prodGammaℝ_zero (s : ℂ) : meromorphicOrderAt (prodGammaℝ 0) s = 0 := by
+  rw [prodGammaℝ_zero, analyticAt_const.meromorphicOrderAt_eq,
+    analyticAt_const.analyticOrderAt_eq_zero.mpr one_ne_zero]
+  rfl
+
+/-- `prodGammaℝ` has no zeros of its own, so its order is at most `0` at every point. -/
+lemma meromorphicOrderAt_prodGammaℝ_nonpos (N : Multiset ℤ) (s : ℂ) :
+    meromorphicOrderAt (prodGammaℝ N) s ≤ 0 := by
+  induction N using Multiset.induction with
+  | empty => exact (meromorphicOrderAt_prodGammaℝ_zero s).le
+  | cons a t ih =>
+    rw [prodGammaℝ_cons, meromorphicOrderAt_mul (meromorphicAt_Gammaℝ_add _ s)
+      (meromorphicAt_prodGammaℝ t s)]
+    exact add_nonpos (meromorphicOrderAt_Gammaℝ_add_nonpos _ s) ih
+
+private lemma add_nonneg_iff_of_nonpos {x y : WithTop ℤ} (hx : x ≤ 0) (hy : y ≤ 0) :
+    0 ≤ x + y ↔ 0 ≤ x ∧ 0 ≤ y := by
+  refine ⟨fun h ↦ ?_, fun ⟨h₁, h₂⟩ ↦ by rw [le_antisymm hx h₁, le_antisymm hy h₂, add_zero]⟩
+  refine ⟨?_, ?_⟩ <;> by_contra hlt <;> rw [not_le] at hlt
+  · exact absurd (h.trans (add_le_add_right hy x |>.trans_eq (add_zero x))) hlt.not_ge
+  · exact absurd (h.trans (add_le_add_left hx y |>.trans_eq (zero_add y))) hlt.not_ge
+
+lemma meromorphicOrderAt_prodGammaℝ_nonneg_iff {shifts : Multiset ℤ} {s : ℂ} :
+    0 ≤ meromorphicOrderAt (prodGammaℝ shifts) s ↔
+      ∀ a ∈ shifts, 0 ≤ meromorphicOrderAt (fun z ↦ Gammaℝ (z + (a : ℂ))) s := by
+  induction shifts using Multiset.induction with
+  | empty => exact ⟨fun _ _ h ↦ absurd h (Multiset.notMem_zero _), fun _ ↦
+      (meromorphicOrderAt_prodGammaℝ_zero s).ge⟩
+  | cons a t ih =>
+    rw [prodGammaℝ_cons, meromorphicOrderAt_mul (meromorphicAt_Gammaℝ_add _ s)
+      (meromorphicAt_prodGammaℝ t s),
+      add_nonneg_iff_of_nonpos (meromorphicOrderAt_Gammaℝ_add_nonpos _ s)
+        (meromorphicOrderAt_prodGammaℝ_nonpos t s), ih]
+    simp [Multiset.mem_cons, or_imp, forall_and]
+
+theorem meromorphicOrderAt_Gammaℝ_add_intCast_nonneg_iff {a m : ℤ} :
+    0 ≤ meromorphicOrderAt (fun z ↦ Gammaℝ (z + (a : ℂ))) (m : ℂ) ↔ Odd (m + a) ∨ 0 < m + a := by
+  rw [← not_lt, meromorphicOrderAt_Gammaℝ_add_neg_iff,
+    show ((m : ℂ) + (a : ℂ)) = (((m + a : ℤ)) : ℂ) by push_cast; ring,
+    Gammaℝ_intCast_eq_zero_iff, Int.odd_iff, Int.even_iff]
+  lia
+
+lemma meromorphicOrderAt_prodGammaℝ_intCast_nonneg_iff {shifts : Multiset ℤ} {m : ℤ} :
+    0 ≤ meromorphicOrderAt (prodGammaℝ shifts) (m : ℂ) ↔
+      ∀ a ∈ shifts, Odd (m + a) ∨ 0 < m + a := by
+  simp only [meromorphicOrderAt_prodGammaℝ_nonneg_iff,
+    meromorphicOrderAt_Gammaℝ_add_intCast_nonneg_iff]
+
+end Complex

--- a/FormalConjecturesForMathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -16,10 +16,13 @@ limitations under the License.
 module
 
 public import Mathlib.NumberTheory.DirichletCharacter.Basic
+public import Mathlib.Analysis.Fourier.ZMod
 
 @[expose] public section
 
 namespace DirichletCharacter
+
+open ZMod Finset
 
 instance {S : Type*} [DecidableEq S] [CommRing S] {m : ℕ} :
     DecidablePred (Odd (S := S) (m := m)) :=
@@ -28,5 +31,88 @@ instance {S : Type*} [DecidableEq S] [CommRing S] {m : ℕ} :
 instance {S : Type*} [DecidableEq S] [CommRing S] {m : ℕ} :
     DecidablePred (Even (S := S) (m := m)) :=
   fun ψ ↦ decidable_of_iff (ψ (-1) = 1) <| by rfl
+
+section Comp
+
+variable {R R' : Type*} [CommRing R] [CommRing R'] {N : ℕ} [NeZero N]
+  {f : R →+* R'} {χ : DirichletCharacter R N}
+
+/-- Post-composition with an injective ring homomorphism does not change the set of levels a
+Dirichlet character factors through. -/
+lemma factorsThrough_ringHomComp_iff (hf : Function.Injective f) {d : ℕ} :
+    FactorsThrough (χ.ringHomComp f) d ↔ FactorsThrough χ d := by
+  have hker : (χ.ringHomComp f).toUnitHom.ker = χ.toUnitHom.ker := by
+    ext u
+    simp only [MonoidHom.mem_ker, ← Units.val_inj, Units.val_one, MulChar.coe_toUnitHom,
+      MulChar.ringHomComp_apply]
+    exact ⟨fun h ↦ hf (by rw [h, map_one]), fun h ↦ by rw [h, map_one]⟩
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩ <;>
+    rw [factorsThrough_iff_ker_unitsMap h.dvd] <;>
+    exact hker ▸ (factorsThrough_iff_ker_unitsMap h.dvd).mp h
+
+/-- Post-composition with an injective ring homomorphism does not change the conductor. -/
+lemma conductor_ringHomComp (hf : Function.Injective f) :
+    conductor (χ.ringHomComp f) = conductor χ := by
+  have h : conductorSet (χ.ringHomComp f) = conductorSet χ :=
+    Set.ext fun _ ↦ factorsThrough_ringHomComp_iff hf
+  simp [conductor, h]
+
+/-- Post-composition with an injective ring homomorphism preserves primitivity. -/
+lemma IsPrimitive.ringHomComp (hχ : χ.IsPrimitive) (hf : Function.Injective f) :
+    IsPrimitive (χ.ringHomComp f) := by
+  rwa [isPrimitive_def, conductor_ringHomComp hf]
+
+end Comp
+
+section Inv
+
+variable {R : Type*} [CommMonoidWithZero R] {N : ℕ} {χ : DirichletCharacter R N}
+
+/-- The inverse of a primitive Dirichlet character is primitive. -/
+lemma IsPrimitive.inv (hχ : χ.IsPrimitive) : χ⁻¹.IsPrimitive := by
+  rw [isPrimitive_def, conductor_inv]
+  exact hχ
+
+end Inv
+
+section GaussSum
+
+variable {N : ℕ} [NeZero N] {χ : DirichletCharacter ℂ N}
+
+/-- The Gauss sums of a primitive Dirichlet character and of its inverse multiply to
+`χ (-1) * N`. Compare `gaussSum_mul_gaussSum_eq_card`, which assumes the source is a field. -/
+theorem IsPrimitive.gaussSum_mul_gaussSum_inv (hχ : χ.IsPrimitive) :
+    gaussSum χ stdAddChar * gaussSum χ⁻¹ stdAddChar = χ (-1) * N := by
+  have h₁ : (𝓕 (⇑χ)) = fun k ↦ (fun j ↦ (⇑χ⁻¹) (-j)) k * gaussSum χ stdAddChar :=
+    funext hχ.fourierTransform_eq_inv_mul_gaussSum
+  have h₂ : (𝓕 (𝓕 (⇑χ))) 1 = χ 1 * gaussSum χ⁻¹ stdAddChar * gaussSum χ stdAddChar := by
+    simp [h₁, ZMod.dft_mul_const, ZMod.dft_comp_neg, hχ.inv.fourierTransform_eq_inv_mul_gaussSum]
+  simp only [ZMod.dft_dft, MulChar.map_one, one_mul, smul_eq_mul] at h₂
+  linear_combination -h₂
+
+/-- The Gauss sum of a primitive Dirichlet character does not vanish. -/
+lemma IsPrimitive.gaussSum_ne_zero (hχ : χ.IsPrimitive) : gaussSum χ stdAddChar ≠ 0 := fun h ↦ by
+  have h := h ▸ hχ.gaussSum_mul_gaussSum_inv
+  rw [zero_mul] at h
+  exact mul_ne_zero (MulChar.apply_ne_zero_iff.mpr isUnit_one.neg)
+    (Nat.cast_ne_zero.mpr (NeZero.ne N)) h.symm
+
+end GaussSum
+
+section IsAlgebraic
+
+variable {N : ℕ} [NeZero N]
+
+/-- The values of a Dirichlet character over `ℂ` are algebraic. -/
+lemma isAlgebraic_apply (χ : DirichletCharacter ℂ N) (a : ZMod N) : IsAlgebraic ℚ (χ a) := by
+  rw [isAlgebraic_iff_isIntegral]
+  by_cases ha : IsUnit a
+  · obtain ⟨u, rfl⟩ := ha
+    refine IsIntegral.of_pow (n := Fintype.card (ZMod N)ˣ) Fintype.card_pos ?_
+    rw [← MulChar.pow_apply_coe, χ.pow_card_eq_one, MulChar.one_apply_coe]
+    exact isIntegral_one
+  · exact χ.map_nonunit ha ▸ isIntegral_zero
+
+end IsAlgebraic
 
 end DirichletCharacter


### PR DESCRIPTION
This PR provides a general framework for stating Deligne's conjectures for special values of L-function in various cases. Informally, these are the statements that $L(M, n)/c^+(M, n)\in E$, where $M$ is a motive, $n$ is a critical integer, $c^+(M, n)$ is the period, and $E$ is some algebraic subfield of $\mathbb{C}$. We avoid formalizing the definition of a motive and instead define `Deligne.Pkg` parameterized by an arbitrary index type, containing the data $(L, E, w, \gamma, c, \sigma)$ + conditions on expected behaviour of these inputs. This has the added benefit that one can state the conjecture in cases where motives are not known in general (e.g., Bianchi modular forms). However it comes at the cost of certain trivial edge cases, which are documented in `SpecialValues.lean`.