### PR TITLE
fix(OEIS/64169): the prime criterion fails at 16843^2

### DIFF
--- a/FormalConjectures/OEIS/64169.lean
+++ b/FormalConjectures/OEIS/64169.lean
@@ -57,9 +57,12 @@ theorem a_5 : a 5 = 77 := by
 
 /--
 "Conjecture: for $n > 2$, $n$ divides $a(n-2)$ if and only if $n$ is a prime.
-Checked up to 20000. - _Amiram Eldar_ and _Thomas Ordowski_, Jul 27 2019"-/
-@[category research open, AMS 11]
-theorem conjecture (n : ℕ) (hn : 2 < n) : (n : ℤ) ∣ a (n - 2) ↔ n.Prime := by
+Checked up to 20000. - _Amiram Eldar_ and _Thomas Ordowski_, Jul 27 2019
+
+This is false for the composite number $16843^2$.-/
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-ant-j0j0g4uzligm1k41/oeis_64169_conjecture_0/Submission/Spec.lean#L514"]
+theorem conjecture : ¬ ∀ (n : ℕ), 2 < n → ((n : ℤ) ∣ a (n - 2) ↔ n.Prime) := by
   sorry
 
 end OeisA64169


### PR DESCRIPTION
**What changed**

- `conjecture` is restated as the negation of the original universal claim and marked
  `research solved`, with a `formal_proof using lean4` attribute.

**Why**

Eldar and Ordowski conjectured that for `n > 2`, `n ∣ a(n-2)` exactly when `n` is prime, checked
to 20000. **It fails at `n = 16843²`**, the square of a Wolstenholme prime, which is composite but
divides the corresponding term.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- This file's `a` returns `ℤ` (`(H n).num - (H n).den`); the external `A064169` returns `ℕ` via
  `Int.natAbs` of the same difference, using Mathlib's `harmonic`, which is this file's `H`.
  Divisibility by `n` is unaffected by the absolute value.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
