### PR TITLE
fix(OEIS/38552): compare odd and even fundamental discriminants, not radicands

### DIFF
--- a/FormalConjectures/OEIS/38552.lean
+++ b/FormalConjectures/OEIS/38552.lean
@@ -26,8 +26,9 @@ The conjectures state that:
 2. This is also the largest absolute value of negative fundamental discriminant $d$ for
    class number $n$.
 3. For even $n$, if $k$ is the largest odd number with $h(-k) = n$ and $k'$ is the largest
-   even number with $h(-k') = n$, then $k > k'$. The $n$-th term is the larger of $k$ and
-   $k'$, so this says that the $n$-th term is odd. Conjecture 1 implies it.
+   even number with $h(-k') = n$, then $k > k'$. Here $h(D)$ is the class number of the
+   quadratic field with discriminant $D$, so $k$ and $k'$ are absolute values of negative
+   fundamental discriminants, not radicands. The source states conjecture 2 in this form.
 
 The squarefree condition in the definition is needed for the maximum to exist, since
 $\mathbb{Q}(\sqrt{-k}) = \mathbb{Q}(\sqrt{-4k})$.
@@ -119,10 +120,15 @@ theorem isA038552_eq_largestNegFundDisc {n k : ℕ} (h : IsA038552 n k) :
     IsLargestNegFundDiscrForClassNumber (n := n) k := by
   sorry
 
-/-- For even class number $n$, the $n$-th term of A038552 is odd. The source states this as:
-the largest odd squarefree $k$ with $h(-k) = n$ is greater than the largest even one. -/
+/-- For even class number $n$, let $k$ be the largest odd number such that the quadratic field
+with discriminant $-k$ has class number $n$, and let $k'$ be the largest even such number, when
+they exist. Then $k > k'$. -/
 @[category research open, AMS 11]
-theorem odd_of_isA038552 {n k : ℕ} (hn : Even n) (h : IsA038552 n k) : Odd k := by
+theorem largestEven_lt_largestOdd_negFundDisc {n k k' : ℕ} (hn : Even n)
+    (hk : IsGreatest {m : ℕ | Odd m ∧ IsFundamentalDiscr (-m : ℤ) ∧
+      classNumberOfDiscriminant (-m : ℤ) = n} k)
+    (hk' : IsGreatest {m : ℕ | Even m ∧ IsFundamentalDiscr (-m : ℤ) ∧
+      classNumberOfDiscriminant (-m : ℤ) = n} k') : k' < k := by
   sorry
 
 end OeisA38552


### PR DESCRIPTION
`OeisA38552.odd_of_isA038552` asserted that for even class number `n` the largest squarefree *radicand* `k` with `IsA038552 n k` is odd. The OEIS comment says something different: the largest odd `k` with `h(-k) = n` is greater than the largest even `k'` with `h(-k') = n`, where `k`, `k'` range over absolute values of negative *fundamental discriminants*. Radicand parity and discriminant parity do not match (a radicand `r ≡ 1 (mod 4)` such as 5 has even discriminant `-4r`; an even radicand gives magnitude `4r`, not `r`), so the Lean statement was not the source's claim.

**Change:** replace `odd_of_isA038552` by `largestEven_lt_largestOdd_negFundDisc`: for even `n`, if `k` is `IsGreatest` among odd `m` with `IsFundamentalDiscr (-m)` and `classNumberOfDiscriminant (-m) = n`, and `k'` is `IsGreatest` among the even such `m`, then `k' < k`. This reuses the file's existing `IsFundamentalDiscr` / `classNumberOfDiscriminant`. The module docstring's item 3 is corrected accordingly (it previously claimed the statement was about the parity of the `n`-th term and followed from conjecture 1).

**Checked:** `lake --wfail build FormalConjectures.OEIS.«38552»` passes with no warnings.

Fixes #5692
