### PR TITLE
fix(ErdosProblems/830): count amicable pairs a ≤ b instead of ℕ-halving

### DIFF
--- a/FormalConjectures/ErdosProblems/830.lean
+++ b/FormalConjectures/ErdosProblems/830.lean
@@ -29,11 +29,10 @@ namespace Erdos830
 
 open scoped Classical in
 /--
-Let $A(x)$ counts the number of amicable $1\leq a\leq b\leq x$.
+Let $A(x)$ count the number of amicable pairs $1\leq a\leq b\leq x$.
 -/
 noncomputable abbrev A (x : ℝ) : ℝ :=
-  (1 / 2) * Finset.card <| (Finset.Icc 1 ⌊x⌋₊ ×ˢ Finset.Icc 1 ⌊x⌋₊).filter
-    fun (a, b) ↦ IsAmicable a b
+  ((Finset.Icc 1 ⌊x⌋₊ ×ˢ Finset.Icc 1 ⌊x⌋₊).filter fun (a, b) ↦ a ≤ b ∧ IsAmicable a b).card
 
 /-- **Erdos Problem 830, Part 1**
 We say that $a,b\in \mathbb{N}$ are an amicable pair if $\sigma(a)=\sigma(b)=a+b$. Are there


### PR DESCRIPTION
`Erdos830.A x` was defined as `(1 / 2) * Finset.card <| S`, which parses as `((1 / 2) * Finset.card) S`: the `1 / 2` and the product live in `Finset _ → ℕ` (Pi instances), and only the resulting natural number is cast to ℝ. Since `1 / 2 = 0` in ℕ, `A` was identically zero (`example (x : ℝ) : A x = 0 := by simp [A, Pi.mul_apply]` closes). The source defines `A(x)` as the number of amicable pairs `1 ≤ a ≤ b ≤ x` (so `A(284) = 1`); with `A = 0` the growth question in `erdos_830.parts.ii` was unsatisfiable and the three `variants` were bounds on zero.

**Change**: `A x` now directly counts the pairs `1 ≤ a ≤ b ≤ ⌊x⌋₊` with `IsAmicable a b` (no halving, no division), and the docstring is tidied to match. Statements of the theorems are unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«830»` — `Build completed successfully`, no warnings.

Fixes #5668
