### PR TITLE
fix(WrittenOnTheWallII/GraphConjecture133): drop the floor on l G

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture133.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture133.lean
@@ -34,15 +34,12 @@ WOWII [Conjecture 133](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/):
 
 For a simple connected graph $G$,
 $\operatorname{path}(G) \ge \operatorname{rad}(G) +
-\lfloor \mathrm{avg}_v\, l(v) \rfloor^{cC_4(G)}$,
+(\mathrm{avg}_v\, l(v))^{cC_4(G)}$,
 where $\operatorname{path}(G)$ is the path number of the graph (number of vertices of a largest induced path),
 $\operatorname{rad}(G)$ is the radius (minimum eccentricity, as a natural number),
 $\mathrm{avg}_v\, l(v) = l(G)$ is the average independence number of vertex
 neighbourhoods, and $cC_4(G)$ is the $C_4$-free characteristic function
 (1 if $G$ is $C_4$-free, not necessarily induced, and 0 otherwise).
-
-We read DeLaVina's bracket notation `[average of λ(v)]` in the source as the
-floor (a standard Graffiti.pc convention), hence `⌊l G⌋` in Lean.
 -/
 @[category research open, AMS 5]
 theorem conjecture133 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected) :
@@ -50,7 +47,7 @@ theorem conjecture133 (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected
     let hasC4 := ∃ a b c d : α, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d ∧
       G.Adj a b ∧ G.Adj b c ∧ G.Adj c d ∧ G.Adj d a
     let cC4 : ℕ := if hasC4 then 0 else 1
-    (rad : ℝ) + (⌊l G⌋ : ℝ) ^ cC4 ≤ (path G : ℝ) := by
+    (rad : ℝ) + l G ^ cC4 ≤ (path G : ℝ) := by
   sorry
 
 -- Sanity checks


### PR DESCRIPTION
`conjecture133` stated `rad G + ⌊l G⌋ ^ cC4 ≤ path G`, flooring the average neighbourhood independence number `l G`. The WOWII source states `path(G) ≥ rad(G) + [avg_v l(v)]^{cC4(G)}` with the brackets acting as grouping, not floor. Since `rad` and `path` are integers, the floor weakened the bound by one whenever `l G` is non-integral (e.g. `P_3`, where `l = 4/3`).

**Change:** remove the floor so the conclusion reads `rad + l G ^ cC4 ≤ path G`, and delete the docstring note that justified the floor as a "Graffiti.pc convention".

**Checked:** `lake --wfail build FormalConjectures.WrittenOnTheWallII.GraphConjecture133` passes with no warnings.

Fixes #5717
