### PR TITLE
fix(ErdosProblems/888): semiprime bound has leading constant 1

### DIFF
--- a/FormalConjectures/ErdosProblems/888.lean
+++ b/FormalConjectures/ErdosProblems/888.lean
@@ -83,8 +83,8 @@ also works, showing $(1+o(1))\frac{\log\log n}{\log n}n \leq \lvert A\rvert$ is 
 -/
 @[category research solved, AMS 11]
 theorem erdos_888.variants.semiprimes :
-    (fun n : ℕ ↦ (Nat.findGreatest (p n) n : ℝ)) ≫
-      (fun n : ℕ ↦ (n : ℝ) * Real.log (Real.log n) / Real.log n) := by
+    ∃ c : ℕ → ℝ, c =o[atTop] (1 : ℕ → ℝ) ∧ ∀ᶠ n : ℕ in atTop,
+      (1 + c n) * ((n : ℝ) * Real.log (Real.log n) / Real.log n) ≤ Nat.findGreatest (p n) n := by
   sorry
 
 end Erdos888


### PR DESCRIPTION
`Erdos888.erdos_888.variants.semiprimes` stated only `M(n) ≫ n log log n / log n` (a lower bound up to an unspecified positive constant, so e.g. half the bound would also satisfy it). The cited source ([erdosproblems.com/888](https://www.erdosproblems.com/888), Cambie–Weisenberg) gives the sharp bound $(1+o(1))\frac{\log\log n}{\log n}n \le |A|$ with leading constant $1$, which the docstring already quotes.

**Change**: restate the theorem as `∃ c : ℕ → ℝ, c =o[atTop] 1 ∧ ∀ᶠ n in atTop, (1 + c n) * (n * log (log n) / log n) ≤ Nat.findGreatest (p n) n`, the repository's usual encoding of a `(1+o(1))` bound (cf. `ErdosProblems/208.lean`, `497.lean`). Docstring and attributes unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«888»` — Build completed successfully.

Fixes #5671
