### PR TITLE
fix(ErdosProblems/692): count local maximum plateaus with encard

### DIFF
--- a/FormalConjectures/ErdosProblems/692.lean
+++ b/FormalConjectures/ErdosProblems/692.lean
@@ -47,6 +47,14 @@ def IsDelta₁ (n m : ℕ) (δ : ℝ) : Prop :=
   (exactlyOneDivisorIn n m).HasDensity δ
 
 /--
+The set of local maxima of the sequence `f` on `(a, ∞)`. Each local maximum is recorded by the
+first index `m` of a maximal interval `[m, b]` on which `f` is constant, with `f` strictly smaller
+at `m - 1` and at `b + 1`.
+-/
+def localMaxima (f : ℕ → ℝ) (a : ℕ) : Set ℕ :=
+  {m | a < m ∧ f (m - 1) < f m ∧ ∃ b, m ≤ b ∧ (∀ j ∈ Set.Icc m b, f j = f m) ∧ f (b + 1) < f m}
+
+/--
 Let $\delta_1(n,m)$ be the density of the set of integers with exactly one divisor in $(n,m)$.
 Is $\delta_1(n,m)$ unimodular for $m>n+1$ (i.e. increases until some $m$ then decreases
 thereafter)?
@@ -94,13 +102,13 @@ theorem erdos_692.variants.cambie_three :
 
 /--
 Cambie [Ca25] has shown that, for fixed $n$, the sequence $\delta_1(n,m)$ has superpolynomially
-many local maxima $m$.
+many local maxima $m$. A local maximum is a maximal run of equal values of the sequence that is
+strictly larger than the values just before and just after the run.
 -/
 @[category research solved, AMS 11]
 theorem erdos_692.variants.cambie_local_maxima (k : ℕ) :
     ∀ δ : ℕ → ℕ → ℝ, (∀ a b, IsDelta₁ a b (δ a b)) →
-      ∀ᶠ n : ℕ in atTop, (n : ℝ) ^ k ≤
-        ({m : ℕ | n + 1 < m ∧ δ n (m - 1) ≤ δ n m ∧ δ n (m + 1) ≤ δ n m}.ncard : ℝ) := by
+      ∀ᶠ n : ℕ in atTop, (n : ℕ∞) ^ k ≤ (localMaxima (δ n) (n + 1)).encard := by
   sorry
 
 end Erdos692


### PR DESCRIPTION
`erdos_692.variants.cambie_local_maxima` bounded `n^k` by the `ncard` of the set of `m > n+1` with `δ n (m-1) ≤ δ n m` and `δ n (m+1) ≤ δ n m`. For every `n` this set is infinite: whenever `m` and `m-1` each have at least two divisors in `(n, ·)` (e.g. `m = 36s+28` with `s ≥ n`), adding the divisors `m-1` and `m` does not change the exactly-one-divisor set, so `δ n (m-1) = δ n m = δ n (m+1)`. Hence `ncard` was `0` and the statement asserted `n^k ≤ 0`. Cambie [Ca25, Thm. 3] counts genuine local maxima of the sequence `(δ₁(n,m))_{m ≥ n+2}` (alternating strict increases and strict decreases).

**Change**: add `localMaxima f a : Set ℕ`, the set of first indices `m > a` of maximal runs `[m, b]` on which `f` is constant with `f (m-1) < f m` and `f (b+1) < f m` (each local maximum plateau is counted once), and restate the theorem as `∀ᶠ n in atTop, (n : ℕ∞) ^ k ≤ (localMaxima (δ n) (n + 1)).encard`. Using `encard` keeps the bound meaningful even if the set is infinite. Docstring updated; other declarations unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«692»'` succeeds.

Fixes #5664
