### PR TITLE
fix(GreensOpenProblems/3): open product-free subsets of (0,1) have measure < 1/3

### DIFF
--- a/FormalConjectures/GreensOpenProblems/3.lean
+++ b/FormalConjectures/GreensOpenProblems/3.lean
@@ -19,17 +19,24 @@ import FormalConjecturesUtil
 /-!
 # Ben Green's Open Problem 3
 
-*Reference:* [Ben Green's Open Problem 3](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.3 Problem 3)
+*References:*
+- [Ben Green's Open Problem 3](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#section.3 Problem 3)
+- [FGY26] Franchi, Leonardo and Gowers, W. T. and Yip, Fredy, *Product-free subsets of $(0,1)$*,
+  [arXiv:2607.06073](https://arxiv.org/abs/2607.06073), Theorem 1.1.
 -/
 
 open Set MeasureTheory
 
 namespace Green3
 
-/-- Suppose that $A \subset [0,1]$ is open and has measure greater than $\frac{1}{3}$. Is there a solution to $xy = z$ with $x, y, z \in A$? -/
-@[category research open, AMS 11]
+/-- Suppose that $A \subset [0,1]$ is open and has measure greater than $\frac{1}{3}$. Is there a
+solution to $xy = z$ with $x, y, z \in A$?
+
+The answer is yes. [FGY26] prove that an open product-free subset of $(0,1)$ has measure strictly
+less than $\frac{1}{3}$. -/
+@[category research solved, AMS 11]
 theorem green_3 :
-    answer(sorry) ↔ ∀ A : Set ℝ,
+    answer(True) ↔ ∀ A : Set ℝ,
       IsOpen A → A ⊆ Icc 0 1 → volume A > 1/3 →
         ∃ x y z, x ∈ A ∧ y ∈ A ∧ z ∈ A ∧ x * y = z := by
   sorry


### PR DESCRIPTION
Addresses the "Green 3" item of #4927.

**What changed**

- `green_3` is `research solved` with `answer(True)`.
- Franchi–Gowers–Yip added to the references.

**Why**

Leonardo Franchi, W. T. Gowers and Fredy Yip, *Product-free subsets of $(0,1)$*,
[arXiv:2607.06073](https://arxiv.org/abs/2607.06073), Theorem 1.1:

> Let `A` be an open product-free subset of `(0,1)`. Then `|A| < 1/3`.

Their abstract states the intent directly: "The third problem in Ben Green's collection of 100 open
problems asks whether an open subset of `(0,1)` that does not contain `x, y, z` with `xy = z` must
have measure at most `1/3`. We give an affirmative answer to this question."

**Statement match.** This declaration asks whether every open `A ⊆ Icc 0 1` with `volume A > 1/3`
contains `x, y, z` with `x * y = z`. Two small points:

- An open `A ⊆ Icc 0 1` is automatically contained in `(0,1)`: if `0 ∈ A` then some `(-ε, ε) ⊆ A`,
  which would leave `[0,1]`. Likewise at `1`. So the paper's hypothesis applies.
- Theorem 1.1 is the contrapositive of what is asked, and is in fact slightly stronger: it gives
  `|A| < 1/3` for product-free `A`, so `volume A > 1/3` (indeed `≥ 1/3`) already forces `A` not to
  be product-free, i.e. gives the required `x, y, z`.

Hence the answer is `True`.

The paper defines product-free exactly as this declaration does — no `x, y, z ∈ A` with `xy = z`,
with no distinctness condition — and `|A|` is Lebesgue measure, matching `MeasureTheory.volume`.

**Evidence.** A 53-page human-authored argument, whose main auxiliary result (Theorem 1.2, on
`|A+A|` and `|A-A|` for Borel sets of finite measure) is presented as being of independent
interest. For transparency: it is arXiv v1, posted 7 July 2026, and I have not found a record of
acceptance. I am proposing the status change because the result is a conventional
human mathematical proof and was already recorded as a known solution in #4927 — but if you would
rather wait for publication, that is a reasonable call and I am happy to close this.

No formalisation exists, so the declaration keeps its literature-backed `sorry`, as is usual here.

*AI assistance: this item was listed in #4927 and surfaced again by an OpenAI Codex agent during a
repository-wide sweep. The paper's Theorem 1.1 and the statement match above were read and checked
with Claude Opus 5.*
