### PR TITLE
fix(ErdosProblems/450): ask for the window threshold y(ε,n) itself

### DIFF
--- a/FormalConjectures/ErdosProblems/450.lean
+++ b/FormalConjectures/ErdosProblems/450.lean
@@ -22,9 +22,6 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/450](https://www.erdosproblems.com/450)
 -/
 
-open Filter
-open scoped Topology
-
 namespace Erdos450
 
 /-- `m` has a divisor strictly between `n` and `2n`. -/
@@ -44,18 +41,22 @@ every `y ≥ Y ε n`, the window is `ε`-sparse. -/
 def IsSufficientScale (Y : ℝ → ℕ → ℕ) : Prop :=
   ∀ ε : ℝ, 0 < ε → ∃ N : ℕ, ∀ n : ℕ, N ≤ n → ∀ y : ℕ, Y ε n ≤ y → UniformlySparse ε n y
 
+/-- The least window length `y₀` such that every window `(x, x+y)` with `y ≥ y₀` is
+`ε`-sparse, or `⊤` if no such `y₀` exists. -/
+noncomputable def windowThreshold (ε : ℝ) (n : ℕ) : ℕ∞ :=
+  ⨅ y : {y : ℕ // ∀ z ≥ y, UniformlySparse ε n z}, (y.1 : ℕ∞)
+
 /--
 How large must $y=y(\epsilon,n)$ be such that the number of integers in
 $(x,x+y)$ with a divisor in $(n,2n)$ is at most $\epsilon y$?
 
-A **linear** scale is known to suffice (see `erdos_450.linear_scale_suffices`).
-Whether the optimal scale is *sublinear* — a sufficient `Y` with `Y ε n = o(n)` —
-is open.
+The bound is required for every $x$ and every window length at least $y$, and
+$y(\epsilon,n)$ is the least such threshold (or $\infty$ if there is none).
+A **linear** scale $y \le C(\epsilon) n$ is known to suffice for fixed $\epsilon$
+and all large $n$ (see `erdos_450.linear_scale_suffices`).
 -/
 @[category research open, AMS 11]
-theorem erdos_450 : answer(sorry) ↔
-    ∃ Y : ℝ → ℕ → ℕ, IsSufficientScale Y ∧
-      ∀ ε : ℝ, 0 < ε → Tendsto (fun n : ℕ => (Y ε n : ℝ) / n) atTop (𝓝 0) := by
+theorem erdos_450 (ε : ℝ) (hε : 0 < ε) (n : ℕ) : windowThreshold ε n = answer(sorry) := by
   sorry
 
 /--


### PR DESCRIPTION
`erdos_450` asked whether a *sublinear* sufficient window scale exists (`Y ε n = o(n)`). The source (erdosproblems.com/450, Erdős–Graham p. 89) asks how large $y = y(\epsilon,n)$ must be so that every window $(x, x+y)$ contains at most $\epsilon y$ integers with a divisor in $(n, 2n)$; it imposes no sublinearity. The sublinear question is also trivially false: all $n-1$ integers in $(n, 2n)$ have such a divisor, so any sufficient scale has $Y(\epsilon, n) > n$ for $\epsilon < 1/2$, and `answer(False)` closes the old statement.

**Change**: add `windowThreshold ε n : ℕ∞`, the least $y_0$ such that every window length $y \ge y_0$ is uniformly $\epsilon$-sparse ($\top$ if none), and restate the headline as `windowThreshold ε n = answer(sorry)` for `0 < ε`. The docstring states the chosen (uniform-in-$x$, threshold) reading. The existing definitions and the solved linear-scale companion are unchanged; the now-unused `open Filter` / `open scoped Topology` are removed.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«450»'` passes.

Fixes #5653
