### PR TITLE
fix(ForMathlib/NumberTheory/NormalNumber): define normality via digit blocks

### DIFF
--- a/FormalConjectures/Wikipedia/AlgebraicNormality.lean
+++ b/FormalConjectures/Wikipedia/AlgebraicNormality.lean
@@ -20,6 +20,8 @@ import FormalConjecturesUtil
 # Normality of Irrational Algebraic Numbers
 
 It is unknown whether every irrational algebraic real number is normal in any integer base.
+Here a real number is *normal in base* $b$ if, for every $k \ge 1$, every string of $k$ digits
+appears in its base-$b$ expansion with asymptotic frequency $1/b^k$.
 The stronger conjecture that every irrational algebraic real number is absolutely normal is stated
 separately: normality in one base and normality in every base are not equivalent definitions.
 

--- a/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
+++ b/FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean
@@ -21,9 +21,10 @@ public import Mathlib.Topology.MetricSpace.Pseudo.Defs
 /-!
 # Normal numbers
 
-A real number $x$ is *normal in base* $b$ if every digit
+A real number $x$ is *simply normal in base* $b$ if every digit
 $d \in \{0,1,\dots,b-1\}$ appears with asymptotic frequency $1/b$
-in the base-$b$ expansion of $x$.
+in the base-$b$ expansion of $x$. It is *normal in base* $b$ if, for every
+$k \ge 1$, every string of $k$ digits appears with asymptotic frequency $1/b^k$.
 
 A number that is normal in every integer base $b \ge 2$
 is called *absolutely normal*.
@@ -38,6 +39,7 @@ classical constants such as $\pi$, $e$, or $\sqrt{2}$ are normal in any base.
 ## Main definitions
 
 * `digitSeq`: the sequence of digits in the base-`b` fractional expansion of a real number.
+* `IsSimplyNormalInBase`: a real number is simply normal in base `b`.
 * `IsNormalInBase`: a real number is normal in base `b`.
 * `IsAbsolutelyNormal`: a real number is normal in every base `b ≥ 2`.
 -/
@@ -57,16 +59,34 @@ where `{x}` denotes the fractional part of `x`. -/
 noncomputable def digitSeq (b : ℕ) (x : ℝ) (n : ℕ) : ℕ :=
   ⌊(b : ℝ) ^ (n + 1) * Int.fract x⌋₊ % b
 
-/-- A real number `x` is *normal in base* `b`
+/-- A real number `x` is *simply normal in base* `b`
 if every digit `d < b` appears with asymptotic frequency `1 / b`
 in the base-`b` fractional expansion of `x`. -/
-noncomputable def IsNormalInBase (b : ℕ) (x : ℝ) : Prop :=
+noncomputable def IsSimplyNormalInBase (b : ℕ) (x : ℝ) : Prop :=
   ∀ d : ℕ, d < b →
     Tendsto
       (fun n : ℕ =>
         (((Finset.range n).filter (fun k => digitSeq b x k = d)).card : ℝ) / n)
       atTop
       (nhds (1 / (b : ℝ)))
+
+/-- A real number `x` is *normal in base* `b`
+if every string `w` of `k` digits `< b` appears with asymptotic frequency `1 / b ^ k`
+in the base-`b` fractional expansion of `x`, that is, the proportion of positions `i < n`
+at which `w` occurs tends to `1 / b ^ k`. -/
+noncomputable def IsNormalInBase (b : ℕ) (x : ℝ) : Prop :=
+  ∀ (k : ℕ) (w : Fin k → ℕ), (∀ j, w j < b) →
+    Tendsto
+      (fun n : ℕ =>
+        (((Finset.range n).filter (fun i => ∀ j : Fin k, digitSeq b x (i + j) = w j)).card : ℝ) / n)
+      atTop
+      (nhds (1 / (b : ℝ) ^ k))
+
+/-- A number that is normal in base `b` is simply normal in base `b`. -/
+theorem IsNormalInBase.isSimplyNormalInBase {b : ℕ} {x : ℝ} (h : IsNormalInBase b x) :
+    IsSimplyNormalInBase b x := by
+  intro d hd
+  simpa [Fin.forall_fin_one] using h 1 (fun _ => d) (fun _ => hd)
 
 /-- A real number `x` is *absolutely normal*
 if it is normal in every integer base `b ≥ 2`. -/


### PR DESCRIPTION
`NormalNumber.IsNormalInBase b x` (in `FormalConjecturesForMathlib/NumberTheory/NormalNumber.lean`) only required each single digit `d < b` to appear in the base-`b` expansion with limiting frequency `1/b`. That is *simple* normality (satisfied, for instance, by `1/3` in base 2), not normality, which requires every block of `k` digits to occur with limiting frequency `1/b^k` for every `k ≥ 1`. As a result `AlgebraicNormality.irrational_algebraic_normal_in_some_base` and `NormalNumber.pi_normal_base_ten` (and, through `IsAbsolutelyNormal`, the absolute-normality statement) asserted only simple normality where the sources conjecture normality.

**Change:** rename the existing predicate to `IsSimplyNormalInBase`, and define `IsNormalInBase b x` as: for every `k` and every word `w : Fin k → ℕ` of digits `< b`, the proportion of positions `i < n` at which `w` occurs in `digitSeq b x` tends to `1 / b ^ k`. Add `IsNormalInBase.isSimplyNormalInBase` (the `k = 1` case). `IsAbsolutelyNormal`, `AlgebraicNormality` and `NormalityOfPi` pick up the corrected notion unchanged; module docstrings are updated to state both notions.

**Checked:** `lake --wfail build FormalConjecturesForMathlib.NumberTheory.NormalNumber FormalConjectures.Wikipedia.AlgebraicNormality FormalConjectures.Wikipedia.NormalityOfPi` passes with no warnings.

Judgement call: the old predicate is kept under the name `IsSimplyNormalInBase` rather than deleted, since simple normality is a standard notion in its own right.

Fixes #5700, fixes #5710
