### PR TITLE
fix(ErdosProblems/672): make answer(True) affirm that a perfect power exists

### DIFF
--- a/FormalConjectures/ErdosProblems/672.lean
+++ b/FormalConjectures/ErdosProblems/672.lean
@@ -31,11 +31,13 @@ def Erdos672With (k l : ℕ) : Prop :=
 
 /--
 Can the product of an arithmetic progression of positive integers $n, n + d, ..., n + (k - 1)d$
-of length ≥ 4, with $(n, d) = 1$, be a perfect power?
+of length $k ≥ 4$, with $(n, d) = 1$, be a perfect power?
+
+Erdős believed not, i.e. that `Erdos672With k l` holds for all $k ≥ 4$ and $l > 1$.
 -/
 @[category research open, AMS 11]
 theorem erdos_672 :
-    answer(sorry) ↔ ∀ᵉ (k) (l > 1), k ≥ 4 → Erdos672With k l := by
+    answer(sorry) ↔ ∃ᵉ (k ≥ 4) (l > 1), ¬ Erdos672With k l := by
   sorry
 
 /-- According to https://www.erdosproblems.com/672, Euler proved this. -/


### PR DESCRIPTION
[erdosproblems.com/672](https://www.erdosproblems.com/672) asks whether the product of an arithmetic progression $n, n+d, \ldots, n+(k-1)d$ of positive integers of length $k \geq 4$ with $(n,d) = 1$ can be a perfect power (Erdős believed not). `erdos_672` stated `answer(sorry) ↔ ∀ᵉ (k) (l > 1), k ≥ 4 → Erdos672With k l`, where `Erdos672With k l` says no such product is an $l$-th power. So `answer(True)` denied the question and `answer(False)` affirmed it.

**Change**: the statement is now `answer(sorry) ↔ ∃ᵉ (k ≥ 4) (l > 1), ¬ Erdos672With k l`, so `answer(True)` affirms that some such product is a perfect power. The docstring records Erdős's expected negative answer. `Erdos672With` and the Euler/Obláth variants are unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«672»'` (Build completed successfully).

Fixes #5663
