### PR TITLE
fix(Wikipedia/RegularPrimes): restrict Kummer's criterion to even Bernoulli indices

### DIFF
--- a/FormalConjectures/Wikipedia/RegularPrimes.lean
+++ b/FormalConjectures/Wikipedia/RegularPrimes.lean
@@ -54,11 +54,12 @@ lemma small_regular_primes :
     { 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31 } ⊆ regularPrimes := by
   sorry
 
-/-- An equivalent definition of a regular prime `p` is that it does not divide the numerator of the
-first `p-3` Bernoulli numbers. Not in Mathlib. -/
+/-- **Kummer's criterion.** An equivalent definition of a regular prime `p` is that it does not
+divide the numerator of any of the Bernoulli numbers $B_k$ for $k = 2, 4, 6, \dots, p - 3$.
+Not in Mathlib. -/
 @[category textbook, AMS 11]
 theorem isRegularPrime_iff_Bernoulli (p : ℕ) [Fact p.Prime] :
-    IsRegularPrime p ↔ ∀ k ∈ Finset.Icc 2 (p - 3), ¬ (p : ℤ) ∣ (bernoulli' k).num := by
+    IsRegularPrime p ↔ ∀ k ∈ Finset.Icc 2 (p - 3), Even k → ¬ (p : ℤ) ∣ (bernoulli' k).num := by
   sorry
 
 /-- The set of irregular primes is infinite. -/


### PR DESCRIPTION
`isRegularPrime_iff_Bernoulli` quantified over every index `k ∈ [2, p - 3]`. Mathlib's `bernoulli' k` is `0` for odd `k ≥ 3`, so `(p : ℤ) ∣ (bernoulli' 3).num` holds for every `p`; for `p ≥ 7` the index `3` lies in the range and the right-hand side was false, i.e. the statement declared every prime `p ≥ 7` irregular (contradicting `small_regular_primes`).

**Change:** Kummer's criterion only involves the even-indexed Bernoulli numbers `B_2, B_4, …, B_{p-3}`, so add `Even k →` inside the quantifier and state the criterion explicitly in the docstring. Attributes unchanged.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.RegularPrimes` passes with no warnings.

Fixes #5711
