### PR TITLE
fix(ErdosProblems/891): assume Dickson's conjecture in the Weisenberg variant

### DIFF
--- a/FormalConjectures/ErdosProblems/891.lean
+++ b/FormalConjectures/ErdosProblems/891.lean
@@ -15,6 +15,7 @@ limitations under the License.
 -/
 
 import FormalConjecturesUtil
+import FormalConjectures.Wikipedia.Dickson
 
 /-!
 # Erdős Problem 891
@@ -68,9 +69,13 @@ $p_1\cdots p_k$ with $p_1\cdots p_k-1$. Indeed, let $L_k$ be the lowest common m
 integers at most $p_1\cdots p_k$. By Dickson's conjecture [Wikipedia], there are infinitely many
 $n'$ such that $\frac{L_k}{m}n'+1$ is prime for all $1\leq m < p_1\cdots p_k$. It follows that,
 if $n=L_kn'+1$, then all integers in $[n,n+p_1\cdots p_k-1)$ have at most $k$ prime factors.
+
+The statement is conditional on Dickson's conjecture, formalised as
+`Dickson.dickson_conjecture`.
 -/
-@[category research open, AMS 11]
-theorem erdos_891.variants.weisenberg (k : ℕ) (hk : k ≥ 2) :
+@[category research solved, AMS 11]
+theorem erdos_891.variants.weisenberg (k : ℕ) (hk : k ≥ 2)
+    (hdickson : type_of% Dickson.dickson_conjecture) :
     ∃ᶠ n in atTop,
       ∀ m ∈ Ico n (n + (∏ i ∈ range k, i.nth Nat.Prime) - 1),
       ω m ≤ k := by


### PR DESCRIPTION
`erdos_891.variants.weisenberg` stated, unconditionally for every `k ≥ 2`, that there are infinitely many `n` such that every integer in `[n, n + p₁⋯pₖ − 1)` has at most `k` distinct prime factors. The source (erdosproblems.com/891) only records this as Weisenberg's observation that **Dickson's conjecture implies** it; the unconditional statement is not known.

**Change:** add Dickson's conjecture as a hypothesis, `(hdickson : type_of% Dickson.dickson_conjecture)`, importing `FormalConjectures.Wikipedia.Dickson` (same pattern as `erdos_287.variants.prime_conjecture_implies` / `erdos_1135`). Since the implication itself is an established observation, the category is changed from `research open` to `research solved`, matching `erdos_252.variants.schinzel`. The docstring notes the conditional nature of the statement.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«891»`

Fixes #5672
