### PR TITLE
fix(OEIS/93456): infinitely many terms are not divisible by the previous one

### DIFF
--- a/FormalConjectures/OEIS/93456.lean
+++ b/FormalConjectures/OEIS/93456.lean
@@ -55,10 +55,11 @@ theorem a_4 : a 4 = 720 := by decide +native
 
 /--
 Conjecture: There are finitely many numbers such that $a(n)$ is not $\equiv 0 \pmod{a(n-1)}$.
-(Also mentioned in A093455.)-/
-@[category research open, AMS 11]
+(Also mentioned in A093455.) In fact there are infinitely many such numbers.-/
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-ant-j0j0g4uzligm1k41/oeis_93456_conjecture_0/Submission/Spec.lean#L109"]
 theorem conjecture :
-    Set.Finite {n : ℕ | 1 < n ∧ ¬ (a (n - 1) ∣ a n)} := by
+    ¬ Set.Finite {n : ℕ | 1 < n ∧ ¬ (a (n - 1) ∣ a n)} := by
   sorry
 
 end OeisA93456


### PR DESCRIPTION
**What changed**

- `conjecture` is restated as the negation of the original finiteness claim and marked
  `research solved`, with a `formal_proof using lean4` attribute.

**Why**

The conjecture is that only finitely many `n` satisfy `a(n-1) ∤ a(n)`. **There are infinitely
many.** The linked proof produces, above any bound, a suitable `n` via a large prime.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `a` is verbatim identical to this file's product of composites in `Icc (C(n,2)+1) (C(n+1,2))`.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
