### PR TITLE
fix(GreensOpenProblems/45): state Green's tenfold covering question

### DIFF
--- a/FormalConjectures/GreensOpenProblems/45.lean
+++ b/FormalConjectures/GreensOpenProblems/45.lean
@@ -27,5 +27,23 @@ such that every integer $\leq N$ lies in at least 10 of them?
 - [Ben Green's Open Problem 45](https://people.maths.ox.ac.uk/greenbj/papers/open-problems.pdf#problem.45)
 - [erdosproblems.com/689](https://www.erdosproblems.com/689)
 
-This file points to the canonical formalization in `FormalConjectures.ErdosProblems.«689»`.
+The version of this problem with $10$ replaced by $2$ is `Erdos689.erdos_689` in
+`FormalConjectures.ErdosProblems.«689»`.
 -/
+
+namespace Green45
+
+/--
+Can we pick residue classes $a_p \pmod{p}$, one for each prime $p \leq N$, such that every
+integer $\leq N$ lies in at least $10$ of them?
+
+Erdős remarks that he does not know how to answer it with $10$ replaced by $2$;
+this is `Erdos689.erdos_689`.
+-/
+@[category research open, AMS 11]
+theorem green_45 :
+    answer(sorry) ↔ ∀ᶠ N in .atTop, ∃ a : ℕ → ℕ, ∀ m ∈ Finset.Icc 1 N,
+      10 ≤ (Finset.Icc 1 N |>.filter fun p => p.Prime ∧ a p ≡ m [MOD p]).card := by
+  sorry
+
+end Green45


### PR DESCRIPTION
`GreensOpenProblems/45.lean` declared no statement of its own and redirected to `Erdos689.erdos_689`, whose coverage condition is `2 ≤ (...).card`, i.e. the Erdős-website twofold question. Green's Problem 45 asks something stronger: for all large `N`, can one choose residues `a_p (mod p)` for the primes `p ≤ N` so that every integer `m ≤ N` lies in at least **ten** of these classes?

**Change:** add `Green45.green_45 : answer(sorry) ↔ ∀ᶠ N in .atTop, ∃ a : ℕ → ℕ, ∀ m ∈ Finset.Icc 1 N, 10 ≤ (Finset.Icc 1 N |>.filter fun p => p.Prime ∧ a p ≡ m [MOD p]).card` — the same shape as `erdos_689` with `2` replaced by `10` — and rewrite the module docstring so it no longer calls `erdos_689` "the canonical formalization" but describes it as the version with `10` replaced by `2` (as Erdős remarks).

**Checked:** `lake --wfail build FormalConjectures.GreensOpenProblems.«45»` passes with no warnings.

Fixes #5681
