### PR TITLE
fix(WrittenOnTheWallII/GraphConjecture34): average nonzero pair distances

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture34.lean
@@ -29,25 +29,34 @@ open SimpleGraph
 
 variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 
--- TODO: this statement is tagged `solved` but does not record the answer; determine it and
--- replace `answer(sorry)` with `answer(True)` or `answer(False)`.
-set_option linter.style.category_answer false in
 /--
 WOWII [Conjecture 34](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `path(G) ≥ ⌈dist_avg(C, V) + dist_avg(M, V)⌉`,
-where `path(G)` is the floor of the average distance of `G`, `C` is the set of center
-vertices (those with minimum eccentricity), `M` is the set of maximum-degree vertices,
-and `dist_avg(S, V)` is the average distance from all vertices to the set `S`.
+For a simple connected graph $G$,
+$\operatorname{path}(G) \ge \lceil \operatorname{dist}\_{\operatorname{avg}}(C, V)
++ \operatorname{dist}\_{\operatorname{avg}}(M, V) \rceil$,
+where $\operatorname{path}(G)$ is the number of vertices of a largest induced path of $G$,
+$C$ is the set of center vertices (those with minimum eccentricity), $M$ is the set of
+maximum-degree vertices, and $\operatorname{dist}\_{\operatorname{avg}}(S, V)$ is the average
+of all nonzero distances $\operatorname{dist}\_G(s, v)$ with $s \in S$ and $v \in V$.
+
+The conjecture is false. Let $G$ be the tree on $39$ vertices formed by a vertex with three
+pendant leaves, joined by a path of five edges to the root of a perfect binary tree of depth
+four. Then $\operatorname{path}(G) = 11$, while $C$ and $M$ are singletons whose distance sums
+are $154$ and $266$, so the bound is $\lceil (154 + 266) / 38 \rceil = 12$.
 -/
 @[category research solved, AMS 5]
 theorem conjecture34 :
-  answer(sorry) ↔
+  answer(False) ↔
     ∀ (α : Type) [Fintype α] [DecidableEq α] [Nontrivial α]
       (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected),
       let C : Set α := center G
       let M : Set α := {v | G.degree v = G.maxDegree}
-      Int.ceil (distavg G C + distavg G M) ≤ (path G : ℤ) := by
+      let distAvg (S : Set α) : ℝ :=
+        open scoped Classical in
+        let pairs := (S.toFinset ×ˢ Finset.univ).filter (fun p => G.dist p.1 p.2 ≠ 0)
+        (∑ p ∈ pairs, (G.dist p.1 p.2 : ℝ)) / pairs.card
+      Int.ceil (distAvg C + distAvg M) ≤ (path G : ℤ) := by
   sorry
 
 -- Sanity checks


### PR DESCRIPTION
`WrittenOnTheWallII.GraphConjecture34.conjecture34` bounded `path(G)` using `SimpleGraph.distavg G S`, the mean over all vertices `v` of the minimum distance from `v` to the set `S`, including the zero terms for `v ∈ S`. The source's `dist_avg(S, V)` is instead the average of all nonzero pairwise distances `d(s, v)` with `s ∈ S` and `v ∈ V` (the double distance sum divided by `|S|(|V| - 1)`).

**Change:** replace `distavg` by an inline `distAvg S` computing the average of the nonzero `G.dist s v` over `S × V`, for both the center set `C` and the maximum-degree set `M`. With the corrected quantity the statement is false: the tree on 39 vertices given by a vertex with three pendant leaves, joined by a path of five edges to the root of a perfect binary tree of depth four, has `path(G) = 11` while `C` and `M` are singletons with distance sums `154` and `266`, giving bound `⌈420/38⌉ = 12`. The theorem now records `answer(False)` (dropping the linter-suppressed `answer(sorry)`), with the counterexample documented in the docstring.

**Checked:** `lake --wfail build FormalConjectures.WrittenOnTheWallII.«GraphConjecture34»` passes with no warnings.

Judgement call: the WOWII source still lists this conjecture as open, but the counterexample above was verified against the corrected definition, so `answer(False)` is recorded. `GraphConjecture33` uses `distavg` with the same defect; that is left for a separate issue.

Fixes #5720
