### PR TITLE
fix(OEIS/109905): align the answer polarity with the source question

### DIFF
--- a/FormalConjectures/OEIS/109905.lean
+++ b/FormalConjectures/OEIS/109905.lean
@@ -58,7 +58,8 @@ theorem a_5 : a 5 = 7 := by decide
 $a(n) = 0$ for $n = 1$, $6$, $30$ and $54$. Are there any others?
 -/
 @[category research open, AMS 11]
-theorem conjecture : answer(sorry) ↔ {n : ℕ | n > 0 ∧ a n = 0} = {1, 6, 30, 54} := by
+theorem conjecture :
+    answer(sorry) ↔ ∃ n : ℕ, n > 0 ∧ a n = 0 ∧ n ∉ ({1, 6, 30, 54} : Finset ℕ) := by
   sorry
 
 end OeisA109905


### PR DESCRIPTION
`OeisA109905.conjecture` stated `answer(sorry) ↔ {n | n > 0 ∧ a n = 0} = {1, 6, 30, 54}`, so `answer(True)` would mean there is *no* further zero. The OEIS entry asks "a(n) = 0 for n = 1, 6, 30 and 54. Are there any others?", i.e. `answer(True)` should mean another zero *exists*. The Lean right-hand side was the negation of the source proposition.

**Change:** restate the right-hand side as `∃ n : ℕ, n > 0 ∧ a n = 0 ∧ n ∉ ({1, 6, 30, 54} : Finset ℕ)` so the yes/no polarity matches the question.

**Checked:** `lake --wfail build FormalConjectures.OEIS.«109905»` passes with no warnings.

Fixes #5689
