### PR TITLE
fix(WrittenOnTheWallII/GraphConjecture23): average pairwise distances in M

### DIFF
--- a/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
+++ b/FormalConjectures/WrittenOnTheWallII/GraphConjecture23.lean
@@ -32,20 +32,20 @@ variable {α : Type*} [Fintype α] [DecidableEq α] [Nontrivial α]
 /--
 WOWII [Conjecture 23](http://cms.dt.uh.edu/faculty/delavinae/research/wowII/)
 
-For a simple connected graph `G`, `b(G) ≥ ⌊α(G) + dist_avg(M, V) / 2⌋`, where `b(G)` is
+For a simple connected graph `G`, `b(G) ≥ ⌊α(G) + dist_avg(M) / 2⌋`, where `b(G)` is
 the size of a largest induced bipartite subgraph, `α(G)` is the independence number,
-and `M` is the set of maximum-degree vertices, and `dist_avg(M, V)` is the average
-distance from all vertices to `M`.
+`M` is the set of maximum-degree vertices, and `dist_avg(M)` is the average distance
+between distinct vertices of `M`.
 
 This conjecture is false; there is a counterexample with `b(G) = 19`, `α(G) = 15`,
-and `dist_avg(M, V) = 10`.
+and `dist_avg(M) = 10`.
 -/
 @[category research solved, AMS 5]
 theorem conjecture23 : answer(False) ↔
   ∀ (α : Type) [Fintype α] [DecidableEq α] [Nontrivial α]
     (G : SimpleGraph α) [DecidableRel G.Adj] (h : G.Connected),
     let M : Set α := {v | G.degree v = G.maxDegree}
-    ⌊(G.indepNum : ℝ) + distavg G M / 2⌋ ≤ (b G : ℝ) := by
+    ⌊(G.indepNum : ℝ) + distAvgSet G M / 2⌋ ≤ (b G : ℝ) := by
   sorry
 
 -- Sanity checks

--- a/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
+++ b/FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean
@@ -95,6 +95,21 @@ noncomputable def distMaxSet (G : SimpleGraph α) (S : Set α) : ℕ :=
   let members := Finset.univ.filter (fun v : α => v ∈ S)
   (members ×ˢ members).sup (fun p => G.dist p.1 p.2)
 
+/-- The average distance between distinct vertices of a set `S`:
+$\operatorname{dist}_{\operatorname{avg}}(S)$ is the mean of $\operatorname{dist}_G(u, v)$ over
+all ordered pairs $(u, v)$ of distinct vertices of $S$. Returns `0` when $S$ contains fewer than
+two vertices.
+
+This is DeLaVina's `dist_avg(S)` invariant ("average distance between maximum degree
+vertices" when `S = M`), used in WOWII conjecture 23. It is distinct from `distavg`,
+which averages the distances from *all* vertices of `G` to the set. -/
+noncomputable def distAvgSet (G : SimpleGraph α) (S : Set α) : ℝ :=
+  open scoped Classical in
+  let pairs := (S.toFinset ×ˢ S.toFinset).filter (fun p => p.1 ≠ p.2)
+  if pairs.Nonempty then
+    (∑ p ∈ pairs, (G.dist p.1 p.2 : ℝ)) / (pairs.card : ℝ)
+  else 0
+
 /-- Average distance from all vertices to a given set. -/
 noncomputable def distavg (G : SimpleGraph α) (S : Set α) : ℝ :=
   if Fintype.card α > 0 then


### PR DESCRIPTION
`conjecture23` used `distavg G M`, which is the average over *all* vertices `v` of `G` of the distance from `v` to the set `M` of maximum-degree vertices. WOWII's `dist_avg(M)` is instead the average distance between distinct vertices both lying in `M`. The two inequalities are genuinely different (the audit gives a graph where the source's inequality fails but the Lean one holds).

**Change:** add `SimpleGraph.distAvgSet G S : ℝ` to `FormalConjecturesForMathlib/Combinatorics/SimpleGraph/VertexDistance.lean` — the mean of `G.dist u v` over ordered pairs `(u, v)` of distinct vertices of `S`, defaulting to `0` when `S` has fewer than two vertices — and restate `conjecture23` with `distAvgSet G M`; docstrings updated. The existing `distavg` (vertex-to-set average) is left untouched since other conjectures use it.

**Checked:** `lake --wfail build FormalConjectures.WrittenOnTheWallII.GraphConjecture23` passes with no warnings.

Note for reviewers: the same "average distance within a set" notion is defined by a local `let` in the fix for #5719; if both land, that one could be switched to `distAvgSet`.

Fixes #5718
