### PR TITLE
fix(OEIS/103885): link a proof of the subsequence recurrence

### DIFF
--- a/FormalConjectures/OEIS/103885.lean
+++ b/FormalConjectures/OEIS/103885.lean
@@ -91,7 +91,8 @@ The $4m$ zeros of the polynomial $Q(2m,n^2)$ seem to belong to the interval $[-1
 $4m - 2$ of these zeros appear to be approximated by the rational numbers
 $\pm k/(3m)$, where $1 \le k \le 3m - 2$, $k$ not a multiple of $3$.
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-lite-200usd-sol-nk5wh4g0vh3546nm/oeis_a103885_conjecture_0/Submission/Spec.lean#L2587"]
 theorem conjecture (m : ℕ) (hm : 1 ≤ m) :
     ∃ (P Q : Polynomial ℝ),
       -- P and Q have degree 2m


### PR DESCRIPTION
**What changed**

- `conjecture` is marked `research solved` with a `formal_proof using lean4` attribute. The
  statement is unchanged.

**Why**

The conjectured polynomial recurrence for the subsequence `b(n) = a(mn)` **holds** for every
`m ≥ 1`, with the stated degree and symmetry conditions on the two polynomials.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `A103885` and `A103885_subsequence_real` are verbatim identical to this file's `a` and
  `aSubsequenceReal`.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-5.6 Sol** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
