### PR TITLE
fix(Wikipedia/LehmerMahlerMeasureProblem): add missing hypotheses

### DIFF
--- a/FormalConjectures/Wikipedia/LehmerMahlerMeasureProblem.lean
+++ b/FormalConjectures/Wikipedia/LehmerMahlerMeasureProblem.lean
@@ -57,10 +57,10 @@ theorem lehmer_mahler_measure_problem.variants.best (f : ℤ[X])
   sorry
 
 /--
-If $f$ is not reciprocal and $M(f) > 1$ then $M(f) \ge M(X^3 - X - 1)$.
+If $f$ is irreducible and not reciprocal and $M(f) > 1$ then $M(f) \ge M(X^3 - X - 1)$.
 -/
 @[category research solved, AMS 11]
-theorem lehmer_mahler_measure_problem.variants.not_reciprocal (f : ℤ[X])
+theorem lehmer_mahler_measure_problem.variants.not_reciprocal (f : ℤ[X]) (hi : Irreducible f)
     (hf : mahlerMeasureZ f > 1) (hf' : f.reverse ≠ f) :
     mahlerMeasureZ f ≥ mahlerMeasureZ (X^3 - X - 1) := by
   sorry
@@ -70,11 +70,12 @@ def Polynomial.HasOddCoeffs (f : Polynomial ℤ) : Prop :=
   ∀ i ≤ f.natDegree, Odd (f.coeff i)
 
 /--
-If all the coefficients of $f$ are odd and $M(f) > 1$, then $M(f) \ge M(X^2 - X - 1)$.
+If $f$ is not reciprocal, all the coefficients of $f$ are odd and $M(f) > 1$, then
+$M(f) \ge M(X^2 - X - 1)$.
 -/
 @[category research solved, AMS 11]
 theorem lehmer_mahler_measure_problem.variants.odd (f : ℤ[X])
-    (hf : mahlerMeasureZ f > 1) (hf' : f.HasOddCoeffs) :
+    (hf : mahlerMeasureZ f > 1) (hf' : f.reverse ≠ f) (hf'' : f.HasOddCoeffs) :
     mahlerMeasureZ f ≥ mahlerMeasureZ (X^2 - X - 1) := by
   sorry
 


### PR DESCRIPTION
Two solved variants were stated too strongly. `variants.not_reciprocal` bounded `M(f)` below by `M(X^3 - X - 1)` for every non-reciprocal `f` with `M(f) > 1`, but Smyth's theorem requires `f` irreducible (`X * lehmerPolynomial` is non-reciprocal with measure 1.176… < 1.324…). `variants.odd` bounded every odd-coefficient `f` with `M(f) > 1` by the golden ratio, but the source result requires `f` non-reciprocal (the reciprocal `X^6+X^5-X^4-X^3-X^2+X+1` has all-odd coefficients and measure 1.556… < 1.618…).

**Change:** add `(hi : Irreducible f)` to `variants.not_reciprocal` and `(hf' : f.reverse ≠ f)` to `variants.odd`; docstrings updated accordingly.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.LehmerMahlerMeasureProblem` passes with no warnings.

Fixes #5706
