### PR TITLE
fix(ErdosProblems/884): assume the qualitative prime tuples conjecture

### DIFF
--- a/FormalConjectures/ErdosProblems/884.lean
+++ b/FormalConjectures/ErdosProblems/884.lean
@@ -15,7 +15,6 @@ limitations under the License.
 -/
 
 import FormalConjecturesUtil
-import FormalConjectures.Wikipedia.HardyLittlewood
 
 /-!
 # Erdős Problem 884
@@ -86,19 +85,22 @@ theorem erdos_884 :
   sorry
 
 /--
-In September 2025, Terence Tao gave a conditional _negative_ answer to Erdos conjecture 884,
-disproving it under the assumption of the *Qualitative Hardy-Littlewood Conjecture*.
-See [here](https://terrytao.wordpress.com/wp-content/uploads/2025/09/erdos-884.pdf).
-The *qualitative* version of the conjecture only states that there are infinitely many tuples
-of primes and does not require any asymptotical bounds and as such is a corollary of the general
-form of the Hardy-Littlewood Conjecture.
-We state the 'weaker' implication using general Hardy-Littlewood here, since this conjecture is
-already formalized.
+In September 2025, Terence Tao gave a conditional _negative_ answer to Erdős problem 884,
+disproving it under the assumption of the *qualitative Hardy–Littlewood prime tuples
+conjecture*, see Conjecture 1.1 and Theorem 1.1 of
+[Tao25](https://terrytao.wordpress.com/wp-content/uploads/2025/09/erdos-884.pdf).
+
+The qualitative conjecture states that for every admissible tuple $(h_1, \dotsc, h_k)$ of
+integers, i.e. one which avoids at least one residue class modulo $p$ for every prime $p$,
+there are infinitely many natural numbers $n$ such that $n + h_1, \dotsc, n + h_k$ are all
+prime. Unlike the full Hardy–Littlewood conjecture, it does not give an asymptotic for the
+number of such $n$.
 -/
 @[category research solved, AMS 11]
-theorem erdos_884_false_of_hardy_littlewood :
-    ∀ (k : ℕ) (m : Fin k.succ → ℕ), HardyLittlewood.FirstHardyLittlewoodConjectureFor m
-    → ¬Erdos884Prop := by
+theorem erdos_884_false_of_hardy_littlewood
+    (hHL : ∀ H : Finset ℤ, (∀ p : ℕ, p.Prime → ∃ a : ℤ, ∀ h ∈ H, ¬ (p : ℤ) ∣ a + h) →
+      {n : ℕ | ∀ h ∈ H, Prime ((n : ℤ) + h)}.Infinite) :
+    ¬Erdos884Prop := by
   sorry
 
 end Erdos884


### PR DESCRIPTION
`Erdos884.erdos_884_false_of_hardy_littlewood` stated `∀ k m, FirstHardyLittlewoodConjectureFor m → ¬Erdos884Prop`, quantifying the tuple outside the implication, and `FirstHardyLittlewoodConjectureFor` is only an `IsBigO` upper bound. So the hypothesis is provable for one tuple (`k = 0`, `m = fun _ => 1`, whose count is identically zero) and the theorem was equivalent to the unconditional `¬Erdos884Prop`. Tao's Theorem 1.1 assumes Conjecture 1.1 (qualitative Hardy–Littlewood prime tuples conjecture): for every admissible tuple of integers there are infinitely many `n` with all `n + hᵢ` prime, and the argument uses it for arbitrarily large tuples.

**Change**: the theorem now takes the qualitative prime tuples conjecture as a single hypothesis, quantified over all admissible `H : Finset ℤ` inside the antecedent (admissibility as in `SchinzelCondition`: for every prime `p` some residue class `-a` is avoided by `H`). The docstring is updated to match Tao's Conjecture 1.1 and the now-unused `Wikipedia.HardyLittlewood` import is removed. The `IsBigO`-vs-`∼` defect of `FirstHardyLittlewoodConjectureFor` itself is tracked separately in #4996 and is not touched here.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«884»'` — Build completed successfully.

Fixes #5670
