### PR TITLE
fix(GreensOpenProblems/51): Ruzsa's upper bound has exponent 2/3 + ε

### DIFF
--- a/FormalConjectures/GreensOpenProblems/51.lean
+++ b/FormalConjectures/GreensOpenProblems/51.lean
@@ -92,12 +92,15 @@ theorem green_51.lower_ap :
         exp (c * log (N : ℝ) ^ (1/2 : ℝ)) ≤ guaranteedMaxAPLength N α := by
   sorry
 
-/-- It is known that $A + A$ need not contain an arithmetic progression of length $\sim \exp(c (\log N)^{2/3})$ [Ruz91]. -/
+/--
+It is known that $A + A$ need not contain an arithmetic progression of length
+$\sim \exp(c (\log N)^{2/3 + \varepsilon})$, for any $\varepsilon > 0$ [Ruz91].
+-/
 @[category research solved, AMS 5 11]
 theorem green_51.upper_ap :
-    ∀ (α : ℝ), 0 < α → α < 1/2 →
+    ∀ (α : ℝ), 0 < α → α < 1/2 → ∀ (ε : ℝ), 0 < ε →
       ∃ c > 0, ∀ᶠ (N : ℕ) in atTop,
-        guaranteedMaxAPLength N α ≤ exp (c * log (N : ℝ) ^ (2/3 : ℝ)) := by
+        guaranteedMaxAPLength N α ≤ exp (c * log (N : ℝ) ^ (2/3 + ε : ℝ)) := by
   sorry
 
 end Green51


### PR DESCRIPTION
`green_51.upper_ap` stated that for every `0 < α < 1/2` there is `c > 0` with `guaranteedMaxAPLength N α ≤ exp (c * (log N)^(2/3))` for all large `N`. Ruzsa's result [Ruz91] is weaker: for every `ε > 0` there is `c = c(α, ε) > 0` with the bound `exp (c * (log N)^(2/3 + ε))`. Since a fixed exponent `2/3` cannot absorb the `ε`, the Lean statement claimed a strictly stronger, unproved bound.

**Change:** add `∀ (ε : ℝ), 0 < ε →` before the existential and replace the exponent `2/3` by `2/3 + ε`; docstring updated to match.

**Checked:** `lake --wfail build FormalConjectures.GreensOpenProblems.«51»` passes with no warnings.

Fixes #5682
