### PR TITLE
fix(ErdosProblems/786): Selfridge's set has density greater than 1/e - ε

### DIFF
--- a/FormalConjectures/ErdosProblems/786.lean
+++ b/FormalConjectures/ErdosProblems/786.lean
@@ -177,7 +177,7 @@ $$
 \sum_{i=1}^k \frac{1}{p_i} < 1 < \sum_{i=1}^{k + 1} \frac{1}{p_i},
 $$
 and let $A$ be the set of all naturals divisible by exactly one of $p_1, ..., p_k$ (with
-multiplicity $1$). Then $A$ has density $\frac{1}{e} - \epsilon$ and has the property
+multiplicity $1$). Then $A$ has density $> \frac{1}{e} - \epsilon$ and has the property
 that $a_1\cdots a_r = b_1\cdots b_s$ with $a_i, b_j\in A$ can only hold when $r = s$.
 -/
 @[category research solved, AMS 11]
@@ -186,7 +186,7 @@ theorem erdos_786.parts.i.selfridge (ε : ℝ) (hε : 0 < ε ∧ ε < 1 / rexp 1
       ∑ q ∈ consecutivePrimesFrom p k, (1 : ℝ) / q < 1 ∧
         1 < ∑ q ∈ consecutivePrimesFrom p (k + 1), (1 : ℝ) / q ∧
           letI A := { n | ∑ q ∈ consecutivePrimesFrom p k, (n : ℕ).factorization q = 1 }
-          A.HasDensity (1 / rexp 1 - ε) ∧ A.IsMulCardSet := by
+          ∃ δ, 1 / rexp 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet := by
   sorry
 
 end Erdos786


### PR DESCRIPTION
`erdos_786.parts.i.selfridge` concluded `A.HasDensity (1 / rexp 1 - ε)` for the set `A` fixed by `p` and `k`. The density of that set does not depend on `ε`, so the same `A` would have to have two distinct densities for two values of `ε`, and the statement was false. The source ([erdosproblems.com/786](https://www.erdosproblems.com/786)) says Selfridge's construction gives a set of density $1/e - \epsilon$ for any $\epsilon > 0$, i.e. density greater than $1/e - \epsilon$.

**Change**: the conclusion is now `∃ δ, 1 / rexp 1 - ε < δ ∧ A.HasDensity δ ∧ A.IsMulCardSet`, mirroring the form used in `erdos_786.parts.i`. The docstring now says the density is $> \frac{1}{e} - \epsilon$.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«786»'` completes successfully with no warnings.

Fixes #5667
