### PR TITLE
fix(OEIS/181546): link a proof of the ratio limit

### DIFF
--- a/FormalConjectures/OEIS/181546.lean
+++ b/FormalConjectures/OEIS/181546.lean
@@ -71,7 +71,8 @@ Conjecture: Given $F(n,L) = \sum_{k=0}^{\lfloor n/2 \rfloor} \binom{n-k}{k}^L$, 
 $\lim_{n\to\infty} F(n+1,L)/F(n,L) = (\mathrm{Fibonacci}(L)\sqrt{5} + \mathrm{Lucas}(L))/2$ for
 $L \ge 0$ where $\mathrm{Fibonacci}(n) = \mathrm{A000045}(n)$ and
 $\mathrm{Lucas}(n) = \mathrm{A000032}(n)$.-/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-full-50usd-ant-j0j0g4uzligm1k41/oeis_181546_conjecture_0/Submission/Spec.lean#L1210"]
 theorem conjecture (L : ℕ) :
     Tendsto (fun n => (F (n + 1) L : ℝ) / (F n L : ℝ)) atTop (nhds (limitValue L)) := by
   sorry


### PR DESCRIPTION
**What changed**

- `conjecture` is marked `research solved` with a `formal_proof using lean4` attribute. The
  statement is unchanged.

**Why**

The conjectured limit `F(n+1,L)/F(n,L) → (Fib(L)·√5 + Lucas(L))/2` **holds** for every `L`.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `F` is verbatim identical to this file's `F`.

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **Claude Opus 4.8** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
