### PR TITLE
fix(Wikipedia/SnakeInTheBox): restore the `- 7` in the upper bound denominator

### DIFF
--- a/FormalConjectures/Wikipedia/SnakeInTheBox.lean
+++ b/FormalConjectures/Wikipedia/SnakeInTheBox.lean
@@ -101,14 +101,15 @@ theorem snake_dim_nine_lower_bound : 190 ≤ LongestSnakeInTheBox 9 := by
 -- TODO(firsching): add more known bounds and open conjecture for a few small dimensions
 
 /--
-An upper bound of the maximal length of the longest snake in a box is given by
+For $n \geq 2$, an upper bound of the maximal length of the longest snake in a box is given by
 $$
 1 + 2^{n-1}\frac{6n}{6n + \frac{1}{6\sqrt{6}}n^{\frac 1 2} - 7}.
 $$
+The case $n = 1$ is excluded since the right-hand side is negative there.
 -/
 @[category research solved, AMS 5]
-theorem snake_upper_bound (n : ℕ) : LongestSnakeInTheBox n
-    ≤ (1 : ℝ) + 2 ^ (n - 1) * (6 * n) / (6 * n + (1 / (6 * √6) * √n)) := by
+theorem snake_upper_bound (n : ℕ) (hn : 2 ≤ n) : LongestSnakeInTheBox n
+    ≤ (1 : ℝ) + 2 ^ (n - 1) * (6 * n) / (6 * n + (1 / (6 * √6) * √n) - 7) := by
   sorry
 
 end SnakeInBox


### PR DESCRIPTION
`SnakeInBox.snake_upper_bound` bounded `LongestSnakeInTheBox n` by `1 + 2^(n-1) * 6n / (6n + n^{1/2}/(6√6))`, dropping the `- 7` from the denominator of the cited bound `1 + 2^{n-1} · 6n / (6n + n^{1/2}/(6√6) - 7)`. The Lean right-hand side is therefore strictly smaller for every `n ≥ 2`, so the declaration asserted a strictly stronger (unsourced) upper bound.

**Change:** restore the `- 7` in the denominator. The corrected right-hand side is negative at `n = 1` (where the bound is false), so the theorem now assumes `2 ≤ n`, and the docstring records this.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.SnakeInTheBox` passes with no warnings.

Judgement call: the added `2 ≤ n` hypothesis is the minimal restriction making the stated bound true; the issue's separate coil-vs-snake scoping question is left untouched.

Fixes #5714
