### PR TITLE
fix(ErdosProblems/564): make the constant c a positive real

### DIFF
--- a/FormalConjectures/ErdosProblems/564.lean
+++ b/FormalConjectures/ErdosProblems/564.lean
@@ -35,7 +35,7 @@ $$ R_3(n) \geq 2^{2^{cn}}? $$
 -/
 @[category research open, AMS 5]
 theorem erdos_564 : answer(sorry) ↔
-    ∃ c > 0, ∀ᶠ n in atTop, (2 : ℝ)^(2 : ℝ)^(c * n) ≤ hypergraphRamsey 3 n := by
+    ∃ c > (0 : ℝ), ∀ᶠ n : ℕ in atTop, (2 : ℝ) ^ (2 : ℝ) ^ (c * n) ≤ hypergraphRamsey 3 n := by
   sorry
 
 end Erdos564


### PR DESCRIPTION
In `erdos_564` the constant `c` in the exponent `2^(2^(c * n))` had no type ascription and was elaborated as `ℕ` (since `n : ℕ`). With `0 < c` this forces `c ≥ 1`, so the statement reduces to `R_3(n) ≥ 2^{2^n}` eventually, which is false by the known upper bound `R_3(n) < 2^{2^n}` of Erdős–Hajnal–Rado. The source ([erdosproblems.com/564](https://www.erdosproblems.com/564)) asks for some real constant `c > 0`, possibly smaller than 1.

**Change**: quantify `∃ c > (0 : ℝ)` and annotate `∀ᶠ n : ℕ in atTop`, so the exponent is `c * (n : ℝ)`. Docstring unchanged (it already matches the source).

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«564»` — Build completed successfully.

Fixes #5660
