### PR TITLE
fix(ErdosProblems/973): m2_bounds holds only for sufficiently large n

### DIFF
--- a/FormalConjectures/ErdosProblems/973.lean
+++ b/FormalConjectures/ErdosProblems/973.lean
@@ -65,11 +65,11 @@ theorem erdos_973.variants.le_one :
 In [Er92f] (a different) Erdős refines this analysis, proving that if
 $M_2=\min_{z_j} \max_{2\leq k\leq n+1} \left\lvert \sum_{1\leq j\leq n}z_j^k\right\rvert$
 where the minimum is taken over all $z_j\in \mathbb{C}$ with $\max \lvert z_j\rvert=1$, then
-$(1.746)^{-n} < M_2 < (1.745)^{-n}$.
+$(1.746)^{-n} < M_2 < (1.745)^{-n}$ for all sufficiently large $n$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_973.variants.m2_bounds :
-    ∀ n : ℕ, n ≥ 2 → ∀ M_2 : ℝ,
+    ∀ᶠ n : ℕ in atTop, ∀ M_2 : ℝ,
       IsGLB { M | ∃ z : ℕ → ℂ,
         (∀ j ∈ Icc 1 n, ‖z j‖ ≤ 1) ∧
         (∃ j ∈ Icc 1 n, ‖z j‖ = 1) ∧


### PR DESCRIPTION
`Erdos973.erdos_973.variants.m2_bounds` asserted the bounds `(1.746)^{-n} < M_2 < (1.745)^{-n}` on the greatest lower bound `M_2` for every `n ≥ 2`. The source ([Er92f]) proves them only for all sufficiently large `n`, and the upper bound already fails at `n = 2`, where the infimum of `max(‖a² + b²‖, ‖a³ + b³‖)` is at least `2/5 > 1.745⁻²`.

**Change:** replace the quantifier `∀ n : ℕ, n ≥ 2 →` by `∀ᶠ n : ℕ in atTop,` and add "for all sufficiently large $n$" to the docstring. The body of the statement is unchanged.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«973»` passes with no warnings.

Fixes #5678
