### PR TITLE
fix(Wikipedia/Transcendental): use Euler–Mascheroni, not Catalan, in Rivoal disjunction

### DIFF
--- a/FormalConjectures/Wikipedia/Transcendental.lean
+++ b/FormalConjectures/Wikipedia/Transcendental.lean
@@ -132,11 +132,15 @@ theorem exp_add_pi_or_exp_add_mul_transcendental :
   sorry
 
 /--
-At least one of Catalan constant and the Gompertz constant is transcendental.
+At least one of the Euler–Mascheroni constant $\gamma$ and the Gompertz constant $\delta$ is
+transcendental.
+
+[Ri12] Rivoal, T. (2012). On the arithmetic nature of the values of the gamma function, Euler's
+constant, and Gompertz's constant. Michigan Mathematical Journal, 61(2), 239–254.
 -/
 @[category research solved, AMS 11 33]
-theorem transcendental_catalanConstant_or_gompertzConstant :
-    Transcendental ℚ catalanConstant ∨ Transcendental ℚ gompertzConstant := by
+theorem transcendental_eulerMascheroniConstant_or_gompertzConstant :
+    Transcendental ℚ eulerMascheroniConstant ∨ Transcendental ℚ gompertzConstant := by
   sorry
 
 /--


### PR DESCRIPTION
`transcendental_catalanConstant_or_gompertzConstant` stated that at least one of Catalan's constant G = β(2) and the Gompertz constant δ is transcendental. The cited result (Rivoal, *On the arithmetic nature of the values of the gamma function, Euler's constant, and Gompertz's constant*, Michigan Math. J. 61 (2012)) is that at least one of the **Euler–Mascheroni constant γ** and δ is transcendental; nothing of the sort is known for Catalan's constant, so the Lean statement asserted an unproved disjunction.

**Change:** replace `catalanConstant` by `eulerMascheroniConstant` in the statement, rename the theorem to `transcendental_eulerMascheroniConstant_or_gompertzConstant`, and update the docstring with the Rivoal reference.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.Transcendental` passes with no warnings.

Fixes #5716
