### PR TITLE
feat(Arxiv): finite generation of the cohomology of finite-dimensional Hopf algebras

### DIFF
--- a/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
+++ b/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
@@ -28,9 +28,31 @@ module over it for every finite-dimensional $A$-module $M$. They state the conje
 finite tensor category; the finite-dimensional modules over a finite-dimensional Hopf algebra form
 the main class of examples, and the conjecture is open already in this case.
 
+The question for an arbitrary finite-dimensional Hopf algebra is already posed, and expressly left
+open, in Friedlander and Suslin's paper: "We do not know whether it is reasonable to expect finite
+generation of the cohomology of an arbitrary finite dimensional Hopf algebra." What is due to
+Etingof and Ostrik is the assertion that the answer is yes, together with its extension to every
+finite tensor category.
+
 The conjecture holds when $A$ is cocommutative, that is, when $A$ is the group algebra of a finite
 group scheme (Friedlander–Suslin). For the group algebra $k[G]$ of a finite group $G$ it is the
-theorem of Evens and Venkov. Etingof and Ostrik note that it also holds when $A$ is commutative.
+theorem of Evens and Venkov, proved for a $p$-group by Golod. Etingof and Ostrik note that it also holds when $A$ is commutative.
+
+Etingof and Ostrik work throughout the section containing the conjecture under the standing
+assumption that $k$ is algebraically closed, whereas the statements below are for an arbitrary
+field. The generalisation is valid. For a field extension $K/k$ one has
+$\mathrm{Ext}^*_{A \otimes_k K}(K, K) \cong \mathrm{Ext}^*_A(k, k) \otimes_k K$, because $k$
+admits a resolution by finitely generated free $A$-modules and $K$ is flat over $k$; and finite
+generation descends, because the finitely many elements of $R = \mathrm{Ext}^*_A(k, k)$ occurring
+in a finite set of $K$-algebra generators of $R \otimes_k K$ generate a $k$-subalgebra $R'$ with
+$R' \otimes_k K = R \otimes_k K$, whence $R' = R$ by faithful flatness. The same argument applies
+to the module statement. The theorems of Friedlander–Suslin and of Evens–Venkov are stated below
+over an arbitrary field because that is the generality in which they are proved.
+
+$\mathrm{Ext}$ is taken in the category of all $A$-modules rather than in the finite tensor
+category of finite-dimensional ones. For finite-dimensional $A$ the two agree on
+finite-dimensional modules, as the module docstring of
+`FormalConjecturesForMathlib.RingTheory.Bialgebra.Cohomology` explains.
 
 *References:*
 * [arXiv:math/0301027](https://arxiv.org/abs/math/0301027) P. Etingof, V. Ostrik, *Finite tensor
@@ -39,6 +61,10 @@ theorem of Evens and Venkov. Etingof and Ostrik note that it also holds when $A$
   *Cohomology of finite group schemes over a field*, Invent. Math. 127 (1997), 209–270.
 * [Evens](https://doi.org/10.1090/S0002-9947-1961-0137742-1) L. Evens, *The cohomology ring of a
   finite group*, Trans. Amer. Math. Soc. 101 (1961), 224–239.
+* B. B. Venkov, *Cohomology algebras for some classifying spaces*, Dokl. Akad. Nauk SSSR 127
+  (1959), 943–944.
+* E. S. Golod, *The cohomology ring of a finite $p$-group*, Dokl. Akad. Nauk SSSR 125 (1959),
+  703–706.
 -/
 
 open Bialgebra
@@ -89,5 +115,20 @@ $k$-algebra. -/
 theorem cohomologyRing_finiteType_monoidAlgebra (G : Type u) [Group G] [Finite G] :
     Algebra.FiniteType k (cohomologyRing k (MonoidAlgebra k G)) := by
   sorry
+
+omit [FiniteDimensional k A] in
+/-- Sanity check: taking the coefficient module `M` of the module statement to be `k` itself
+gives back the cohomology ring. -/
+@[category test, AMS 16 18]
+theorem cohomology_trivialModuleCat :
+    cohomology k A (trivialModuleCat k A) = cohomologyRing k A :=
+  rfl
+
+omit [FiniteDimensional k A] in
+/-- Sanity check: the cohomology ring is not the zero ring, over which every finiteness statement
+would hold trivially. -/
+@[category test, AMS 16 18]
+theorem cohomologyRing_nontrivial : Nontrivial (cohomologyRing k A) :=
+  Bialgebra.nontrivial_cohomologyRing
 
 end HopfAlgebraCohomology

--- a/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
+++ b/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
@@ -1,0 +1,147 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Finite generation of the cohomology of finite-dimensional Hopf algebras
+
+Let $A$ be a finite-dimensional Hopf algebra over a field $k$, and view $k$ as an $A$-module
+through the counit. The cohomology ring
+$$H^*(A, k) = \mathrm{Ext}^*_A(k, k) = \bigoplus_{n \ge 0} \mathrm{Ext}^n_A(k, k)$$
+is a graded-commutative $k$-algebra under the Yoneda product. Etingof and Ostrik conjecture that
+it is a finitely generated $k$-algebra, and that $\mathrm{Ext}^*_A(k, M)$ is a finitely generated
+module over it for every finite-dimensional $A$-module $M$. They state the conjecture for every
+finite tensor category; the finite-dimensional modules over a finite-dimensional Hopf algebra form
+the main class of examples, and the conjecture is open already in this case.
+
+The conjecture holds when $A$ is cocommutative, that is, when $A$ is the group algebra of a finite
+group scheme (Friedlander–Suslin). For the group algebra $k[G]$ of a finite group $G$ it is the
+theorem of Evens and Venkov. Etingof and Ostrik note that it also holds when $A$ is commutative.
+
+*References:*
+* [arXiv:math/0301027](https://arxiv.org/abs/math/0301027) P. Etingof, V. Ostrik, *Finite tensor
+  categories*, Mosc. Math. J. 4 (2004), no. 3, 627–654; Conjecture 2.18.
+* [Friedlander–Suslin](https://doi.org/10.1007/s002220050119) E. M. Friedlander, A. Suslin,
+  *Cohomology of finite group schemes over a field*, Invent. Math. 127 (1997), 209–270.
+* [Evens](https://doi.org/10.1090/S0002-9947-1961-0137742-1) L. Evens, *The cohomology ring of a
+  finite group*, Trans. Amer. Math. Soc. 101 (1961), 224–239.
+-/
+
+open CategoryTheory Abelian Bialgebra
+open scoped DirectSum ModuleCat.Algebra
+
+universe u
+
+namespace HopfAlgebraCohomology
+
+section Definitions
+
+variable (k : Type u) [Field k] (A : Type u) [Ring A] [Bialgebra k A]
+
+/-- The cohomology ring $H^*(A, k) = \mathrm{Ext}^*_A(k, k)$ of the bialgebra $A$ over $k$, where
+$k$ is the trivial $A$-module through the counit and `Ext` is taken in `ModuleCat A`, the category
+of all $A$-modules. It is a graded $k$-algebra under the Yoneda product. -/
+abbrev cohomologyRing : Type u :=
+  ⨁ n, Ext (trivialModuleCat k A) (trivialModuleCat k A) n
+
+/-- The cohomology $H^*(A, M) = \mathrm{Ext}^*_A(k, M)$ of the bialgebra $A$ over $k$ with
+coefficients in the $A$-module $M$. It is a graded module over `cohomologyRing k A` under the
+Yoneda product. -/
+abbrev cohomology (M : ModuleCat.{u} A) : Type u :=
+  ⨁ n, Ext (trivialModuleCat k A) M n
+
+variable {k A}
+
+/-- The product on `cohomologyRing k A` is the Yoneda composition of extensions. -/
+@[category API, AMS 16 18]
+theorem of_mul_of {a b : ℕ} (x : Ext (trivialModuleCat k A) (trivialModuleCat k A) a)
+    (y : Ext (trivialModuleCat k A) (trivialModuleCat k A) b) :
+    (DirectSum.of _ a x : cohomologyRing k A) * DirectSum.of _ b y =
+      DirectSum.of _ (a + b) (x.comp y rfl) :=
+  DirectSum.of_mul_of x y
+
+variable (k A) in
+/-- A scalar $c \in k$ acts on `cohomologyRing k A` as $c$ times the identity in degree $0$. -/
+@[category API, AMS 16 18]
+theorem algebraMap_apply (c : k) :
+    algebraMap k (cohomologyRing k A) c =
+      DirectSum.of _ 0 (Ext.mk₀ (c • 𝟙 (trivialModuleCat k A))) :=
+  rfl
+
+/-- The action of `cohomologyRing k A` on `cohomology k A M` is the Yoneda composition of
+extensions. -/
+@[category API, AMS 16 18]
+theorem of_smul_of {M : ModuleCat.{u} A} {a b : ℕ}
+    (x : Ext (trivialModuleCat k A) (trivialModuleCat k A) a) (y : Ext (trivialModuleCat k A) M b) :
+    (DirectSum.of _ a x : cohomologyRing k A) • (DirectSum.of _ b y : cohomology k A M) =
+      DirectSum.of _ (a + b) (x.comp y rfl) :=
+  DirectSum.Gmodule.of_smul_of (A := fun n ↦ Ext (trivialModuleCat k A) (trivialModuleCat k A) n)
+    (M := fun n ↦ Ext (trivialModuleCat k A) M n) x y
+
+variable (k A) in
+/-- In degree $0$, the cohomology ring is the endomorphism ring of the trivial module. -/
+@[category API, AMS 16 18]
+theorem nonempty_addEquiv_zero :
+    Nonempty (Ext (trivialModuleCat k A) (trivialModuleCat k A) 0 ≃+
+      (trivialModuleCat k A ⟶ trivialModuleCat k A)) :=
+  ⟨Ext.addEquiv₀⟩
+
+end Definitions
+
+variable (k : Type u) [Field k] (A : Type u) [Ring A] [HopfAlgebra k A] [FiniteDimensional k A]
+
+/-- **Finite generation conjecture** (Etingof–Ostrik, Conjecture 2.18, algebra part).
+For every finite-dimensional Hopf algebra $A$ over a field $k$, the cohomology ring
+$H^*(A, k) = \mathrm{Ext}^*_A(k, k)$ is a finitely generated $k$-algebra. -/
+@[category research open, AMS 16 18]
+theorem cohomologyRing_finiteType : Algebra.FiniteType k (cohomologyRing k A) := by
+  sorry
+
+/-- **Finite generation conjecture** (Etingof–Ostrik, Conjecture 2.18, module part).
+For every finite-dimensional Hopf algebra $A$ over a field $k$ and every finite-dimensional
+$A$-module $M$, the cohomology $H^*(A, M) = \mathrm{Ext}^*_A(k, M)$ is a finitely generated module
+over $H^*(A, k)$. -/
+@[category research open, AMS 16 18]
+theorem cohomology_finite (M : ModuleCat.{u} A) [FiniteDimensional k M] :
+    Module.Finite (cohomologyRing k A) (cohomology k A M) := by
+  sorry
+
+/-- **Friedlander–Suslin.** If $A$ is a finite-dimensional cocommutative Hopf algebra over a
+field $k$, that is, the group algebra of a finite group scheme over $k$, then $H^*(A, k)$ is a
+finitely generated $k$-algebra. -/
+@[category research solved, AMS 14 16 18]
+theorem cohomologyRing_finiteType_of_isCocomm [Coalgebra.IsCocomm k A] :
+    Algebra.FiniteType k (cohomologyRing k A) := by
+  sorry
+
+/-- **Friedlander–Suslin.** If $A$ is a finite-dimensional cocommutative Hopf algebra over a
+field $k$ and $M$ is a finite-dimensional $A$-module, then $H^*(A, M)$ is a finitely generated
+module over $H^*(A, k)$. -/
+@[category research solved, AMS 14 16 18]
+theorem cohomology_finite_of_isCocomm [Coalgebra.IsCocomm k A] (M : ModuleCat.{u} A)
+    [FiniteDimensional k M] : Module.Finite (cohomologyRing k A) (cohomology k A M) := by
+  sorry
+
+/-- **Evens–Venkov.** For a finite group $G$ and a field $k$, the cohomology ring
+$H^*(G, k) = \mathrm{Ext}^*_{k[G]}(k, k)$ of the group algebra $k[G]$ is a finitely generated
+$k$-algebra. -/
+@[category research solved, AMS 16 20]
+theorem cohomologyRing_finiteType_monoidAlgebra (G : Type u) [Group G] [Finite G] :
+    Algebra.FiniteType k (cohomologyRing k (MonoidAlgebra k G)) := by
+  sorry
+
+end HopfAlgebraCohomology

--- a/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
+++ b/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
@@ -41,66 +41,12 @@ theorem of Evens and Venkov. Etingof and Ostrik note that it also holds when $A$
   finite group*, Trans. Amer. Math. Soc. 101 (1961), 224–239.
 -/
 
-open CategoryTheory Abelian Bialgebra
-open scoped DirectSum ModuleCat.Algebra
+open Bialgebra
+open scoped ModuleCat.Algebra
 
 universe u
 
 namespace HopfAlgebraCohomology
-
-section Definitions
-
-variable (k : Type u) [Field k] (A : Type u) [Ring A] [Bialgebra k A]
-
-/-- The cohomology ring $H^*(A, k) = \mathrm{Ext}^*_A(k, k)$ of the bialgebra $A$ over $k$, where
-$k$ is the trivial $A$-module through the counit and `Ext` is taken in `ModuleCat A`, the category
-of all $A$-modules. It is a graded $k$-algebra under the Yoneda product. -/
-abbrev cohomologyRing : Type u :=
-  ⨁ n, Ext (trivialModuleCat k A) (trivialModuleCat k A) n
-
-/-- The cohomology $H^*(A, M) = \mathrm{Ext}^*_A(k, M)$ of the bialgebra $A$ over $k$ with
-coefficients in the $A$-module $M$. It is a graded module over `cohomologyRing k A` under the
-Yoneda product. -/
-abbrev cohomology (M : ModuleCat.{u} A) : Type u :=
-  ⨁ n, Ext (trivialModuleCat k A) M n
-
-variable {k A}
-
-/-- The product on `cohomologyRing k A` is the Yoneda composition of extensions. -/
-@[category API, AMS 16 18]
-theorem of_mul_of {a b : ℕ} (x : Ext (trivialModuleCat k A) (trivialModuleCat k A) a)
-    (y : Ext (trivialModuleCat k A) (trivialModuleCat k A) b) :
-    (DirectSum.of _ a x : cohomologyRing k A) * DirectSum.of _ b y =
-      DirectSum.of _ (a + b) (x.comp y rfl) :=
-  DirectSum.of_mul_of x y
-
-variable (k A) in
-/-- A scalar $c \in k$ acts on `cohomologyRing k A` as $c$ times the identity in degree $0$. -/
-@[category API, AMS 16 18]
-theorem algebraMap_apply (c : k) :
-    algebraMap k (cohomologyRing k A) c =
-      DirectSum.of _ 0 (Ext.mk₀ (c • 𝟙 (trivialModuleCat k A))) :=
-  rfl
-
-/-- The action of `cohomologyRing k A` on `cohomology k A M` is the Yoneda composition of
-extensions. -/
-@[category API, AMS 16 18]
-theorem of_smul_of {M : ModuleCat.{u} A} {a b : ℕ}
-    (x : Ext (trivialModuleCat k A) (trivialModuleCat k A) a) (y : Ext (trivialModuleCat k A) M b) :
-    (DirectSum.of _ a x : cohomologyRing k A) • (DirectSum.of _ b y : cohomology k A M) =
-      DirectSum.of _ (a + b) (x.comp y rfl) :=
-  DirectSum.Gmodule.of_smul_of (A := fun n ↦ Ext (trivialModuleCat k A) (trivialModuleCat k A) n)
-    (M := fun n ↦ Ext (trivialModuleCat k A) M n) x y
-
-variable (k A) in
-/-- In degree $0$, the cohomology ring is the endomorphism ring of the trivial module. -/
-@[category API, AMS 16 18]
-theorem nonempty_addEquiv_zero :
-    Nonempty (Ext (trivialModuleCat k A) (trivialModuleCat k A) 0 ≃+
-      (trivialModuleCat k A ⟶ trivialModuleCat k A)) :=
-  ⟨Ext.addEquiv₀⟩
-
-end Definitions
 
 variable (k : Type u) [Field k] (A : Type u) [Ring A] [HopfAlgebra k A] [FiniteDimensional k A]
 

--- a/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
+++ b/FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean
@@ -22,17 +22,20 @@ import FormalConjecturesUtil
 Let $A$ be a finite-dimensional Hopf algebra over a field $k$, and view $k$ as an $A$-module
 through the counit. The cohomology ring
 $$H^*(A, k) = \mathrm{Ext}^*_A(k, k) = \bigoplus_{n \ge 0} \mathrm{Ext}^n_A(k, k)$$
-is a graded-commutative $k$-algebra under the Yoneda product. Etingof and Ostrik conjecture that
-it is a finitely generated $k$-algebra, and that $\mathrm{Ext}^*_A(k, M)$ is a finitely generated
-module over it for every finite-dimensional $A$-module $M$. They state the conjecture for every
-finite tensor category; the finite-dimensional modules over a finite-dimensional Hopf algebra form
-the main class of examples, and the conjecture is open already in this case.
+is a graded-commutative $k$-algebra under the Yoneda product. The finite generation conjecture
+asserts that it is a finitely generated $k$-algebra, and that $\mathrm{Ext}^*_A(k, M)$ is a
+finitely generated module over it for every finite-dimensional $A$-module $M$. Etingof and Ostrik
+state it for every finite tensor category; the finite-dimensional modules over a finite-dimensional
+Hopf algebra form the main class of examples, and the conjecture is open already in this case.
 
-The question for an arbitrary finite-dimensional Hopf algebra is already posed, and expressly left
-open, in Friedlander and Suslin's paper: "We do not know whether it is reasonable to expect finite
-generation of the cohomology of an arbitrary finite dimensional Hopf algebra." What is due to
-Etingof and Ostrik is the assertion that the answer is yes, together with its extension to every
-finite tensor category.
+The conjecture is not due to any one author. The question for a finite-dimensional Hopf algebra was
+asked by a number of mathematicians and had circulated since at least the 1990s: Friedlander and
+Suslin record it while expressly declining to answer it ("We do not know whether it is reasonable
+to expect finite generation of the cohomology of an arbitrary finite dimensional Hopf algebra"),
+and Friedlander and Negron later describe the conjecture as having "existed as a question at least
+since the 90's" and as "recently stated explicitly in the work of Etingof and Ostrik". What Etingof
+and Ostrik contribute is that explicit statement, together with its extension from Hopf algebras to
+every finite tensor category; it is their Conjecture 2.18 that is formalised here.
 
 The conjecture holds when $A$ is cocommutative, that is, when $A$ is the group algebra of a finite
 group scheme (Friedlander–Suslin). For the group algebra $k[G]$ of a finite group $G$ it is the
@@ -65,6 +68,12 @@ finite-dimensional modules, as the module docstring of
   (1959), 943–944.
 * E. S. Golod, *The cohomology ring of a finite $p$-group*, Dokl. Akad. Nauk SSSR 125 (1959),
   703–706.
+* [Friedlander–Negron](https://doi.org/10.2140/ant.2018.12.1281) E. M. Friedlander, C. Negron,
+  *Cohomology for Drinfeld doubles of some infinitesimal group schemes*, Algebra Number Theory 12
+  (2018), 1281–1309; the conjecture and its history, p. 1281.
+* [Oberwolfach](https://doi.org/10.4171/OWR/2019/11) H. Krause, S. Witherspoon, J. J. Zhang
+  (organisers), *Mini-Workshop: Cohomology of Hopf Algebras and Tensor Categories*, Oberwolfach
+  Rep. (2019), 663–693; "asked by a number of mathematicians", p. 664.
 -/
 
 open Bialgebra

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -16,6 +16,7 @@ limitations under the License.
 module  -- shake: keep-all --deprecated_module: ignore
 
 public import FormalConjecturesForMathlib.Algebra.GCDMonoid.Finset
+public import FormalConjecturesForMathlib.Algebra.GradedMonoid
 public import FormalConjecturesForMathlib.Algebra.Group.Action.Pointwise.Set.Basic
 public import FormalConjecturesForMathlib.Algebra.Group.GrowthFunction
 public import FormalConjecturesForMathlib.Algebra.Group.Indicator
@@ -174,6 +175,7 @@ public import FormalConjecturesForMathlib.Order.Interval.Finset.Nat
 public import FormalConjecturesForMathlib.Order.Nat
 public import FormalConjecturesForMathlib.Order.Unimodular
 public import FormalConjecturesForMathlib.Probability.FiniteMethod
+public import FormalConjecturesForMathlib.RingTheory.Bialgebra.Cohomology
 public import FormalConjecturesForMathlib.RingTheory.Bialgebra.TrivialModule
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Basic
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Defs

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -19,6 +19,7 @@ public import FormalConjecturesForMathlib.Algebra.GCDMonoid.Finset
 public import FormalConjecturesForMathlib.Algebra.Group.Action.Pointwise.Set.Basic
 public import FormalConjecturesForMathlib.Algebra.Group.GrowthFunction
 public import FormalConjecturesForMathlib.Algebra.Group.Indicator
+public import FormalConjecturesForMathlib.Algebra.Homology.DerivedCategory.Ext.GradedAlgebra
 public import FormalConjecturesForMathlib.Algebra.MvPolynomial.PoissonBracket
 public import FormalConjecturesForMathlib.Algebra.MvPolynomial.RegularFunction
 public import FormalConjecturesForMathlib.Algebra.Order.Group.Pointwise.Interval
@@ -173,6 +174,7 @@ public import FormalConjecturesForMathlib.Order.Interval.Finset.Nat
 public import FormalConjecturesForMathlib.Order.Nat
 public import FormalConjecturesForMathlib.Order.Unimodular
 public import FormalConjecturesForMathlib.Probability.FiniteMethod
+public import FormalConjecturesForMathlib.RingTheory.Bialgebra.TrivialModule
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Basic
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Defs
 public import FormalConjecturesForMathlib.RingTheory.Ideal.Maximal

--- a/FormalConjecturesForMathlib/Algebra/GradedMonoid.lean
+++ b/FormalConjecturesForMathlib/Algebra/GradedMonoid.lean
@@ -1,0 +1,39 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.GradedMonoid
+
+@[expose] public section
+
+/-!
+# Equality in a graded monoid
+
+`GradedMonoid.mk_eq_mk` proves an equality `GradedMonoid.mk i a = GradedMonoid.mk j b` from
+`i = j` and `HEq a b`. It is `Sigma.ext` stated for `GradedMonoid.mk`, so that unification only
+sees the arguments of `GradedMonoid.mk` and never has to reduce projections of the two sides.
+-/
+
+namespace GradedMonoid
+
+variable {ι : Type*} {A : ι → Type*}
+
+/-- Equality of two elements of `GradedMonoid A` written with `GradedMonoid.mk`. -/
+lemma mk_eq_mk {i j : ι} {a : A i} {b : A j} (h : i = j) (h' : HEq a b) :
+    GradedMonoid.mk i a = GradedMonoid.mk j b :=
+  Sigma.ext h h'
+
+end GradedMonoid

--- a/FormalConjecturesForMathlib/Algebra/Homology/DerivedCategory/Ext/GradedAlgebra.lean
+++ b/FormalConjecturesForMathlib/Algebra/Homology/DerivedCategory/Ext/GradedAlgebra.lean
@@ -18,6 +18,7 @@ module
 public import Mathlib.Algebra.DirectSum.Algebra
 public import Mathlib.Algebra.Homology.DerivedCategory.Ext.Linear
 public import Mathlib.Algebra.Module.GradedModule
+public import FormalConjecturesForMathlib.Algebra.GradedMonoid
 
 @[expose] public noncomputable section
 
@@ -38,6 +39,9 @@ that `⨁ n, Ext X Y n` is a module over `⨁ n, Ext X X n`.
   `fun n ↦ Ext X X n` when `C` is `R`-linear.
 * `CategoryTheory.Abelian.Ext.instGmodule`: the graded module structure on `fun n ↦ Ext X Y n`
   over `fun n ↦ Ext X X n`.
+
+The proofs of the graded axioms compare elements of `GradedMonoid` in different degrees; they use
+`GradedMonoid.mk_eq_mk` and `Ext.comp_heq` to reduce these to equalities in a single degree.
 -/
 
 universe w t v u
@@ -118,11 +122,6 @@ instance instGmodule : DirectSum.Gmodule (fun n ↦ Ext X X n) (fun n ↦ Ext X 
   zero_smul β := zero_comp _ _ β _ rfl
 
 variable (R : Type t) [CommRing R] [Linear R C]
-
-/-- Equality of two elements of `GradedMonoid A` written with `GradedMonoid.mk`. -/
-lemma _root_.GradedMonoid.mk_eq_mk {ι : Type*} {A : ι → Type*} {i j : ι} {a : A i} {b : A j}
-    (h : i = j) (h' : HEq a b) : GradedMonoid.mk i a = GradedMonoid.mk j b :=
-  Sigma.ext h h'
 
 instance instGAlgebra : DirectSum.GAlgebra R (fun n ↦ Ext X X n) where
   toFun :=

--- a/FormalConjecturesForMathlib/Algebra/Homology/DerivedCategory/Ext/GradedAlgebra.lean
+++ b/FormalConjecturesForMathlib/Algebra/Homology/DerivedCategory/Ext/GradedAlgebra.lean
@@ -1,0 +1,147 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.DirectSum.Algebra
+public import Mathlib.Algebra.Homology.DerivedCategory.Ext.Linear
+public import Mathlib.Algebra.Module.GradedModule
+
+@[expose] public noncomputable section
+
+/-!
+# The Yoneda algebra of an object of an abelian category
+
+Let `C` be an abelian category with `HasExt C` and let `X : C`. The Yoneda composition
+`Ext.comp : Ext X X a → Ext X X b → Ext X X (a + b)` makes the family `fun n ↦ Ext X X n` a
+graded ring, so that `⨁ n, Ext X X n` is a ring: the Yoneda algebra `Ext^*(X, X)` of `X`.
+When `C` is `R`-linear for a commutative ring `R`, it is a graded `R`-algebra.
+For `Y : C`, the family `fun n ↦ Ext X Y n` is a graded module over `fun n ↦ Ext X X n`, so
+that `⨁ n, Ext X Y n` is a module over `⨁ n, Ext X X n`.
+
+## Main declarations
+
+* `CategoryTheory.Abelian.Ext.instGRing`: the graded ring structure on `fun n ↦ Ext X X n`.
+* `CategoryTheory.Abelian.Ext.instGAlgebra`: the graded `R`-algebra structure on
+  `fun n ↦ Ext X X n` when `C` is `R`-linear.
+* `CategoryTheory.Abelian.Ext.instGmodule`: the graded module structure on `fun n ↦ Ext X Y n`
+  over `fun n ↦ Ext X X n`.
+-/
+
+universe w t v u
+
+open DirectSum
+
+namespace CategoryTheory.Abelian.Ext
+
+variable {C : Type u} [Category.{v} C] [Abelian C] [HasExt.{w} C]
+
+section
+
+variable {X Y Z : C}
+
+/-- Up to `HEq`, the composition `Ext.comp` does not depend on the proof of the degree
+equation. -/
+lemma comp_heq {a b c c' : ℕ} (α : Ext X Y a) (β : Ext Y Z b) (h : a + b = c)
+    (h' : a + b = c') : HEq (α.comp β h) (α.comp β h') := by
+  subst h h'
+  rfl
+
+end
+
+variable (X Y : C)
+
+instance instGOne : GradedMonoid.GOne (fun n ↦ Ext X X n) where
+  one := mk₀ (𝟙 X)
+
+instance instGMul : GradedMonoid.GMul (fun n ↦ Ext X X n) where
+  mul α β := α.comp β rfl
+
+instance instGSMul : GradedMonoid.GSMul (fun n ↦ Ext X X n) (fun n ↦ Ext X Y n) where
+  smul α β := α.comp β rfl
+
+variable {X Y}
+
+@[simp]
+lemma gOne_eq : (GradedMonoid.GOne.one : Ext X X 0) = mk₀ (𝟙 X) := rfl
+
+@[simp]
+lemma gMul_eq {a b : ℕ} (α : Ext X X a) (β : Ext X X b) :
+    GradedMonoid.GMul.mul α β = α.comp β rfl := rfl
+
+@[simp]
+lemma gSMul_eq {a b : ℕ} (α : Ext X X a) (β : Ext X Y b) :
+    GradedMonoid.GSMul.smul α β = α.comp β rfl := rfl
+
+variable (X Y)
+
+instance instGMonoid : GradedMonoid.GMonoid (fun n ↦ Ext X X n) where
+  one_mul := fun ⟨n, α⟩ ↦ Sigma.ext (zero_add n)
+    ((comp_heq _ _ rfl (zero_add n)).trans (heq_of_eq (mk₀_id_comp α)))
+  mul_one := fun ⟨n, α⟩ ↦ Sigma.ext (add_zero n)
+    ((comp_heq _ _ rfl (add_zero n)).trans (heq_of_eq (comp_mk₀_id α)))
+  mul_assoc := fun ⟨a, α⟩ ⟨b, β⟩ ⟨c, γ⟩ ↦ Sigma.ext (add_assoc a b c)
+    ((heq_of_eq (comp_assoc α β γ rfl rfl rfl)).trans (comp_heq _ _ _ rfl))
+
+instance instGRing : DirectSum.GRing (fun n ↦ Ext X X n) where
+  mul_zero α := comp_zero α X _ _ rfl
+  zero_mul β := zero_comp _ _ β _ rfl
+  mul_add α β γ := comp_add α β γ rfl
+  add_mul α β γ := add_comp α β γ rfl
+  natCast n := n • mk₀ (𝟙 X)
+  natCast_zero := zero_nsmul _
+  natCast_succ n := succ_nsmul (mk₀ (𝟙 X)) n
+  intCast n := n • mk₀ (𝟙 X)
+  intCast_ofNat n := natCast_zsmul (mk₀ (𝟙 X)) n
+  intCast_negSucc_ofNat n := negSucc_zsmul (mk₀ (𝟙 X)) n
+
+instance instGmodule : DirectSum.Gmodule (fun n ↦ Ext X X n) (fun n ↦ Ext X Y n) where
+  one_smul := fun ⟨n, β⟩ ↦ Sigma.ext (zero_add n)
+    ((comp_heq _ _ rfl (zero_add n)).trans (heq_of_eq (mk₀_id_comp β)))
+  mul_smul := fun ⟨a, α⟩ ⟨b, α'⟩ ⟨c, β⟩ ↦ Sigma.ext (add_assoc a b c)
+    ((heq_of_eq (comp_assoc α α' β rfl rfl rfl)).trans (comp_heq _ _ _ rfl))
+  smul_add α β β' := comp_add α β β' rfl
+  smul_zero α := comp_zero α Y _ _ rfl
+  add_smul α α' β := add_comp α α' β rfl
+  zero_smul β := zero_comp _ _ β _ rfl
+
+variable (R : Type t) [CommRing R] [Linear R C]
+
+/-- Equality of two elements of `GradedMonoid A` written with `GradedMonoid.mk`. -/
+lemma _root_.GradedMonoid.mk_eq_mk {ι : Type*} {A : ι → Type*} {i j : ι} {a : A i} {b : A j}
+    (h : i = j) (h' : HEq a b) : GradedMonoid.mk i a = GradedMonoid.mk j b :=
+  Sigma.ext h h'
+
+instance instGAlgebra : DirectSum.GAlgebra R (fun n ↦ Ext X X n) where
+  toFun :=
+    { toFun r := mk₀ (r • 𝟙 X)
+      map_zero' := by simp
+      map_add' r s := by simp [mk₀_smul, mk₀_add, add_smul] }
+  map_one := by simp
+  map_mul r s := GradedMonoid.mk_eq_mk rfl (heq_of_eq (by
+    change mk₀ ((r * s) • 𝟙 X) = (mk₀ (r • 𝟙 X)).comp (mk₀ (s • 𝟙 X)) (zero_add 0)
+    simp [smul_smul, mul_comm]))
+  commutes r := fun ⟨n, α⟩ ↦ by
+    change GradedMonoid.mk (0 + n) ((mk₀ (r • 𝟙 X)).comp α rfl) =
+      GradedMonoid.mk (n + 0) (α.comp (mk₀ (r • 𝟙 X)) rfl)
+    refine GradedMonoid.mk_eq_mk (by simp) ((comp_heq _ _ rfl (zero_add n)).trans
+      ((heq_of_eq ?_).trans (comp_heq _ _ (add_zero n) rfl)))
+    simp [mk₀_smul]
+  smul_def r := fun ⟨n, α⟩ ↦ by
+    change GradedMonoid.mk n (r • α) = GradedMonoid.mk (0 + n) ((mk₀ (r • 𝟙 X)).comp α rfl)
+    exact GradedMonoid.mk_eq_mk (zero_add n).symm
+      ((heq_of_eq (by simp [mk₀_smul])).trans (comp_heq _ _ (zero_add n) rfl))
+
+end CategoryTheory.Abelian.Ext

--- a/FormalConjecturesForMathlib/RingTheory/Bialgebra/Cohomology.lean
+++ b/FormalConjecturesForMathlib/RingTheory/Bialgebra/Cohomology.lean
@@ -1,0 +1,95 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Ext.HasExt
+public import FormalConjecturesForMathlib.Algebra.Homology.DerivedCategory.Ext.GradedAlgebra
+public import FormalConjecturesForMathlib.RingTheory.Bialgebra.TrivialModule
+
+@[expose] public noncomputable section
+
+/-!
+# Cohomology of a bialgebra
+
+Let `A` be a bialgebra over a field `k`, and let `k` be the trivial `A`-module through the counit
+(`Bialgebra.trivialModuleCat k A`). We define
+
+* `Bialgebra.cohomologyRing k A`: the cohomology ring `H^*(A, k) = ⨁ n, Ext^n_A(k, k)`, a graded
+  `k`-algebra under the Yoneda product;
+* `Bialgebra.cohomology k A M`: the cohomology `H^*(A, M) = ⨁ n, Ext^n_A(k, M)` with coefficients
+  in an `A`-module `M`, a graded module over `H^*(A, k)`.
+
+Here `Ext` is taken in `ModuleCat A`, the category of all `A`-modules. The `k`-linear structure
+of `ModuleCat A` is the scoped instance `ModuleCat.Algebra.instLinear`, in which `k` acts on
+morphisms through `algebraMap k A`; the `k`-algebra structure on `cohomologyRing k A` is
+registered as an instance, so downstream files do not need to open that scope.
+-/
+
+open CategoryTheory Abelian
+open scoped DirectSum ModuleCat.Algebra
+
+universe u
+
+namespace Bialgebra
+
+variable (k : Type u) [Field k] (A : Type u) [Ring A] [Bialgebra k A]
+
+/-- The cohomology ring `H^*(A, k) = ⨁ n, Ext^n_A(k, k)` of the bialgebra `A` over `k`, where `k`
+is the trivial `A`-module through the counit and `Ext` is taken in `ModuleCat A`. It is a graded
+`k`-algebra under the Yoneda product. -/
+abbrev cohomologyRing : Type u :=
+  ⨁ n, Ext (trivialModuleCat k A) (trivialModuleCat k A) n
+
+/-- The cohomology `H^*(A, M) = ⨁ n, Ext^n_A(k, M)` of the bialgebra `A` over `k` with
+coefficients in the `A`-module `M`. It is a graded module over `cohomologyRing k A` under the
+Yoneda product. -/
+abbrev cohomology (M : ModuleCat.{u} A) : Type u :=
+  ⨁ n, Ext (trivialModuleCat k A) M n
+
+instance : Algebra k (cohomologyRing k A) :=
+  inferInstance
+
+instance (M : ModuleCat.{u} A) : Module (cohomologyRing k A) (cohomology k A M) :=
+  inferInstance
+
+variable {k A}
+
+/-- The product on `cohomologyRing k A` is the Yoneda composition of extensions. -/
+lemma cohomologyRing_of_mul_of {a b : ℕ}
+    (x : Ext (trivialModuleCat k A) (trivialModuleCat k A) a)
+    (y : Ext (trivialModuleCat k A) (trivialModuleCat k A) b) :
+    (DirectSum.of _ a x : cohomologyRing k A) * DirectSum.of _ b y =
+      DirectSum.of _ (a + b) (x.comp y rfl) :=
+  DirectSum.of_mul_of x y
+
+variable (k A) in
+/-- A scalar `c : k` acts on `cohomologyRing k A` as `c` times the identity in degree `0`. -/
+lemma cohomologyRing_algebraMap_apply (c : k) :
+    algebraMap k (cohomologyRing k A) c =
+      DirectSum.of _ 0 (Ext.mk₀ (c • 𝟙 (trivialModuleCat k A))) :=
+  rfl
+
+/-- The action of `cohomologyRing k A` on `cohomology k A M` is the Yoneda composition of
+extensions. -/
+lemma cohomology_of_smul_of {M : ModuleCat.{u} A} {a b : ℕ}
+    (x : Ext (trivialModuleCat k A) (trivialModuleCat k A) a)
+    (y : Ext (trivialModuleCat k A) M b) :
+    (DirectSum.of _ a x : cohomologyRing k A) • (DirectSum.of _ b y : cohomology k A M) =
+      DirectSum.of _ (a + b) (x.comp y rfl) :=
+  DirectSum.Gmodule.of_smul_of (A := fun n ↦ Ext (trivialModuleCat k A) (trivialModuleCat k A) n)
+    (M := fun n ↦ Ext (trivialModuleCat k A) M n) x y
+
+end Bialgebra

--- a/FormalConjecturesForMathlib/RingTheory/Bialgebra/Cohomology.lean
+++ b/FormalConjecturesForMathlib/RingTheory/Bialgebra/Cohomology.lean
@@ -32,10 +32,20 @@ Let `A` be a bialgebra over a field `k`, and let `k` be the trivial `A`-module t
 * `Bialgebra.cohomology k A M`: the cohomology `H^*(A, M) = ⨁ n, Ext^n_A(k, M)` with coefficients
   in an `A`-module `M`, a graded module over `H^*(A, k)`.
 
-Here `Ext` is taken in `ModuleCat A`, the category of all `A`-modules. The `k`-linear structure
-of `ModuleCat A` is the scoped instance `ModuleCat.Algebra.instLinear`, in which `k` acts on
-morphisms through `algebraMap k A`; the `k`-algebra structure on `cohomologyRing k A` is
-registered as an instance, so downstream files do not need to open that scope.
+Here `Ext` is taken in `ModuleCat A`, the category of all `A`-modules, and not in the category of
+finite-dimensional ones. When `A` is finite-dimensional over a field the two give the same groups
+on finite-dimensional modules: such a module admits a resolution by finitely generated free
+`A`-modules, which are again finite-dimensional and are projective in both categories, and `Ext`
+is computed from that single resolution either way. So `cohomologyRing k A` is the cohomology of
+the finite tensor category of finite-dimensional `A`-modules, which is what the literature means
+by `H^*(A, k)`.
+
+Two `k`-structures on `ModuleCat A` are involved, and only one of them is scoped.
+`ModuleCat.linearOverField`, giving `Linear k (ModuleCat A)`, is a global instance, so the
+`k`-algebra structure on `cohomologyRing k A` registered below needs no `open scoped`. The
+`k`-module structure on an individual object, `ModuleCat.moduleOfAlgebraModule`, is a *scoped*
+instance; in both, `k` acts through `algebraMap k A`. A file that mentions `FiniteDimensional k M`
+for `M : ModuleCat A` therefore does have to `open scoped ModuleCat.Algebra`.
 -/
 
 open CategoryTheory Abelian
@@ -81,6 +91,24 @@ lemma cohomologyRing_algebraMap_apply (c : k) :
     algebraMap k (cohomologyRing k A) c =
       DirectSum.of _ 0 (Ext.mk₀ (c • 𝟙 (trivialModuleCat k A))) :=
   rfl
+
+/-- The cohomology ring is not the zero ring: its degree-zero part contains the identity of the
+trivial module. In particular a finiteness statement about `cohomologyRing k A` is not vacuous. -/
+lemma nontrivial_cohomologyRing : Nontrivial (cohomologyRing k A) := by
+  have hid : (𝟙 (trivialModuleCat k A)) ≠ 0 := by
+    intro h
+    have h1 : (1 : k) = 0 := congrArg (fun f => ModuleCat.Hom.hom f (1 : k)) h
+    exact one_ne_zero h1
+  have hmk : (Ext.mk₀ (𝟙 (trivialModuleCat k A)) : Ext _ _ 0) ≠ 0 := fun h =>
+    hid ((Ext.mk₀_bijective (trivialModuleCat k A) (trivialModuleCat k A)).injective
+      (by simpa using h))
+  refine ⟨⟨1, 0, ?_⟩⟩
+  intro h
+  apply hmk
+  rw [DirectSum.one_def] at h
+  rw [← Ext.gOne_eq]
+  exact DirectSum.of_injective
+    (β := fun n ↦ Ext (trivialModuleCat k A) (trivialModuleCat k A) n) 0 (by simpa using h)
 
 /-- The action of `cohomologyRing k A` on `cohomology k A M` is the Yoneda composition of
 extensions. -/

--- a/FormalConjecturesForMathlib/RingTheory/Bialgebra/TrivialModule.lean
+++ b/FormalConjecturesForMathlib/RingTheory/Bialgebra/TrivialModule.lean
@@ -1,0 +1,51 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.RingTheory.Bialgebra.Basic
+
+@[expose] public noncomputable section
+
+/-!
+# The trivial module of a bialgebra
+
+If `A` is a bialgebra over a commutative ring `R`, the counit `A →ₐ[R] R` makes `R` into an
+`A`-module, the trivial module. We package it as the object `Bialgebra.trivialModuleCat R A` of
+`ModuleCat A`.
+-/
+
+universe u v
+
+namespace Bialgebra
+
+variable (R : Type u) (A : Type v) [CommRing R] [Ring A] [Bialgebra R A]
+
+/-- The trivial module of the bialgebra `A` over `R`: the ring `R` on which `A` acts through the
+counit `A →ₐ[R] R`, as an object of `ModuleCat A`. -/
+def trivialModuleCat : ModuleCat.{u} A :=
+  letI := Module.compHom R (counitAlgHom R A).toRingHom
+  ModuleCat.of A R
+
+variable {R A}
+
+/-- The bialgebra `A` acts on its trivial module through the counit. The carrier of
+`trivialModuleCat R A` is `R` by definition, so the product on the right is the product of `R`. -/
+lemma trivialModuleCat_smul (a : A) (r : trivialModuleCat R A) :
+    a • r = HMul.hMul (α := R) (β := R) (counitAlgHom R A a) r :=
+  rfl
+
+end Bialgebra

--- a/FormalConjecturesForMathlib/RingTheory/Bialgebra/TrivialModule.lean
+++ b/FormalConjecturesForMathlib/RingTheory/Bialgebra/TrivialModule.lean
@@ -15,7 +15,9 @@ limitations under the License.
 -/
 module
 
+public import Mathlib.Algebra.Category.ModuleCat.Algebra
 public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.Bialgebra.Basic
 
 @[expose] public noncomputable section
@@ -26,6 +28,12 @@ public import Mathlib.RingTheory.Bialgebra.Basic
 If `A` is a bialgebra over a commutative ring `R`, the counit `A →ₐ[R] R` makes `R` into an
 `A`-module, the trivial module. We package it as the object `Bialgebra.trivialModuleCat R A` of
 `ModuleCat A`.
+
+Over a field `k`, restricting scalars along `algebraMap k A` recovers the `k`-module structure of
+`k` itself (`Bialgebra.trivialModuleCat_smul_base`), so the trivial module is one-dimensional;
+`Bialgebra.trivialModuleCatLinearEquiv` and the `FiniteDimensional` instance record this. That
+`k`-module structure is `ModuleCat.moduleOfAlgebraModule`, a *scoped* instance, so a file stating
+`FiniteDimensional k (trivialModuleCat k A)` must `open scoped ModuleCat.Algebra`.
 -/
 
 universe u v
@@ -47,5 +55,36 @@ variable {R A}
 lemma trivialModuleCat_smul (a : A) (r : trivialModuleCat R A) :
     a • r = HMul.hMul (α := R) (β := R) (counitAlgHom R A a) r :=
   rfl
+
+section Field
+
+open scoped ModuleCat.Algebra
+
+variable {k : Type u} {B : Type v} [Field k] [Ring B] [Bialgebra k B]
+
+/-- The `k`-module structure on the trivial module of a bialgebra over a field `k`, obtained by
+restricting scalars along `algebraMap k B`, is the module structure of `k` itself: the counit is a
+`k`-algebra map, so it sends `algebraMap k B c` to `c`. -/
+lemma trivialModuleCat_smul_base (c : k) (r : trivialModuleCat k B) :
+    c • r = HMul.hMul (α := k) (β := k) c r := by
+  rw [show c • r = (algebraMap k B c) • r from rfl, trivialModuleCat_smul,
+    AlgHom.commutes]
+  rfl
+
+variable (k B) in
+/-- The trivial module of a bialgebra over a field `k` is `k` itself as a `k`-module; in
+particular it is one-dimensional. -/
+def trivialModuleCatLinearEquiv : trivialModuleCat k B ≃ₗ[k] k where
+  toFun r := r
+  map_add' _ _ := rfl
+  map_smul' := trivialModuleCat_smul_base
+  invFun r := r
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+instance : FiniteDimensional k (trivialModuleCat k B) :=
+  Module.Finite.equiv (trivialModuleCatLinearEquiv k B).symm
+
+end Field
 
 end Bialgebra


### PR DESCRIPTION
Fixes #5599

Adds the finite generation conjecture for a finite-dimensional Hopf algebra `A` over a field `k`:
the cohomology ring `H^*(A, k) = Ext^*_A(k, k)` is a finitely generated `k`-algebra, and
`Ext^*_A(k, M)` is a finitely generated module over it for every finite-dimensional `M`. The
statement formalised is Etingof and Ostrik's Conjecture 2.18
([arXiv:math/0301027](https://arxiv.org/abs/math/0301027)), which states it for every finite tensor
category; the module docstring records that the conjecture is not due to any one author — the
question circulated from at least the 1990s and is recorded, and left open, by Friedlander and
Suslin, and Etingof and Ostrik's contribution is the explicit statement and its extension to finite
tensor categories.

`FormalConjectures/Arxiv/math.0301027/FiniteGenerationOfCohomology.lean` (new) states the two open
cases (`cohomologyRing_finiteType`, `cohomology_finite`), three solved ones — the cocommutative
case of Friedlander–Suslin (`cohomologyRing_finiteType_of_isCocomm`, `cohomology_finite_of_isCocomm`)
and the group-algebra case of Evens and Venkov (`cohomologyRing_finiteType_monoidAlgebra`) — and
two `category test` sanity checks.

Mathlib has no Yoneda algebra structure on `Ext`, so four new modules in
`FormalConjecturesForMathlib` supply one, none with a `sorry`:

- `Algebra/Homology/DerivedCategory/Ext/GradedAlgebra.lean`: for `X` in an abelian category with
  `HasExt`, Yoneda composition makes `fun n ↦ Ext X X n` a `DirectSum.GRing`, a
  `DirectSum.GAlgebra R` when the category is `R`-linear, and `fun n ↦ Ext X Y n` a
  `DirectSum.Gmodule` over it.
- `RingTheory/Bialgebra/TrivialModule.lean`: `Bialgebra.trivialModuleCat R A`, the base ring with
  `A` acting through the counit; over a field, its linear equivalence with `k` and the resulting
  `FiniteDimensional` instance.
- `RingTheory/Bialgebra/Cohomology.lean`: `cohomologyRing k A := ⨁ n, Ext k k n` and
  `cohomology k A M := ⨁ n, Ext k M n`, the algebra and module instances, the lemmas identifying
  the product and the action with Yoneda composition, and `nontrivial_cohomologyRing`.
- `Algebra/GradedMonoid.lean`: `GradedMonoid.mk_eq_mk`.

Formalisation choices:

- `Ext` is taken in `ModuleCat A`. For finite-dimensional `A` this agrees with `Ext` in the finite
  tensor category of finite-dimensional modules, because `k` has a resolution by finitely generated
  free `A`-modules that is projective in both; the module docstring says so. `k` and `A` share a
  universe because `HasExt.{u} (ModuleCat.{u} A)` needs `Small.{u} A`.
- The statements are over an arbitrary field, whereas Etingof and Ostrik assume `k` algebraically
  closed throughout the section containing the conjecture. The module docstring gives the base
  change and faithfully flat descent argument that makes the stronger form equivalent.
  Friedlander–Suslin and Evens–Venkov are proved over an arbitrary field, so stating them in that
  generality is faithful to the sources.
- Graded commutativity of `H^*(A, k)` is not formalised; the module docstring says so.

How I checked it:

- `lake --wfail build FormalConjecturesForMathlib 'FormalConjectures.Arxiv.«math.0301027».FiniteGenerationOfCohomology'`,
  a full warning-free `lake --wfail build`, and `lake --wfail test`.
- Conjecture 2.18 and its known cases read against the arXiv source of Etingof–Ostrik;
  Theorem 1.1 read against the published Friedlander–Suslin paper; the attribution checked against
  Friedlander–Negron (Algebra Number Theory 12 (2018), 1281) and the Oberwolfach mini-workshop
  report (Oberwolfach Rep. (2019), 664).
- `Nontrivial (cohomologyRing k A)` is proved, so the finiteness statements are not vacuously true.

AI disclosure: this formalisation was drafted and audited with Claude Code, and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGrhjQTEh578C2MhoZyf6k
