### PR TITLE
fix(ErdosProblems/918): assume GCH in the Erdős–Hajnal ℵ_k variant

### DIFF
--- a/FormalConjectures/ErdosProblems/918.lean
+++ b/FormalConjectures/ErdosProblems/918.lean
@@ -44,7 +44,7 @@ theorem erdos_918.parts.i :
 every subgraph on $\aleph_\omega$ vertices has chromatic number $\leq\aleph_0$? -/
 -- Formalisation note: `ω` here is `Ordinal.omega0`, from `open scoped Ordinal`, as in 623.lean.
 -- It is the fixed first infinite ordinal, not a variable: `variants.erdos_hajnal` settles every
--- finite `k`, and `ℵ_ω` is the limit of that family, so this asks the single next case.
+-- finite `k` under GCH, and `ℵ_ω` is the limit of that family, so this asks the single next case.
 @[category research open, AMS 5]
 theorem erdos_918.parts.ii :
     answer(sorry) ↔
@@ -75,13 +75,16 @@ theorem erdos_918.variants.all_subgraphs.parts.ii :
       ∀ (H : G.Subgraph) (_ : #H.verts = ℵ_ ω), H.coe.chromaticCardinal ≤ ℵ₀ := by
   sorry
 
-/-- A question of Erd\H{o}s and Hajnal [ErHa68b], who proved that for every finite $k$
-there is a graph with chromatic number $\aleph_1$ and $\aleph_k$ vertices where each subgraph on
-less than $\aleph_k$ vertices has chromatic number $\leq \aleph_0$. -/
+/-- A question of Erd\H{o}s and Hajnal [ErHa68b], who proved, assuming the generalized continuum
+hypothesis, that for every finite $k \geq 1$ there is a graph with chromatic number $\aleph_1$ and
+$\aleph_k$ vertices where each subgraph on less than $\aleph_k$ vertices has chromatic number
+$\leq \aleph_0$. -/
 -- Formalisation note: the source is missing the assumption that the graph have ℵₖ vertices
--- which can be found in [ErHa68b]
+-- which can be found in [ErHa68b, Corollary 1]. That corollary assumes the generalized continuum
+-- hypothesis, stated here as `2 ^ c = Order.succ c` for every infinite cardinal `c`.
 @[category research solved, AMS 5]
-theorem erdos_918.variants.erdos_hajnal (k : ℕ) (hk : 0 < k) : ∃ (V : Type u) (G : SimpleGraph V),
+theorem erdos_918.variants.erdos_hajnal (hGCH : ∀ c : Cardinal.{u}, ℵ₀ ≤ c → 2 ^ c = Order.succ c)
+    (k : ℕ) (hk : 0 < k) : ∃ (V : Type u) (G : SimpleGraph V),
     #V = ℵ_ k ∧ G.chromaticCardinal = ℵ₁ ∧
       ∀ (W : Set V) (_ : #W < ℵ_ k), (G.induce W).chromaticCardinal ≤ ℵ₀ := by
   sorry


### PR DESCRIPTION
`erdos_918.variants.erdos_hajnal` asserted, for every finite `k ≥ 1` and with no further hypothesis, a graph on `ℵ_ k` vertices with chromatic number `ℵ₁` whose induced subgraphs on fewer than `ℵ_ k` vertices have chromatic number `≤ ℵ₀`. In [ErHa68b] this is Corollary 1 (p. 86), which is stated and proved under the generalized continuum hypothesis. The unconditional result (Theorem 2) has `exp_{k-1}(ℵ₀)⁺` vertices, not `ℵ_k`.

**Change.** Add the hypothesis `hGCH : ∀ c : Cardinal.{u}, ℵ₀ ≤ c → 2 ^ c = Order.succ c` to `erdos_918.variants.erdos_hajnal`, and update its docstring and the formalisation note so statement, docstring and source agree. The category stays `research solved`. No other statement in the file changes.

**Checked.** `lake --wfail build 'FormalConjectures.ErdosProblems.«918»'` builds without warnings.

Fixes #5674
