### PR TITLE
fix(ErdosProblems/965): one colouring defeats every arity k in the variant

### DIFF
--- a/FormalConjectures/ErdosProblems/965.lean
+++ b/FormalConjectures/ErdosProblems/965.lean
@@ -47,11 +47,16 @@ theorem erdos_965 :
   sorry
 
 /--
-In fact, in both [Ko16] and [SWCol] a generalized example for $k$-sums is constructed.
+For every 2-coloring of ℝ, is there some $k ≥ 2$ and an uncountable set $A ⊆ ℝ$ such that all
+sums $a_1 + \cdots + a_k$ of $k$ distinct elements of $A$ have the same colour?
+
+In fact, in both [Ko16] and [SWCol] a single 2-coloring of ℝ is constructed such that for every
+$k ≥ 2$ and every uncountable $A ⊆ ℝ$ the sums of $k$ distinct elements of $A$ are not
+monochromatic.
 -/
 @[category research solved, AMS 3 5]
 theorem erdos_965.variants.generalization : answer(False) ↔
-     ∀ᵉ (k ≥ 2), ∀ f : ℝ → Fin 2, ∃ A : Set ℝ, ¬ A.Countable ∧ ∀ s t : Finset ℝ,
+    ∀ f : ℝ → Fin 2, ∃ k ≥ 2, ∃ A : Set ℝ, ¬ A.Countable ∧ ∀ s t : Finset ℝ,
       ↑s ⊆ A → ↑t ⊆ A → s.card = k → t.card = k → f (s.sum id) = f (t.sum id) := by
   sorry
 


### PR DESCRIPTION
`erdos_965.variants.generalization` stated `answer(False) ↔ ∀ k ≥ 2, ∀ f, ∃ A, …`. Unfolding the `answer(False)`, this asserts only `∃ k ≥ 2, ¬ P(k)`: a counterexample colouring at a *single* arity, which already follows from `erdos_965` itself (`k = 2`). The cited results [Ko16] and [SWCol] are stronger: they construct one 2-colouring `f : ℝ → Fin 2` that is a counterexample for *every* `k ≥ 2` simultaneously.

**Change:** move the arity quantifier inside the colouring quantifier: `answer(False) ↔ ∀ f : ℝ → Fin 2, ∃ k ≥ 2, ∃ A : Set ℝ, ¬ A.Countable ∧ …`. Its negation is now "there is a colouring such that for every `k ≥ 2` and every uncountable `A`, the `k`-sums are not monochromatic", matching the sources. The docstring states the question and the result explicitly.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«965»` passes with no warnings.

Fixes #5677
