### PR TITLE
fix(Wikipedia/InverseGalois): require an algebraically closed field in complex_function_field

### DIFF
--- a/FormalConjectures/Wikipedia/InverseGalois.lean
+++ b/FormalConjectures/Wikipedia/InverseGalois.lean
@@ -90,11 +90,11 @@ theorem inverse_galois_problem.variants.complex_rational_functions
 
 /--
 Every finite group is realisable over the field of rational functions
-with coefficients `K`, where `K` is any field of characteristic 0.
+with coefficients `K`, where `K` is any algebraically closed field of characteristic 0.
 -/
 @[category research solved, AMS 12]
 theorem inverse_galois_problem.variants.complex_function_field
-    {G K : Type*} [Field K] [CharZero K] [Fintype G] [Group G] :
+    {G K : Type*} [Field K] [IsAlgClosed K] [CharZero K] [Fintype G] [Group G] :
     IsRealizable (RatFunc K) G := by
   sorry
 


### PR DESCRIPTION
`inverse_galois_problem.variants.complex_function_field` claimed that every finite group is realisable over `RatFunc K` for *any* field `K` of characteristic zero. The cited Wikipedia result only covers algebraically closed fields of characteristic zero; with `K = ℚ` the old statement would (via Hilbert irreducibility) settle the open inverse Galois problem.

**Change:** add `[IsAlgClosed K]` to the theorem and say "algebraically closed" in the docstring. Category stays `research solved`.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.InverseGalois` passes with no warnings.

Fixes #5705
