### PR TITLE
fix(ErdosProblems/959): ask for the order of extremalGap, not a log-exponent

### DIFF
--- a/FormalConjectures/ErdosProblems/959.lean
+++ b/FormalConjectures/ErdosProblems/959.lean
@@ -25,7 +25,6 @@ import FormalConjecturesUtil
 namespace Erdos959
 
 open EuclideanGeometry Filter
-open scoped Topology
 
 noncomputable section
 
@@ -76,13 +75,10 @@ the distance $d$ is determined, ordered so that
 $f(d_1)\geq f(d_2)\geq \cdots \geq f(d_k)$. Estimate
 $$\max (f(d_1)-f(d_2)),$$
 where the maximum is taken over all $A$ of size $n$ (this is `extremalGap n`).
-
-The asymptotic order of `extremalGap` is not known; a natural formalization of
-"estimate" asks whether it has a well-defined polynomial growth exponent.
 -/
 @[category research open, AMS 52]
-theorem erdos_959 : answer(sorry) ↔
-    ∃ γ : ℝ, Tendsto (fun n : ℕ => Real.log (extremalGap n) / Real.log n) atTop (𝓝 γ) := by
+theorem erdos_959 :
+    (fun n ↦ (extremalGap n : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 /--


### PR DESCRIPTION
`Erdos959.erdos_959` was stated as `∃ γ, Tendsto (fun n => log (extremalGap n) / log n) atTop (𝓝 γ)`, i.e. "does `extremalGap` have a well-defined polynomial growth exponent?". The source asks to *estimate* `max (f(d₁) − f(d₂))`, i.e. to determine the order of magnitude of `extremalGap n`. A logarithmic exponent does not determine that: `n log n` and `n^(1 + c / log log n)` both have exponent `1` while their ratio is unbounded.

**Change:** restate as `(fun n ↦ (extremalGap n : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ)`, the repository's usual encoding of an "estimate" question; drop the now-unused `open scoped Topology` and the docstring paragraph that justified the limit formulation.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«959»` passes with no warnings.

Reviewer note (unchanged in this PR): the `formal_proof` link on `erdos_959.lower_bound` may overclaim what the referenced external file actually proves; worth a glance but out of scope here.

Fixes #5676
