### PR TITLE
fix(ErdosProblems/60): restrict He-Ma-Yang variant to q = 2^k

### DIFF
--- a/FormalConjectures/ErdosProblems/60.lean
+++ b/FormalConjectures/ErdosProblems/60.lean
@@ -46,12 +46,15 @@ theorem erdos_60 :
 /- ## Variants and partial results -/
 
 /--
-He, Ma, and Yang [HeMaYa21] proved the conjecture when $n = q^2 + q + 1$ for some even integer $q$.
+He, Ma, and Yang [HeMaYa21] proved the conjecture when $n = q^2 + q + 1$ for some $q = 2^k$: they
+showed that for large even $q$ every graph on $q^2 + q + 1$ vertices with
+$\frac{1}{2}q(q+1)^2 + 1$ edges contains at least $q - 1$ copies of $C_4$, and
+$\mathrm{ex}(q^2 + q + 1; C_4) = \frac{1}{2}q(q+1)^2$ when $q = 2^k$.
 -/
 @[category research solved, AMS 5]
 theorem erdos_60.variants.he_ma_yang :
     ∃ c : ℝ, c > 0 ∧
-      ∀ (q : ℕ) (_hq : Even q),
+      ∀ (q : ℕ) (_hq : q.isPowerOfTwo),
         ∀ (G : SimpleGraph (Fin (q^2 + q + 1))) [DecidableRel G.Adj],
           (extremalNumber (q^2 + q + 1) (cycleGraph 4) < G.edgeFinset.card) →
           (c * Real.sqrt ((q^2 + q + 1) : ℝ) ≤ ({ H' : G.Subgraph | Nonempty (H'.coe ≃g cycleGraph 4) }.ncard : ℝ)) := by


### PR DESCRIPTION
`erdos_60.variants.he_ma_yang` asserted that for **every even** `q`, any graph on `q^2 + q + 1` vertices with more than `ex(q^2 + q + 1; C_4)` edges has `≫ sqrt(n)` copies of `C_4`. He, Ma and Yang (JCTB 2021, Theorem 1.3) prove the bound for graphs with `q(q+1)^2/2 + 1` edges and large even `q`; this threshold equals `ex(q^2 + q + 1; C_4)` only when an orthogonal polarity graph of order `q` exists, i.e. for `q = 2^k` (Corollary: `h(q^2+q+1) = q - 1` for `q = 2^k`). For even `q` with no projective plane of order `q` the extremal number is strictly smaller (their follow-up paper shows `ex ≤ q(q+1)^2/2 - q/2 + o(q)` for such `q`), so the old statement asserted cases that are not proven.

**Change**: replace the hypothesis `Even q` by `q.isPowerOfTwo` and expand the docstring to state what He–Ma–Yang actually prove. Statement shape, attributes and proof (`sorry`) are otherwise unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«60»` — Build completed successfully.

Fixes #5662
