### PR TITLE
fix(ErdosProblems/598): quantify the infinite cardinal inside the answer

### DIFF
--- a/FormalConjectures/ErdosProblems/598.lean
+++ b/FormalConjectures/ErdosProblems/598.lean
@@ -26,8 +26,6 @@ namespace Erdos598
 
 open Cardinal
 
-variable (m : Type*) [Infinite m]
-
 /--
 Let $\kappa = (2^{\aleph_0})^+$. This is the successor cardinal of the continuum.
 -/
@@ -41,6 +39,7 @@ $X \subseteq m$ with $|X| = \kappa$ contains subsets of all possible colours?
 -/
 @[category research open, AMS 3 5]
 theorem erdos_598 : answer(sorry) ↔
+    ∀ (m : Type*) [Infinite m],
     ∃ c : { s : Set m // s.Countable } → κ.out,
     ∀ X : Set m, #X = κ →
     c '' { s : { sub : Set m // sub.Countable } | s.1 ⊆ X } = Set.univ := by


### PR DESCRIPTION
`erdos_598` fixed the infinite type `m` as a `variable` outside `answer(sorry) ↔`, so the statement read `∀ m [Infinite m], A ↔ P(m)`. For `m = ℕ` no subset has cardinality `κ = (2^ℵ₀)⁺`, so `P(ℕ)` holds for any colouring and the template forced `answer(True)`; a negative answer could not be expressed. The source asks whether, for every infinite cardinal `m`, such a colouring exists, i.e. `A ↔ ∀ m, P(m)`.

**Change:** remove the `variable (m : Type*) [Infinite m]` and quantify `∀ (m : Type*) [Infinite m]` inside the right-hand side of the iff. Docstring, attributes and the rest of the statement are unchanged.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«598»` — Build completed successfully.

Fixes #5661
