### PR TITLE
fix(Wikipedia/Fuglede): dim_3_or_higher fails in every dimension n ≥ 3

### DIFF
--- a/FormalConjectures/Wikipedia/Fuglede.lean
+++ b/FormalConjectures/Wikipedia/Fuglede.lean
@@ -52,12 +52,14 @@ theorem FugledeConjecture.variants.dim_2 :
   sorry
 
 /--
-**Fuglede's conjecture** in three or higher dimensions has been disproven.
+**Fuglede's conjecture** fails in every dimension `n ≥ 3`: for each such `n` there is a bounded
+subset of ℝ^n with positive Lebesgue measure that is spectral but does not tile ℝ^n by translation,
+or that tiles ℝ^n by translation but is not spectral.
 (Note that counterexamples in lower dimensions would also disprove the conjecture in higher dimensions.)
 -/
 @[category research solved, AMS 42 46 47]
-theorem FugledeConjecture.variants.dim_3_or_higher :
-    answer(False) ↔ ∀ n : ℕ, 3 ≤ n → FugledeConjectureFor n := by
+theorem FugledeConjecture.variants.dim_3_or_higher (n : ℕ) (hn : 3 ≤ n) :
+    ¬ FugledeConjectureFor n := by
   sorry
 
 end Fuglede


### PR DESCRIPTION
`FugledeConjecture.variants.dim_3_or_higher` stated `answer(False) ↔ ∀ n : ℕ, 3 ≤ n → FugledeConjectureFor n`. Unfolding the `answer(False)`, this is `∃ n ≥ 3, ¬ FugledeConjectureFor n`, i.e. failure in *some* dimension, witnessed by a single counterexample. The source (Tao's counterexample in dimension 5, later pushed down to dimension 3, with counterexamples lifting to higher dimensions) says the conjecture fails in *every* dimension `n ≥ 3`.

**Change:** restate as `theorem ... (n : ℕ) (hn : 3 ≤ n) : ¬ FugledeConjectureFor n`, and expand the docstring to spell out what "fails" means (a bounded positive-measure set that is spectral but not a translational tile, or vice versa).

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.Fuglede` passes with no warnings.

Fixes #5703
