### PR TITLE
fix(WrittenOnTheWallII/GraphConjecture32): average distances within A

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture32.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture32.lean
@@ -34,11 +34,13 @@ WOWII [Conjecture 32](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
 For a simple connected graph $G$,
 $\operatorname{path}(G) \ge \operatorname{dist}\_{\operatorname{avg}}(A) + 0.5 \cdot \operatorname{ecc}\_{\operatorname{avg}}(M)$,
-where $\operatorname{path}(G)$ is the floor of the average distance of $G$, $A$ is the
-set of minimum-degree vertices, $M$ is the set of maximum-degree vertices,
-$\operatorname{dist}\_{\operatorname{avg}}(A)$ is the average distance from all vertices
-to $A$, and $\operatorname{ecc}\_{\operatorname{avg}}(M)$ is the average eccentricity
-of the vertices in $M$.
+where $\operatorname{path}(G)$ is the number of vertices of a largest induced path of $G$,
+$A$ is the set of minimum-degree vertices, $M$ is the set of maximum-degree vertices,
+$\operatorname{dist}\_{\operatorname{avg}}(A)$ is the average of all nonzero distances
+$\operatorname{dist}\_G(u, v)$ with $u, v \in A$ (i.e. the average over ordered pairs of
+distinct vertices of $A$; it is taken to be $0$ when $A$ has fewer than two vertices), and
+$\operatorname{ecc}\_{\operatorname{avg}}(M)$ is the average eccentricity of the vertices
+in $M$.
 
 The conjecture is false, the authors present a counterexample: "The path on 5 vertices
 is a counterexample, path = 5, distavg(A) = 4 and the average of eccentricity of maximum
@@ -50,8 +52,9 @@ theorem conjecture32 : answer(False) ↔
       (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected),
       let A : Finset α := Finset.univ.filter (fun v => G.degree v = G.minDegree)
       let M : Finset α := Finset.univ.filter (fun v => G.degree v = G.maxDegree)
+      let distavgA : ℝ := (∑ p ∈ A.offDiag, (G.dist p.1 p.2 : ℝ)) / (A.offDiag.card : ℝ)
       let eccavg (S : Finset α) : ℝ := (∑ v ∈ S, (G.eccent v).toNat) / (S.card : ℝ)
-      distavg G A + (1 / 2 : ℝ) * eccavg M ≤ (path G : ℝ) := by
+      distavgA + (1 / 2 : ℝ) * eccavg M ≤ (path G : ℝ) := by
   sorry
 
 -- Sanity checks


### PR DESCRIPTION
`conjecture32` used `distavg G A` = `(1/|V|) · ∑_v min_{a ∈ A} d(v, a)`, the average distance from *all* vertices to the set `A` of minimum-degree vertices. The source's `distavg(A)` is the average of the nonzero distances `d(u, v)` between members `u, v ∈ A`. On the source's own counterexample `P₅` (with `A = {0, 4}`) the Lean inequality read `32/15 ≤ 5` (true) instead of the source's `16/3 ≤ 5` (false), so the `answer(False)` statement was misformalized.

**Change:** replace `distavg G A` by the average of `G.dist p.1 p.2` over `A.offDiag` (ordered pairs of distinct vertices of `A`; `0` by convention when `|A| < 2`). The docstring now spells out this definition and also corrects the description of `path(G)` (number of vertices of a largest induced path, not the floor of the average distance).

**Checked:** `lake --wfail build FormalConjectures.WrittenOnTheWallII.GraphConjecture32` passes with no warnings.

Note: averaging over ordered pairs equals averaging over unordered pairs since `d` is symmetric; ordered pairs (`offDiag`) avoid a `Sym2` detour.

Fixes #5719
