### PR TITLE
fix(OEIS/55487): conclude the prime p exists instead of assuming it

### DIFF
--- a/FormalConjectures/OEIS/55487.lean
+++ b/FormalConjectures/OEIS/55487.lean
@@ -62,13 +62,12 @@ Conjecture: unless $n! + 1$ is prime (i.e., $n \in \text{A002981}$), $a(n) = p q
 least prime $> \sqrt{n!}$ such that $(p - 1) \mid n!$ and $q = \frac{n!}{p - 1} + 1$ is prime.
 - M. F. Hasler, Oct 04 2009
 
-We assume $a(n) \ne 0$ and $(p(n)).\text{Prime}$ to ensure the `sInf` searches are non-empty
-and do not collapse to $0 = 0$.
+The conclusion $(p(n)).\text{Prime}$ asserts that such a prime $p$ exists: if no prime satisfies
+the search conditions then `p n` is `sInf ∅ = 0`, which is not prime.
 -/
 @[category research open, AMS 11]
-theorem conjecture (n : ℕ) (hn : 1 ≤ n) (h_not_prime : ¬ isFactorialPrime n)
-    (ha : a n ≠ 0) (hp : (p n).Prime) :
-    a n = p n * q n := by
+theorem conjecture (n : ℕ) (hn : 1 ≤ n) (h_not_prime : ¬ isFactorialPrime n) :
+    (p n).Prime ∧ a n = p n * q n := by
   sorry
 
 end OeisA55487


### PR DESCRIPTION
`OeisA55487.conjecture` assumed `hp : (p n).Prime` (and `ha : a n ≠ 0`) and concluded only `a n = p n * q n`. So for any non-factorial-prime `n` where no prime `p > √n!` with `(p - 1) ∣ n!` and `n!/(p-1) + 1` prime exists, the statement was vacuous. Hasler's conjecture (OEIS A055487 comments) asserts that for every such `n ≥ 1` the prime pair *exists* and `a(n) = p q`.

**Change:** drop `ha` and `hp`; the conclusion becomes `(p n).Prime ∧ a n = p n * q n`. Existence is encoded by `(p n).Prime`, since `p n = sInf ∅ = 0` when no such prime exists and `0` is not prime. `ha` is redundant: `a n = p n * q n` with `p n` prime and `q n ≥ 1` forces `a n ≠ 0`.

**Checked:** `lake --wfail build FormalConjectures.OEIS.«55487»` passes with no warnings.

Fixes #5694
