### PR TITLE
fix(ErdosProblems/920): Bradač's lower bound has exponent 1 - 1/(k-1) for k ≥ 5

### DIFF
--- a/FormalConjectures/ErdosProblems/920.lean
+++ b/FormalConjectures/ErdosProblems/920.lean
@@ -84,13 +84,14 @@ theorem erdos_920.variants.lower_bound_k_eq_4 :
   sorry
 
 /--
-A positive answer to this question for all $k\geq 5$ follows from the lower bound in
-[erdosproblems.com/986] given by Bradač [Br26].
+A positive answer to this question for all $k\geq 5$, i.e.
+$f_k(n) \gg \frac{n^{1-\frac{1}{k-1}}}{(\log n)^{c_k}}$ for some constant $c_k>0$, follows from
+the lower bound in [erdosproblems.com/986] given by Bradač [Br26].
 -/
 @[category research solved, AMS 5]
-theorem erdos_920.variants.lower_bound_k_ge_5 (k : ℕ) (hk : k ≥ 3) :
+theorem erdos_920.variants.lower_bound_k_ge_5 (k : ℕ) (hk : k ≥ 5) :
     ∃ c > 0, (fun n ↦ f k n) ≫ (fun (n : ℕ) ↦
-    (n : ℝ) ^ (1 - 2 / ((k : ℝ) + 1)) / (log n) ^ c) := by
+    (n : ℝ) ^ (1 - 1 / ((k : ℝ) - 1)) / (log n) ^ c) := by
   sorry
 
 end Erdos920


### PR DESCRIPTION
`erdos_920.variants.lower_bound_k_ge_5` asserted `f_k(n) ≫ n^(1 - 2/(k+1)) / (log n)^c` for all `k ≥ 3`. The result it cites (Bradač [Br26], via the lower bound at erdosproblems.com/986) is `f_k(n) ≫ n^(1 - 1/(k-1)) / (log n)^{c_k}` for `k ≥ 5` — e.g. `n^(3/4)` rather than `n^(2/3)` at `k = 5` — so the Lean statement gave a strictly weaker bound than the source and was stated on a wider range of `k` than its name and docstring claim.

**Change:** replace the exponent `1 - 2 / (k + 1)` by `1 - 1 / (k - 1)` and the hypothesis `hk : k ≥ 3` by `hk : k ≥ 5`; the docstring now states the bound explicitly.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«920»` passes with no warnings.

Fixes #5675
