### PR TITLE
fix(Wikipedia/Sendov): the low-degree result covers degrees at most 8

### DIFF
--- a/FormalConjectures/Wikipedia/Sendov.lean
+++ b/FormalConjectures/Wikipedia/Sendov.lean
@@ -57,10 +57,10 @@ $$f(z)=(z-r_{1})\cdots (z-r_{n}),\qquad (n\geq 2)$$
 with all roots $r_1, ..., r_n$ inside the closed unit disk $|z| ≤ 1$, each of the $n$ roots is at a
 distance no more than $1$ from at least one critical point.
 
-It has been shown that Sendov's conjecture holds when the degree of $n$ is at most $9$.
+It has been shown that Sendov's conjecture holds when the degree $n$ is at most $8$.
 -/
 @[category research solved, AMS 12 30 52]
-theorem sendov_conjecture.variants.le_nine (n : ℕ) (hn : n ∈ Set.Icc 2 9) :
+theorem sendov_conjecture.variants.le_eight (n : ℕ) (hn : n ∈ Set.Icc 2 8) :
     n.SatisfiesSendovConjecture := by
   sorry
 


### PR DESCRIPTION
`sendov_conjecture.variants.le_nine` assumed `hn : n ∈ Set.Icc 2 9`, asserting Sendov's conjecture for polynomials of degree 2 through 9. The cited low-degree result (Brown–Xiang) establishes the conjecture only for degree `n < 9`, i.e. degrees 2 through 8; the docstring repeated the same off-by-one.

**Change:** tighten the hypothesis to `n ∈ Set.Icc 2 8`, rename the theorem to `sendov_conjecture.variants.le_eight`, and correct the docstring.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.Sendov` passes with no warnings.

Note: Sendov's conjecture is reportedly proved in full (Aug 2026; see PR #5560). This PR only corrects the low-degree variant and leaves the status of the main statement to that PR.

Fixes #5712
