### PR TITLE
fix(OEIS/48153): link a proof of the (n^2-1)/2 bound

### DIFF
--- a/FormalConjectures/OEIS/48153.lean
+++ b/FormalConjectures/OEIS/48153.lean
@@ -55,7 +55,8 @@ theorem a_5 : a 5 = 10 := by
 
 /--
 "Conjecture: $a(n) <= \frac{n^2-1}{2}$. - _Aspen A.M. Meissner_, Mar 06 2025"-/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-lite-200usd-ant-me0xxoowyqauyrvj/oeis_48153_conjecture_0/Submission/Spec.lean#L3215"]
 theorem conjecture (n : ℕ) (hn : 1 ≤ n) : a n ≤ (n ^ 2 - 1) / 2 := by
   sorry
 


### PR DESCRIPTION
**What changed**

- `conjecture` is marked `research solved` with a `formal_proof using lean4` attribute. The
  statement is unchanged — the conjectured bound holds.

**Why**

Aspen A.M. Meissner's conjecture that `a(n) ≤ (n² - 1)/2` is **true**, and the linked development
proves it for all `n ≥ 1`.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- The external `A048153` sums over `Finset.range n` where this file sums over `Finset.Icc 1 n`.
  These agree: the `k = 0` term is `0`, and the `k = n` term is `n² mod n = 0`, so the two ranges
  differ only by terms that vanish.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
