### PR TITLE
fix(ErdosProblems/785): take A, B positive; Chen–Fang bound uses min

### DIFF
--- a/FormalConjectures/ErdosProblems/785.lean
+++ b/FormalConjectures/ErdosProblems/785.lean
@@ -62,8 +62,8 @@ def IsExactAdditiveComplement (A B : Set ℕ) : Prop :=
     Tendsto (fun x : ℕ => (counting A x * counting B x : ℝ) / (x : ℝ)) atTop (𝓝 1)
 
 /--
-Let $A,B\subseteq \mathbb{N}$ be infinite sets such that $A+B$ contains all large integers.
-Let $A(x)=\lvert A\cap [1,x]\rvert$ and similarly for $B(x)$. Is it true that if
+Let $A,B\subseteq \mathbb{N}$ be infinite sets of positive integers such that $A+B$ contains all
+large integers. Let $A(x)=\lvert A\cap [1,x]\rvert$ and similarly for $B(x)$. Is it true that if
 $A(x)B(x)\sim x$ then
 $$A(x)B(x)-x\to \infty$$
 as $x\to \infty$?
@@ -77,7 +77,7 @@ This was formalized in Lean by van Doorn using Aristotle.
 @[category research solved, AMS 11, formal_proof using lean4 at
 "https://github.com/Woett/Lean-files/blob/main/ErdosProblem785.lean"]
 theorem erdos_785 : answer(True) ↔
-    ∀ A B : Set ℕ, A.Infinite → B.Infinite → IsExactAdditiveComplement A B →
+    ∀ A B : Set ℕ, A.Infinite → B.Infinite → 0 ∉ A → 0 ∉ B → IsExactAdditiveComplement A B →
       Tendsto (fun x : ℕ => (counting A x * counting B x : ℝ) - (x : ℝ)) atTop atTop := by
   sorry
 
@@ -87,7 +87,7 @@ do not exist, as reported in [Er57] and [Er61]).
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.danzer :
-    ∃ A B : Set ℕ, A.Infinite ∧ B.Infinite ∧ IsExactAdditiveComplement A B := by
+    ∃ A B : Set ℕ, A.Infinite ∧ B.Infinite ∧ 0 ∉ A ∧ 0 ∉ B ∧ IsExactAdditiveComplement A B := by
   sorry
 
 /--
@@ -96,19 +96,20 @@ $$A(x)B(x)-x=o(A(x)).$$
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.sarkozy_szemeredi (A B : Set ℕ) (hA : A.Infinite) (hB : B.Infinite)
-    (h : IsExactAdditiveComplement A B) :
+    (hA₀ : 0 ∉ A) (hB₀ : 0 ∉ B) (h : IsExactAdditiveComplement A B) :
     ¬ (fun x : ℕ => (counting A x * counting B x : ℝ) - (x : ℝ)) =o[atTop]
       (fun x : ℕ => (counting A x : ℝ)) := by
   sorry
 
 /--
-Chen and Fang [ChFa15] proved $A(x)B(x)-x\ll A(x)^c$ cannot hold for any constant $c>0$.
+Chen and Fang [ChFa15] proved $A(x)B(x)-x\ll \min(A(x),B(x))^c$ cannot hold for any constant
+$c>0$. In particular $A(x)B(x)-x\ll A(x)^c$ cannot hold when $A$ is the sparser of the two sets.
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.chen_fang (A B : Set ℕ) (hA : A.Infinite) (hB : B.Infinite)
-    (h : IsExactAdditiveComplement A B) (c : ℝ) (hc : 0 < c) :
+    (hA₀ : 0 ∉ A) (hB₀ : 0 ∉ B) (h : IsExactAdditiveComplement A B) (c : ℝ) (hc : 0 < c) :
     ¬ (fun x : ℕ => (counting A x * counting B x : ℝ) - (x : ℝ)) =O[atTop]
-      (fun x : ℕ => (counting A x : ℝ) ^ c) := by
+      (fun x : ℕ => (min (counting A x) (counting B x) : ℝ) ^ c) := by
   sorry
 
 /--
