### PR TITLE
fix(Wikipedia/MeanValueProblem): put Tischler hypotheses on p(X+z)-p(z)

### DIFF
--- a/FormalConjectures/Wikipedia/MeanValueProblem.lean
+++ b/FormalConjectures/Wikipedia/MeanValueProblem.lean
@@ -32,7 +32,8 @@ The conjecture has been proven for:
 * `K = 4`
   [The fundamental theorem of algebra and complexity theory](https://www.ams.org/journals/bull/1981-04-01/S0273-0979-1981-14858-8/)
   by *Steve Smale*
-* `K = (d-1)/d` if $p$ has real roots or all the roots of $p$ have the same norm.
+* `K = (d-1)/d` at a point $z$ if the normalised polynomial $p(X + z) - p(z)$ has only real
+  roots, or if all its nonzero roots have the same norm.
   [Critical points and values of complex polynomials](https://doi.org/10.1016/0885-064X(89)90019-8)
   by *David Tischler*
 -/
@@ -61,27 +62,32 @@ lemma mean_value_problem_leq_4 (p : Polynomial ℂ) (hp : 2 ≤ p.degree) (z : �
   sorry
 
 /--
-The following tighter bound depending on the degree $d$ of the polynomial $p$,
-in the case of $p$ only having real roots has been shown by Tischler.
-$|p(z)-p(c)|/|z-c| \le (d-1)/d \cdot |p'(z)|$
+The following tighter bound depending on the degree $d$ of the polynomial $p$ has been shown by
+Tischler. Let $z$ be a complex number such that the normalised polynomial $p(X + z) - p(z)$ has
+only real roots, i.e. every $x$ with $p(x) = p(z)$ satisfies
+$\operatorname{Im} x = \operatorname{Im} z$. Then there is a critical point $c$ of $p$ such that
+$|p(z)-p(c)|/|z-c| \le (d-1)/d \cdot |p'(z)|$.
 -/
 
 @[category research solved, AMS 12]
-lemma mean_value_problem_of_real_roots (p : Polynomial ℂ) (hp : 2 ≤ p.natDegree)
-    (h : ∀ x : ℂ, p.IsRoot x → x.im = 0) (z : ℂ) (K : ℝ) :
+lemma mean_value_problem_of_real_roots (p : Polynomial ℂ) (hp : 2 ≤ p.natDegree) (z : ℂ)
+    (h : ∀ x : ℂ, p.eval x = p.eval z → x.im = z.im) (K : ℝ) :
     ∃ c : ℂ, p.derivative.eval c = 0 ∧
       ‖p.eval z - p.eval c‖ / ‖z - c‖ ≤ (p.natDegree - 1)/ p.natDegree * ‖p.derivative.eval z‖ := by
   sorry
 
 /--
-The following tighter bound depending on the degree $d$ of the polynomial $p$,
-in the case of $p$ all roots having the same norm has been shown by Tischler.
+The following tighter bound depending on the degree $d$ of the polynomial $p$ has been shown by
+Tischler. Let $z$ be a complex number such that all nonzero roots of the normalised polynomial
+$p(X + z) - p(z)$ have the same norm, i.e. all $x \ne z$ with $p(x) = p(z)$ have the same
+distance to $z$. Then there is a critical point $c$ of $p$ such that
 $|p(z) - p(c)|/|z-c| \le (d-1)/d \cdot |p'(z)|$.
 -/
 
 @[category research solved, AMS 12]
-lemma mean_value_problem_of_roots_same_norm (p : Polynomial ℂ) (hp : 2 ≤ p.natDegree)
-    (h : ∀ x y : ℂ, p.IsRoot x ∧ p.IsRoot y → ‖x‖=‖y‖) (z : ℂ) (K : ℝ) :
+lemma mean_value_problem_of_roots_same_norm (p : Polynomial ℂ) (hp : 2 ≤ p.natDegree) (z : ℂ)
+    (h : ∀ x y : ℂ, p.eval x = p.eval z → p.eval y = p.eval z → x ≠ z → y ≠ z →
+      ‖x - z‖ = ‖y - z‖) (K : ℝ) :
     ∃ c : ℂ, p.derivative.eval c = 0 ∧
       ‖p.eval z - p.eval c‖ / ‖z - c‖ ≤ (p.natDegree - 1)/ p.natDegree * ‖p.derivative.eval z‖ := by
   sorry


### PR DESCRIPTION
`MeanValueProblem.mean_value_problem_of_real_roots` and `mean_value_problem_of_roots_same_norm` placed the real-root and equal-norm hypotheses on the roots of `p` itself, while concluding the `(d-1)/d` bound at every point `z`. Tischler's special cases instead place these conditions on the (nonzero) roots of the normalised polynomial `p(X + z) - p(z)`. For example `X^3 - X` has only real roots but violates Tischler's condition at `z = 2i`, and fails the old equal-norm hypothesis at `z = 0` although its nonzero roots `±1` have equal norm.

**Change:** transport both hypotheses to `p(X + z) - p(z)`, phrased in terms of the points `x` with `p.eval x = p.eval z`: the real-roots lemma now assumes every such `x` has `x.im = z.im`, and the same-norm lemma assumes all such `x ≠ z` have the same `‖x - z‖`. `z` is moved before the hypothesis so it can be referenced. The module docstring and both lemma docstrings are updated to describe the corrected special cases.

**Checked:** `lake --wfail build FormalConjectures.Wikipedia.MeanValueProblem` passes with no warnings.

Fixes #5708
