### PR TITLE
fix(OEIS/46969): conjecture2 fails at n = 236791

### DIFF
--- a/FormalConjectures/OEIS/46969.lean
+++ b/FormalConjectures/OEIS/46969.lean
@@ -128,15 +128,17 @@ theorem conjecture1 (n : ℕ) (hn : 2 < n) : (a (a005382 n) / 12).Prime := by
 Conjecture II: if $\frac{a(n)}{12}$ is prime, then $\frac{a(n-1)}{12} - (n-1)$,
 $\frac{a(n)}{12} - n$ and $\frac{a(n+2)}{12} - (n+2)$ are multiples of 6.
 - Lorenzo Sauras Altuzarra, Oct 13 2020
+
+This is false for $n = 236791$.
 -/
-@[category research open, AMS 11]
-theorem conjecture2 (n : ℕ) (hn : 2 ≤ n)
-    (h_div : 12 ∣ a n) (h_prime : Nat.Prime (a n / 12))
-    (h_div_prev : 12 ∣ a (n - 1)) (h_div_succ : 12 ∣ a (n + 2)) :
-    6 ∣ ((a (n - 1) / 12 : ℤ) - (n - 1 : ℤ)) ∧
-    6 ∣ ((a n / 12 : ℤ) - (n : ℤ)) ∧
-    6 ∣ ((a (n + 2) / 12 : ℤ) - (n + 2 : ℤ)) := by
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-ant-j0j0g4uzligm1k41/oeis_a046969_conjecture_2/Submission/Spec.lean#L845"]
+theorem conjecture2 :
+    ¬ ∀ (n : ℕ), 2 ≤ n → 12 ∣ a n → Nat.Prime (a n / 12) →
+      12 ∣ a (n - 1) → 12 ∣ a (n + 2) →
+      6 ∣ ((a (n - 1) / 12 : ℤ) - (n - 1 : ℤ)) ∧
+      6 ∣ ((a n / 12 : ℤ) - (n : ℤ)) ∧
+      6 ∣ ((a (n + 2) / 12 : ℤ) - (n + 2 : ℤ)) := by
   sorry
 
 end OeisA46969
-


### PR DESCRIPTION
**What changed**

- `conjecture2` is restated as the negation of the original universal claim and marked
  `research solved`, with a `formal_proof using lean4` attribute.

**Why**

Conjecture II asserts a trio of divisibility-by-6 congruences whenever the stated hypotheses
hold. **It fails at `n = 236791`**, where the hypotheses hold but the middle congruence does not.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `a` is verbatim identical to this file's Bernoulli-denominator definition. The
  external statement writes the hypotheses as `a n % 12 = 0` where this file writes `12 ∣ a n`;
  these are the same condition on naturals.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
