### PR TITLE
fix(ErdosProblems/486): only forbid residues modulo n for 0 < n < m

### DIFF
--- a/FormalConjectures/ErdosProblems/486.lean
+++ b/FormalConjectures/ErdosProblems/486.lean
@@ -25,13 +25,19 @@ import FormalConjecturesUtil
 namespace Erdos486
 
 /--
-For each $n \in \mathbb{N}$ choose some $X_n \subseteq \mathbb{Z}/n\mathbb{Z}$.
-Let $B = \{m \in \mathbb{N} : \forall n, m \not\equiv x \pmod{n} \text{ for all } x \in X_n\}$.
+Let $A \subseteq \mathbb{N}$, and for each $n \in A$ choose some
+$X_n \subseteq \mathbb{Z}/n\mathbb{Z}$. Let
+$B = \{m \in \mathbb{N} : m \not\in X_n \pmod{n} \text{ for all } n \in A \text{ with } m > n\}$.
 Must $B$ have a logarithmic density?
+
+The set $A$ is encoded by taking $X_n = \emptyset$ for $n \notin A$. Only positive moduli
+$n$ are considered, since $\mathbb{Z}/0\mathbb{Z} = \mathbb{Z}$ would allow $B$ to be an
+arbitrary set.
 -/
 @[category research open, AMS 11]
 theorem erdos_486 : answer(sorry) ↔
-    ∀ X : (n : ℕ) → Set (ZMod n), ∃ d, {m : ℕ | ∀ n, (m : ZMod n) ∉ X n}.HasLogDensity d := by
+    ∀ X : (n : ℕ) → Set (ZMod n),
+      ∃ d, {m : ℕ | ∀ n, 0 < n → n < m → (m : ZMod n) ∉ X n}.HasLogDensity d := by
   sorry
 
 end Erdos486


### PR DESCRIPTION
`Erdos486.erdos_486` required `(m : ZMod n) ∉ X n` for every modulus `n`. This includes `n = 0` (where `ZMod 0 = ℤ`, so `X 0` alone makes `B` an arbitrary set of naturals with no logarithmic density) and every `n ≥ m`. The source (erdosproblems.com/486, updated after Terence Tao's comment pointing to the activation threshold `b ≥ a_i` in [Er61, p.236]) only forbids `m` from the residues in `X_n` for `n ∈ A` with `m > n`; without that threshold there is a cheap negative answer.

**Change**: the set is now `{m : ℕ | ∀ n, 0 < n → n < m → (m : ZMod n) ∉ X n}`. The docstring is updated to the source wording and explains that `A` is encoded by `X_n = ∅` for `n ∉ A` and that only positive moduli are considered.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«486»'` — Build completed successfully, no warnings.

Fixes #5654
