### PR TITLE
fix(OEIS/84046): a 27 = 0 but 27 is not an even square

### DIFF
--- a/FormalConjectures/OEIS/84046.lean
+++ b/FormalConjectures/OEIS/84046.lean
@@ -98,9 +98,14 @@ theorem a_3 : a 3 = 5 := by
   exact h_least.csInf_eq
 
 /--
-Conjecture: if a(k) = 0 then k is an even square.-/
-@[category research open, AMS 11]
-theorem conjecture (k : ℕ) (h : a k = 0) : ∃ m : ℕ, k = (2 * m) ^ 2 := by
+Conjecture: if a(k) = 0 then k is an even square.
+
+This is false for $k = 27$. Every candidate $x^{27} - 27$ factors as
+$(x^9 - 3)(x^{18} + 3x^9 + 9)$, so $a(27) = 0$, but $27$ is not an even square.
+-/
+@[category research solved, AMS 11, formal_proof using lean4 at
+  "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-oai-jajpvieznaevpoyg/a084046_conjecture_0/Submission/Spec.lean#L17"]
+theorem conjecture : ¬ ∀ k : ℕ, a k = 0 → ∃ m : ℕ, k = (2 * m) ^ 2 := by
   sorry
 
 end OeisA84046


### PR DESCRIPTION
**What changed**

- `conjecture` is restated as the negation of the original claim and marked `research solved`,
  with a `formal_proof using lean4` attribute.

**Why**

The conjecture is that `a(k) = 0` implies `k` is an even square. **It fails at `k = 27`.**
Every candidate is of the form `x^27 - 27 = (x^9)^3 - 3^3`, which factors as
`(x^9 - 3)(x^18 + 3x^9 + 9)`; for `x ≥ 2` both factors exceed `1`, so no prime of that form
exists and `a(27) = 0`. But `27` is not an even square.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `a` is verbatim identical to this file's: `sInf {p | p.Prime ∧ ∃ k, k ^ n = p + n}`.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-5.5** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
