### PR TITLE
fix(OEIS/103662): conjecture only that some exponent has no zeroless power

### DIFF
--- a/FormalConjectures/OEIS/103662.lean
+++ b/FormalConjectures/OEIS/103662.lean
@@ -77,11 +77,11 @@ theorem a_3 : a 3 = 8 := by
 
 /--
 For statistical reasons it is conjectured that the sequence is finite.
-This is formalized as the assertion that for large enough $n$, no valid zeroless power exists,
-which in our definition results in $a(n) = 0$.
+Finite means here that for some $n$, no power $b^n$ with base $b > 1$ has a zeroless decimal
+representation, which in our definition results in $a(n) = 0$.
 -/
 @[category research open, AMS 11]
-theorem conjecture : ∃ N : ℕ, ∀ n : ℕ, n > N → a n = 0 := by
+theorem conjecture : ∃ n : ℕ, a n = 0 := by
   sorry
 
 /--


### PR DESCRIPTION
`OeisA103662.conjecture` stated `∃ N, ∀ n > N, a n = 0`: every sufficiently large exponent `n` has no base `b > 1` such that `b ^ n` has a zeroless decimal representation. OEIS A103662 only conjectures that the sequence is finite, meaning that *some* exponent has no valid base (`∃ n, a n = 0`), which is strictly weaker than the eventual statement.

**Change:** restate the conjecture as `∃ n : ℕ, a n = 0` and rewrite the docstring to explain that "finite" means some exponent `n` admits no zeroless power `b ^ n` with `b > 1`, which in this file's definition gives `a n = 0`.

**Checked:** `lake --wfail build FormalConjectures.OEIS.«103662»` passes with no warnings.

Fixes #5688
