### PR TITLE
fix(OEIS/141057): link a proof of the supercongruences

### DIFF
--- a/FormalConjectures/OEIS/141057.lean
+++ b/FormalConjectures/OEIS/141057.lean
@@ -56,7 +56,8 @@ theorem a_4 : a 4 = 6219 := by decide
 /--
 Conjecture: the supercongruences $a(n \cdot p^k) \equiv a(n \cdot p^{k-1}) \pmod{p^{3k}}$ hold
 for primes $p \ge 5$ and positive integers $n$ and $k$.-/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-ant-j0j0g4uzligm1k41/oeis_a141057_supercongruence_conjecture/Submission/Spec.lean#L955"]
 theorem conjecture1 (p k n : ℕ) (hp : p.Prime) (h_p_ge_5 : 5 ≤ p) (h_k_pos : 1 ≤ k)
     (h_n_pos : 1 ≤ n) :
     (a (n * p ^ k) : ℤ) ≡ a (n * p ^ (k - 1)) [ZMOD (p ^ (3 * k))] := by


### PR DESCRIPTION
**What changed**

- `conjecture1` is marked `research solved` with a `formal_proof using lean4` attribute. The
  statement is unchanged.

**Why**

The supercongruences `a(n·pᵏ) ≡ a(n·p^{k-1}) (mod p^{3k})` **hold** for all primes `p ≥ 5` and
all positive `n`, `k`.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- The two definitions look different but agree. This file has
  `a n = ∑_k C(n,k)³ · ∑_{j≤k} C(k,j)³`; the external `A141057` has
  `∑_{n₁} ∑_{n₂ ≤ n-n₁} (C(n,n₁)·C(n-n₁,n₂))³`. Substituting `k = n - n₁` and using
  `C(n,n₁) = C(n,n-n₁)` turns the second into the first.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
