### PR TITLE
fix(OEIS/113213): require the prime pair 2^n ± m to eventually exist

### DIFF
--- a/FormalConjectures/OEIS/113213.lean
+++ b/FormalConjectures/OEIS/113213.lean
@@ -54,9 +54,14 @@ theorem a_5 : a 5 = 9 := by decide
 
 /--
 Conjecture: $a(n) = O(n^3)$.
+
+The source defines $a(n)$ as the least $m$ with $2^n - m$ and $2^n + m$ prime, so it
+implicitly asserts that such an $m$ exists. Since `a n = 0` when no such $m$ exists, the
+existence of a prime pair is stated explicitly for all sufficiently large $n$.
 -/
 @[category research open, AMS 11]
 theorem conjecture :
+    (∀ᶠ n : ℕ in Filter.atTop, ∃ m, (2 ^ n - m).Prime ∧ (2 ^ n + m).Prime) ∧
     (fun n : ℕ => (a n : ℝ)) =O[Filter.atTop] (fun n : ℕ => (n ^ 3 : ℝ)) := by
   sorry
 


### PR DESCRIPTION
`a n` is computed as `s.headD 0`, so it is `0` whenever no `m` with `2^n - m` and `2^n + m` both prime exists. The bare statement `a n = O(n^3)` was therefore equivalent to "for large `n`, either no prime pair exists or some witness is `≤ C·n^3`"; it would hold vacuously if prime pairs stopped existing. The source's `a(n) = O(n^3)` presumes `a(n)` is the least such `m`, i.e. it asserts that for all large `n` a prime pair exists with a witness bounded by `C·n^3`.

**Change:** conjoin `∀ᶠ n in atTop, ∃ m, (2 ^ n - m).Prime ∧ (2 ^ n + m).Prime` before the `=O[atTop]` bound, and document the fallback in the docstring.

**Checked:** `lake --wfail build FormalConjectures.OEIS.«113213»` passes with no warnings.

Note: existence is stated eventually rather than for all `n` since `a 1 = 0` (no pair for `n = 1`), matching the asymptotic nature of the claim.

Fixes #5690
