### PR TITLE
fix(OEIS/1223): prime-gap blocks need not recur infinitely often

### DIFF
--- a/FormalConjectures/OEIS/1223.lean
+++ b/FormalConjectures/OEIS/1223.lean
@@ -61,10 +61,15 @@ theorem a_3 : a 3 = 2 := by
 /--
 Any subsequence a(n .. n+m) with n > 2 (as to exclude the
 untypical primes 2 and 3) should occur infinitely many times at other starting points k.
+
+This is false. The five-term block starting at $n = 3$ is $(2,4,2,4,2)$, and a congruence
+modulo $5$ shows that it occurs only at $n = 3$.
 -/
-@[category research open, AMS 11]
-theorem conjecture (n m : ℕ) (hn : n ≥ 3) :
-    Set.Infinite {k : ℕ | gapSubsequence k (m + 1) = gapSubsequence n (m + 1)} := by
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-oai-jajpvieznaevpoyg/prime_gap_subsequences_occur_infinitely_often/Submission/Spec.lean#L134"]
+theorem conjecture :
+    ¬ ∀ (n m : ℕ), n ≥ 3 →
+      Set.Infinite {k : ℕ | gapSubsequence k (m + 1) = gapSubsequence n (m + 1)} := by
   sorry
 
 end OeisA1223


### PR DESCRIPTION
**What changed**

- `conjecture` is restated as the negation of the original universal claim and marked
  `research solved`, with a `formal_proof using lean4` attribute.

**Why**

The OEIS comment asks whether every gap block `a(n..n+m)` with `n > 2` recurs infinitely often
at other starting points. **It does not.** The five-term block beginning at `n = 3` is
`(2, 4, 2, 4, 2)`, and a congruence argument modulo `5` shows it occurs only at `n = 3`, so the
set of matching starting points is a singleton rather than infinite.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `a` and `gap_subsequence` are verbatim identical to this file's `a` and `gapSubsequence`.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-5.5** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
