### PR TITLE
fix(OEIS/52709): link a proof of Wiseman's counting conjecture

### DIFF
--- a/FormalConjectures/OEIS/52709.lean
+++ b/FormalConjectures/OEIS/52709.lean
@@ -88,7 +88,8 @@ initial interval of positive integers and avoiding three terms
 $(\dots, x, \dots, y, \dots, z, \dots)$ such that $x \le y \le z$.
 - Gus Wiseman, Jun 17 2021
 -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-ant-j0j0g4uzligm1k41/oeis_52709_conjecture_0/Submission/Spec.lean#L1289"]
 theorem conjecture (n : ℕ) (hn : 0 < n) [Fintype (sequencesCountedByA052709 n)] :
     a n = Fintype.card (sequencesCountedByA052709 n) := by
   sorry


### PR DESCRIPTION
**What changed**

- `conjecture` is marked `research solved` with a `formal_proof using lean4` attribute. The
  statement is unchanged.

**Why**

Gus Wiseman's conjecture is **true**: `a(n)` does count the length-`(n-1)` sequences covering an
initial interval of positive integers and avoiding a weakly increasing three-term pattern.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `A052709`, `covers_initial_interval` and `has_nondecreasing_pattern_3` are verbatim
  identical to this file's `a`, `coversInitialInterval` and `hasNondecreasingPattern3`, and its
  `avoids_pattern_xyz` is the negation of the latter, matching `avoidsPatternXYZ`. The external
  theorem carries the same `[Fintype …]` instance argument that this file's declaration already
  has.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
