### PR TITLE
fix(Wikipedia/Fermat): ask whether a non-squarefree Fermat number exists

### DIFF
--- a/FormalConjectures/Wikipedia/Fermat.lean
+++ b/FormalConjectures/Wikipedia/Fermat.lean
@@ -46,10 +46,10 @@ theorem infinite_fermat_composite : answer(sorry) ↔ Infinite {n : ℕ | ¬Prim
   sorry
 
 /--
-Are all Fermat numbers are square-free?
+Does a Fermat number exist that is not square-free?
 -/
 @[category research open, AMS 11]
-theorem all_fermat_squarefree : answer(sorry) ↔ ∀ n : ℕ, Squarefree n.fermatNumber := by
+theorem exists_fermat_not_squarefree : answer(sorry) ↔ ∃ n : ℕ, ¬Squarefree n.fermatNumber := by
   sorry
 
 end Fermat


### PR DESCRIPTION
`all_fermat_squarefree` stated `answer(sorry) ↔ ∀ n : ℕ, Squarefree n.fermatNumber`, i.e. "are all Fermat numbers square-free?". Wikipedia's open problem is the opposite question: "does a Fermat number exist that is not square-free?". Since `answer(sorry)` is filled in as a truth value, the Lean statement had its polarity reversed relative to the source (a `True` answer in Lean would mean a `False` answer to the source's question).

**Change:** restate as `answer(sorry) ↔ ∃ n : ℕ, ¬Squarefree n.fermatNumber`, rename the theorem to `exists_fermat_not_squarefree`, and fix the docstring (which also had a stray "are").

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.Fermat` passes with no warnings.

Fixes #5702
