### PR TITLE
fix(Arxiv/2605.02731/DeanCycles): the k >= 6 case is due to Luo, Ma and Zhao

### DIFF
--- a/FormalConjectures/Arxiv/2605.02731/DeanCycles.lean
+++ b/FormalConjectures/Arxiv/2605.02731/DeanCycles.lean
@@ -28,6 +28,8 @@ import FormalConjecturesUtil
   Discrete Math. (1993), 133--139.
 - [ChSa94] Chen, G. and Saito, A., Graphs with a cycle of length divisible by three.
   J. Combin. Theory Ser. B (1994), 277--292.
+- [LuMaZh26] Luo, Yufan and Ma, Jie and Zhao, Ziyuan, Dean's conjecture and cycles modulo k.
+  [arXiv:2601.13552](https://arxiv.org/abs/2601.13552) (2026).
 -/
 
 open SimpleGraph
@@ -77,7 +79,7 @@ theorem dean_conjecture.variants.four {V : Type} [Fintype V] [DecidableEq V]
   sorry
 
 /--
-The cases $k \geq 6$, proved by Liu, Ma and Zhao (2026). With [ChSa94] and [DeLeSa93] this
+The cases $k \geq 6$, proved by Luo, Ma and Zhao [LuMaZh26]. With [ChSa94] and [DeLeSa93] this
 leaves `dean_conjecture.variants.five` as the only open case.
 -/
 @[category research solved, AMS 5]


### PR DESCRIPTION
**What changed**

- The docstring for `dean_conjecture.variants.six_le` credits **Luo**, Ma and Zhao rather than
  "Liu, Ma and Zhao".
- Their paper is added to the reference list.

**Why**

The authors of the `k ≥ 6` result are **Yufan Luo**, Jie Ma and Ziyuan Zhao, *Dean's conjecture and
cycles modulo k*, [arXiv:2601.13552](https://arxiv.org/abs/2601.13552). Its abstract states that
Dean's conjecture "has been verified for `k ∈ {3,4}`" and remains open for `k ≥ 5`, and the paper
proves it for every `k ≥ 6` — which is what this declaration records.

The file previously named "Liu" and did not cite the paper at all, so there was no way for a reader
to find the source.

No statement, proof or category is changed.

*AI assistance: found by an OpenAI Codex agent during a repository-wide sweep. The authorship was
then confirmed with Claude Opus 5 against the arXiv listing for 2601.13552 and against the
bibliography of a later paper citing it.*
