### PR TITLE
fix(ErdosProblems/505): require Borsuk covering sets to be subsets of S

### DIFF
--- a/FormalConjectures/ErdosProblems/505.lean
+++ b/FormalConjectures/ErdosProblems/505.lean
@@ -24,6 +24,9 @@ import FormalConjecturesUtil
 **Borsuk's conjecture** (1933): Is every bounded set of diameter 1 in $\mathbb{R}^n$
 the union of at most $n + 1$ sets of diameter strictly less than 1?
 
+The covering sets are required to be subsets of the set being covered. This loses no
+generality (intersect each covering set with $S$) and guarantees that they are bounded.
+
 Erdős [Er44] suspected this is false for sufficiently large $n$. Confirmed
 by Kahn–Kalai [KK93], who disproved the conjecture for $n \geq 2015$.
 The current best is $n \geq 64$ (Jenrich–Brouwer, 2014).
@@ -55,7 +58,7 @@ theorem erdos_505.test_dim_one
     (S : Set (EuclideanSpace ℝ (Fin 1)))
     (hS : Bornology.IsBounded S) (hd : 0 < diam S) :
     ∃ (F : Fin 2 → Set (EuclideanSpace ℝ (Fin 1))),
-      S ⊆ ⋃ i, F i ∧ ∀ i, diam (F i) < diam S := by
+      (∀ i, F i ⊆ S) ∧ S ⊆ ⋃ i, F i ∧ ∀ i, diam (F i) < diam S := by
   sorry
 
 /-- **Erdős Problem 505** (disproved). Borsuk's conjecture is false for
@@ -73,7 +76,7 @@ theorem erdos_505 : ∃ (n : ℕ),
     ∃ (S : Set (EuclideanSpace ℝ (Fin n))),
       Bornology.IsBounded S ∧ 0 < diam S ∧
         ∀ (F : Fin (n + 1) → Set (EuclideanSpace ℝ (Fin n))),
-          S ⊆ ⋃ i, F i →
+          (∀ i, F i ⊆ S) → S ⊆ ⋃ i, F i →
           ∃ i, diam S ≤ diam (F i) := by
   sorry
 
@@ -87,7 +90,7 @@ theorem erdos_505.small_dim (n : ℕ) (hn : n ≤ 3)
     (S : Set (EuclideanSpace ℝ (Fin n)))
     (hS : Bornology.IsBounded S) (hd : 0 < diam S) :
     ∃ (F : Fin (n + 1) → Set (EuclideanSpace ℝ (Fin n))),
-      S ⊆ ⋃ i, F i ∧ ∀ i, diam (F i) < diam S := by
+      (∀ i, F i ⊆ S) ∧ S ⊆ ⋃ i, F i ∧ ∀ i, diam (F i) < diam S := by
   sorry
 
 end Erdos505


### PR DESCRIPTION
`erdos_505`, `erdos_505.small_dim` and `erdos_505.test_dim_one` only required `S ⊆ ⋃ i, F i` with `diam (F i) < diam S`. Since `Metric.diam` is `0` on unbounded sets, `F i = Set.univ` satisfies this, so `small_dim` and `test_dim_one` were trivially true and `erdos_505` was false. Borsuk's problem ([erdosproblems.com/505](https://www.erdosproblems.com/505)) asks for a cover of `S` by bounded sets of strictly smaller diameter.

**Change:** require the covering sets to be subsets of `S` (`∀ i, F i ⊆ S`) in all three statements. This loses no generality (intersect each piece with `S`) and forces the pieces to be bounded, so `Metric.diam` gives their true diameter. It also matches the linked Aristotle proof, which partitions `S`. A short note on this choice was added to the module docstring.

**Checked:** `lake --wfail build 'FormalConjectures.ErdosProblems.«505»'` — Build completed successfully, no warnings.

Fixes #5657
