### PR TITLE
fix(ErdosProblems/429): quantify the shift n over the integers

### DIFF
--- a/FormalConjectures/ErdosProblems/429.lean
+++ b/FormalConjectures/ErdosProblems/429.lean
@@ -35,8 +35,8 @@ namespace Erdos429
 
 /--
 Is it true that, if $A\subseteq \mathbb{N}$ is sparse enough and does not cover all residue
-classes modulo $p$ for any prime $p$, then there exists some $n$ such that $n+a$ is prime for
-all $a\in A$?
+classes modulo $p$ for any prime $p$, then there exists some $n\in \mathbb{Z}$ such that $n+a$ is
+prime for all $a\in A$?
 
 Weisenberg [We24] has shown the answer is no: $A$ can be arbitrarily sparse and missing at
 least one residue class modulo every prime $p$, and yet $A+n$ is not contained in the primes
@@ -47,7 +47,7 @@ theorem erdos_429 : answer(False) ↔
     ∃ f : ℕ → ℕ, Tendsto f atTop atTop ∧
       ∀ A : Set ℕ, A.Infinite → (∀ N, (A ∩ Set.Icc 1 N).ncard ≤ f N) →
         (∀ p : ℕ, p.Prime → ∃ b : ZMod p, ∀ a ∈ A, (a : ZMod p) ≠ b) →
-        ∃ n : ℕ, ∀ a ∈ A, (n + a).Prime := by
+        ∃ n : ℤ, ∀ a ∈ A, (n + a).toNat.Prime := by
   sorry
 
 end Erdos429


### PR DESCRIPTION
`erdos_429` ended with `∃ n : ℕ, ∀ a ∈ A, (n + a).Prime`, so the negated statement only claimed that some sparse admissible `A` admits no *nonnegative* shift into the primes. That is trivially true (e.g. `A = {p_k + 1}` with `p_k ≡ 1 mod (k+2)!` defeats every `n ≥ 0` while `A - 1` consists of primes), whereas the source states Weisenberg's result for every shift `n ∈ ℤ`.

**Change**: quantify `n` over `ℤ` and read "`n + a` is prime" as `(n + a).toNat.Prime`, which is exactly what the cited external formal proof establishes (`∀ n : ℤ, ∃ b ∈ B, ¬ Nat.Prime (Int.toNat (b + n))`). Docstring updated to say `n ∈ ℤ`.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«429»` — Build completed successfully.

Fixes #5650
