### PR TITLE
fix(OEIS/185895): sign changes occur exactly at triangular numbers

### DIFF
--- a/FormalConjectures/OEIS/185895.lean
+++ b/FormalConjectures/OEIS/185895.lean
@@ -103,7 +103,8 @@ $a(n)$ differs in sign from $a(n-1)$ if and only if $n$ is a triangular number
 (checked up to $n = 1225 = (50 \cdot 51)/2$).
 - _Peter Bala_, Mar 17 2022
 -/
-@[category research open, AMS 11]
+@[category research solved, AMS 11,
+  formal_proof using lean4 at "https://github.com/epoch-research/LeanOpenProblems-results/blob/f02efd9a8c5fc6a735d2a90c33e24f7278ce0ffc/runs/oeis-lite-200usd-sol-nk5wh4g0vh3546nm/oeis_185895_conjecture_1/Submission/Spec.lean#L4835"]
 theorem conjecture1 (n : ℕ) (hn : 0 < n) :
     a n * a (n - 1) < 0 ↔ IsTriangular n := by
   sorry
@@ -129,4 +130,3 @@ theorem conjecture3 (p : ℕ) (hp : p.Prime) (n k : ℕ) (hn : 0 < n) (hk : 0 < 
   sorry
 
 end OeisA185895
-


### PR DESCRIPTION
**What changed**

- `conjecture1` is marked `research solved` with a `formal_proof using lean4` attribute. The
  statement is unchanged.

**Why**

Peter Bala's conjecture is **true**: `a(n)` differs in sign from `a(n-1)` exactly when `n` is a
triangular number. It had been checked only to `n = 1225`.

**Audit of the linked proof**

- Verified by **SafeVerify**, which kernel-replays the target and submission `.olean` files
  and reports the axioms of each declaration. Its report for this task lists exactly `propext`,
  `Quot.sound` and `Classical.choice` for every declaration, with no failure mode. (Lean v4.27.0.)
- Source-level inspection at the pinned commit also shows no `sorry`, no project `axiom`, no
  `native_decide`; the pinned line is the theorem itself.
- Its `A185895` is this file's `a`: the `n!`-scaled coefficient of `xⁿ` in
  `∏_{k=1}^{n} (1 - xᵏ/k!)`, taken as an integer (the coefficients are integers, so the external
  `.num` and this file's `.floor` agree).

*AI assistance: the match between this declaration and the external proof was found by an OpenAI Codex agent during a repository-wide sweep. The linked Lean proof itself was generated by **GPT-5.6 Sol** in the OEIS Open benchmark ([Adamczewski, 2026](https://arxiv.org/pdf/2608.11941)); its `scores.json` records the verifier verdict `C` (accepted). The statement match and the `sorry`/axiom audit of the linked proof were carried out with Claude Opus 5.*
