### PR TITLE
fix(ErdosProblems/855): require one uniform threshold for x and y

### DIFF
--- a/FormalConjectures/ErdosProblems/855.lean
+++ b/FormalConjectures/ErdosProblems/855.lean
@@ -31,11 +31,11 @@ namespace Erdos855
 
 /--
 Erdős Problem 855 (Segal's conjecture): $\pi(x + y) \le \pi(x) + \pi(y)$
-for sufficiently large $x, y$.
+for all sufficiently large $x, y$, i.e. for all $x, y \ge N$ for some $N$.
 -/
 @[category research open, AMS 11]
 theorem erdos_855 : answer(sorry) ↔
-    ∀ᶠ x in atTop, ∀ᶠ y in atTop, π (x + y) ≤ π x + π y := by
+    ∀ᶠ (xy : ℕ × ℕ) in atTop ×ˢ atTop, π (xy.1 + xy.2) ≤ π xy.1 + π xy.2 := by
   sorry
 
 end Erdos855


### PR DESCRIPTION
`Erdos855.erdos_855` was stated as `∀ᶠ x in atTop, ∀ᶠ y in atTop, π (x + y) ≤ π x + π y`, so the threshold for `y` was allowed to depend on `x`. The source ([erdosproblems.com/855](https://www.erdosproblems.com/855)) asks whether the inequality holds "for large x and y", i.e. for all pairs `(x, y)` with `x` and `y` jointly sufficiently large — a single threshold `N` with `N ≤ x → N ≤ y → π (x + y) ≤ π x + π y`. (The nested version is a genuinely different statement: for fixed `x` the inequality for all large `y` is a separate conjecture discussed on the same page.)

**Change**: restate the right-hand side as `∀ᶠ (xy : ℕ × ℕ) in atTop ×ˢ atTop, π (xy.1 + xy.2) ≤ π xy.1 + π xy.2` (by `Filter.eventually_atTop_prod_self` this is exactly the single uniform threshold), and update the docstring accordingly.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«855»`

Fixes #5669
