### PR TITLE
fix(LittProblems/1): require the ODE denominator to be nonzero at the solution

### DIFF
--- a/FormalConjectures/LittProblems/1.lean
+++ b/FormalConjectures/LittProblems/1.lean
@@ -53,16 +53,19 @@ namespace LamLitt
 
 /--
 A power series $f$ is a solution of an algebraic ODE defined by the rational function
-$g \in \mathbb{Q}(z, y_0, \dots, y_{n-1})$ if $f^{(n)}(z) = g(z, f(z), f'(z), \dots, f^{(n-1)}(z))$.
+$g \in \mathbb{Q}(z, y_0, \dots, y_{n-1})$ if $f^{(n)}(z) = g(z, f(z), f'(z), \dots, f^{(n-1)}(z))$
+and $g(0, f(0), f'(0), \dots, f^{(n-1)}(0))$ is defined. Concretely, $g = p / q$ for polynomials
+$p, q$ with $q(0, f(0), \dots, f^{(n-1)}(0)) \neq 0$, so that $q(z, f(z), \dots, f^{(n-1)}(z))$
+is an invertible power series, and
+$f^{(n)}(z) \cdot q(z, f(z), \dots, f^{(n-1)}(z)) = p(z, f(z), \dots, f^{(n-1)}(z))$.
 The variable indexed by `0 : Fin (n + 1)` corresponds to $z$, and the variable indexed by
 `i.succ` corresponds to $y_i = f^{(i)}(z)$.
 -/
 def IsSolutionOfAlgebraicODE (n : ℕ) (f : PowerSeries ℚ) (g : MvRatFunc (Fin (n + 1)) ℚ) : Prop :=
   let pt : Fin (n + 1) → PowerSeries ℚ := Fin.cases X (fun i : Fin n ↦ (derivative ℚ)^[i.val] f)
   ∃ p q : MvPolynomial (Fin (n + 1)) ℚ,
-    q ≠ 0 ∧
     g = (algebraMap _ _ p) / (algebraMap _ _ q) ∧
-    IsDefined (Fin (n + 1)) ℚ g (PowerSeries.constantCoeff ∘ pt) ∧
+    q.eval (PowerSeries.constantCoeff ∘ pt) ≠ 0 ∧
     (derivative ℚ)^[n] f * MvPolynomial.aeval pt q = MvPolynomial.aeval pt p
 
 def ℤAdjoinInvNat (N : ℕ) : Subalgebra ℤ ℚ := Algebra.adjoin ℤ {(1 / N : ℚ)}


### PR DESCRIPTION
`LamLitt.IsSolutionOfAlgebraicODE` required only `q ≠ 0` and took regularity of `g` at the initial point from `IsDefined`, which picks its *own* numerator/denominator representation unrelated to the witnesses `p, q`. Consequently, whenever `aeval pt q = 0` the cleared equation `f⁽ⁿ⁾ · q(pt) = p(pt)` held trivially (both sides `0`), so e.g. `X` was a "solution" of `f' = 0`, and `variants.integrality_implies_algebraicity` became false for the non-algebraic series `Σ binom(2k,k)² zᵏ/16ᵏ`. The source's ODE `f⁽ⁿ⁾ = g(z, f, …, f⁽ⁿ⁻¹⁾)` has a denominator that is nonzero along the solution.

**Change:** replace `q ≠ 0 ∧ … ∧ IsDefined … g (constantCoeff ∘ pt)` by `q.eval (constantCoeff ∘ pt) ≠ 0` for the *same* `p, q` that represent `g`. Then `q(z, f, …, f⁽ⁿ⁻¹⁾)` is an invertible power series, so the cleared equation is genuinely equivalent to `f⁽ⁿ⁾ = g(z, f, …)`. (`q ≠ 0` is implied.) Docstring expanded to spell this out.

**Checked:** `lake --wfail build FormalConjectures.LittProblems.«1»` passes with no warnings.

Fixes #5686
