### PR TITLE
fix(GreensOpenProblems/16): forbid all nontrivial Zhao solutions

### DIFF
--- a/FormalConjectures/GreensOpenProblems/16.lean
+++ b/FormalConjectures/GreensOpenProblems/16.lean
@@ -49,28 +49,27 @@ theorem green_16 (N : ℕ) :
   sorry
 
 /-- From [Ruzsa] $f(N) \gg N^{1/2}$. -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11]
 theorem green_16_lower_bound :
     (fun N ↦ (N : ℝ) ^ (1 / 2 : ℝ)) ≪ fun N ↦ (f N : ℝ) := by
   sorry
 
 /-- From [Schoen and Sisask] $f(N) \ll N \cdot e^{-c(\log N)^{1/7}}$. -/
-@[category research open, AMS 5 11]
+@[category research solved, AMS 5 11]
 theorem green_16_upper_bound :
     ∃ c > (0 : ℝ), (fun N ↦ (f N : ℝ)) ≪ fun N ↦ (N : ℝ) * exp (-c * (log N) ^ (1 / 7 : ℝ)) := by
   sorry
 
-/-- $f(N) \gg N \cdot e^{-c(\log N)^{1/7}}$. -/
-@[category research open, AMS 5 11]
-theorem green_16_conjectured_lower_bound :
-    ∃ c > (0 : ℝ), (fun N ↦ (N : ℝ) * exp (-c * (log N) ^ (1 / 7 : ℝ))) ≪ fun N ↦ (f N : ℝ) := by
-  sorry
+/-- A solution $(x, y, z, x', y', z')$ of $x + 2y + 3z = x' + 2y' + 3z'$ is *trivial* if for every
+value $a$ the coefficients of the variables equal to $a$ have the same sum on both sides. -/
+def IsTrivialZhaoSolution (x y z x' y' z' : ℕ) : Prop :=
+  ∀ a : ℕ, (if x = a then 1 else 0) + (if y = a then 2 else 0) + (if z = a then 3 else 0) =
+    (if x' = a then 1 else 0) + (if y' = a then 2 else 0) + (if z' = a then 3 else 0)
 
 /-- A set has no nontrivial solution to $x + 2y + 3z = x' + 2y' + 3z'$. -/
 def ZhaoSolutionFree (A : Finset ℕ) : Prop :=
-  ∀ x y z x' y' z', x ∈ A → y ∈ A → z ∈ A → x' ∈ A → y' ∈ A → z' ∈ A →
-    [x, y, z, x', y', z'].Nodup →
-    x + 2 * y + 3 * z ≠ x' + 2 * y' + 3 * z'
+  ∀ x ∈ A, ∀ y ∈ A, ∀ z ∈ A, ∀ x' ∈ A, ∀ y' ∈ A, ∀ z' ∈ A,
+    x + 2 * y + 3 * z = x' + 2 * y' + 3 * z' → IsTrivialZhaoSolution x y z x' y' z'
 
 /-- The maximum size of a Zhao-solution-free subset of $[N]$. -/
 noncomputable def g (N : ℕ) : ℕ :=


### PR DESCRIPTION
`Green16.ZhaoSolutionFree` forbade only solutions of $x + 2y + 3z = x' + 2y' + 3z'$ with six pairwise distinct values. Green's Problem 16 comments ask for a subset of $[N]$ of size $N^{1/3 - o(1)}$ with no *nontrivial* solutions, where (following Ruzsa) a solution is trivial when the coefficients of the variables taking each value sum to the same amount on both sides. For example $\{1, 2, 3\}$ satisfied the old predicate despite the nontrivial solution $(1, 1, 3, 2, 2, 2)$. The file also asserted a lower bound $f(N) \gg N e^{-c(\log N)^{1/7}}$ that Green states only as the Schoen–Sisask upper bound.

**Change**
- Add `IsTrivialZhaoSolution` (coefficient sums agree on every equal-value class) and redefine `ZhaoSolutionFree` to require every solution in the set to be trivial; `g` and `zhao_question` now use the intended avoidance condition.
- Remove `green_16_conjectured_lower_bound` (no source poses it).
- Retag `green_16_lower_bound` (Ruzsa) and `green_16_upper_bound` (Schoen–Sisask) as `research solved`, as Green calls them the best known bounds.

**Checked**: `lake --wfail build 'FormalConjectures.GreensOpenProblems.«16»'` passes with no warnings.

Fixes #5679
