### PR TITLE
fix(ErdosProblems/44): greedy Sidon construction gives size N^{1/3}

### DIFF
--- a/FormalConjectures/ErdosProblems/44.lean
+++ b/FormalConjectures/ErdosProblems/44.lean
@@ -120,11 +120,12 @@ theorem sidon_set_lower_bound (N : ℕ) (hN : 1 ≤ N) :
   sorry
 
 /--
-The greedy construction gives a Sidon set of size approximately `√N`.
+The greedy construction gives a Sidon set `A ⊆ {1, ..., N}` of size at least $N^{1/3}$,
+stated here as $N \le |A|^3$. See Section 1 of [arXiv:2103.15850](https://arxiv.org/abs/2103.15850).
 -/
 @[category textbook, AMS 5 11]
 theorem greedy_sidon_construction (N : ℕ) (hN : 1 ≤ N) :
-    ∃ᵉ (A ⊆ Finset.Icc 1 N), IsSidon (A : Set ℕ) ∧ A.card ≥ N.sqrt := by
+    ∃ᵉ (A ⊆ Finset.Icc 1 N), IsSidon (A : Set ℕ) ∧ N ≤ A.card ^ 3 := by
   sorry
 
 end Erdos44


### PR DESCRIPTION
`Erdos44.greedy_sidon_construction` asserted that for every `N ≥ 1` there is a Sidon subset `A ⊆ {1, ..., N}` with `A.card ≥ Nat.sqrt N`, and its docstring attributed this to the greedy construction. The greedy argument only gives a Sidon set of size at least `N^{1/3}` (Balogh–Füredi–Roy, arXiv:2103.15850, Section 1): e.g. the greedy (Mian–Chowla) set up to 289 has 16 elements while `Nat.sqrt 289 = 17`. The `⌊√N⌋` bound is not the cited textbook fact.

**Change**: the conclusion is now `N ≤ A.card ^ 3` (size at least `N^{1/3}`, stated without rounding), and the docstring states the cube-root bound and cites the source. Category and AMS tags are unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«44»'` — Build completed successfully.

Fixes #5651