@@ -117,7 +118,7 @@ we must have $A(2x)/A(x)\to 1$ and $B(2x)/B(x)\to 2$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.narkiewicz (A B : Set ℕ) (hA : A.Infinite) (hB : B.Infinite)
-    (h : IsExactAdditiveComplement A B) :
+    (hA₀ : 0 ∉ A) (hB₀ : 0 ∉ B) (h : IsExactAdditiveComplement A B) :
     (Tendsto (fun x : ℕ => (counting A (2 * x) : ℝ) / (counting A x : ℝ)) atTop (𝓝 1) ∧
       Tendsto (fun x : ℕ => (counting B (2 * x) : ℝ) / (counting B x : ℝ)) atTop (𝓝 2)) ∨
     (Tendsto (fun x : ℕ => (counting B (2 * x) : ℝ) / (counting B x : ℝ)) atTop (𝓝 1) ∧
@@ -132,7 +133,7 @@ for infinitely many $x$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.ruzsa_upper_bound (w : ℕ → ℝ) (hw : Tendsto w atTop atTop) :
-    ∃ A B : Set ℕ, A.Infinite ∧ B.Infinite ∧ IsExactAdditiveComplement A B ∧
+    ∃ A B : Set ℕ, A.Infinite ∧ B.Infinite ∧ 0 ∉ A ∧ 0 ∉ B ∧ IsExactAdditiveComplement A B ∧
       ∃ᶠ x : ℕ in atTop, (counting A x * counting B x : ℝ) - (x : ℝ) < w x := by
   sorry
 
@@ -143,7 +144,7 @@ $$A(x)B(x)-x > (1-o(1))\frac{a^*(x)}{A(x)}.$$
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.ruzsa_lower_bound (A B : Set ℕ) (hA : A.Infinite) (hB : B.Infinite)
-    (h : IsExactAdditiveComplement A B) :
+    (hA₀ : 0 ∉ A) (hB₀ : 0 ∉ B) (h : IsExactAdditiveComplement A B) :
     (∀ ε > (0 : ℝ), ∀ᶠ x : ℕ in atTop,
         (1 - ε) * (aStar A x : ℝ) / (counting A x : ℝ)
           < (counting A x * counting B x : ℝ) - (x : ℝ)) ∨
@@ -160,7 +161,7 @@ They later [ChFa14] improved $5/4$ to $3-\sqrt{3}\approx 1.268$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.chen_fang_limsup (A B : Set ℕ) (hA : A.Infinite) (hB : B.Infinite)
-    (h : IsAdditiveComplement A B)
+    (hA₀ : 0 ∉ A) (hB₀ : 0 ∉ B) (h : IsAdditiveComplement A B)
     (hlim : limsup (fun x : ℕ => ((counting A x * counting B x : ℝ) / (x : ℝ) : EReal)) atTop
       < ((3 - Real.sqrt 3 : ℝ) : EReal)) :
     Tendsto (fun x : ℕ => (counting A x * counting B x : ℝ) - (x : ℝ)) atTop atTop := by
@@ -171,7 +172,7 @@ Chen conjectures that this should be true with $3/2$.
 -/
 @[category research open, AMS 11]
 theorem erdos_785.variants.chen_conjecture : answer(sorry) ↔
-    ∀ A B : Set ℕ, A.Infinite → B.Infinite → IsAdditiveComplement A B →
+    ∀ A B : Set ℕ, A.Infinite → B.Infinite → 0 ∉ A → 0 ∉ B → IsAdditiveComplement A B →
       limsup (fun x : ℕ => ((counting A x * counting B x : ℝ) / (x : ℝ) : EReal)) atTop
           < ((3 / 2 : ℝ) : EReal) →
         Tendsto (fun x : ℕ => (counting A x * counting B x : ℝ) - (x : ℝ)) atTop atTop := by
@@ -184,7 +185,7 @@ for which $A(x)B(x)-x=1$ for infinitely many $x$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_785.variants.chen_fang_sharp :
-    ∃ A B : Set ℕ, A.Infinite ∧ B.Infinite ∧ IsAdditiveComplement A B ∧
+    ∃ A B : Set ℕ, A.Infinite ∧ B.Infinite ∧ 0 ∉ A ∧ 0 ∉ B ∧ IsAdditiveComplement A B ∧
       limsup (fun x : ℕ => ((counting A x * counting B x : ℝ) / (x : ℝ) : EReal)) atTop
           = ((3 / 2 : ℝ) : EReal) ∧
       ∃ᶠ x : ℕ in atTop, (counting A x * counting B x : ℝ) - (x : ℝ) = 1 := by


### PR DESCRIPTION
The source (and the cited formal proof by van Doorn) takes $A, B$ to be sets of positive integers, but the Lean statements allowed $0 \in A$ or $0 \in B$ while `counting A x = |A ∩ [1, x]|` ignores `0`. A zero summand makes `A + B` easier to cover without changing the counting functions, so the statements did not match the source. Separately, `chen_fang` bounded $A(x)B(x)-x$ by `counting A x ^ c` with nothing making $A$ the sparse set; for the denser set and $c = 2$ the $O$-bound holds trivially, so that statement was false. Chen–Fang [ChFa15] actually prove $A(x)B(x)-x \ge \min(A(x),B(x))^M$ for every $M > 1$.

**Change**: add `0 ∉ A` / `0 ∉ B` to every statement in the file (hypotheses for the universal ones, conjuncts for the existential ones), state the main problem's docstring with "sets of positive integers", and replace `counting A x ^ c` by `(min (counting A x) (counting B x) : ℝ) ^ c` in `chen_fang`, with the docstring updated accordingly.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«785»` builds successfully.

Fixes #5666
