### PR TITLE
feat: Gross-Kuz'min conjecture

### DIFF
--- a/FormalConjectures/Paper/GrossKuzmin.lean
+++ b/FormalConjectures/Paper/GrossKuzmin.lean
@@ -1,0 +1,260 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# The Gross-Kuz'min conjecture
+
+Let $K$ be a number field, $p$ a prime, and $S_p$ the set of primes $\mathfrak{p}$ of
+$\mathcal{O}_K$ above $p$. Let $E' = \mathcal{O}_K[1/p]^\times$ be the group of *$p$-units* of
+$K$, the elements of $K^\times$ that are units at every prime away from $S_p$. **Gross's
+regulator map** sends a $p$-unit to the vector of $p$-adic logarithms of its local norms,
+$$\rho : E' \to \bigoplus_{\mathfrak{p} \in S_p} \mathbb{Q}_p, \qquad
+x \mapsto \big(\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)\big)_{\mathfrak{p} \in S_p}.$$
+
+**The Gross-Kuz'min conjecture** states that the image of $\mathbb{Z}_p \otimes E'$ under $\rho$
+has $\mathbb{Z}_p$-rank $|S_p| - 1$. This is the largest value it can take: the coordinates of
+$\rho(x)$ always sum to $\log_p N_{K/\mathbb{Q}}(x) = \log_p(\pm p^k) = 0$, so the image lies in a
+hyperplane.
+
+The conjecture is the exact analogue for $p$-units of Leopoldt's conjecture for units, which says
+that the matrix of $p$-adic logarithms of a fundamental system of units has full rank. Like
+Leopoldt's, it is known for $K/\mathbb{Q}$ abelian, by Greenberg building on the $p$-adic Baker
+theorem of Ax and Brumer.
+
+## The dictionary
+
+Two things are said differently here than in the sources, both because Mathlib says them that
+way and neither changing the content.
+
+* **The local norm is computed with embeddings.** Mathlib `v4.33.1` gives $K_\mathfrak{p}$ no
+  $\mathbb{Q}_p$-algebra structure, so $N_{K_\mathfrak{p}/\mathbb{Q}_p}$ is not available. Since
+  $K \otimes_\mathbb{Q} \mathbb{Q}_p = \prod_{\mathfrak{p} \in S_p} K_\mathfrak{p}$, the
+  embeddings $\sigma : K \to \mathbb{C}_p$ inducing $\mathfrak{p}$ are exactly the embeddings of
+  $K_\mathfrak{p}$ restricted to $K$, and $\log_p$ turns the norm into a sum:
+  $$\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x) = \sum_{\sigma \mapsto \mathfrak{p}}
+  \log_p \sigma(x).$$
+  The right-hand side is `logNorm`, and `Induces σ 𝔭` is "$\sigma$ induces $\mathfrak{p}$",
+  written as $\mathfrak{p}$ being the pullback along $\sigma$ of the maximal ideal of
+  $\mathbb{C}_p$.
+
+  This identification is where the statement rests on mathematics not proved here. That
+  distinct primes use disjoint sets of embeddings is `Induces.unique`, and that an induced prime
+  lies above $p$ is `mem_asIdeal_of_induces`. Two further facts are used only informally, and
+  they are not equally out of reach. First, that **every** $\mathfrak{p} \in S_p$ is induced by
+  at least one embedding: this is the one that matters for soundness, since if some
+  $\mathfrak{p}$ had no embedding over it then `logNorm` would be `0` at that coordinate and the
+  conjecture below would state something weaker than it should. It is within reach of Mathlib
+  `v4.33.1` — pass to the Galois closure, where the Galois group acts transitively on the primes
+  above $p$, and restrict — but it is not done here. Second, that $\mathfrak{p}$ is induced by
+  **exactly** $[K_\mathfrak{p} : \mathbb{Q}_p]$ embeddings, which is what makes `logNorm` the
+  local norm on the nose: this one does need $K_\mathfrak{p}$ as a finite
+  $\mathbb{Q}_p$-algebra, the same missing structure that makes
+  $N_{K_\mathfrak{p}/\mathbb{Q}_p}$ unavailable. Until both are available, a reader should check
+  `logNorm` against the displayed formula by hand.
+* **The rank is a $\mathbb{C}_p$-dimension.** The $\mathbb{Z}_p$-rank of the image of
+  $\mathbb{Z}_p \otimes E'$ in $\mathbb{Q}_p^{S_p}$ is the $\mathbb{Q}_p$-dimension of the span of
+  $\rho(E')$, and extending scalars to $\mathbb{C}_p$ does not change it. Taking the span inside
+  $\mathbb{C}_p^{S_p}$ avoids having to see that the local norms are rational.
+  `FormalConjectures.Wikipedia.LeopoldtConjecture` states Leopoldt's conjecture the same way,
+  as `Matrix.rank` of a matrix over $\mathbb{C}_p$.
+
+The remaining objects match the sources directly:
+
+* $S_p$ is `PrimesAbove K p` and $|S_p|$ is `Nat.card (PrimesAbove K p)`, which is at least `1`
+  (`zero_lt_card_primesAbove`) so that `|S_p| - 1` is an honest subtraction;
+* $E'$ is `pUnits K p`, Mathlib's `Set.unit` for the set $S_p$, which is
+  $\mathcal{O}_K[1/p]^\times$ by `Set.unitEquivUnitsInteger`;
+* $\log_p$ is `PadicIwasawaLog.iwasawaLog`, Iwasawa's extension of the logarithm with
+  $\log_p p = 0$. This convention is forced here: $\sigma(x)$ is a $p$-unit, not a unit, so it
+  has nonzero valuation and the naive series does not converge at it. The Iwasawa logarithm is
+  defined on all of $\mathbb{C}_p^\times$ (`PadicIwasawaLog.PadicComplex.hasIwasawaLog_iff`), and
+  every $\sigma(x)$ summed over in `logNorm` is nonzero (`hasIwasawaLog_embedding`), so no junk
+  value is involved;
+* $\rho$ is `grossRegulator` and the span of its image is `regulatorSpan`.
+
+*References:*
+- L. J. Federer, B. H. Gross, *Regulators and Iwasawa modules*, with an appendix by W. Sinnott,
+  Invent. Math. **62** (1981), 443-457: the conjecture in the $p$-unit regulator form used here,
+  and its equivalence with Kuz'min's class field theoretic form.
+- L. V. Kuz'min, *The Tate module of algebraic number fields*, Izv. Akad. Nauk SSSR Ser. Mat.
+  **36** (1972), 267-327: the original class field theoretic statement, that the
+  $\Gamma$-coinvariants of the Galois group of the maximal abelian pro-$p$ extension of
+  $K_\infty$ unramified and totally split above $p$ are finite.
+- P. Mihăilescu, *The Gross-Kuz'min conjecture for CM fields*,
+  [arXiv:1107.1146](https://arxiv.org/abs/1107.1146), §1: the $p$-units are
+  $E'(K) = (\mathcal{O}(K)[1/p])^\times$ and the conjecture is the non-vanishing of the
+  $p$-adic regulator $R(E'(K))$; the same author's *Leopoldt's Conjecture for CM fields*,
+  [arXiv:1105.4544](https://arxiv.org/abs/1105.4544), is the source for
+  `FormalConjectures.Wikipedia.LeopoldtConjecture`.
+- J.-F. Jaulent, *Sur les normes cyclotomiques et les conjectures de Leopoldt et de
+  Gross-Kuz'min*, [arXiv:1509.02743](https://arxiv.org/abs/1509.02743): the two conjectures
+  side by side, and the reformulation through the logarithmic class group.
+- R. Greenberg, *On a certain l-adic representation*, Invent. Math. **21** (1973), 117-124: the
+  conjecture for abelian $K/\mathbb{Q}$.
+-/
+
+open IsDedekindDomain NumberField
+
+open scoped NumberField
+
+namespace GrossKuzmin
+
+variable (K : Type*) [Field K] [NumberField K] (p : ℕ) [Fact p.Prime]
+
+/- ## The primes above `p` -/
+
+/-- $S_p$ as a type: the primes $\mathfrak{p}$ of $\mathcal{O}_K$ with $\mathfrak{p} \mid p$. -/
+abbrev PrimesAbove : Type _ := {v : HeightOneSpectrum (𝓞 K) // (p : 𝓞 K) ∈ v.asIdeal}
+
+/-- $S_p$ as a set of primes, the shape `Set.unit` wants for the $p$-units. -/
+abbrev primesAboveSet : Set (HeightOneSpectrum (𝓞 K)) := {v | (p : 𝓞 K) ∈ v.asIdeal}
+
+instance : Finite (PrimesAbove K p) := by
+  have hpne : (p : 𝓞 K) ≠ 0 := Nat.cast_ne_zero.2 (Fact.out (p := p.Prime)).ne_zero
+  have hp0 : Ideal.span {(p : 𝓞 K)} ≠ 0 := by
+    simpa [Ideal.span_singleton_eq_bot] using hpne
+  apply Set.Finite.to_subtype
+  refine (Ideal.finite_factors (R := 𝓞 K) hp0).subset fun v hv ↦ ?_
+  exact Ideal.dvd_iff_le.2 ((Ideal.span_singleton_le_iff_mem _).2 hv)
+
+/-- Some prime of $\mathcal{O}_K$ lies above `p`: `p` is a prime of `ℤ`, and the extension
+`ℤ → 𝓞 K` is integral, so going up provides a prime over it. -/
+@[category API, AMS 11]
+theorem nonempty_primesAbove : Nonempty (PrimesAbove K p) := by
+  have hpz : Prime (p : ℤ) := Nat.prime_iff_prime_int.1 (Fact.out : p.Prime)
+  have : (Ideal.span {(p : ℤ)}).IsPrime := (Ideal.span_singleton_prime hpz.ne_zero).2 hpz
+  obtain ⟨⟨Q, hQprime, hQover⟩⟩ :
+      Nonempty (Ideal.primesOver (Ideal.span {(p : ℤ)}) (𝓞 K)) := inferInstance
+  have hmem : (p : 𝓞 K) ∈ Q := by
+    have hspan : (p : ℤ) ∈ Ideal.span {(p : ℤ)} := Ideal.mem_span_singleton_self _
+    rw [hQover.over] at hspan
+    simpa using hspan
+  have hne : Q ≠ ⊥ := fun hQ ↦ by
+    rw [hQ, Ideal.mem_bot] at hmem
+    exact Nat.cast_ne_zero.2 (Fact.out : p.Prime).ne_zero hmem
+  exact ⟨⟨⟨Q, hQprime, hne⟩, hmem⟩⟩
+
+/-- $|S_p| \geq 1$, so that the `|S_p| - 1` of the conjecture is not a truncated subtraction. -/
+@[category API, AMS 11]
+theorem zero_lt_card_primesAbove : 0 < Nat.card (PrimesAbove K p) :=
+  Nat.card_pos_iff.2 ⟨nonempty_primesAbove K p, inferInstance⟩
+
+/- ## The `p`-units -/
+
+/-- $E' = \mathcal{O}_K[1/p]^\times$, the group of $p$-units of `K`: the elements of $K^\times$
+whose valuation is `1` at every prime away from $S_p$. This is the unit group of the ring
+$\mathcal{O}_K[1/p]$ of $S_p$-integers by `Set.unitEquivUnitsInteger`. -/
+noncomputable abbrev pUnits : Subgroup Kˣ := (primesAboveSet K p).unit K
+
+/- ## Gross's regulator map -/
+
+/-- `Induces σ v` says that the prime `v` of $\mathcal{O}_K$ is the one induced by the embedding
+$\sigma : K \to \mathbb{C}_p$, that is, the pullback along $\sigma$ of the maximal ideal
+$\{z : \|z\| < 1\}$ of $\mathbb{C}_p$. An embedding induces at most one prime
+(`Induces.unique`), and a prime it induces lies above `p` (`mem_asIdeal_of_induces`). That every
+$\sigma$ induces one is true, but is not proved here; see the module docstring. -/
+def Induces {K : Type*} [Field K] [NumberField K] {p : ℕ} [Fact p.Prime] (σ : K →+* ℂ_[p])
+    (v : HeightOneSpectrum (𝓞 K)) : Prop :=
+  ∀ y : 𝓞 K, y ∈ v.asIdeal ↔ ‖σ (y : K)‖ < 1
+
+/-- The prime induced by an embedding $K \to \mathbb{C}_p$ lies above `p`, since
+$\|p\|_p < 1$. -/
+@[category API, AMS 11]
+theorem mem_asIdeal_of_induces {K : Type*} [Field K] [NumberField K] {p : ℕ} [Fact p.Prime]
+    {σ : K →+* ℂ_[p]} {v : HeightOneSpectrum (𝓞 K)} (h : Induces σ v) :
+    (p : 𝓞 K) ∈ v.asIdeal := by
+  refine (h (p : 𝓞 K)).2 ?_
+  have hcast : σ ((p : 𝓞 K) : K) = ((p : ℕ) : ℂ_[p]) := by simp
+  rw [hcast]
+  exact PadicIwasawaLog.PadicComplex.norm_natCast_p_lt_one
+
+/-- An embedding induces at most one prime: the induced prime is determined as the set
+$\{y : \|\sigma(y)\| < 1\}$. So the fibres of $\sigma \mapsto \mathfrak{p}$ are disjoint, and
+the sums `logNorm` over distinct primes involve disjoint sets of embeddings. -/
+@[category API, AMS 11]
+theorem Induces.unique {K : Type*} [Field K] [NumberField K] {p : ℕ} [Fact p.Prime]
+    {σ : K →+* ℂ_[p]} {v w : HeightOneSpectrum (𝓞 K)} (hv : Induces σ v) (hw : Induces σ w) :
+    v = w :=
+  HeightOneSpectrum.ext (Ideal.ext fun y ↦ (hv y).trans (hw y).symm)
+
+open scoped Classical in
+/-- $\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)$, computed as $\sum_\sigma \log_p \sigma(x)$
+over the embeddings $\sigma : K \to \mathbb{C}_p$ inducing $\mathfrak{p}$. See the module
+docstring for why the local norm is spelled out this way. -/
+noncomputable def logNorm (x : K) (v : HeightOneSpectrum (𝓞 K)) : ℂ_[p] :=
+  ∑ σ ∈ Finset.univ.filter fun σ : K →+* ℂ_[p] ↦ Induces σ v,
+    PadicIwasawaLog.iwasawaLog p (σ x)
+
+/-- Every summand of `logNorm` at a $p$-unit, hence every summand of `grossRegulator`, is a
+genuine Iwasawa logarithm rather than the junk value: a $p$-unit is a nonzero element of `K` and
+an embedding $\sigma : K \to \mathbb{C}_p$ is injective, so
+$\sigma(x) \in \mathbb{C}_p^\times$ lies in the domain of `iwasawaLog`
+(`PadicIwasawaLog.PadicComplex.hasIwasawaLog_iff`). -/
+@[category API, AMS 11]
+theorem hasIwasawaLog_embedding (x : pUnits K p) (σ : K →+* ℂ_[p]) :
+    PadicIwasawaLog.HasIwasawaLog p (σ ((x : Kˣ) : K)) :=
+  PadicIwasawaLog.PadicComplex.hasIwasawaLog_iff.2
+    fun h => (x : Kˣ).ne_zero (σ.injective (h.trans (map_zero σ).symm))
+
+/-- **Gross's regulator map** $\rho : E' \to \bigoplus_{\mathfrak{p} \in S_p} \mathbb{Q}_p$,
+$x \mapsto (\log_p N_{K_\mathfrak{p}/\mathbb{Q}_p}(x))_\mathfrak{p}$, with $\mathbb{C}_p$ in
+place of $\mathbb{Q}_p$. -/
+noncomputable def grossRegulator (x : pUnits K p) (v : PrimesAbove K p) : ℂ_[p] :=
+  logNorm K p ((x : Kˣ) : K) v.1
+
+/-- The $\mathbb{C}_p$-span of the image of Gross's regulator map. Its dimension is the
+$\mathbb{Z}_p$-rank of the image of $\mathbb{Z}_p \otimes E'$ that the conjecture is about; see
+the module docstring for why the span is taken over $\mathbb{C}_p$ rather than $\mathbb{Q}_p$. -/
+noncomputable def regulatorSpan : Submodule ℂ_[p] (PrimesAbove K p → ℂ_[p]) :=
+  Submodule.span ℂ_[p] (Set.range (grossRegulator K p))
+
+/- ## The conjecture -/
+
+/--
+**The Gross-Kuz'min conjecture.** Let $K$ be a number field, $p$ a prime, $S_p$ the set of
+primes of $K$ above $p$ and $E' = \mathcal{O}_K[1/p]^\times$ the $p$-units. Then the image of
+Gross's regulator map
+$$\rho : E' \to \bigoplus_{\mathfrak{p} \in S_p} \mathbb{Q}_p, \qquad
+x \mapsto \big(\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)\big)_\mathfrak{p}$$
+spans a subspace of dimension $|S_p| - 1$.
+
+This is the maximum possible: the coordinates of $\rho(x)$ sum to
+$\log_p N_{K/\mathbb{Q}}(x) = 0$, so the image lies in the hyperplane $\sum_\mathfrak{p} = 0$.
+Equivalently the $p$-adic regulator $R(E'(K))$ of the $p$-units is nonzero
+[Mihăilescu, §1], and equivalently Kuz'min's Iwasawa module has finite $\Gamma$-coinvariants
+[Federer-Gross].
+
+The conjecture is trivially true when $p$ has a single prime above it in $K$, for instance when
+$p$ is inert or totally ramified: then $|S_p| - 1 = 0$.
+-/
+@[category research open, AMS 11]
+theorem gross_kuzmin_conjecture :
+    Module.finrank ℂ_[p] (regulatorSpan K p) = Nat.card (PrimesAbove K p) - 1 := by
+  sorry
+
+/--
+**Greenberg's theorem.** The Gross-Kuz'min conjecture holds when $K$ is an abelian extension of
+$\mathbb{Q}$. As for Leopoldt's conjecture in the abelian case, the input is the $p$-adic
+analogue of Baker's theorem on linear forms in logarithms, proved by Brumer.
+-/
+@[category research solved, AMS 11]
+theorem gross_kuzmin_conjecture.variants.abelian [IsAbelianGalois ℚ K] :
+    Module.finrank ℂ_[p] (regulatorSpan K p) = Nat.card (PrimesAbove K p) - 1 := by
+  sorry
+
+end GrossKuzmin

--- a/FormalConjectures/Paper/GrossKuzmin.lean
+++ b/FormalConjectures/Paper/GrossKuzmin.lean
@@ -29,7 +29,9 @@ x \mapsto \big(\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)\big)_{\mathfrak{p} \i
 **The Gross-Kuz'min conjecture** states that the image of $\mathbb{Z}_p \otimes E'$ under $\rho$
 has $\mathbb{Z}_p$-rank $|S_p| - 1$. This is the largest value it can take: the coordinates of
 $\rho(x)$ always sum to $\log_p N_{K/\mathbb{Q}}(x) = \log_p(\pm p^k) = 0$, so the image lies in a
-hyperplane.
+hyperplane. Maksoud [Conjecture 1.3] states the conjecture as the surjectivity of $-\rho$, after
+$p$-adic completion, onto this hyperplane, which is the same thing since the hyperplane has rank
+$|S_p| - 1$.
 
 The conjecture is the exact analogue for $p$-units of Leopoldt's conjecture for units, which says
 that the matrix of $p$-adic logarithms of a fundamental system of units has full rank. Like
@@ -74,49 +76,16 @@ way and neither changing the content.
   `FormalConjectures.Wikipedia.LeopoldtConjecture` states Leopoldt's conjecture the same way,
   as `Matrix.rank` of a matrix over $\mathbb{C}_p$.
 
-The remaining objects match the sources directly:
-
-* $S_p$ is `NumberField.PrimesAbove K p`, from
-  `FormalConjecturesForMathlib.NumberTheory.NumberField.PrimesAbove`, and $|S_p|$ is
-  `Nat.card (PrimesAbove K p)`, which is at least `1` (`zero_lt_card_primesAbove`) so that
-  `|S_p| - 1` is an honest subtraction;
-* $E'$ is `pUnits K p`, Mathlib's `Set.unit` for the set $S_p$, which is
-  $\mathcal{O}_K[1/p]^\times$ by `Set.unitEquivUnitsInteger`;
-* $\log_p$ is `PadicIwasawaLog.iwasawaLog`, Iwasawa's extension of the logarithm with
-  $\log_p p = 0$, from `FormalConjecturesForMathlib.NumberTheory.Padics.IwasawaLog`. It is built
-  on `NormedSpace.log`, the logarithm series vendored from
-  [mathlib#43670](https://github.com/leanprover-community/mathlib4/pull/43670) as
-  `FormalConjecturesForMathlib.Analysis.Normed.Algebra.Logarithm`, by
-  $\log_p x = \log(x^N / p^m) / N$ for any $N \geq 1$ and $m$ putting $x^N / p^m$ in the disc
-  of convergence. The extension cannot be avoided: $\sigma(x)$ is a $p$-unit, not a unit, so it
-  has nonzero valuation and the series does not converge at it. Nor can the inputs be restricted
-  to principal units, as `leopoldt_conjecture.variants.padicRegulator` does for units: a $p$-unit
-  that is a principal unit at every prime above $p$ is a unit, and for $K = \mathbb{Q}(i)$ and
-  $p = 5$ the only such unit is $1$, so the span would be $0$ instead of having dimension
-  $|S_p| - 1 = 1$. The Iwasawa logarithm is defined on all of $\mathbb{C}_p^\times$
-  (`PadicIwasawaLog.PadicComplex.hasIwasawaLog_iff`), and every $\sigma(x)$ summed over in
-  `logNorm` is nonzero (`hasIwasawaLog_embedding`), so no junk value is involved;
-* $\rho$ is `grossRegulator` and the span of its image is `regulatorSpan`.
+The remaining objects match the sources directly.
 
 *References:*
-- L. J. Federer, B. H. Gross, *Regulators and Iwasawa modules*, with an appendix by W. Sinnott,
-  Invent. Math. **62** (1981), 443-457: for CM fields, the non-vanishing of the $p$-adic
-  regulator of the minus $p$-units, and its equivalence with the minus part of Kuz'min's form.
+- A. Maksoud, *On the rank of Leopoldt's and Gross's regulator maps*, Doc. Math. **28** (2023),
+  1441-1471, [arXiv:2201.08203](https://arxiv.org/abs/2201.08203), (2) and Conjecture 1.3: the
+  statement formalised here, as the surjectivity of Gross's regulator map onto the hyperplane.
+- B. H. Gross, *$p$-adic $L$-series at $s = 0$*, J. Fac. Sci. Univ. Tokyo Sect. IA Math. **28**
+  (1981), 979-994: Gross's formulation of the conjecture.
 - L. V. Kuz'min, *The Tate module of algebraic number fields*, Izv. Akad. Nauk SSSR Ser. Mat.
-  **36** (1972), 267-327: the original class field theoretic statement, that the
-  $\Gamma$-coinvariants of the Galois group of the maximal abelian pro-$p$ extension of
-  $K_\infty$ unramified and totally split above $p$ are finite.
-- P. Mihăilescu, *The Gross-Kuz'min conjecture for CM fields*,
-  [arXiv:1107.1146v1](https://arxiv.org/abs/1107.1146v1), §1: the $p$-units are
-  $E'(K) = (\mathcal{O}(K)[1/p])^\times$ and, for CM fields, the conjecture is the
-  non-vanishing of the $p$-adic regulator $R(E'(K))$; the same author's *Leopoldt's Conjecture
-  for CM fields*, [arXiv:1105.4544](https://arxiv.org/abs/1105.4544), is the source for
-  `FormalConjectures.Wikipedia.LeopoldtConjecture`.
-- J.-F. Jaulent, *Sur les normes cyclotomiques et les conjectures de Leopoldt et de
-  Gross-Kuz'min*, [arXiv:1509.02743](https://arxiv.org/abs/1509.02743): Scolie 6, whose exact
-  sequence on $p$-units shows that the rank of $\rho$ falls short of $|S_p| - 1$ by the
-  $\mathbb{Z}_p$-rank of the logarithmic class group, and Théorème 5, that this group is
-  isomorphic to the $\Gamma$-coinvariants of Kuz'min's module.
+  **36** (1972), 267-327: the original class field theoretic statement.
 - R. Greenberg, *On a certain l-adic representation*, Invent. Math. **21** (1973), 117-124: the
   conjecture for abelian $K/\mathbb{Q}$.
 -/
@@ -218,12 +187,8 @@ x \mapsto \big(\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)\big)_\mathfrak{p}$$
 spans a subspace of dimension $|S_p| - 1$.
 
 This is the maximum possible: the coordinates of $\rho(x)$ sum to
-$\log_p N_{K/\mathbb{Q}}(x) = 0$, so the image lies in the hyperplane $\sum_\mathfrak{p} = 0$.
-Equivalently, the logarithmic class group of $K$ is finite, which is to say that Kuz'min's
-Iwasawa module has finite $\Gamma$-coinvariants [Jaulent, Scolie 6 and Théorème 5]. For a CM
-field the statement implies that Gross's $p$-adic regulator $R(E'(K))$ of the minus $p$-units
-is nonzero, and Federer and Gross show that this is equivalent to the minus part of Kuz'min's
-form [Mihăilescu, §1]. -/
+$\log_p N_{K/\mathbb{Q}}(x) = 0$, so the image lies in the hyperplane $\sum_\mathfrak{p} = 0$,
+and the conjecture says that the image spans it [Maksoud, Conjecture 1.3]. -/
 @[category research open, AMS 11]
 theorem gross_kuzmin_conjecture :
     Module.finrank ℂ_[p] (regulatorSpan K p) = Nat.card (PrimesAbove K p) - 1 := by

--- a/FormalConjectures/Paper/GrossKuzmin.lean
+++ b/FormalConjectures/Paper/GrossKuzmin.lean
@@ -75,16 +75,26 @@ way and neither changing the content.
 
 The remaining objects match the sources directly:
 
-* $S_p$ is `PrimesAbove K p` and $|S_p|$ is `Nat.card (PrimesAbove K p)`, which is at least `1`
-  (`zero_lt_card_primesAbove`) so that `|S_p| - 1` is an honest subtraction;
+* $S_p$ is `NumberField.PrimesAbove K p`, from
+  `FormalConjecturesForMathlib.NumberTheory.NumberField.PrimesAbove`, and $|S_p|$ is
+  `Nat.card (PrimesAbove K p)`, which is at least `1` (`zero_lt_card_primesAbove`) so that
+  `|S_p| - 1` is an honest subtraction;
 * $E'$ is `pUnits K p`, Mathlib's `Set.unit` for the set $S_p$, which is
   $\mathcal{O}_K[1/p]^\times$ by `Set.unitEquivUnitsInteger`;
 * $\log_p$ is `PadicIwasawaLog.iwasawaLog`, Iwasawa's extension of the logarithm with
-  $\log_p p = 0$. This convention is forced here: $\sigma(x)$ is a $p$-unit, not a unit, so it
-  has nonzero valuation and the naive series does not converge at it. The Iwasawa logarithm is
-  defined on all of $\mathbb{C}_p^\times$ (`PadicIwasawaLog.PadicComplex.hasIwasawaLog_iff`), and
-  every $\sigma(x)$ summed over in `logNorm` is nonzero (`hasIwasawaLog_embedding`), so no junk
-  value is involved;
+  $\log_p p = 0$, from `FormalConjecturesForMathlib.NumberTheory.Padics.IwasawaLog`. It is built
+  on `NormedSpace.log`, the logarithm series vendored from
+  [mathlib#43670](https://github.com/leanprover-community/mathlib4/pull/43670) as
+  `FormalConjecturesForMathlib.Analysis.Normed.Algebra.Logarithm`, by
+  $\log_p x = \log(x^N / p^m) / N$ for any $N \geq 1$ and $m$ putting $x^N / p^m$ in the disc
+  of convergence. The extension cannot be avoided: $\sigma(x)$ is a $p$-unit, not a unit, so it
+  has nonzero valuation and the series does not converge at it. Nor can the inputs be restricted
+  to principal units, as `leopoldt_conjecture.variants.padicRegulator` does for units: a $p$-unit
+  that is a principal unit at every prime above $p$ is a unit, and for $K = \mathbb{Q}(i)$ and
+  $p = 5$ the only such unit is $1$, so the span would be $0$ instead of having dimension
+  $|S_p| - 1 = 1$. The Iwasawa logarithm is defined on all of $\mathbb{C}_p^\times$
+  (`PadicIwasawaLog.PadicComplex.hasIwasawaLog_iff`), and every $\sigma(x)$ summed over in
+  `logNorm` is nonzero (`hasIwasawaLog_embedding`), so no junk value is involved;
 * $\rho$ is `grossRegulator` and the span of its image is `regulatorSpan`.
 
 *References:*
@@ -117,9 +127,6 @@ namespace GrossKuzmin
 variable (K : Type*) [Field K] [NumberField K] (p : ℕ) [Fact p.Prime]
 
 /- ## The primes above `p` -/
-
-/-- $S_p$ as a type: the primes $\mathfrak{p}$ of $\mathcal{O}_K$ with $\mathfrak{p} \mid p$. -/
-abbrev PrimesAbove : Type _ := {v : HeightOneSpectrum (𝓞 K) // (p : 𝓞 K) ∈ v.asIdeal}
 
 /-- $S_p$ as a set of primes, the shape `Set.unit` wants for the $p$-units. -/
 abbrev primesAboveSet : Set (HeightOneSpectrum (𝓞 K)) := {v | (p : 𝓞 K) ∈ v.asIdeal}

--- a/FormalConjectures/Paper/GrossKuzmin.lean
+++ b/FormalConjectures/Paper/GrossKuzmin.lean
@@ -66,6 +66,7 @@ way and neither changing the content.
   $\mathbb{Q}_p$-algebra, the same missing structure that makes
   $N_{K_\mathfrak{p}/\mathbb{Q}_p}$ unavailable. Until both are available, a reader should check
   `logNorm` against the displayed formula by hand.
+
 * **The rank is a $\mathbb{C}_p$-dimension.** The $\mathbb{Z}_p$-rank of the image of
   $\mathbb{Z}_p \otimes E'$ in $\mathbb{Q}_p^{S_p}$ is the $\mathbb{Q}_p$-dimension of the span of
   $\rho(E')$, and extending scalars to $\mathbb{C}_p$ does not change it. Taking the span inside
@@ -99,21 +100,23 @@ The remaining objects match the sources directly:
 
 *References:*
 - L. J. Federer, B. H. Gross, *Regulators and Iwasawa modules*, with an appendix by W. Sinnott,
-  Invent. Math. **62** (1981), 443-457: the conjecture in the $p$-unit regulator form used here,
-  and its equivalence with Kuz'min's class field theoretic form.
+  Invent. Math. **62** (1981), 443-457: for CM fields, the non-vanishing of the $p$-adic
+  regulator of the minus $p$-units, and its equivalence with the minus part of Kuz'min's form.
 - L. V. Kuz'min, *The Tate module of algebraic number fields*, Izv. Akad. Nauk SSSR Ser. Mat.
   **36** (1972), 267-327: the original class field theoretic statement, that the
   $\Gamma$-coinvariants of the Galois group of the maximal abelian pro-$p$ extension of
   $K_\infty$ unramified and totally split above $p$ are finite.
 - P. Mihăilescu, *The Gross-Kuz'min conjecture for CM fields*,
-  [arXiv:1107.1146](https://arxiv.org/abs/1107.1146), §1: the $p$-units are
-  $E'(K) = (\mathcal{O}(K)[1/p])^\times$ and the conjecture is the non-vanishing of the
-  $p$-adic regulator $R(E'(K))$; the same author's *Leopoldt's Conjecture for CM fields*,
-  [arXiv:1105.4544](https://arxiv.org/abs/1105.4544), is the source for
+  [arXiv:1107.1146v1](https://arxiv.org/abs/1107.1146v1), §1: the $p$-units are
+  $E'(K) = (\mathcal{O}(K)[1/p])^\times$ and, for CM fields, the conjecture is the
+  non-vanishing of the $p$-adic regulator $R(E'(K))$; the same author's *Leopoldt's Conjecture
+  for CM fields*, [arXiv:1105.4544](https://arxiv.org/abs/1105.4544), is the source for
   `FormalConjectures.Wikipedia.LeopoldtConjecture`.
 - J.-F. Jaulent, *Sur les normes cyclotomiques et les conjectures de Leopoldt et de
-  Gross-Kuz'min*, [arXiv:1509.02743](https://arxiv.org/abs/1509.02743): the two conjectures
-  side by side, and the reformulation through the logarithmic class group.
+  Gross-Kuz'min*, [arXiv:1509.02743](https://arxiv.org/abs/1509.02743): Scolie 6, whose exact
+  sequence on $p$-units shows that the rank of $\rho$ falls short of $|S_p| - 1$ by the
+  $\mathbb{Z}_p$-rank of the logarithmic class group, and Théorème 5, that this group is
+  isomorphic to the $\Gamma$-coinvariants of Kuz'min's module.
 - R. Greenberg, *On a certain l-adic representation*, Invent. Math. **21** (1973), 117-124: the
   conjecture for abelian $K/\mathbb{Q}$.
 -/
@@ -131,42 +134,24 @@ variable (K : Type*) [Field K] [NumberField K] (p : ℕ) [Fact p.Prime]
 /-- $S_p$ as a set of primes, the shape `Set.unit` wants for the $p$-units. -/
 abbrev primesAboveSet : Set (HeightOneSpectrum (𝓞 K)) := {v | (p : 𝓞 K) ∈ v.asIdeal}
 
-instance : Finite (PrimesAbove K p) := by
-  have hpne : (p : 𝓞 K) ≠ 0 := Nat.cast_ne_zero.2 (Fact.out (p := p.Prime)).ne_zero
-  have hp0 : Ideal.span {(p : 𝓞 K)} ≠ 0 := by
-    simpa [Ideal.span_singleton_eq_bot] using hpne
-  apply Set.Finite.to_subtype
-  refine (Ideal.finite_factors (R := 𝓞 K) hp0).subset fun v hv ↦ ?_
-  exact Ideal.dvd_iff_le.2 ((Ideal.span_singleton_le_iff_mem _).2 hv)
+instance : Finite (PrimesAbove K p) :=
+  ((Ideal.finite_factors (I := Ideal.span {(p : 𝓞 K)}) (by simp [NeZero.ne p])).subset
+    fun _ ↦ Ideal.dvd_span_singleton.2).to_subtype
 
-/-- Some prime of $\mathcal{O}_K$ lies above `p`: `p` is a prime of `ℤ`, and the extension
-`ℤ → 𝓞 K` is integral, so going up provides a prime over it. -/
 @[category API, AMS 11]
 theorem nonempty_primesAbove : Nonempty (PrimesAbove K p) := by
-  have hpz : Prime (p : ℤ) := Nat.prime_iff_prime_int.1 (Fact.out : p.Prime)
-  have : (Ideal.span {(p : ℤ)}).IsPrime := (Ideal.span_singleton_prime hpz.ne_zero).2 hpz
-  obtain ⟨⟨Q, hQprime, hQover⟩⟩ :
-      Nonempty (Ideal.primesOver (Ideal.span {(p : ℤ)}) (𝓞 K)) := inferInstance
-  have hmem : (p : 𝓞 K) ∈ Q := by
-    have hspan : (p : ℤ) ∈ Ideal.span {(p : ℤ)} := Ideal.mem_span_singleton_self _
-    rw [hQover.over] at hspan
-    simpa using hspan
-  have hne : Q ≠ ⊥ := fun hQ ↦ by
-    rw [hQ, Ideal.mem_bot] at hmem
-    exact Nat.cast_ne_zero.2 (Fact.out : p.Prime).ne_zero hmem
-  exact ⟨⟨⟨Q, hQprime, hne⟩, hmem⟩⟩
-
-/-- $|S_p| \geq 1$, so that the `|S_p| - 1` of the conjecture is not a truncated subtraction. -/
-@[category API, AMS 11]
-theorem zero_lt_card_primesAbove : 0 < Nat.card (PrimesAbove K p) :=
-  Nat.card_pos_iff.2 ⟨nonempty_primesAbove K p, inferInstance⟩
+  obtain ⟨⟨Q, hQprime, hQover⟩⟩ : Nonempty (Ideal.primesOver (Ideal.span {(p : ℤ)}) (𝓞 K)) :=
+    inferInstance
+  exact ⟨⟨⟨Q, hQprime, Ideal.ne_bot_of_liesOver_of_ne_bot (p := Ideal.span {(p : ℤ)})
+    (by simp [NeZero.ne p]) Q⟩, by simpa [hQover.over] using Ideal.mem_span_singleton_self (p : ℤ)⟩⟩
 
 /- ## The `p`-units -/
 
 /-- $E' = \mathcal{O}_K[1/p]^\times$, the group of $p$-units of `K`: the elements of $K^\times$
 whose valuation is `1` at every prime away from $S_p$. This is the unit group of the ring
 $\mathcal{O}_K[1/p]$ of $S_p$-integers by `Set.unitEquivUnitsInteger`. -/
-noncomputable abbrev pUnits : Subgroup Kˣ := (primesAboveSet K p).unit K
+noncomputable
+abbrev pUnits : Subgroup Kˣ := (primesAboveSet K p).unit K
 
 /- ## Gross's regulator map -/
 
@@ -179,33 +164,24 @@ def Induces {K : Type*} [Field K] [NumberField K] {p : ℕ} [Fact p.Prime] (σ :
     (v : HeightOneSpectrum (𝓞 K)) : Prop :=
   ∀ y : 𝓞 K, y ∈ v.asIdeal ↔ ‖σ (y : K)‖ < 1
 
-/-- The prime induced by an embedding $K \to \mathbb{C}_p$ lies above `p`, since
-$\|p\|_p < 1$. -/
 @[category API, AMS 11]
 theorem mem_asIdeal_of_induces {K : Type*} [Field K] [NumberField K] {p : ℕ} [Fact p.Prime]
-    {σ : K →+* ℂ_[p]} {v : HeightOneSpectrum (𝓞 K)} (h : Induces σ v) :
-    (p : 𝓞 K) ∈ v.asIdeal := by
+    {σ : K →+* ℂ_[p]} {v : HeightOneSpectrum (𝓞 K)} (h : Induces σ v) : (p : 𝓞 K) ∈ v.asIdeal := by
   refine (h (p : 𝓞 K)).2 ?_
-  have hcast : σ ((p : 𝓞 K) : K) = ((p : ℕ) : ℂ_[p]) := by simp
-  rw [hcast]
-  exact PadicIwasawaLog.PadicComplex.norm_natCast_p_lt_one
+  simpa [map_natCast] using PadicIwasawaLog.PadicComplex.norm_natCast_p_lt_one
 
-/-- An embedding induces at most one prime: the induced prime is determined as the set
-$\{y : \|\sigma(y)\| < 1\}$. So the fibres of $\sigma \mapsto \mathfrak{p}$ are disjoint, and
-the sums `logNorm` over distinct primes involve disjoint sets of embeddings. -/
 @[category API, AMS 11]
 theorem Induces.unique {K : Type*} [Field K] [NumberField K] {p : ℕ} [Fact p.Prime]
     {σ : K →+* ℂ_[p]} {v w : HeightOneSpectrum (𝓞 K)} (hv : Induces σ v) (hw : Induces σ w) :
-    v = w :=
-  HeightOneSpectrum.ext (Ideal.ext fun y ↦ (hv y).trans (hw y).symm)
+    v = w := HeightOneSpectrum.ext (Ideal.ext fun y ↦ (hv y).trans (hw y).symm)
 
 open scoped Classical in
 /-- $\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)$, computed as $\sum_\sigma \log_p \sigma(x)$
 over the embeddings $\sigma : K \to \mathbb{C}_p$ inducing $\mathfrak{p}$. See the module
 docstring for why the local norm is spelled out this way. -/
-noncomputable def logNorm (x : K) (v : HeightOneSpectrum (𝓞 K)) : ℂ_[p] :=
-  ∑ σ ∈ Finset.univ.filter fun σ : K →+* ℂ_[p] ↦ Induces σ v,
-    PadicIwasawaLog.iwasawaLog p (σ x)
+noncomputable
+def logNorm (x : K) (v : HeightOneSpectrum (𝓞 K)) : ℂ_[p] :=
+  ∑ σ ∈ Finset.univ.filter fun σ : K →+* ℂ_[p] ↦ Induces σ v, PadicIwasawaLog.iwasawaLog p (σ x)
 
 /-- Every summand of `logNorm` at a $p$-unit, hence every summand of `grossRegulator`, is a
 genuine Iwasawa logarithm rather than the junk value: a $p$-unit is a nonzero element of `K` and
@@ -221,19 +197,20 @@ theorem hasIwasawaLog_embedding (x : pUnits K p) (σ : K →+* ℂ_[p]) :
 /-- **Gross's regulator map** $\rho : E' \to \bigoplus_{\mathfrak{p} \in S_p} \mathbb{Q}_p$,
 $x \mapsto (\log_p N_{K_\mathfrak{p}/\mathbb{Q}_p}(x))_\mathfrak{p}$, with $\mathbb{C}_p$ in
 place of $\mathbb{Q}_p$. -/
-noncomputable def grossRegulator (x : pUnits K p) (v : PrimesAbove K p) : ℂ_[p] :=
+noncomputable
+def grossRegulator (x : pUnits K p) (v : PrimesAbove K p) : ℂ_[p] :=
   logNorm K p ((x : Kˣ) : K) v.1
 
 /-- The $\mathbb{C}_p$-span of the image of Gross's regulator map. Its dimension is the
 $\mathbb{Z}_p$-rank of the image of $\mathbb{Z}_p \otimes E'$ that the conjecture is about; see
 the module docstring for why the span is taken over $\mathbb{C}_p$ rather than $\mathbb{Q}_p$. -/
-noncomputable def regulatorSpan : Submodule ℂ_[p] (PrimesAbove K p → ℂ_[p]) :=
+noncomputable
+def regulatorSpan : Submodule ℂ_[p] (PrimesAbove K p → ℂ_[p]) :=
   Submodule.span ℂ_[p] (Set.range (grossRegulator K p))
 
 /- ## The conjecture -/
 
-/--
-**The Gross-Kuz'min conjecture.** Let $K$ be a number field, $p$ a prime, $S_p$ the set of
+/-- **The Gross-Kuz'min conjecture.** Let $K$ be a number field, $p$ a prime, $S_p$ the set of
 primes of $K$ above $p$ and $E' = \mathcal{O}_K[1/p]^\times$ the $p$-units. Then the image of
 Gross's regulator map
 $$\rho : E' \to \bigoplus_{\mathfrak{p} \in S_p} \mathbb{Q}_p, \qquad
@@ -242,23 +219,18 @@ spans a subspace of dimension $|S_p| - 1$.
 
 This is the maximum possible: the coordinates of $\rho(x)$ sum to
 $\log_p N_{K/\mathbb{Q}}(x) = 0$, so the image lies in the hyperplane $\sum_\mathfrak{p} = 0$.
-Equivalently the $p$-adic regulator $R(E'(K))$ of the $p$-units is nonzero
-[Mihăilescu, §1], and equivalently Kuz'min's Iwasawa module has finite $\Gamma$-coinvariants
-[Federer-Gross].
-
-The conjecture is trivially true when $p$ has a single prime above it in $K$, for instance when
-$p$ is inert or totally ramified: then $|S_p| - 1 = 0$.
--/
+Equivalently, the logarithmic class group of $K$ is finite, which is to say that Kuz'min's
+Iwasawa module has finite $\Gamma$-coinvariants [Jaulent, Scolie 6 and Théorème 5]. For a CM
+field the statement implies that Gross's $p$-adic regulator $R(E'(K))$ of the minus $p$-units
+is nonzero, and Federer and Gross show that this is equivalent to the minus part of Kuz'min's
+form [Mihăilescu, §1]. -/
 @[category research open, AMS 11]
 theorem gross_kuzmin_conjecture :
     Module.finrank ℂ_[p] (regulatorSpan K p) = Nat.card (PrimesAbove K p) - 1 := by
   sorry
 
-/--
-**Greenberg's theorem.** The Gross-Kuz'min conjecture holds when $K$ is an abelian extension of
-$\mathbb{Q}$. As for Leopoldt's conjecture in the abelian case, the input is the $p$-adic
-analogue of Baker's theorem on linear forms in logarithms, proved by Brumer.
--/
+/-- **Greenberg's theorem.** The Gross-Kuz'min conjecture holds when $K$ is an abelian extension of
+$\mathbb{Q}$. -/
 @[category research solved, AMS 11]
 theorem gross_kuzmin_conjecture.variants.abelian [IsAbelianGalois ℚ K] :
     Module.finrank ℂ_[p] (regulatorSpan K p) = Nat.card (PrimesAbove K p) - 1 := by

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -34,6 +34,7 @@ public import FormalConjecturesForMathlib.Analysis.Equidistribution.ModOne
 public import FormalConjecturesForMathlib.Analysis.Fourier.SpectralSets
 public import FormalConjecturesForMathlib.Analysis.HasGaps
 public import FormalConjecturesForMathlib.Analysis.Matrix.Spectrum
+public import FormalConjecturesForMathlib.Analysis.Normed.Algebra.Logarithm
 public import FormalConjecturesForMathlib.Analysis.Real.Cardinality
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.AdditiveCharacter
 public import FormalConjecturesForMathlib.Analysis.SpecialFunctions.Log.Basic
@@ -152,8 +153,10 @@ public import FormalConjecturesForMathlib.NumberTheory.Lacunary
 public import FormalConjecturesForMathlib.NumberTheory.LegendreSymbol.Basic
 public import FormalConjecturesForMathlib.NumberTheory.NormalNumber
 public import FormalConjecturesForMathlib.NumberTheory.NumberField.FundamentalDiscriminant
+public import FormalConjecturesForMathlib.NumberTheory.NumberField.PrimesAbove
 public import FormalConjecturesForMathlib.NumberTheory.NumberField.Quadratic
 public import FormalConjecturesForMathlib.NumberTheory.Padics.IwasawaLog
+public import FormalConjecturesForMathlib.NumberTheory.Padics.OneUnits
 public import FormalConjecturesForMathlib.NumberTheory.PisotNumber
 public import FormalConjecturesForMathlib.NumberTheory.PracticalNumbers
 public import FormalConjecturesForMathlib.NumberTheory.PrimeGap

--- a/FormalConjecturesForMathlib.lean
+++ b/FormalConjecturesForMathlib.lean
@@ -153,6 +153,7 @@ public import FormalConjecturesForMathlib.NumberTheory.LegendreSymbol.Basic
 public import FormalConjecturesForMathlib.NumberTheory.NormalNumber
 public import FormalConjecturesForMathlib.NumberTheory.NumberField.FundamentalDiscriminant
 public import FormalConjecturesForMathlib.NumberTheory.NumberField.Quadratic
+public import FormalConjecturesForMathlib.NumberTheory.Padics.IwasawaLog
 public import FormalConjecturesForMathlib.NumberTheory.PisotNumber
 public import FormalConjecturesForMathlib.NumberTheory.PracticalNumbers
 public import FormalConjecturesForMathlib.NumberTheory.PrimeGap

--- a/FormalConjecturesForMathlib/Analysis/Normed/Algebra/Logarithm.lean
+++ b/FormalConjecturesForMathlib/Analysis/Normed/Algebra/Logarithm.lean
@@ -1,0 +1,220 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.Algebra.Algebra.TransferInstance
+public import Mathlib.Algebra.Star.Module
+public import Mathlib.Analysis.Analytic.OfScalars
+
+/-!
+# The logarithm in a topological algebra
+
+This file is a copy of `Mathlib/Analysis/Normed/Algebra/Logarithm.lean` from
+[mathlib#43670](https://github.com/leanprover-community/mathlib4/pull/43670) by Kevin Buzzard,
+which is not yet merged. It is vendored here so that Leopoldt's conjecture can be stated with
+mathlib's logarithm rather than a bespoke one; delete this file and import mathlib's once the
+pull request lands. The only edits are two lemma names that do not exist in the pinned mathlib:
+`dite_eq_right` is replaced by `dif_neg` in `log_of_isEmpty_algebra_rat`, and `dite_eq_left` by
+`dif_pos` in `log_eq_logSeries_sum`.
+
+In this file we define `NormedSpace.log : 𝔸 → 𝔸`, the logarithm
+`log x = ∑ₙ ((-1) ^ (n + 1) / n) • (x - 1) ^ n` in a topological ring `𝔸`, following the
+development style of `NormedSpace.exp` (see `Mathlib/Analysis/Normed/Algebra/Exponential.lean`).
+It is the value at `x - 1` of the `FormalMultilinearSeries` `NormedSpace.logSeries ℚ 𝔸`, where the
+`ℚ`-algebra structure on `𝔸` is chosen using `Classical.choice`. It takes the junk value `0`
+if the series does not converge or if `𝔸` has no `ℚ`-algebra structure (equivalently,
+if `1 / n` doesn't correspond to what a mathematician thinks).
+
+This file only contains the definition and its immediate algebraic properties; convergence of
+the series and the relation to `NormedSpace.exp` are left to later files.
+
+## Main definitions
+
+* `NormedSpace.logSeries 𝕂 𝔸`: the formal multilinear series whose `n`-th term is
+  `(xᵢ) ↦ ((-1) ^ (n + 1) / n : 𝕂) • ∏ xᵢ`; its sum at `x - 1` is `log x`.
+* `NormedSpace.log`: the logarithm `𝔸 → 𝔸`.
+
+## Main results
+
+* `NormedSpace.log_eq_tsum`: `log` as a `tsum`.
+* `NormedSpace.log_one`, `NormedSpace.log_op`, `NormedSpace.star_log`, `NormedSpace.log_mem`,
+  `Commute.log`: immediate properties.
+
+## TODO
+
+* Ultrametric convergence: if `K` is a complete ultrametric normed field of characteristic zero
+  then the series converges on the whole disc `‖x - 1‖ < 1` (no choice of prime is needed: the
+  natural numbers of norm `< 1` form a prime ideal of `ℕ`, and if it is `pℕ` then
+  `‖n‖ = ‖p‖ ^ padicValNat p n`).
+* If moreover `‖(p : K)‖ < 1` for a prime `p`, Iwasawa's formula
+  `log x = lim (x ^ p ^ k - 1) / p ^ k` gives `log (x * y) = log x + log y` on that disc, hence
+  `log_inv`, `log_pow`, `log_zpow` etc.
+* The formal identity `log ((1 + X) * (1 + Y)) = log (1 + X) + log (1 + Y)` in `ℚ⟦X, Y⟧`.
+* Relation with `NormedSpace.exp`: `exp (log x) = x` and `log (exp x) = x` whenever both series
+  converge.
+* In the ultrametric case, the computation of where the series for exp and log converge
+  (`‖x - 1‖ ^ (p - 1) < ‖(p : K)‖` for log).
+* `‖log x‖ = ‖x - 1‖` when the series converges
+* Analyticity: `HasFPowerSeriesOnBall log (logSeries 𝕂 𝔸) 1 (logSeries 𝕂 𝔸).radius` and its
+  consequences, mirroring `NormedSpace.analyticAt_exp_of_mem_ball`.
+* Over `ℝ` and `ℂ`, `NormedSpace.log` agrees with `Real.log` and `Complex.log` on `‖x - 1‖ < 1`.
+* Analytic continuation of `log` in the ultrametric case (probably best to be opinionated
+  and define `log p = 0` so we get a "canonical branch" analogous to how mathlib has
+  chosen a branch of `Complex.log`).
+-/
+
+@[expose] public section
+
+namespace NormedSpace
+
+open FormalMultilinearSeries
+
+section TopologicalAlgebra
+
+variable (𝕂 𝔸 : Type*) [Field 𝕂] [Ring 𝔸] [Algebra 𝕂 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸]
+
+/-- `logSeries 𝕂 𝔸` is the `FormalMultilinearSeries` whose `n`-th term is the map
+`(xᵢ) : 𝔸ⁿ ↦ ((-1) ^ (n + 1) / n : 𝕂) • ∏ xᵢ`; its `0`-th term is `0` since `1 / 0 = 0`.
+The corresponding sum evaluated at `x - 1` is the logarithm `NormedSpace.log x`. -/
+def logSeries : FormalMultilinearSeries 𝕂 𝔸 𝔸 := fun n =>
+  ((-1) ^ (n + 1) / n : 𝕂) • ContinuousMultilinearMap.mkPiAlgebraFin 𝕂 n 𝔸
+
+theorem logSeries_eq_ofScalars : logSeries 𝕂 𝔸 = ofScalars 𝔸 fun n ↦ ((-1) ^ (n + 1) / n : 𝕂) := by
+  simp_rw [FormalMultilinearSeries.ext_iff, logSeries, ofScalars, implies_true]
+
+variable {𝕂 𝔸}
+
+open scoped Classical in
+/-- `NormedSpace.log : 𝔸 → 𝔸` is the logarithm `log x = ∑ₙ ((-1) ^ (n + 1) / n) • (x - 1) ^ n`.
+It is defined as the sum of the `FormalMultilinearSeries` `logSeries ℚ 𝔸` at `x - 1`, in the same
+way as `NormedSpace.exp`, and takes the junk value `0` where the series does not converge.
+
+If `𝔸` can't be equipped with a `ℚ`-algebra structure, we use the junk value `0`.
+-/
+noncomputable irreducible_def log (x : 𝔸) : 𝔸 :=
+  if h : Nonempty (Algebra ℚ 𝔸) then
+    letI _ := h.some
+    (NormedSpace.logSeries ℚ 𝔸).sum (x - 1)
+  else
+    0
+
+/-- The junk value when `𝔸` can't be equipped with a `ℚ`-algebra structure. -/
+@[simp]
+theorem log_of_isEmpty_algebra_rat [IsEmpty (Algebra ℚ 𝔸)] (x : 𝔸) : log x = 0 := by
+  rw [log, dif_neg (not_nonempty_iff.mpr ‹_›)]
+
+theorem logSeries_apply_eq (x : 𝔸) (n : ℕ) :
+    (logSeries 𝕂 𝔸 n fun _ => x) = ((-1) ^ (n + 1) / n : 𝕂) • x ^ n := by simp [logSeries]
+
+theorem logSeries_sum_eq (x : 𝔸) :
+    (logSeries 𝕂 𝔸).sum x = ∑' n : ℕ, ((-1) ^ (n + 1) / n : 𝕂) • x ^ n :=
+  tsum_congr fun n => logSeries_apply_eq x n
+
+private lemma neg_one_pow_div_natCast_eq_inv_intCast (T : Type*) [DivisionRing T] (k n : ℕ) :
+    ((-1) ^ k / n : T) = (((-1) ^ k * n : ℤ) : T)⁻¹ := by
+  rcases Nat.even_or_odd k with hk | hk <;> simp [hk.neg_one_pow, div_eq_mul_inv, inv_neg]
+
+/-- If `E` is a module over two division rings `R` and `S`, then scalar multiplication by the
+coefficients `(-1) ^ k / n` of the logarithm series agree in `R` and `S`. -/
+private lemma neg_one_pow_div_natCast_smul_eq {E : Type*} (R S : Type*) [AddCommGroup E]
+    [DivisionRing R] [DivisionRing S] [Module R E] [Module S E] (k n : ℕ) (x : E) :
+    ((-1) ^ k / n : R) • x = ((-1) ^ k / n : S) • x := by
+  rw [neg_one_pow_div_natCast_eq_inv_intCast R, neg_one_pow_div_natCast_eq_inv_intCast S,
+    inv_intCast_smul_eq R S]
+
+theorem logSeries_sum_eq_rat [Algebra ℚ 𝔸] : (logSeries 𝕂 𝔸).sum = (logSeries ℚ 𝔸).sum := by
+  ext; simp_rw [logSeries_sum_eq, neg_one_pow_div_natCast_smul_eq 𝕂 ℚ]
+
+theorem logSeries_eq_logSeries_rat [Algebra ℚ 𝔸] (n : ℕ) :
+    ⇑(logSeries 𝕂 𝔸 n) = logSeries ℚ 𝔸 n := by
+  ext c
+  simp [logSeries, neg_one_pow_div_natCast_smul_eq 𝕂 ℚ]
+
+variable (𝕂) in
+theorem log_eq_logSeries_sum [CharZero 𝕂] : log = fun x : 𝔸 ↦ (logSeries 𝕂 𝔸).sum (x - 1) := by
+  ext x
+  rw [log, dif_pos ⟨RestrictScalars.algebra ℚ 𝕂 𝔸⟩, ← @logSeries_sum_eq_rat (𝕂 := 𝕂)]
+
+variable (𝕂) in
+theorem log_eq_tsum [CharZero 𝕂] :
+    log = fun x : 𝔸 ↦ ∑' n : ℕ, ((-1) ^ (n + 1) / n : 𝕂) • (x - 1) ^ n := by
+  rw [log_eq_logSeries_sum 𝕂]
+  ext x
+  exact logSeries_sum_eq (x - 1)
+
+theorem logSeries_apply_zero (n : ℕ) : logSeries 𝕂 𝔸 n (fun _ ↦ (0 : 𝔸)) = 0 := by
+  rw [logSeries_apply_eq]
+  rcases n with - | n
+  · simp
+  · rw [zero_pow (Nat.succ_ne_zero _), smul_zero]
+
+@[simp]
+theorem log_one : log (1 : 𝔸) = 0 := by
+  rw [log]
+  split_ifs
+  · simp_rw [sub_self, logSeries_sum_eq, ← logSeries_apply_eq, logSeries_apply_zero, tsum_zero]
+  · rfl
+
+@[simp]
+theorem log_op [T2Space 𝔸] (x : 𝔸) : log (MulOpposite.op x) = MulOpposite.op (log x) := by
+  obtain h | ⟨⟨_⟩⟩ := isEmpty_or_nonempty (Algebra ℚ 𝔸)
+  · have : IsEmpty (Algebra ℚ 𝔸ᵐᵒᵖ) := ⟨fun _ => h.elim <| (RingEquiv.opOp 𝔸).algebra ℚ⟩
+    simp
+  · rw [log_eq_tsum ℚ, log_eq_tsum ℚ]
+    simp_rw [← MulOpposite.op_one, ← MulOpposite.op_sub, ← MulOpposite.op_pow,
+      ← MulOpposite.op_smul, tsum_op]
+
+theorem star_log [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] (x : 𝔸) :
+    star (log x) = log (star x) := by
+  obtain _ | ⟨⟨_⟩⟩ := isEmpty_or_nonempty (Algebra ℚ 𝔸)
+  · simp
+  · simp_rw [log_eq_tsum ℚ, tsum_star, star_rat_smul, star_pow, star_sub, star_one]
+
+/-- A subring of `𝔸` that is closed topologically and under `ℚ`-scaling is closed under `log`. -/
+theorem log_mem
+    {R S : Type*} [Monoid R] [SMul ℚ R] [MulAction R 𝔸] [Algebra ℚ 𝔸] [IsScalarTower ℚ R 𝔸]
+    [SetLike S 𝔸] [SubringClass S 𝔸] [SMulMemClass S R 𝔸] {s : S}
+    (h_closed : IsClosed (s : Set 𝔸)) {x : 𝔸} (h : x ∈ s) :
+    log x ∈ s := by
+  have := SMulMemClass.ofIsScalarTower S ℚ R 𝔸
+  rw [log_eq_tsum ℚ]
+  exact tsum_mem h_closed fun i => SMulMemClass.smul_mem _ <| pow_mem (sub_mem h (one_mem s)) _
+
+end NormedSpace.TopologicalAlgebra
+
+namespace Commute
+
+open NormedSpace
+
+variable {𝔸 : Type*} [Ring 𝔸] [TopologicalSpace 𝔸] [IsTopologicalRing 𝔸]
+
+theorem log_right [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) :
+    Commute x (log y) := by
+  obtain _ | ⟨⟨_⟩⟩ := isEmpty_or_nonempty (Algebra ℚ 𝔸)
+  · simp
+  · rw [log_eq_tsum ℚ]
+    exact Commute.tsum_right x fun n =>
+      ((h.sub_right (Commute.one_right x)).pow_right n).smul_right _
+
+theorem log_left [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) :
+    Commute (log x) y :=
+  h.symm.log_right.symm
+
+theorem log [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) :
+    Commute (log x) (log y) :=
+  h.log_left.log_right
+
+end Commute

--- a/FormalConjecturesForMathlib/NumberTheory/NumberField/PrimesAbove.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NumberField/PrimesAbove.lean
@@ -1,0 +1,85 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
+
+@[expose] public section
+
+/-!
+# The primes of a number field above a rational prime
+
+For a number field `K` and a prime `p`, `NumberField.PrimesAbove K p` is the type of primes
+`𝔭` of `𝓞 K` dividing `p`, as a subtype of the height one spectrum, the divisibility `𝔭 ∣ p`
+being spelled `(p : 𝓞 K) ∈ 𝔭`. At such a prime the completion `K_𝔭` has residue characteristic
+`p`, so `‖p‖ < 1` there; this is recorded as an instance, since it is what gives the principal
+units of `K_𝔭` their `ℤ_[p]`-module structure.
+
+The norm on `K_𝔭` detects congruences modulo `𝔭`: mathlib's
+`NumberField.FinitePlace.norm_lt_one_iff_mem` says an algebraic integer has norm `< 1` under the
+embedding `K → K_𝔭` exactly when it lies in `𝔭`. The two results below restate this for the maps
+`ℕ → K_𝔭` and `𝓞 K → K_𝔭`, which is the form needed when working inside `K_𝔭` itself.
+
+## Main definitions
+
+* `NumberField.PrimesAbove K p`: the primes of `𝓞 K` above `p`.
+
+## Main results
+
+* `IsDedekindDomain.HeightOneSpectrum.norm_natCast_lt_one`: `‖p‖ < 1` in `K_𝔭` for `𝔭 ∣ p`,
+  together with the corresponding `Fact` instance on `NumberField.PrimesAbove`.
+* `IsDedekindDomain.HeightOneSpectrum.norm_algebraMap_sub_one_lt`: an algebraic integer `x`
+  congruent to `1` modulo `𝔭` satisfies `‖x - 1‖ < 1` in `K_𝔭`, i.e. maps to a principal unit.
+-/
+
+open IsDedekindDomain
+
+open scoped NumberField
+
+namespace NumberField
+
+/-- The primes `𝔭` of `𝓞 K` above the rational prime `p`, as a subtype of the height one
+spectrum of `𝓞 K`. -/
+abbrev PrimesAbove (K : Type*) [Field K] [NumberField K] (p : ℕ) : Type _ :=
+  {v : HeightOneSpectrum (𝓞 K) // (p : 𝓞 K) ∈ v.asIdeal}
+
+end NumberField
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+variable {K : Type*} [Field K] [NumberField K] (v : HeightOneSpectrum (𝓞 K))
+
+theorem norm_natCast_lt_one {p : ℕ} (hv : (p : 𝓞 K) ∈ v.asIdeal) :
+    ‖((p : ℕ) : v.adicCompletion K)‖ < 1 := by
+  rw [← map_natCast' (algebraMap (𝓞 K) (adicCompletion K v)) rfl _]
+  exact (NumberField.FinitePlace.norm_lt_one_iff_mem _ _ _).2 hv
+
+theorem norm_algebraMap_sub_one_lt {x : 𝓞 K} (hx : x - 1 ∈ v.asIdeal) :
+    ‖algebraMap (𝓞 K) (v.adicCompletion K) x - 1‖ < 1 := by
+  rw [← map_one (algebraMap (𝓞 K) (v.adicCompletion K)), ← map_sub]
+  exact (NumberField.FinitePlace.norm_lt_one_iff_mem K v _).2 hx
+
+end IsDedekindDomain.HeightOneSpectrum
+
+namespace NumberField
+
+/-- Each `K_𝔭` with `𝔭 ∣ p` has residue characteristic `p`. This is the instance that gives the
+principal units of `K_𝔭` their `ℤ_[p]`-module structure. -/
+instance (K : Type*) [Field K] [NumberField K] (p : ℕ) (v : PrimesAbove K p) :
+    Fact (‖((p : ℕ) : v.1.adicCompletion K)‖ < 1) :=
+  ⟨v.1.norm_natCast_lt_one v.2⟩
+
+end NumberField

--- a/FormalConjecturesForMathlib/NumberTheory/NumberField/PrimesAbove.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NumberField/PrimesAbove.lean
@@ -25,8 +25,8 @@ public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 For a number field `K` and a prime `p`, `NumberField.PrimesAbove K p` is the type of primes
 `𝔭` of `𝓞 K` dividing `p`, as a subtype of the height one spectrum, the divisibility `𝔭 ∣ p`
 being spelled `(p : 𝓞 K) ∈ 𝔭`. At such a prime the completion `K_𝔭` has residue characteristic
-`p`, so `‖p‖ < 1` there; this is recorded as an instance, since it is what gives the principal
-units of `K_𝔭` their `ℤ_[p]`-module structure.
+`p`, so `‖p‖ < 1` there: this is the hypothesis under which the principal units of `K_𝔭` form a
+`ℤ_[p]`-module (`OneUnits.instModule`).
 
 The norm on `K_𝔭` detects congruences modulo `𝔭`: mathlib's
 `NumberField.FinitePlace.norm_lt_one_iff_mem` says an algebraic integer has norm `< 1` under the
@@ -39,8 +39,7 @@ embedding `K → K_𝔭` exactly when it lies in `𝔭`. The two results below r
 
 ## Main results
 
-* `IsDedekindDomain.HeightOneSpectrum.norm_natCast_lt_one`: `‖p‖ < 1` in `K_𝔭` for `𝔭 ∣ p`,
-  together with the corresponding `Fact` instance on `NumberField.PrimesAbove`.
+* `IsDedekindDomain.HeightOneSpectrum.norm_natCast_lt_one`: `‖p‖ < 1` in `K_𝔭` for `𝔭 ∣ p`.
 * `IsDedekindDomain.HeightOneSpectrum.norm_algebraMap_sub_one_lt`: an algebraic integer `x`
   congruent to `1` modulo `𝔭` satisfies `‖x - 1‖ < 1` in `K_𝔭`, i.e. maps to a principal unit.
 -/
@@ -73,13 +72,3 @@ theorem norm_algebraMap_sub_one_lt {x : 𝓞 K} (hx : x - 1 ∈ v.asIdeal) :
   exact (NumberField.FinitePlace.norm_lt_one_iff_mem K v _).2 hx
 
 end IsDedekindDomain.HeightOneSpectrum
-
-namespace NumberField
-
-/-- Each `K_𝔭` with `𝔭 ∣ p` has residue characteristic `p`. This is the instance that gives the
-principal units of `K_𝔭` their `ℤ_[p]`-module structure. -/
-instance (K : Type*) [Field K] [NumberField K] (p : ℕ) (v : PrimesAbove K p) :
-    Fact (‖((p : ℕ) : v.1.adicCompletion K)‖ < 1) :=
-  ⟨v.1.norm_natCast_lt_one v.2⟩
-
-end NumberField

--- a/FormalConjecturesForMathlib/NumberTheory/Padics/IwasawaLog.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Padics/IwasawaLog.lean
@@ -61,32 +61,25 @@ homomorphism with `log p = 0`. The ultrametric estimates on `1`-units are those 
 
 namespace PadicIwasawaLog
 
-variable {p : ℕ} [hp : Fact p.Prime] {K : Type*} [NontriviallyNormedField K]
-  [IsUltrametricDist K] [CompleteSpace K] [CharZero K]
+variable {p : ℕ}
 
 /-! ### The Iwasawa logarithm: its domain, and its definition -/
 
 section Iwasawa
 
-omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+variable {K : Type*} [NontriviallyNormedField K]
+
 /-- `HasPrincipalUnitPow u` says that some positive power of `u` is a `1`-unit, `‖u ^ m - 1‖ < 1`.
-This holds for every unit of the valuation ring of a field whose residue field is algebraic
-over `𝔽_p` — finite extensions of `ℚ_p`, `ℚ_p`-bar and `ℂ_p` — of which only the `ℚ_p`-bar case
-is proved here (`PadicAlgCl.hasPrincipalUnitPow_of_norm_eq_one`). -/
+-/
 def HasPrincipalUnitPow (u : K) : Prop :=
   ∃ m : ℕ, 0 < m ∧ ‖u ^ m - 1‖ < 1
 
-omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
 variable (p) in
 /-- `HasIwasawaLog p x` says that some positive power of `x` is a `1`-unit times a power of `p`:
-`‖x ^ N / p ^ m - 1‖ < 1` for some `N ≥ 1` and `m : ℤ`. This is the domain of the Iwasawa
-logarithm; in `ℂ_p` it is all of `ℂ_p^×` (`PadicComplex.hasIwasawaLog_iff`) [Wiki]: "every element
-w of C×_p can be written as w = p^r · ζ · z with r a rational number, ζ a root of unity, and
-|z−1|_p < 1". -/
+`‖x ^ N / p ^ m - 1‖ < 1` for some `N ≥ 1` and `m : ℤ`. -/
 def HasIwasawaLog (x : K) : Prop :=
   ∃ N : ℕ, 0 < N ∧ ∃ m : ℤ, ‖x ^ N / ((p : ℕ) : K) ^ m - 1‖ < 1
 
-omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
 variable (p) in
 /-- The **Iwasawa logarithm**: the unique extension of `NormedSpace.log` from the `1`-units to
 `HasIwasawaLog p` (all of `ℂ_p^×` when `K = ℂ_p`) which is a homomorphism and has `log p = 0`
@@ -101,46 +94,29 @@ noncomputable def iwasawaLog (x : K) : K := by
       (Nat.find h : K)
   else 0
 
-omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- A `1`-unit lies in the domain of the Iwasawa logarithm: take `N = 1` and `m = 0`. -/
 theorem HasIwasawaLog.of_norm_sub_one_lt {u : K} (hu : ‖u - 1‖ < 1) : HasIwasawaLog p u :=
   ⟨1, one_pos, 0, by simpa using hu⟩
 
-omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- Only nonzero elements have an Iwasawa logarithm, since `0 ^ N / p ^ m - 1 = -1`. -/
 theorem HasIwasawaLog.ne_zero {x : K} (hx : HasIwasawaLog p x) : x ≠ 0 := by
-  rintro rfl
   obtain ⟨N, hN, m, h⟩ := hx
-  rw [zero_pow hN.ne', zero_div, zero_sub, norm_neg, norm_one] at h
-  exact lt_irrefl _ h
+  intro rfl
+  simp [zero_pow hN.ne'] at h
 
-omit [CompleteSpace K] in
-/-- The domain of the Iwasawa logarithm is closed under multiplication: if `x ^ N / p ^ m` and
-`y ^ N' / p ^ m'` are `1`-units, then so is `(x * y) ^ (N * N') / p ^ (m * N' + m' * N)`, which
-is their product of powers. -/
-theorem HasIwasawaLog.mul {x y : K} (hx : HasIwasawaLog p x) (hy : HasIwasawaLog p y) :
-    HasIwasawaLog p (x * y) := by
+theorem HasIwasawaLog.mul [hp : Fact p.Prime] [IsUltrametricDist K] [CharZero K] {x y : K}
+    (hx : HasIwasawaLog p x) (hy : HasIwasawaLog p y) : HasIwasawaLog p (x * y) := by
   obtain ⟨N, hN, m, h⟩ := hx
   obtain ⟨N', hN', m', h'⟩ := hy
-  have h3ne : ((p : ℕ) : K) ≠ 0 := Nat.cast_ne_zero.mpr hp.out.pos.ne'
   refine ⟨N * N', Nat.mul_pos hN hN', m * N' + m' * N, ?_⟩
-  have e : (x * y) ^ (N * N') / ((p : ℕ) : K) ^ (m * N' + m' * N)
-      = (x ^ N / ((p : ℕ) : K) ^ m) ^ N' * (y ^ N' / ((p : ℕ) : K) ^ m') ^ N := by
-    rw [div_pow, div_pow, ← zpow_natCast (((p : ℕ) : K) ^ m), ← zpow_natCast (((p : ℕ) : K) ^ m'),
-      ← zpow_mul, ← zpow_mul, div_mul_div_comm, ← zpow_add₀ h3ne, mul_pow, pow_mul, pow_mul']
-  rw [e]
-  exact IsUltrametricDist.norm_mul_sub_one_lt (IsUltrametricDist.norm_pow_sub_one_lt h N')
-    (IsUltrametricDist.norm_pow_sub_one_lt h' N)
+  calc _ = ‖(x ^ N / ((p : ℕ) : K) ^ m) ^ N' * (y ^ N' / ((p : ℕ) : K) ^ m') ^ N - 1‖ := by
+        simp [zpow_add₀, hp.out.ne_zero, zpow_mul]; ring_nf
+       _ < 1 := IsUltrametricDist.norm_mul_sub_one_lt (IsUltrametricDist.norm_pow_sub_one_lt h N')
+        (IsUltrametricDist.norm_pow_sub_one_lt h' N)
 
-omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- `HasIwasawaLog` is transported along norm-preserving ring homomorphisms
-(e.g. `ℚ_p`-bar → `ℂ_p`). -/
 theorem HasIwasawaLog.map {L : Type*} [NontriviallyNormedField L] (f : K →+* L)
     (hf : ∀ y : K, ‖f y‖ = ‖y‖) {x : K} (hx : HasIwasawaLog p x) : HasIwasawaLog p (f x) := by
   obtain ⟨N, hN, m, h⟩ := hx
   refine ⟨N, hN, m, ?_⟩
-  rw [← map_natCast f, ← map_zpow₀, ← map_pow, ← map_div₀, ← map_one f, ← map_sub, hf]
-  exact h
+  simpa only [← map_natCast f, ← map_zpow₀, ← map_pow, ← map_div₀, ← map_one f, ← map_sub, hf]
 
 end Iwasawa
 
@@ -148,124 +124,72 @@ end Iwasawa
 
 section PadicComplex
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- `‖p‖ = 1/p` in `ℚ_p`-bar, since the norm there extends the one of `ℚ_p`. -/
+variable [hp : Fact p.Prime]
+
 theorem PadicAlgCl.norm_natCast_p : ‖((p : ℕ) : PadicAlgCl p)‖ = (p : ℝ)⁻¹ := by
   rw [← map_natCast (algebraMap ℚ_[p] (PadicAlgCl p)), PadicAlgCl.norm_extends, Padic.norm_p]
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- `‖p‖ = 1/p < 1` in `ℂ_[p]`. -/
 theorem PadicComplex.norm_natCast_p_lt_one : ‖((p : ℕ) : ℂ_[p])‖ < 1 := by
-  rw [← PadicComplex.coe_natCast, PadicComplex.norm_extends, PadicAlgCl.norm_natCast_p]
-  exact inv_lt_one_of_one_lt₀ (by exact_mod_cast hp.out.one_lt)
+  simpa [← PadicComplex.coe_natCast, PadicComplex.norm_extends, PadicAlgCl.norm_natCast_p] using
+    inv_lt_one_of_one_lt₀ (by exact_mod_cast hp.out.one_lt)
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- **Value group of `ℚ_p`-bar is `p^ℚ`**: for `y ≠ 0` algebraic over `ℚ_p`, `‖y‖ ^ n = ‖a₀‖` with
-`n = deg (minpoly y)` and `a₀ = (minpoly y).coeff 0 ∈ ℚ_p^×`, so `‖y ^ n / p ^ a‖ = 1` for
-`a = v_p(a₀)`. -/
 theorem PadicAlgCl.exists_norm_pow_div_zpow_eq_one {y : PadicAlgCl p} (hy : y ≠ 0) :
     ∃ b : ℕ, 0 < b ∧ ∃ a : ℤ, ‖y ^ b / ((p : ℕ) : PadicAlgCl p) ^ a‖ = 1 := by
-  have hint : IsIntegral ℚ_[p] y := (Algebra.IsAlgebraic.isAlgebraic y).isIntegral
   set n := (minpoly ℚ_[p] y).natDegree with hn_def
-  have hn : 0 < n := minpoly.natDegree_pos hint
   set a₀ := (minpoly ℚ_[p] y).coeff 0 with ha₀_def
-  have ha₀ : a₀ ≠ 0 := minpoly.coeff_zero_ne_zero hint hy
-  have h1 : ‖y‖ = ‖a₀‖ ^ (1 / n : ℝ) := by
-    rw [← PadicAlgCl.spectralNorm_eq, spectralNorm.spectralNorm_eq_norm_coeff_zero_rpow]
-  have h2 : ‖y‖ ^ n = ‖a₀‖ := by
-    rw [h1, ← Real.rpow_natCast, ← Real.rpow_mul (norm_nonneg _),
-      one_div_mul_cancel (by exact_mod_cast hn.ne'), Real.rpow_one]
-  have h3 : ‖a₀‖ = (p : ℝ) ^ (-a₀.valuation) := Padic.norm_eq_zpow_neg_valuation ha₀
-  have h4 : ‖((p : ℕ) : PadicAlgCl p)‖ = (p : ℝ)⁻¹ := PadicAlgCl.norm_natCast_p
-  have hp0 : (0 : ℝ) < p := by exact_mod_cast hp.out.pos
-  refine ⟨n, hn, a₀.valuation, ?_⟩
-  rw [norm_div, norm_pow, norm_zpow, h2, h3, h4, inv_zpow', div_self (zpow_ne_zero _ hp0.ne')]
+  refine ⟨n, minpoly.natDegree_pos (Algebra.IsAlgebraic.isAlgebraic y).isIntegral, a₀.valuation, ?_⟩
+  rw [norm_div, norm_pow, norm_zpow, ← PadicAlgCl.spectralNorm_eq,
+    spectralNorm.spectralNorm_eq_norm_coeff_zero_rpow, ← Real.rpow_natCast,
+    ← Real.rpow_mul (norm_nonneg _), one_div_mul_cancel (mod_cast (minpoly.natDegree_pos
+    (Algebra.IsAlgebraic.isAlgebraic y).isIntegral).ne'), Real.rpow_one,
+    Padic.norm_eq_zpow_neg_valuation (minpoly.coeff_zero_ne_zero
+    (Algebra.IsAlgebraic.isAlgebraic y).isIntegral hy), PadicAlgCl.norm_natCast_p, inv_zpow',
+    div_self (zpow_ne_zero _ (mod_cast (hp.out.pos).ne'))]
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- **Units of `ℚ_p`-bar have a `1`-unit power**: the powers of `u` lie in the unit ball of the
-finite-dimensional `ℚ_p`-space `ℚ_p[u]`, which is compact, so `‖u ^ j - u ^ i‖ < 1` for some
-`i < j`, and then `‖u ^ (j - i) - 1‖ < 1`. -/
 theorem PadicAlgCl.hasPrincipalUnitPow_of_norm_eq_one {u : PadicAlgCl p} (hu : ‖u‖ = 1) :
     HasPrincipalUnitPow u := by
-  have hint : IsIntegral ℚ_[p] u := (Algebra.IsAlgebraic.isAlgebraic u).isIntegral
   set S : Submodule ℚ_[p] (PadicAlgCl p) := Subalgebra.toSubmodule (Algebra.adjoin ℚ_[p] {u})
-    with hS
-  have : FiniteDimensional ℚ_[p] S := Module.Finite.iff_fg.2 hint.fg_adjoin_singleton
+  have : FiniteDimensional ℚ_[p] S := Module.Finite.iff_fg.2
+    (Algebra.IsAlgebraic.isAlgebraic u).isIntegral.fg_adjoin_singleton
   have : ProperSpace S := FiniteDimensional.proper ℚ_[p] S
-  have hmem : ∀ k : ℕ, u ^ k ∈ S := fun k =>
-    Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℚ_[p] u) k
-  set s : ℕ → S := fun k => ⟨u ^ k, hmem k⟩ with hs_def
-  have hs : ∀ k, s k ∈ Metric.closedBall (0 : S) 1 := by
-    intro k
-    rw [Metric.mem_closedBall, dist_zero_right, Submodule.coe_norm]
-    show ‖u ^ k‖ ≤ 1
-    rw [norm_pow, hu, one_pow]
-  obtain ⟨L, -, ψ, hψ, hlim⟩ := (isCompact_closedBall (0 : S) 1).tendsto_subseq hs
+  set s : ℕ → S := fun k => ⟨u ^ k,
+    Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℚ_[p] u) k⟩ with hs_def
+  have : ∀ k, s k ∈ Metric.closedBall (0 : S) 1 := fun _ ↦ by aesop
+  obtain ⟨L, -, ψ, hψ, hlim⟩ := (isCompact_closedBall (0 : S) 1).tendsto_subseq this
   obtain ⟨k₀, hk₀⟩ := Metric.tendsto_atTop.1 hlim (1 / 2) (by norm_num)
-  have h1 : dist (s (ψ (k₀ + 1))) L < 1 / 2 := hk₀ _ (Nat.le_succ _)
-  have h2 : dist (s (ψ k₀)) L < 1 / 2 := hk₀ _ le_rfl
-  have hij : ψ k₀ < ψ (k₀ + 1) := hψ (Nat.lt_succ_self _)
-  have hd : dist (s (ψ (k₀ + 1))) (s (ψ k₀)) < 1 := by
-    calc dist (s (ψ (k₀ + 1))) (s (ψ k₀))
-        ≤ dist (s (ψ (k₀ + 1))) L + dist (s (ψ k₀)) L := dist_triangle_right _ _ _
-      _ < 1 / 2 + 1 / 2 := add_lt_add h1 h2
-      _ = 1 := by norm_num
-  refine ⟨ψ (k₀ + 1) - ψ k₀, Nat.sub_pos_of_lt hij, ?_⟩
-  have hpow : u ^ ψ (k₀ + 1) = u ^ ψ k₀ * u ^ (ψ (k₀ + 1) - ψ k₀) := by
-    rw [← pow_add, Nat.add_sub_cancel' hij.le]
-  have hnorm : ‖u ^ ψ (k₀ + 1) - u ^ ψ k₀‖ = ‖u ^ (ψ (k₀ + 1) - ψ k₀) - 1‖ := by
-    rw [hpow, ← mul_sub_one, norm_mul, norm_pow, hu, one_pow, one_mul]
-  have hdist : dist (s (ψ (k₀ + 1))) (s (ψ k₀)) = ‖u ^ ψ (k₀ + 1) - u ^ ψ k₀‖ := by
-    rw [dist_eq_norm, Submodule.coe_norm, Submodule.coe_sub]
-  rw [← hnorm, ← hdist]
-  exact hd
+  refine ⟨ψ (k₀ + 1) - ψ k₀, Nat.sub_pos_of_lt (hψ (Nat.lt_succ_self _)), ?_⟩
+  calc _ = ‖u ^ ψ (k₀ + 1) - u ^ ψ k₀‖ := by
+        rw [← Nat.add_sub_cancel' (hψ (Nat.lt_succ_self _)).le, pow_add, ← mul_sub_one, norm_mul,
+          norm_pow, hu, one_pow, one_mul, Nat.succ_eq_add_one, add_tsub_cancel_left]
+       _ = dist (s (ψ (k₀ + 1))) (s (ψ k₀)) := by
+        rw [dist_eq_norm, Submodule.coe_norm, Submodule.coe_sub]
+       _ ≤ dist (s (ψ (k₀ + 1))) L + dist (s (ψ k₀)) L := dist_triangle_right _ _ _
+       _ < 1 / 2 + 1 / 2 := add_lt_add (hk₀ _ (Nat.le_succ _)) (hk₀ _ le_rfl)
+       _ = 1 := by norm_num
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- Every nonzero element of `ℚ_p`-bar has an Iwasawa logarithm. -/
 theorem PadicAlgCl.hasIwasawaLog {y : PadicAlgCl p} (hy : y ≠ 0) : HasIwasawaLog p y := by
   obtain ⟨b, hb, a, h1⟩ := PadicAlgCl.exists_norm_pow_div_zpow_eq_one hy
   obtain ⟨N, hN, h2⟩ := PadicAlgCl.hasPrincipalUnitPow_of_norm_eq_one h1
-  refine ⟨b * N, Nat.mul_pos hb hN, a * N, ?_⟩
-  rwa [pow_mul, zpow_mul, zpow_natCast, ← div_pow]
+  exact ⟨b * N, Nat.mul_pos hb hN, a * N, by rwa [pow_mul, zpow_mul, zpow_natCast, ← div_pow]⟩
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- Density of `ℚ_p`-bar in `ℂ_p`, in the form needed here: every `x ≠ 0` is within `‖x‖` of an
-algebraic element (so `x / y` is a `1`-unit). -/
 theorem PadicComplex.exists_norm_sub_coe_lt {x : ℂ_[p]} (hx : x ≠ 0) :
     ∃ y : PadicAlgCl p, ‖x - y‖ < ‖x‖ := by
   obtain ⟨_, ⟨y, rfl⟩, hd⟩ := Metric.mem_closure_iff.1
     (UniformSpace.Completion.denseRange_coe x) ‖x‖ (norm_pos_iff.2 hx)
   exact ⟨y, by rwa [dist_eq_norm] at hd⟩
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
 /-- **The Iwasawa logarithm is defined on all of `ℂ_p^×`** [Wiki]: `x = y · (x / y)` with `y`
 algebraic and `x / y` a `1`-unit. -/
 theorem PadicComplex.hasIwasawaLog {x : ℂ_[p]} (hx : x ≠ 0) : HasIwasawaLog p x := by
   obtain ⟨y, hy⟩ := PadicComplex.exists_norm_sub_coe_lt hx
-  have hxpos : 0 < ‖x‖ := norm_pos_iff.2 hx
-  have hyx : ‖(y : ℂ_[p])‖ = ‖x‖ := by
-    have h : (y : ℂ_[p]) = x + ((y : ℂ_[p]) - x) := by ring
-    rw [h, IsUltrametricDist.norm_add_eq_max_of_norm_ne_norm (by rw [norm_sub_rev]; exact hy.ne'),
-      max_eq_left (by rw [norm_sub_rev]; exact hy.le)]
-  have hy0 : (y : ℂ_[p]) ≠ 0 := by
-    intro h
-    rw [h, norm_zero] at hyx
-    exact hxpos.ne hyx
-  have hY : HasIwasawaLog p (y : ℂ_[p]) := by
-    have hy0' : y ≠ 0 := by
-      rintro rfl
-      simp at hy0
-    exact (PadicAlgCl.hasIwasawaLog hy0').map (algebraMap (PadicAlgCl p) ℂ_[p])
-      (PadicComplex.norm_extends p)
-  have hz : ‖x / y - 1‖ < 1 := by
-    rw [div_sub_one hy0, norm_div, hyx, div_lt_one hxpos]
-    exact hy
-  have e : (y : ℂ_[p]) * (x / y) = x := by rw [mul_comm, div_mul_cancel₀ _ hy0]
-  rw [← e]
-  exact hY.mul (HasIwasawaLog.of_norm_sub_one_lt hz)
+  have e : (y : ℂ_[p]) * (x / y) = x := by rw [mul_comm, div_mul_cancel₀ _ (by aesop)]
+  rw [show x = y * (x / y) by rw [mul_comm, div_mul_cancel₀ _ (by aesop)]]
+  refine ((PadicAlgCl.hasIwasawaLog (by aesop)).map (algebraMap (PadicAlgCl p) ℂ_[p])
+    (PadicComplex.norm_extends p)).mul (HasIwasawaLog.of_norm_sub_one_lt ?_)
+  rw [div_sub_one (by aesop), norm_div, div_lt_one (by aesop)]
+  simpa using hy.trans_eq (IsUltrametricDist.norm_eq_of_add_norm_lt_max (y := -(y : ℂ_[p]))
+    (by simp [← sub_eq_add_neg, hy]))
 
-omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- The domain of the Iwasawa logarithm in `ℂ_[p]` is exactly `ℂ_[p]^×`. -/
 theorem PadicComplex.hasIwasawaLog_iff {x : ℂ_[p]} : HasIwasawaLog p x ↔ x ≠ 0 :=
   ⟨HasIwasawaLog.ne_zero, PadicComplex.hasIwasawaLog⟩
 

--- a/FormalConjecturesForMathlib/NumberTheory/Padics/IwasawaLog.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Padics/IwasawaLog.lean
@@ -1,0 +1,314 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+public import Mathlib.Analysis.Normed.Field.Ultra
+public import Mathlib.Analysis.Normed.Module.FiniteDimension
+public import Mathlib.NumberTheory.Padics.Complex
+public import Mathlib.NumberTheory.Padics.ProperSpace
+
+/-!
+# The Iwasawa `p`-adic logarithm
+
+The `p`-adic logarithm `log u = -∑ₙ (1 - u)^(n+1) / (n+1)`, converging on the open disc
+`‖u - 1‖ < 1` of an abstract complete ultrametric field `K` of characteristic zero, and Iwasawa's
+extension of it to those `x` some positive power of which is a `1`-unit times a power of `p` —
+which in `K = ℂ_[p]` is every nonzero element.
+
+## Main definitions
+
+* `padicLog`: the logarithm series, converging on the whole open disc `‖u - 1‖ < 1`.
+* `HasIwasawaLog p x`: some power `x ^ N` (`N ≥ 1`) is a `1`-unit times a power of `p`.
+* `iwasawaLog p`: the Iwasawa logarithm, the extension of `padicLog` to `HasIwasawaLog p`
+  characterised by being a homomorphism with `log p = 0`.
+
+## Main results
+
+* `PadicComplex.hasIwasawaLog_iff`: every nonzero element of `ℂ_[p]` has an Iwasawa logarithm.
+
+## Scope
+
+This file carries only what `FormalConjectures.Paper.GrossKuzmin` uses: `iwasawaLog` is the
+`log_p` of Gross's regulator map, and `hasIwasawaLog_iff` is what shows that no junk value of
+`iwasawaLog` is involved there. The analytic theory is deliberately omitted — that `padicLog`
+converges and turns products into sums, that `iwasawaLog` is well defined independently of the
+choice of `N` and `m` below and is a homomorphism with `log p = 0`, and the `p`-adic exponential
+and its inverse relationship with the logarithm for odd `p`. Those are stated in the references
+and would be the content of a full Mathlib development.
+
+## References
+
+* [Con] K. Conrad, *Infinite series in p-adic fields*, §8 (the logarithm).
+* [Kob84] N. Koblitz, *p-adic Numbers, p-adic Analysis, and Zeta-Functions*, Ch. IV.
+* [Wiki] Wikipedia, *p-adic exponential function* (the Iwasawa logarithm).
+-/
+
+@[expose] public section
+
+namespace PadicIwasawaLog
+
+variable {p : ℕ} [hp : Fact p.Prime] {K : Type*} [NontriviallyNormedField K]
+  [IsUltrametricDist K] [CompleteSpace K] [CharZero K]
+
+section Log
+
+omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- The ultrametric logarithm `log u = -∑ₙ (1 - u)^(n+1) / (n+1)`, converging for
+`‖u - 1‖ < 1`; junk value otherwise.  [Kob84, Ch. IV §1]. -/
+noncomputable def padicLog (u : K) : K :=
+  -∑' n : ℕ, (1 - u) ^ (n + 1) / (n + 1)
+
+omit [CompleteSpace K] [CharZero K] in
+/-- A `1`-unit has norm one: `‖1 + x‖ = 1` as soon as `‖x‖ < 1`. -/
+theorem norm_eq_one_of_norm_sub_one_lt_one {u : K} (hu : ‖u - 1‖ < 1) : ‖u‖ = 1 := by
+  have h : u = 1 + (u - 1) := by ring
+  rw [h, IsUltrametricDist.norm_add_eq_max_of_norm_ne_norm (by rw [norm_one]; exact hu.ne'),
+    norm_one, max_eq_left hu.le]
+
+end Log
+
+/-! ### The unit disc is closed under multiplication and powers -/
+
+section OneUnits
+
+omit [CompleteSpace K] [CharZero K] in
+/-- The `1`-units are closed under multiplication:
+`‖uv - 1‖ = ‖(u - 1)v + (v - 1)‖ ≤ max (‖u - 1‖ * ‖v‖) ‖v - 1‖ < 1`. [Con, p. 27]. -/
+theorem norm_mul_sub_one_lt {u v : K} (hu : ‖u - 1‖ < 1) (hv : ‖v - 1‖ < 1) :
+    ‖u * v - 1‖ < 1 := by
+  have h : u * v - 1 = (u - 1) * v + (v - 1) := by ring
+  rw [h]
+  refine lt_of_le_of_lt (IsUltrametricDist.norm_add_le_max _ _) (max_lt ?_ hv)
+  rw [norm_mul, norm_eq_one_of_norm_sub_one_lt_one hv, mul_one]
+  exact hu
+
+omit [CompleteSpace K] [CharZero K] in
+/-- The `1`-units are closed under powers, by induction from `norm_mul_sub_one_lt`. -/
+theorem norm_pow_sub_one_lt {u : K} (hu : ‖u - 1‖ < 1) (n : ℕ) : ‖u ^ n - 1‖ < 1 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ]
+    exact norm_mul_sub_one_lt ih hu
+
+end OneUnits
+
+/-! ### The Iwasawa logarithm: its domain, and its definition -/
+
+section Iwasawa
+
+omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- `HasPrincipalUnitPow u` says that some positive power of `u` is a `1`-unit, `‖u ^ m - 1‖ < 1`.
+This holds for every unit of the valuation ring of a field whose residue field is algebraic
+over `𝔽_p` — finite extensions of `ℚ_p`, `ℚ_p`-bar and `ℂ_p` — of which only the `ℚ_p`-bar case
+is proved here (`PadicAlgCl.hasPrincipalUnitPow_of_norm_eq_one`). -/
+def HasPrincipalUnitPow (u : K) : Prop :=
+  ∃ m : ℕ, 0 < m ∧ ‖u ^ m - 1‖ < 1
+
+omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+variable (p) in
+/-- `HasIwasawaLog p x` says that some positive power of `x` is a `1`-unit times a power of `p`:
+`‖x ^ N / p ^ m - 1‖ < 1` for some `N ≥ 1` and `m : ℤ`. This is the domain of the Iwasawa
+logarithm; in `ℂ_p` it is all of `ℂ_p^×` (`PadicComplex.hasIwasawaLog_iff`) [Wiki]: "every element
+w of C×_p can be written as w = p^r · ζ · z with r a rational number, ζ a root of unity, and
+|z−1|_p < 1". -/
+def HasIwasawaLog (x : K) : Prop :=
+  ∃ N : ℕ, 0 < N ∧ ∃ m : ℤ, ‖x ^ N / ((p : ℕ) : K) ^ m - 1‖ < 1
+
+omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+variable (p) in
+/-- The **Iwasawa logarithm**: the unique extension of `padicLog` from the `1`-units to
+`HasIwasawaLog p` (all of `ℂ_p^×` when `K = ℂ_p`) which is a homomorphism and has `log p = 0`
+[Wiki]. Concretely `iwasawaLog p x = padicLog (x ^ N / p ^ m) / N` for `N ≥ 1`, `m` with
+`‖x ^ N / p ^ m - 1‖ < 1`; the value is independent of that choice, though this file does not
+prove it, and to fix a value here `N` is taken least and `m` by choice. Junk value `0` outside
+the domain. -/
+noncomputable def iwasawaLog (x : K) : K := by
+  classical
+  exact if h : ∃ N : ℕ, 0 < N ∧ ∃ m : ℤ, ‖x ^ N / ((p : ℕ) : K) ^ m - 1‖ < 1 then
+    padicLog (x ^ Nat.find h / ((p : ℕ) : K) ^ Classical.choose (Nat.find_spec h).2) /
+      (Nat.find h : K)
+  else 0
+
+omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- A `1`-unit lies in the domain of the Iwasawa logarithm: take `N = 1` and `m = 0`. -/
+theorem HasIwasawaLog.of_norm_sub_one_lt {u : K} (hu : ‖u - 1‖ < 1) : HasIwasawaLog p u :=
+  ⟨1, one_pos, 0, by simpa using hu⟩
+
+omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- Only nonzero elements have an Iwasawa logarithm, since `0 ^ N / p ^ m - 1 = -1`. -/
+theorem HasIwasawaLog.ne_zero {x : K} (hx : HasIwasawaLog p x) : x ≠ 0 := by
+  rintro rfl
+  obtain ⟨N, hN, m, h⟩ := hx
+  rw [zero_pow hN.ne', zero_div, zero_sub, norm_neg, norm_one] at h
+  exact lt_irrefl _ h
+
+omit [CompleteSpace K] in
+/-- The domain of the Iwasawa logarithm is closed under multiplication: if `x ^ N / p ^ m` and
+`y ^ N' / p ^ m'` are `1`-units, then so is `(x * y) ^ (N * N') / p ^ (m * N' + m' * N)`, which
+is their product of powers. -/
+theorem HasIwasawaLog.mul {x y : K} (hx : HasIwasawaLog p x) (hy : HasIwasawaLog p y) :
+    HasIwasawaLog p (x * y) := by
+  obtain ⟨N, hN, m, h⟩ := hx
+  obtain ⟨N', hN', m', h'⟩ := hy
+  have h3ne : ((p : ℕ) : K) ≠ 0 := Nat.cast_ne_zero.mpr hp.out.pos.ne'
+  refine ⟨N * N', Nat.mul_pos hN hN', m * N' + m' * N, ?_⟩
+  have e : (x * y) ^ (N * N') / ((p : ℕ) : K) ^ (m * N' + m' * N)
+      = (x ^ N / ((p : ℕ) : K) ^ m) ^ N' * (y ^ N' / ((p : ℕ) : K) ^ m') ^ N := by
+    rw [div_pow, div_pow, ← zpow_natCast (((p : ℕ) : K) ^ m), ← zpow_natCast (((p : ℕ) : K) ^ m'),
+      ← zpow_mul, ← zpow_mul, div_mul_div_comm, ← zpow_add₀ h3ne, mul_pow, pow_mul, pow_mul']
+  rw [e]
+  exact norm_mul_sub_one_lt (norm_pow_sub_one_lt h N') (norm_pow_sub_one_lt h' N)
+
+omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- `HasIwasawaLog` is transported along norm-preserving ring homomorphisms
+(e.g. `ℚ_p`-bar → `ℂ_p`). -/
+theorem HasIwasawaLog.map {L : Type*} [NontriviallyNormedField L] (f : K →+* L)
+    (hf : ∀ y : K, ‖f y‖ = ‖y‖) {x : K} (hx : HasIwasawaLog p x) : HasIwasawaLog p (f x) := by
+  obtain ⟨N, hN, m, h⟩ := hx
+  refine ⟨N, hN, m, ?_⟩
+  rw [← map_natCast f, ← map_zpow₀, ← map_pow, ← map_div₀, ← map_one f, ← map_sub, hf]
+  exact h
+
+end Iwasawa
+
+/-! ### Instantiation on `ℚ_p`-bar and `ℂ_p` -/
+
+section PadicComplex
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- `‖p‖ = 1/p` in `ℚ_p`-bar, since the norm there extends the one of `ℚ_p`. -/
+theorem PadicAlgCl.norm_natCast_p : ‖((p : ℕ) : PadicAlgCl p)‖ = (p : ℝ)⁻¹ := by
+  rw [← map_natCast (algebraMap ℚ_[p] (PadicAlgCl p)), PadicAlgCl.norm_extends, Padic.norm_p]
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- `‖p‖ = 1/p < 1` in `ℂ_[p]`. -/
+theorem PadicComplex.norm_natCast_p_lt_one : ‖((p : ℕ) : ℂ_[p])‖ < 1 := by
+  rw [← PadicComplex.coe_natCast, PadicComplex.norm_extends, PadicAlgCl.norm_natCast_p]
+  exact inv_lt_one_of_one_lt₀ (by exact_mod_cast hp.out.one_lt)
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- **Value group of `ℚ_p`-bar is `p^ℚ`**: for `y ≠ 0` algebraic over `ℚ_p`, `‖y‖ ^ n = ‖a₀‖` with
+`n = deg (minpoly y)` and `a₀ = (minpoly y).coeff 0 ∈ ℚ_p^×`, so `‖y ^ n / p ^ a‖ = 1` for
+`a = v_p(a₀)`. -/
+theorem PadicAlgCl.exists_norm_pow_div_zpow_eq_one {y : PadicAlgCl p} (hy : y ≠ 0) :
+    ∃ b : ℕ, 0 < b ∧ ∃ a : ℤ, ‖y ^ b / ((p : ℕ) : PadicAlgCl p) ^ a‖ = 1 := by
+  have hint : IsIntegral ℚ_[p] y := (Algebra.IsAlgebraic.isAlgebraic y).isIntegral
+  set n := (minpoly ℚ_[p] y).natDegree with hn_def
+  have hn : 0 < n := minpoly.natDegree_pos hint
+  set a₀ := (minpoly ℚ_[p] y).coeff 0 with ha₀_def
+  have ha₀ : a₀ ≠ 0 := minpoly.coeff_zero_ne_zero hint hy
+  have h1 : ‖y‖ = ‖a₀‖ ^ (1 / n : ℝ) := by
+    rw [← PadicAlgCl.spectralNorm_eq, spectralNorm.spectralNorm_eq_norm_coeff_zero_rpow]
+  have h2 : ‖y‖ ^ n = ‖a₀‖ := by
+    rw [h1, ← Real.rpow_natCast, ← Real.rpow_mul (norm_nonneg _),
+      one_div_mul_cancel (by exact_mod_cast hn.ne'), Real.rpow_one]
+  have h3 : ‖a₀‖ = (p : ℝ) ^ (-a₀.valuation) := Padic.norm_eq_zpow_neg_valuation ha₀
+  have h4 : ‖((p : ℕ) : PadicAlgCl p)‖ = (p : ℝ)⁻¹ := PadicAlgCl.norm_natCast_p
+  have hp0 : (0 : ℝ) < p := by exact_mod_cast hp.out.pos
+  refine ⟨n, hn, a₀.valuation, ?_⟩
+  rw [norm_div, norm_pow, norm_zpow, h2, h3, h4, inv_zpow', div_self (zpow_ne_zero _ hp0.ne')]
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- **Units of `ℚ_p`-bar have a `1`-unit power**: the powers of `u` lie in the unit ball of the
+finite-dimensional `ℚ_p`-space `ℚ_p[u]`, which is compact, so `‖u ^ j - u ^ i‖ < 1` for some
+`i < j`, and then `‖u ^ (j - i) - 1‖ < 1`. -/
+theorem PadicAlgCl.hasPrincipalUnitPow_of_norm_eq_one {u : PadicAlgCl p} (hu : ‖u‖ = 1) :
+    HasPrincipalUnitPow u := by
+  have hint : IsIntegral ℚ_[p] u := (Algebra.IsAlgebraic.isAlgebraic u).isIntegral
+  set S : Submodule ℚ_[p] (PadicAlgCl p) := Subalgebra.toSubmodule (Algebra.adjoin ℚ_[p] {u})
+    with hS
+  have : FiniteDimensional ℚ_[p] S := Module.Finite.iff_fg.2 hint.fg_adjoin_singleton
+  have : ProperSpace S := FiniteDimensional.proper ℚ_[p] S
+  have hmem : ∀ k : ℕ, u ^ k ∈ S := fun k =>
+    Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℚ_[p] u) k
+  set s : ℕ → S := fun k => ⟨u ^ k, hmem k⟩ with hs_def
+  have hs : ∀ k, s k ∈ Metric.closedBall (0 : S) 1 := by
+    intro k
+    rw [Metric.mem_closedBall, dist_zero_right, Submodule.coe_norm]
+    show ‖u ^ k‖ ≤ 1
+    rw [norm_pow, hu, one_pow]
+  obtain ⟨L, -, ψ, hψ, hlim⟩ := (isCompact_closedBall (0 : S) 1).tendsto_subseq hs
+  obtain ⟨k₀, hk₀⟩ := Metric.tendsto_atTop.1 hlim (1 / 2) (by norm_num)
+  have h1 : dist (s (ψ (k₀ + 1))) L < 1 / 2 := hk₀ _ (Nat.le_succ _)
+  have h2 : dist (s (ψ k₀)) L < 1 / 2 := hk₀ _ le_rfl
+  have hij : ψ k₀ < ψ (k₀ + 1) := hψ (Nat.lt_succ_self _)
+  have hd : dist (s (ψ (k₀ + 1))) (s (ψ k₀)) < 1 := by
+    calc dist (s (ψ (k₀ + 1))) (s (ψ k₀))
+        ≤ dist (s (ψ (k₀ + 1))) L + dist (s (ψ k₀)) L := dist_triangle_right _ _ _
+      _ < 1 / 2 + 1 / 2 := add_lt_add h1 h2
+      _ = 1 := by norm_num
+  refine ⟨ψ (k₀ + 1) - ψ k₀, Nat.sub_pos_of_lt hij, ?_⟩
+  have hpow : u ^ ψ (k₀ + 1) = u ^ ψ k₀ * u ^ (ψ (k₀ + 1) - ψ k₀) := by
+    rw [← pow_add, Nat.add_sub_cancel' hij.le]
+  have hnorm : ‖u ^ ψ (k₀ + 1) - u ^ ψ k₀‖ = ‖u ^ (ψ (k₀ + 1) - ψ k₀) - 1‖ := by
+    rw [hpow, ← mul_sub_one, norm_mul, norm_pow, hu, one_pow, one_mul]
+  have hdist : dist (s (ψ (k₀ + 1))) (s (ψ k₀)) = ‖u ^ ψ (k₀ + 1) - u ^ ψ k₀‖ := by
+    rw [dist_eq_norm, Submodule.coe_norm, Submodule.coe_sub]
+  rw [← hnorm, ← hdist]
+  exact hd
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- Every nonzero element of `ℚ_p`-bar has an Iwasawa logarithm. -/
+theorem PadicAlgCl.hasIwasawaLog {y : PadicAlgCl p} (hy : y ≠ 0) : HasIwasawaLog p y := by
+  obtain ⟨b, hb, a, h1⟩ := PadicAlgCl.exists_norm_pow_div_zpow_eq_one hy
+  obtain ⟨N, hN, h2⟩ := PadicAlgCl.hasPrincipalUnitPow_of_norm_eq_one h1
+  refine ⟨b * N, Nat.mul_pos hb hN, a * N, ?_⟩
+  rwa [pow_mul, zpow_mul, zpow_natCast, ← div_pow]
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- Density of `ℚ_p`-bar in `ℂ_p`, in the form needed here: every `x ≠ 0` is within `‖x‖` of an
+algebraic element (so `x / y` is a `1`-unit). -/
+theorem PadicComplex.exists_norm_sub_coe_lt {x : ℂ_[p]} (hx : x ≠ 0) :
+    ∃ y : PadicAlgCl p, ‖x - y‖ < ‖x‖ := by
+  obtain ⟨_, ⟨y, rfl⟩, hd⟩ := Metric.mem_closure_iff.1
+    (UniformSpace.Completion.denseRange_coe x) ‖x‖ (norm_pos_iff.2 hx)
+  exact ⟨y, by rwa [dist_eq_norm] at hd⟩
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- **The Iwasawa logarithm is defined on all of `ℂ_p^×`** [Wiki]: `x = y · (x / y)` with `y`
+algebraic and `x / y` a `1`-unit. -/
+theorem PadicComplex.hasIwasawaLog {x : ℂ_[p]} (hx : x ≠ 0) : HasIwasawaLog p x := by
+  obtain ⟨y, hy⟩ := PadicComplex.exists_norm_sub_coe_lt hx
+  have hxpos : 0 < ‖x‖ := norm_pos_iff.2 hx
+  have hyx : ‖(y : ℂ_[p])‖ = ‖x‖ := by
+    have h : (y : ℂ_[p]) = x + ((y : ℂ_[p]) - x) := by ring
+    rw [h, IsUltrametricDist.norm_add_eq_max_of_norm_ne_norm (by rw [norm_sub_rev]; exact hy.ne'),
+      max_eq_left (by rw [norm_sub_rev]; exact hy.le)]
+  have hy0 : (y : ℂ_[p]) ≠ 0 := by
+    intro h
+    rw [h, norm_zero] at hyx
+    exact hxpos.ne hyx
+  have hY : HasIwasawaLog p (y : ℂ_[p]) := by
+    have hy0' : y ≠ 0 := by
+      rintro rfl
+      simp at hy0
+    exact (PadicAlgCl.hasIwasawaLog hy0').map (algebraMap (PadicAlgCl p) ℂ_[p])
+      (PadicComplex.norm_extends p)
+  have hz : ‖x / y - 1‖ < 1 := by
+    rw [div_sub_one hy0, norm_div, hyx, div_lt_one hxpos]
+    exact hy
+  have e : (y : ℂ_[p]) * (x / y) = x := by rw [mul_comm, div_mul_cancel₀ _ hy0]
+  rw [← e]
+  exact hY.mul (HasIwasawaLog.of_norm_sub_one_lt hz)
+
+omit [NontriviallyNormedField K] [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
+/-- The domain of the Iwasawa logarithm in `ℂ_[p]` is exactly `ℂ_[p]^×`. -/
+theorem PadicComplex.hasIwasawaLog_iff {x : ℂ_[p]} : HasIwasawaLog p x ↔ x ≠ 0 :=
+  ⟨HasIwasawaLog.ne_zero, PadicComplex.hasIwasawaLog⟩
+
+end PadicComplex
+
+end PadicIwasawaLog

--- a/FormalConjecturesForMathlib/NumberTheory/Padics/IwasawaLog.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Padics/IwasawaLog.lean
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -/
 module
-public import Mathlib.Analysis.Normed.Field.Ultra
+public import FormalConjecturesForMathlib.Analysis.Normed.Algebra.Logarithm
+public import FormalConjecturesForMathlib.NumberTheory.Padics.OneUnits
 public import Mathlib.Analysis.Normed.Module.FiniteDimension
 public import Mathlib.NumberTheory.Padics.Complex
 public import Mathlib.NumberTheory.Padics.ProperSpace
@@ -22,17 +23,20 @@ public import Mathlib.NumberTheory.Padics.ProperSpace
 /-!
 # The Iwasawa `p`-adic logarithm
 
-The `p`-adic logarithm `log u = -∑ₙ (1 - u)^(n+1) / (n+1)`, converging on the open disc
-`‖u - 1‖ < 1` of an abstract complete ultrametric field `K` of characteristic zero, and Iwasawa's
-extension of it to those `x` some positive power of which is a `1`-unit times a power of `p` —
-which in `K = ℂ_[p]` is every nonzero element.
+Iwasawa's extension of the `p`-adic logarithm to those `x` in a complete ultrametric field `K` of
+characteristic zero some positive power of which is a `1`-unit times a power of `p` — which in
+`K = ℂ_[p]` is every nonzero element. It is built on `NormedSpace.log`, the series
+`log u = ∑ₙ ((-1) ^ (n + 1) / n) • (u - 1) ^ n` vendored from
+[mathlib#43670](https://github.com/leanprover-community/mathlib4/pull/43670) as
+`FormalConjecturesForMathlib.Analysis.Normed.Algebra.Logarithm`, through the normalisation
+`log_p x = log (x ^ N / p ^ m) / N`. That pull request lists this extension, the "analytic
+continuation of `log` in the ultrametric case" with `log p = 0`, as future work.
 
 ## Main definitions
 
-* `padicLog`: the logarithm series, converging on the whole open disc `‖u - 1‖ < 1`.
 * `HasIwasawaLog p x`: some power `x ^ N` (`N ≥ 1`) is a `1`-unit times a power of `p`.
-* `iwasawaLog p`: the Iwasawa logarithm, the extension of `padicLog` to `HasIwasawaLog p`
-  characterised by being a homomorphism with `log p = 0`.
+* `iwasawaLog p`: the Iwasawa logarithm `NormedSpace.log (x ^ N / p ^ m) / N` on
+  `HasIwasawaLog p`, characterised by being a homomorphism with `log p = 0`.
 
 ## Main results
 
@@ -42,16 +46,14 @@ which in `K = ℂ_[p]` is every nonzero element.
 
 This file carries only what `FormalConjectures.Paper.GrossKuzmin` uses: `iwasawaLog` is the
 `log_p` of Gross's regulator map, and `hasIwasawaLog_iff` is what shows that no junk value of
-`iwasawaLog` is involved there. The analytic theory is deliberately omitted — that `padicLog`
-converges and turns products into sums, that `iwasawaLog` is well defined independently of the
-choice of `N` and `m` below and is a homomorphism with `log p = 0`, and the `p`-adic exponential
-and its inverse relationship with the logarithm for odd `p`. Those are stated in the references
-and would be the content of a full Mathlib development.
+`iwasawaLog` is involved there. The analytic theory is deliberately omitted, as it is in
+mathlib#43670: that `NormedSpace.log` converges on `‖u - 1‖ < 1` and turns products into sums
+there, and hence that `iwasawaLog` is independent of the choice of `N` and `m` below and is a
+homomorphism with `log p = 0`. The ultrametric estimates on `1`-units are those of
+`FormalConjecturesForMathlib.NumberTheory.Padics.OneUnits`.
 
 ## References
 
-* [Con] K. Conrad, *Infinite series in p-adic fields*, §8 (the logarithm).
-* [Kob84] N. Koblitz, *p-adic Numbers, p-adic Analysis, and Zeta-Functions*, Ch. IV.
 * [Wiki] Wikipedia, *p-adic exponential function* (the Iwasawa logarithm).
 -/
 
@@ -61,49 +63,6 @@ namespace PadicIwasawaLog
 
 variable {p : ℕ} [hp : Fact p.Prime] {K : Type*} [NontriviallyNormedField K]
   [IsUltrametricDist K] [CompleteSpace K] [CharZero K]
-
-section Log
-
-omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
-/-- The ultrametric logarithm `log u = -∑ₙ (1 - u)^(n+1) / (n+1)`, converging for
-`‖u - 1‖ < 1`; junk value otherwise.  [Kob84, Ch. IV §1]. -/
-noncomputable def padicLog (u : K) : K :=
-  -∑' n : ℕ, (1 - u) ^ (n + 1) / (n + 1)
-
-omit [CompleteSpace K] [CharZero K] in
-/-- A `1`-unit has norm one: `‖1 + x‖ = 1` as soon as `‖x‖ < 1`. -/
-theorem norm_eq_one_of_norm_sub_one_lt_one {u : K} (hu : ‖u - 1‖ < 1) : ‖u‖ = 1 := by
-  have h : u = 1 + (u - 1) := by ring
-  rw [h, IsUltrametricDist.norm_add_eq_max_of_norm_ne_norm (by rw [norm_one]; exact hu.ne'),
-    norm_one, max_eq_left hu.le]
-
-end Log
-
-/-! ### The unit disc is closed under multiplication and powers -/
-
-section OneUnits
-
-omit [CompleteSpace K] [CharZero K] in
-/-- The `1`-units are closed under multiplication:
-`‖uv - 1‖ = ‖(u - 1)v + (v - 1)‖ ≤ max (‖u - 1‖ * ‖v‖) ‖v - 1‖ < 1`. [Con, p. 27]. -/
-theorem norm_mul_sub_one_lt {u v : K} (hu : ‖u - 1‖ < 1) (hv : ‖v - 1‖ < 1) :
-    ‖u * v - 1‖ < 1 := by
-  have h : u * v - 1 = (u - 1) * v + (v - 1) := by ring
-  rw [h]
-  refine lt_of_le_of_lt (IsUltrametricDist.norm_add_le_max _ _) (max_lt ?_ hv)
-  rw [norm_mul, norm_eq_one_of_norm_sub_one_lt_one hv, mul_one]
-  exact hu
-
-omit [CompleteSpace K] [CharZero K] in
-/-- The `1`-units are closed under powers, by induction from `norm_mul_sub_one_lt`. -/
-theorem norm_pow_sub_one_lt {u : K} (hu : ‖u - 1‖ < 1) (n : ℕ) : ‖u ^ n - 1‖ < 1 := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    rw [pow_succ]
-    exact norm_mul_sub_one_lt ih hu
-
-end OneUnits
 
 /-! ### The Iwasawa logarithm: its domain, and its definition -/
 
@@ -129,16 +88,16 @@ def HasIwasawaLog (x : K) : Prop :=
 
 omit [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
 variable (p) in
-/-- The **Iwasawa logarithm**: the unique extension of `padicLog` from the `1`-units to
+/-- The **Iwasawa logarithm**: the unique extension of `NormedSpace.log` from the `1`-units to
 `HasIwasawaLog p` (all of `ℂ_p^×` when `K = ℂ_p`) which is a homomorphism and has `log p = 0`
-[Wiki]. Concretely `iwasawaLog p x = padicLog (x ^ N / p ^ m) / N` for `N ≥ 1`, `m` with
+[Wiki]. Concretely `iwasawaLog p x = NormedSpace.log (x ^ N / p ^ m) / N` for `N ≥ 1`, `m` with
 `‖x ^ N / p ^ m - 1‖ < 1`; the value is independent of that choice, though this file does not
 prove it, and to fix a value here `N` is taken least and `m` by choice. Junk value `0` outside
 the domain. -/
 noncomputable def iwasawaLog (x : K) : K := by
   classical
   exact if h : ∃ N : ℕ, 0 < N ∧ ∃ m : ℤ, ‖x ^ N / ((p : ℕ) : K) ^ m - 1‖ < 1 then
-    padicLog (x ^ Nat.find h / ((p : ℕ) : K) ^ Classical.choose (Nat.find_spec h).2) /
+    NormedSpace.log (x ^ Nat.find h / ((p : ℕ) : K) ^ Classical.choose (Nat.find_spec h).2) /
       (Nat.find h : K)
   else 0
 
@@ -170,7 +129,8 @@ theorem HasIwasawaLog.mul {x y : K} (hx : HasIwasawaLog p x) (hy : HasIwasawaLog
     rw [div_pow, div_pow, ← zpow_natCast (((p : ℕ) : K) ^ m), ← zpow_natCast (((p : ℕ) : K) ^ m'),
       ← zpow_mul, ← zpow_mul, div_mul_div_comm, ← zpow_add₀ h3ne, mul_pow, pow_mul, pow_mul']
   rw [e]
-  exact norm_mul_sub_one_lt (norm_pow_sub_one_lt h N') (norm_pow_sub_one_lt h' N)
+  exact IsUltrametricDist.norm_mul_sub_one_lt (IsUltrametricDist.norm_pow_sub_one_lt h N')
+    (IsUltrametricDist.norm_pow_sub_one_lt h' N)
 
 omit hp [IsUltrametricDist K] [CompleteSpace K] [CharZero K] in
 /-- `HasIwasawaLog` is transported along norm-preserving ring homomorphisms

--- a/FormalConjecturesForMathlib/NumberTheory/Padics/OneUnits.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/Padics/OneUnits.lean
@@ -1,0 +1,442 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+module
+public import Mathlib.Analysis.Normed.Field.Ultra
+public import Mathlib.Analysis.SpecificLimits.Basic
+public import Mathlib.NumberTheory.Padics.RingHoms
+public import Mathlib.Topology.Algebra.ConstMulAction
+public import Mathlib.Topology.Algebra.Constructions
+
+/-!
+# `p`-adic powers of principal units
+
+Let `K` be a complete ultrametric field with `‖p‖ < 1`, for instance a finite extension of `ℚ_p`,
+the field `ℂ_[p]`, or the completion of a number field at a prime above `p`. The principal units,
+or `1`-units, `oneUnits K = {u : Kˣ | ‖u - 1‖ < 1}` form a pro-`p` group: `u ^ (p ^ k) → 1`
+(`IsUltrametricDist.tendsto_pow_pow_sub_one`). Hence a principal unit `x` has `p`-adic powers
+`x ^ a = lim x ^ aₙ` for `a ∈ ℤ_p` and integers `aₙ → a`, and `Additive (oneUnits K)` is a
+`ℤ_[p]`-module. Mathlib has no such module structure.
+
+## Main definitions
+
+* `oneUnits K`: the subgroup of `Kˣ` of principal units.
+* `OneUnits.zpPow x a`: the `p`-adic power `x ^ a = lim x ^ (a.appr n)` of `x : K` by `a : ℤ_[p]`
+  (junk value when the sequence does not converge, e.g. if `‖x - 1‖ ≥ 1`).
+* `OneUnits.instModule`: the `ℤ_[p]`-module structure `a • u = u ^ a` on `Additive (oneUnits K)`.
+
+## Main results
+
+* `IsUltrametricDist.norm_mul_sub_one_lt`, `IsUltrametricDist.norm_inv_sub_one`: the open unit
+  disc around `1` is a group.
+* `IsUltrametricDist.norm_pow_pow_sub_one_le`: on the ball `‖u - 1‖ ≤ c ≤ 1` the `n ^ k`-th power
+  map contracts towards `1` by the factor `max c ‖n‖` at each step, uniformly in `u`. Hence
+  `IsUltrametricDist.tendsto_pow_pow_sub_one`: `u ^ (n ^ k) → 1` for a `1`-unit `u` when
+  `‖n‖ < 1`.
+* `OneUnits.tendsto_zpow_of_tendsto`: `x ^ cₙ → x ^ a` for any integers `cₙ → a` in `ℤ_p`.
+* `OneUnits.zpPow_add`, `OneUnits.zpPow_mul`, `OneUnits.mul_zpPow`: the exponent rules.
+* `OneUnits.norm_zpPow_sub_zpPow_le`, `OneUnits.continuous_zpPow`: `x ^ a` is `1`-Lipschitz in
+  `x` and continuous in `a`. Hence the scalar action is continuous in both arguments:
+  `OneUnits.continuous_smul_const` and the `ContinuousConstSMul ℤ_[p] (Additive (oneUnits K))`
+  instance, so `Additive (oneUnits K)` is a topological `ℤ_[p]`-module.
+* `OneUnits.natCast_smul`: natural `p`-adic powers are ordinary powers.
+* `OneUnits.tendsto_appr_nsmul`, `OneUnits.tendsto_appr_nsmul_pi`: `a • u = lim (a.appr n) • u`
+  on the module side, for one group of principal units and for a product of them.
+* `AddSubgroup.smul_mem_of_isClosed`: closed subgroups are `ℤ_[p]`-submodules.
+
+## References
+
+* [Klo] B. Klopsch, *Five lectures on analytic pro-p groups*, LMS-EPSRC short course notes,
+  Oxford 2007, Exercise 6.1 (d)–(f), p. 24: `g ^ λ := lim g ^ λₙ` and the exponent rules.
+* [BG] O. Ben-Bassat, N. Gropper, *Arithmetic field theory via pro-p duality groups*,
+  arXiv:2504.19078, §Notation and conventions, p. 4: the limit is independent of the sequence.
+* [Con] K. Conrad, *Infinite series in p-adic fields*, pp. 13–14 (the strong triangle
+  inequality for `x ^ n - y ^ n`) and p. 27 (the disc `|x - 1| < 1` is a group).
+-/
+
+@[expose] public section
+
+open Filter Topology
+
+theorem PadicInt.tendsto_appr {p : ℕ} [hp : Fact p.Prime] (a : ℤ_[p]) :
+    Tendsto (fun n ↦ (a.appr n : ℤ_[p])) atTop (𝓝 a) := by
+  have : ∀ n : ℕ, ‖((a.appr n : ℤ_[p]) - a)‖ ≤ ((p : ℝ)⁻¹) ^ n := fun n ↦ by
+    calc _ ≤ (p : ℝ) ^ (-n : ℤ) := by simpa [norm_sub_rev] using
+          (PadicInt.norm_le_pow_iff_mem_span_pow _ n).2 (PadicInt.appr_spec n a)
+      _ = ((p : ℝ)⁻¹) ^ n := by rw [zpow_neg, zpow_natCast, inv_pow]
+  simpa [tendsto_iff_norm_sub_tendsto_zero] using squeeze_zero (fun n ↦ norm_nonneg _) this
+    (tendsto_pow_atTop_nhds_zero_of_lt_one (by positivity)
+    (inv_lt_one_of_one_lt₀ (by exact_mod_cast hp.out.one_lt)))
+
+namespace IsUltrametricDist
+
+variable {K : Type*} [NontriviallyNormedField K] [IsUltrametricDist K]
+
+theorem norm_eq_one_of_norm_sub_one_lt_one {u : K} (hu : ‖u - 1‖ < 1) : ‖u‖ = 1 := by
+  rw [← (add_sub_cancel 1 u), IsUltrametricDist.norm_add_eq_max_of_norm_ne_norm
+    (by grind [norm_one]),norm_one, max_eq_left hu.le]
+
+theorem norm_mul_sub_one_lt {u v : K} (hu : ‖u - 1‖ < 1) (hv : ‖v - 1‖ < 1) :
+    ‖u * v - 1‖ < 1 := by
+  simpa [show u * v - 1 = (u - 1) * v + (v - 1) by ring] using lt_of_le_of_lt
+    (IsUltrametricDist.norm_add_le_max _ _)
+    (max_lt (by simpa [norm_mul, norm_eq_one_of_norm_sub_one_lt_one hv, mul_one]) hv)
+
+theorem norm_inv_sub_one {u : K} (hu : ‖u - 1‖ < 1) : ‖u⁻¹ - 1‖ = ‖u - 1‖ := by
+  have : u ≠ 0 := by aesop
+  rw [show u⁻¹ - 1 = (1 - u) / u by grind, norm_div, norm_eq_one_of_norm_sub_one_lt_one hu,
+    div_one, norm_sub_rev]
+
+theorem norm_pow_sub_one_lt {u : K} (hu : ‖u - 1‖ < 1) (n : ℕ) : ‖u ^ n - 1‖ < 1 := by
+  induction n with
+  | zero => simp
+  | succ n ih => simpa [pow_succ] using norm_mul_sub_one_lt ih hu
+
+theorem norm_pow_sub_pow_le {x y : K} (hx : ‖x‖ ≤ 1) (hy : ‖y‖ ≤ 1) (n : ℕ) :
+    ‖x ^ n - y ^ n‖ ≤ ‖x - y‖ := by
+  rw [← (Commute.all x y).geom_sum₂_mul n, norm_mul]
+  refine mul_le_of_le_one_left (norm_nonneg _)
+    (IsUltrametricDist.norm_sum_le_of_forall_le_of_nonneg zero_le_one fun i _ ↦ ?_)
+  simpa using mul_le_one₀ (pow_le_one₀ (norm_nonneg _) hx) (by positivity)
+    (pow_le_one₀ (norm_nonneg _) hy)
+
+theorem norm_pow_sub_one_le {x : K} (hx : ‖x‖ ≤ 1) (n : ℕ) : ‖x ^ n - 1‖ ≤ ‖x - 1‖ := by
+  simpa using norm_pow_sub_pow_le hx (norm_one (α := K)).le n
+
+theorem norm_pow_sub_one_le_mul_max (n : ℕ) {u : K} (hu : ‖u - 1‖ ≤ 1) :
+    ‖u ^ n - 1‖ ≤ ‖u - 1‖ * max ‖u - 1‖ ‖(n : K)‖ := by
+  calc _ = ‖(∑ i ∈ Finset.range n, (u ^ i - 1)) + (n : K)‖ * ‖u - 1‖ := by
+        rw [← norm_mul, Finset.sum_sub_distrib, Finset.sum_const, Finset.card_range, nsmul_eq_mul,
+          mul_one, sub_add_cancel, geom_sum_mul u n]
+    _ ≤ max ‖u - 1‖ ‖(n : K)‖ * ‖u - 1‖ := by
+        refine mul_le_mul_of_nonneg_right ((IsUltrametricDist.norm_add_le_max _ _).trans
+          (max_le_max ?_ le_rfl)) (norm_nonneg _)
+        refine IsUltrametricDist.norm_sum_le_of_forall_le_of_nonneg (norm_nonneg _)
+          fun i _ ↦ norm_pow_sub_one_le ?_ i
+        rw [← sub_add_cancel u 1]
+        exact (IsUltrametricDist.norm_add_le_max _ _).trans (max_le hu (by simp))
+    _ = _ := mul_comm _ _
+
+theorem norm_pow_pow_sub_one_le (n k : ℕ) {c : ℝ} (hc : c ≤ 1) {u : K} (hu : ‖u - 1‖ ≤ c) :
+    ‖u ^ n ^ k - 1‖ ≤ max c ‖(n : K)‖ ^ k * c := by
+  induction k with
+  | zero => simpa using hu
+  | succ k ih =>
+    have h : max c ‖(n : K)‖ ^ k * c ≤ c :=
+      mul_le_of_le_one_left ((norm_nonneg _).trans hu) (pow_le_one₀ (le_max_of_le_left
+        ((norm_nonneg _).trans hu)) (max_le hc (IsUltrametricDist.norm_natCast_le_one K n)))
+    calc _ = _ := by rw [pow_succ, pow_mul]
+      _ ≤ _ := norm_pow_sub_one_le_mul_max n (ih.trans (h.trans hc))
+      _ ≤ _ := mul_le_mul ih (max_le_max (ih.trans h) le_rfl)
+        (le_max_of_le_left (norm_nonneg _)) (by positivity [(norm_nonneg _).trans hu])
+      _ = _ := by ring
+
+theorem tendsto_pow_pow_sub_one {n : ℕ} (hn : ‖(n : K)‖ < 1) {u : K} (hu : ‖u - 1‖ < 1) :
+    Tendsto (fun k : ℕ ↦ u ^ n ^ k - 1) atTop (𝓝 0) := by
+  refine squeeze_zero_norm (fun k ↦ norm_pow_pow_sub_one_le n k hu.le le_rfl) ?_
+  rw [← zero_mul ‖u - 1‖]
+  exact (tendsto_pow_atTop_nhds_zero_of_lt_one (le_max_of_le_left (norm_nonneg _))
+    (max_lt hu hn)).mul_const _
+
+theorem norm_zpow_sub_one_le {x : K} (hx : ‖x - 1‖ < 1) (n : ℤ) : ‖x ^ n - 1‖ ≤ ‖x - 1‖ := by
+  rcases Int.eq_nat_or_neg n with ⟨m, rfl | rfl⟩
+  · simpa using norm_pow_sub_one_le (norm_eq_one_of_norm_sub_one_lt_one hx).le m
+  · simpa [norm_inv_sub_one (norm_pow_sub_one_lt hx m)] using
+    norm_pow_sub_one_le (norm_eq_one_of_norm_sub_one_lt_one hx).le m
+
+theorem norm_div_sub_one {x y : K} (hy : ‖y - 1‖ < 1) : ‖x / y - 1‖ = ‖x - y‖ := by
+  rw [div_sub_one (by aesop), norm_div, norm_eq_one_of_norm_sub_one_lt_one hy, div_one]
+
+theorem norm_sub_lt_one {x y : K} (hx : ‖x - 1‖ < 1) (hy : ‖y - 1‖ < 1) : ‖x - y‖ < 1 :=
+  calc _ = ‖(x - 1) + - (y - 1)‖ := by ring_nf
+    _ ≤ max ‖x - 1‖ ‖-(y - 1)‖ := IsUltrametricDist.norm_add_le_max _ _
+    _ < 1 := by simpa only [norm_neg] using max_lt hx hy
+
+theorem norm_zpow_sub_zpow_le {x y : K} (hx : ‖x - 1‖ < 1) (hy : ‖y - 1‖ < 1) (n : ℤ) :
+    ‖x ^ n - y ^ n‖ ≤ ‖x - y‖ := by
+  have : x ^ n - y ^ n = y ^ n * ((x / y) ^ n - 1) := by
+    rw [div_zpow, mul_sub, mul_one, mul_div_cancel₀ _ (zpow_ne_zero _ (by aesop))]
+  simpa [this, norm_eq_one_of_norm_sub_one_lt_one hy, ← norm_div_sub_one hy] using
+    norm_zpow_sub_one_le (by simpa [norm_div_sub_one hy] using norm_sub_lt_one hx hy) n
+
+end IsUltrametricDist
+
+open IsUltrametricDist
+
+/-- The principal units, or `1`-units, of an ultrametric normed field: the units `u` with
+`‖u - 1‖ < 1`. [Con, p. 27]. -/
+def oneUnits (K : Type*) [NontriviallyNormedField K] [IsUltrametricDist K] : Subgroup Kˣ where
+  carrier := {u | ‖(u : K) - 1‖ < 1}
+  mul_mem' hu hv := norm_mul_sub_one_lt hu hv
+  one_mem' := by simp
+  inv_mem' {u} hu := by simpa [norm_inv_sub_one hu]
+
+namespace OneUnits
+
+@[simp]
+theorem mem_oneUnits_iff {K : Type*} [NontriviallyNormedField K] [IsUltrametricDist K] {u : Kˣ} :
+    u ∈ oneUnits K ↔ ‖(u : K) - 1‖ < 1 := Iff.rfl
+
+section ZpPow
+
+variable {p : ℕ} [Fact p.Prime] {K : Type*} [NontriviallyNormedField K] [IsUltrametricDist K]
+  [CompleteSpace K] [Fact (‖((p : ℕ) : K)‖ < 1)]
+
+omit [Fact p.Prime] [CompleteSpace K] in
+theorem exists_forall_norm_zpow_sub_one_lt {x : K} (hx : ‖x - 1‖ < 1) {ε : ℝ} (hε : 0 < ε) :
+    ∃ k : ℕ, ∀ m : ℤ, (p : ℤ) ^ k ∣ m → ‖x ^ m - 1‖ < ε := by
+  obtain ⟨k, hk⟩ := Metric.tendsto_atTop.1 (tendsto_pow_pow_sub_one (n := p) Fact.out hx) ε hε
+  refine ⟨k, fun m ⟨j, hj⟩ ↦ ?_⟩
+  calc ‖x ^ m - 1‖ = ‖(x ^ ((p : ℤ) ^ k)) ^ j - 1‖ := by rw [← zpow_mul, ← hj]
+    _ ≤ ‖x ^ ((p : ℤ) ^ k) - 1‖ := by
+        refine norm_zpow_sub_one_le ?_ j
+        rw [← Int.natCast_pow, zpow_natCast]
+        exact norm_pow_sub_one_lt hx _
+    _ < ε := by
+      rw [← Int.natCast_pow, zpow_natCast]
+      aesop
+
+omit [CompleteSpace K] in
+theorem tendsto_zpow_of_tendsto_zero {x : K} (hx : ‖x - 1‖ < 1) {c : ℕ → ℤ}
+    (hc : Tendsto (fun n ↦ (c n : ℤ_[p])) atTop (𝓝 0)) :
+    Tendsto (fun n ↦ x ^ c n) atTop (𝓝 1) := by
+  refine Metric.tendsto_atTop.2 fun ε hε ↦ ?_
+  obtain ⟨k, hk⟩ := exists_forall_norm_zpow_sub_one_lt (p := p) hx hε
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.1 hc _ (zpow_pos (a := (p : ℝ))
+    (by exact_mod_cast (Fact.out : p.Prime).pos) (-k : ℤ))
+  refine ⟨N, fun n hn ↦ ?_⟩
+  simpa [dist_eq_norm] using hk _ (mod_cast PadicInt.norm_int_le_pow_iff_dvd.1
+    (dist_zero_right (c n : ℤ_[p]) ▸ hN n hn).le)
+
+
+omit [CompleteSpace K] in
+theorem cauchySeq_pow_appr {x : K} (hx : ‖x - 1‖ < 1) (a : ℤ_[p]) :
+    CauchySeq fun n ↦ x ^ a.appr n := by
+  refine Metric.cauchySeq_iff'.2 fun ε hε ↦ ?_
+  obtain ⟨k, hk⟩ := exists_forall_norm_zpow_sub_one_lt (p := p) hx hε
+  refine ⟨k, fun n hn ↦ ?_⟩
+  obtain ⟨_, hd⟩ := Nat.exists_eq_add_of_le (PadicInt.appr_mono a hn)
+  rw [dist_eq_norm, hd, pow_add, ← mul_sub_one, norm_mul, norm_pow,
+    norm_eq_one_of_norm_sub_one_lt_one hx, one_pow, one_mul, ← zpow_natCast]
+  exact hk _ (by simpa [hd] using Int.natCast_dvd_natCast.2 (PadicInt.dvd_appr_sub_appr a k n hn))
+
+/-- The `p`-adic power `x ^ a = lim x ^ (a.appr n)` of `x : K` by `a : ℤ_[p]`. This is the limit
+of [Klo, Exercise 6.1 (d)] and [BG, p. 4], with `a.appr n` as the approximating integers. The
+value is junk unless the sequence converges, which it does when `‖x - 1‖ < 1`
+(`tendsto_pow_appr`). -/
+noncomputable
+def zpPow (x : K) (a : ℤ_[p]) : K := limUnder atTop fun n ↦ x ^ a.appr n
+
+theorem tendsto_pow_appr {x : K} (hx : ‖x - 1‖ < 1) (a : ℤ_[p]) :
+    Tendsto (fun n ↦ x ^ a.appr n) atTop (𝓝 (zpPow x a)) :=
+  tendsto_nhds_limUnder (cauchySeq_tendsto_of_complete (cauchySeq_pow_appr hx a))
+
+theorem tendsto_zpow_of_tendsto {x : K} (hx : ‖x - 1‖ < 1) {c : ℕ → ℤ} {a : ℤ_[p]}
+    (hc : Tendsto (fun n ↦ (c n : ℤ_[p])) atTop (𝓝 a)) :
+    Tendsto (fun n ↦ x ^ c n) atTop (𝓝 (zpPow x a)) := by
+  simpa [← zpow_natCast, ← zpow_add₀ (a := x) (by aesop)] using (tendsto_pow_appr hx a).mul
+    (tendsto_zpow_of_tendsto_zero (c := fun n ↦ c n - a.appr n) hx
+      (by simpa using hc.sub (PadicInt.tendsto_appr a)))
+
+theorem zpPow_intCast {x : K} (hx : ‖x - 1‖ < 1) (n : ℤ) : zpPow x (n : ℤ_[p]) = x ^ n :=
+  tendsto_nhds_unique (tendsto_zpow_of_tendsto (p := p) hx (c := fun _ ↦ n) tendsto_const_nhds)
+    tendsto_const_nhds
+
+theorem zpPow_natCast {x : K} (hx : ‖x - 1‖ < 1) (n : ℕ) : zpPow x (n : ℤ_[p]) = x ^ n := by
+  rw [← Int.cast_natCast, zpPow_intCast hx (n : ℤ), zpow_natCast]
+
+@[simp]
+theorem zpPow_zero {x : K} (hx : ‖x - 1‖ < 1) : zpPow x (0 : ℤ_[p]) = 1 := by
+  simpa using zpPow_intCast hx 0
+
+@[simp]
+theorem zpPow_one {x : K} (hx : ‖x - 1‖ < 1) : zpPow x (1 : ℤ_[p]) = x := by
+  simpa using zpPow_intCast hx 1
+
+@[simp]
+theorem one_zpPow (a : ℤ_[p]) : zpPow (1 : K) a = 1 :=
+  tendsto_nhds_unique (tendsto_pow_appr (p := p) (by simp) a) (by simp)
+
+/-- `g ^ (λ + μ) = g ^ λ * g ^ μ` [Klo, Exercise 6.1 (d)]. Compute the limit along
+`a.appr n + b.appr n`, which also tends to `a + b`. -/
+theorem zpPow_add {x : K} (hx : ‖x - 1‖ < 1) (a b : ℤ_[p]) :
+    zpPow x (a + b) = zpPow x a * zpPow x b := by
+  have : Tendsto (fun n ↦ (((a.appr n : ℤ) + (b.appr n : ℤ) : ℤ) : ℤ_[p])) atTop (𝓝 (a + b)) :=
+    ((PadicInt.tendsto_appr a).add (PadicInt.tendsto_appr b)).congr fun n ↦ by aesop
+  refine tendsto_nhds_unique ((tendsto_zpow_of_tendsto hx this).congr fun n ↦ ?_)
+    ((tendsto_pow_appr hx a).mul (tendsto_pow_appr hx b))
+  rw [zpow_add₀ (by aesop), zpow_natCast, zpow_natCast]
+
+/-- `(g h) ^ λ = g ^ λ * h ^ λ` for commuting `g, h` [Klo, Exercise 6.1 (d)]: the "sufficient
+condition" of the exercise is automatic in a field. -/
+theorem mul_zpPow {x y : K} (hx : ‖x - 1‖ < 1) (hy : ‖y - 1‖ < 1) (a : ℤ_[p]) :
+    zpPow (x * y) a = zpPow x a * zpPow y a := by
+  refine tendsto_nhds_unique (tendsto_pow_appr (norm_mul_sub_one_lt hx hy) a) ?_
+  simpa only [mul_pow] using (tendsto_pow_appr hx a).mul (tendsto_pow_appr hy a)
+
+/-- `p`-adic powers stay in the closed ball of radius `‖x - 1‖` around `1`: the bound
+`norm_pow_sub_one_le` passes to the limit. This is the image of `ℤ_[p] → cl⟨x⟩` of
+[Klo, Exercise 6.1 (e)]. -/
+theorem norm_zpPow_sub_one_le {x : K} (hx : ‖x - 1‖ < 1) (a : ℤ_[p]) :
+    ‖zpPow x a - 1‖ ≤ ‖x - 1‖ :=
+  le_of_tendsto (((tendsto_pow_appr hx a).sub_const 1).norm) <| Eventually.of_forall fun _ ↦
+    norm_pow_sub_one_le (norm_eq_one_of_norm_sub_one_lt_one hx).le _
+
+theorem norm_zpPow_sub_one_lt {x : K} (hx : ‖x - 1‖ < 1) (a : ℤ_[p]) :
+    ‖zpPow x a - 1‖ < 1 :=
+  (norm_zpPow_sub_one_le hx a).trans_lt hx
+
+@[simp]
+theorem norm_zpPow {x : K} (hx : ‖x - 1‖ < 1) (a : ℤ_[p]) : ‖zpPow x a‖ = 1 :=
+  norm_eq_one_of_norm_sub_one_lt_one (norm_zpPow_sub_one_lt hx a)
+
+theorem zpPow_ne_zero {x : K} (hx : ‖x - 1‖ < 1) (a : ℤ_[p]) : zpPow x a ≠ 0 :=
+  norm_pos_iff.1 ((norm_zpPow hx a) ▸ one_pos)
+
+/-- `x ↦ x ^ a` is `1`-Lipschitz on the principal units: `norm_pow_sub_pow_le` in the limit. -/
+theorem norm_zpPow_sub_zpPow_le {x y : K} (hx : ‖x - 1‖ < 1) (hy : ‖y - 1‖ < 1) (a : ℤ_[p]) :
+    ‖zpPow x a - zpPow y a‖ ≤ ‖x - y‖ :=
+  le_of_tendsto (((tendsto_pow_appr hx a).sub (tendsto_pow_appr hy a)).norm) <|
+    Eventually.of_forall fun _ ↦ norm_pow_sub_pow_le (norm_eq_one_of_norm_sub_one_lt_one hx).le
+    (norm_eq_one_of_norm_sub_one_lt_one hy).le _
+
+theorem zpPow_mul {x : K} (hx : ‖x - 1‖ < 1) (a b : ℤ_[p]) :
+    zpPow x (a * b) = zpPow (zpPow x b) a := by
+  have : Tendsto (fun n ↦ (((a.appr n : ℤ) * (b.appr n : ℤ) : ℤ) : ℤ_[p])) atTop (𝓝 (a * b)) :=
+    ((PadicInt.tendsto_appr a).mul (PadicInt.tendsto_appr b)).congr fun n ↦ (by aesop)
+  have : Tendsto (fun n ↦ (x ^ b.appr n) ^ a.appr n) atTop (𝓝 (zpPow x (a * b))) := by
+    refine (tendsto_zpow_of_tendsto hx this).congr fun n ↦ ?_
+    rw [← pow_mul, ← zpow_natCast x (b.appr n * a.appr n)]
+    grind
+  have h : Tendsto (fun n ↦ (x ^ b.appr n) ^ a.appr n) atTop (𝓝 (zpPow (zpPow x b) a)) :=
+    (tendsto_pow_appr (norm_zpPow_sub_one_lt hx b) a).congr_dist <|
+      squeeze_zero (fun _ ↦ dist_nonneg) (fun n ↦ (dist_eq_norm _ _).trans_le <|
+      norm_pow_sub_pow_le (norm_zpPow hx b).le (by simp [norm_eq_one_of_norm_sub_one_lt_one hx]) _)
+      (by simpa using ((tendsto_pow_appr hx b).const_sub (zpPow x b)).norm)
+  exact tendsto_nhds_unique this h
+
+theorem norm_zpPow_sub_one_le_of_dvd {x : K} (hx : ‖x - 1‖ < 1) {a : ℤ_[p]} {k : ℕ}
+    (h : (p : ℤ_[p]) ^ k ∣ a) : ‖zpPow x a - 1‖ ≤ ‖x ^ p ^ k - 1‖ := by
+  obtain ⟨d, rfl⟩ := h
+  simpa [mul_comm, zpPow_mul hx, ← Nat.cast_pow, zpPow_natCast hx] using norm_zpPow_sub_one_le
+    (norm_pow_sub_one_lt hx _) d
+
+theorem continuous_zpPow {x : K} (hx : ‖x - 1‖ < 1) : Continuous fun a : ℤ_[p] ↦ zpPow x a := by
+  refine Metric.continuous_iff.2 fun b ε hε ↦ ?_
+  obtain ⟨k, hk⟩ := exists_forall_norm_zpow_sub_one_lt (p := p) hx hε
+  refine ⟨(p : ℝ) ^ (-k : ℤ), zpow_pos (mod_cast (Fact.out : p.Prime).pos) _, fun a ha ↦ ?_⟩
+  rw [dist_eq_norm] at ha ⊢
+  rw [← norm_div_sub_one (norm_zpPow_sub_one_lt hx b), ← sub_add_cancel a b, zpPow_add hx,
+    mul_div_cancel_right₀ _ (zpPow_ne_zero hx b)]
+  refine (norm_zpPow_sub_one_le_of_dvd hx (Ideal.mem_span_singleton.1
+    ((PadicInt.norm_le_pow_iff_mem_span_pow (a - b) k).1 ha.le))).trans_lt ?_
+  simpa only [zpow_natCast] using hk ((p ^ k : ℕ) : ℤ) (by simp)
+
+end ZpPow
+
+section Module
+
+variable {p : ℕ} [Fact p.Prime] {K : Type*} [NontriviallyNormedField K] [IsUltrametricDist K]
+  [CompleteSpace K] [Fact (‖((p : ℕ) : K)‖ < 1)]
+
+/-- The `p`-adic power of a principal unit, as a principal unit. -/
+noncomputable
+def zpPowUnit (u : oneUnits K) (a : ℤ_[p]) : oneUnits K :=
+  ⟨Units.mk0 (zpPow ((u : Kˣ) : K) a) (zpPow_ne_zero (mem_oneUnits_iff.1 u.2) a),
+    mem_oneUnits_iff.2 (norm_zpPow_sub_one_lt (mem_oneUnits_iff.1 u.2) a)⟩
+
+noncomputable
+instance instSMul : SMul ℤ_[p] (Additive (oneUnits K)) :=
+  ⟨fun a u ↦ Additive.ofMul (zpPowUnit u.toMul a)⟩
+
+@[simp]
+theorem coe_smul (a : ℤ_[p]) (u : Additive (oneUnits K)) :
+    (((a • u).toMul : Kˣ) : K) = zpPow ((u.toMul : Kˣ) : K) a := rfl
+
+omit [CompleteSpace K] in
+theorem ext_of_coe {u v : Additive (oneUnits K)} (h : ((u.toMul : Kˣ) : K) = ((v.toMul : Kˣ) : K)) :
+  u = v := Additive.toMul.injective (Subtype.ext (Units.ext h))
+
+/-- The `ℤ_[p]`-module structure `a • u = u ^ a` on the principal units. "Regard `G` as a
+finitely generated `ℤ_p`-module" [Klo, Exercise 6.1 (f)]; the six axioms are the exponent rules
+`zpPow_one`, `zpPow_mul`, `one_zpPow`, `mul_zpPow`, `zpPow_add`, `zpPow_zero` of
+[Klo, Exercise 6.1 (d)], read additively. -/
+noncomputable
+instance instModule : Module ℤ_[p] (Additive (oneUnits K)) where
+  one_smul u := ext_of_coe <| by
+    simpa [coe_smul] using zpPow_one (mem_oneUnits_iff.1 u.toMul.2)
+  mul_smul a b u := ext_of_coe <| by
+    simpa [coe_smul, coe_smul, coe_smul] using zpPow_mul (mem_oneUnits_iff.1 u.toMul.2) a b
+  smul_zero a := ext_of_coe <| by simp [coe_smul]
+  smul_add a u v := ext_of_coe <| by
+    rw [coe_smul, toMul_add, Subgroup.coe_mul, Units.val_mul,
+      mul_zpPow (mem_oneUnits_iff.1 u.toMul.2) (mem_oneUnits_iff.1 v.toMul.2) a]
+    rfl
+  add_smul a b u := ext_of_coe <| by
+    rw [coe_smul, zpPow_add (mem_oneUnits_iff.1 u.toMul.2) a b]
+    rfl
+  zero_smul u := ext_of_coe <| by
+    simpa [coe_smul] using zpPow_zero (mem_oneUnits_iff.1 u.toMul.2)
+
+theorem natCast_smul (n : ℕ) (u : Additive (oneUnits K)) : (n : ℤ_[p]) • u = n • u :=
+  ext_of_coe (by simp [zpPow_natCast (mem_oneUnits_iff.1 u.toMul.2)])
+
+omit [CompleteSpace K] [Fact (‖((p : ℕ) : K)‖ < 1)] in
+theorem isInducing_coe :
+    Topology.IsInducing (fun u : Additive (oneUnits K) ↦ ((u.toMul : Kˣ) : K)) :=
+  Units.isEmbedding_val₀.isInducing.comp Topology.IsInducing.subtypeVal
+
+theorem tendsto_appr_nsmul (a : ℤ_[p]) (u : Additive (oneUnits K)) :
+    Tendsto (fun n ↦ a.appr n • u) atTop (𝓝 (a • u)) := by
+  rw [isInducing_coe.tendsto_nhds_iff]
+  have hu : ‖((u.toMul : Kˣ) : K) - 1‖ < 1 := mem_oneUnits_iff.1 u.toMul.2
+  refine (tendsto_pow_appr (p := p) hu a).congr fun n ↦ ?_
+  rw [Function.comp_apply, ← natCast_smul (p := p) (a.appr n) u, coe_smul, zpPow_natCast hu]
+
+theorem tendsto_appr_nsmul_pi {ι : Type*} {F : ι → Type*}
+    [∀ i, NontriviallyNormedField (F i)] [∀ i, IsUltrametricDist (F i)]
+    [∀ i, CompleteSpace (F i)] [∀ i, Fact (‖((p : ℕ) : F i)‖ < 1)]
+    (a : ℤ_[p]) (x : ∀ i, Additive (oneUnits (F i))) :
+    Tendsto (fun n ↦ a.appr n • x) atTop (𝓝 (a • x)) :=
+  tendsto_pi_nhds.2 fun i ↦ tendsto_appr_nsmul a (x i)
+
+theorem continuous_smul_const (u : Additive (oneUnits K)) :
+    Continuous fun a : ℤ_[p] ↦ a • u := by
+  simpa [isInducing_coe.continuous_iff] using (continuous_zpPow
+    (mem_oneUnits_iff.1 u.toMul.2)).congr fun a ↦ by simp
+
+/-- `x ↦ x ^ a` is continuous on the open unit ball around `1`, being `1`-Lipschitz there
+(`norm_zpPow_sub_zpPow_le`). -/
+theorem continuousOn_zpPow (a : ℤ_[p]) :
+    ContinuousOn (fun x : K ↦ zpPow x a) {x : K | ‖x - 1‖ < 1} := by
+  refine Metric.continuousOn_iff.2 fun x hx ε hε ↦ ⟨ε, hε, fun y hy hdist ↦ ?_⟩
+  rw [dist_eq_norm] at hdist ⊢
+  exact lt_of_le_of_lt (norm_zpPow_sub_zpPow_le hy hx a) hdist
+
+instance : ContinuousConstSMul ℤ_[p] (Additive (oneUnits K)) where
+  continuous_const_smul a := by
+    simpa [isInducing_coe.continuous_iff] using ((continuousOn_zpPow (K := K) a).comp_continuous
+      isInducing_coe.continuous fun u ↦ mem_oneUnits_iff.1 u.toMul.2).congr fun u ↦ (by simp)
+
+/-- A closed subgroup of a `ℤ_[p]`-module in which `a • x = lim (a.appr n) • x` is a
+`ℤ_[p]`-submodule. -/
+theorem _root_.AddSubgroup.smul_mem_of_isClosed {M : Type*} [AddCommGroup M] [Module ℤ_[p] M]
+    [TopologicalSpace M] {S : AddSubgroup M} (hS : IsClosed (S : Set M)) {x : M} (hx : x ∈ S)
+    {a : ℤ_[p]} (h : Tendsto (fun n ↦ a.appr n • x) atTop (𝓝 (a • x))) : a • x ∈ S :=
+  hS.mem_of_tendsto h (Eventually.of_forall fun n ↦ S.nsmul_mem hx (a.appr n))
+
+end Module
+
+end OneUnits


### PR DESCRIPTION
We add the Gross-Kuz'min conjecture:
Let $K$ be a number field, $p$ a prime, $S_p$ the set of primes of $K$ above $p$ and $E' = \mathcal{O}_K[1/p]^\times$ the $p$-units.  Then the image of Gross' regulator map: $\rho : E' \to \bigoplus_{\mathfrak{p} \in S_p} \mathbb{Q}_p, \qquad
x \mapsto \big(\log_p N_{K_\mathfrak{p} / \mathbb{Q}_p}(x)\big)_\mathfrak{p}$
spans a subspace of dimension $|S_p| - 1$.

This reuses the following files from #5497
- FormalConjecturesForMathlib/Analysis/Normed/Algebra/Logarithm.lean
- FormalConjecturesForMathlib/NumberTheory/Padics/OneUnits.lean
- FormalConjecturesForMathlib/NumberTheory/NumberField/PrimesAbove.lean

Reference: 
A. Maksoud, *On the rank of Leopoldt's and Gross's regulator maps*, Doc. Math. **28** (2023), 1441-1471, [arXiv:2201.08203](https://arxiv.org/abs/2201.08203), (2) and Conjecture 1.3