### PR TITLE
fix(Wikipedia/InscribedSquare): require smooth embeddings, excluding cusps

### DIFF
--- a/FormalConjectures/Wikipedia/InscribedSquare.lean
+++ b/FormalConjectures/Wikipedia/InscribedSquare.lean
@@ -76,19 +76,23 @@ theorem exists_inscribed_rectangle (γ : Circle → ℝ²) (hγ : IsEmbedding γ
 
 /--
 It is known that every *smooth* Jordan curve admits inscribed rectangles of all aspect ratios.
+Here a smooth Jordan curve is a smooth embedding of the circle into the plane, i.e. a smooth
+simple closed curve with nowhere vanishing velocity.
 -/
 @[category research solved, AMS 51]
 theorem exists_inscribed_rectangle_of_smooth (γ : Circle → ℝ²)
-    (hγ : IsEmbedding γ) (hγ' : ContMDiff (𝓡 1) (𝓡 2) ∞ γ) (r : ℝ) (hr : r > 0) :
+    (hγ : IsSmoothEmbedding (𝓡 1) (𝓡 2) ∞ γ) (r : ℝ) (hr : r > 0) :
     ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) r := by
   sorry
 
 /--
 It is also known that every $C^2$ Jordan curve admits an inscribed square.
+Here a $C^2$ Jordan curve is a $C^2$ embedding of the circle into the plane, i.e. a $C^2$
+simple closed curve with nowhere vanishing velocity.
 -/
 @[category research solved, AMS 51]
 theorem exists_inscribed_square_of_C2 (γ : Circle → ℝ²)
-    (hγ : IsEmbedding γ) (hγ' : ContMDiff (𝓡 1) (𝓡 2) 2 γ) :
+    (hγ : IsSmoothEmbedding (𝓡 1) (𝓡 2) 2 γ) :
     ∃ t₁ t₂ t₃ t₄, IsRectangle (γ t₁) (γ t₂) (γ t₃) (γ t₄) 1 := by
   sorry
 


### PR DESCRIPTION
`exists_inscribed_rectangle_of_smooth` and `exists_inscribed_square_of_C2` assumed only `IsEmbedding γ` together with `ContMDiff (𝓡 1) (𝓡 2) n γ`. That combination still allows curves whose velocity vanishes somewhere, e.g. the cusp `γ(z) = (Re z, (Im z)^3)`, whereas the cited results (inscribed rectangles of every aspect ratio in smooth Jordan curves; inscribed squares in C² Jordan curves) are about *regular* curves, i.e. embeddings with nowhere vanishing derivative. Both theorems therefore quantified over singular curves outside the scope of the sources.

**Change:** replace the two hypotheses `IsEmbedding γ` / `ContMDiff … γ` by the single Mathlib predicate `IsSmoothEmbedding (𝓡 1) (𝓡 2) ∞ γ` (resp. `… 2 γ`), which bundles the topological embedding with an injective differential at every point, and add a sentence to each docstring explaining that this is what "smooth / C² Jordan curve" means here.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.InscribedSquare` passes with no warnings.

Fixes #5704
