### PR TITLE
fix(ErdosProblems/422): specify Hofstadter's Q-sequence by a predicate

### DIFF
--- a/FormalConjectures/ErdosProblems/422.lean
+++ b/FormalConjectures/ErdosProblems/422.lean
@@ -19,7 +19,9 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 422
 
-*Reference:* [erdosproblems.com/422](https://www.erdosproblems.com/422)
+*References:*
+- [erdosproblems.com/422](https://www.erdosproblems.com/422)
+- [OEIS A005185](https://oeis.org/A005185)
 -/
 
 namespace Erdos422
@@ -28,30 +30,58 @@ open Filter
 open scoped Topology
 
 /--
+`IsHofstadterQ f` means that $f$ is Hofstadter's $Q$-sequence (OEIS A005185): $f(1) = f(2) = 1$
+and for $n > 2$
+$$
+f(n) = f(n - f(n - 1)) + f(n - f(n - 2)),
+$$
+where the recurrence requires $f(n - 1) < n$ and $f(n - 2) < n$, so that both arguments on the
+right-hand side are positive integers. The sequence begins $1, 1, 2, 3, 3, 4, \ldots$.
+
+At most one function satisfies this predicate. Some function satisfies it if and only if $f(n)$ is
+well-defined for all $n$, which is not known.
+-/
+def IsHofstadterQ (f : ℕ+ → ℕ+) : Prop :=
+  f 1 = 1 ∧ f 2 = 1 ∧
+  ∀ n : ℕ+, 2 < n →
+    f (n - 1) < n ∧ f (n - 2) < n ∧ f n = f (n - f (n - 1)) + f (n - f (n - 2))
+
+/-- The third term of Hofstadter's $Q$-sequence is $f(3) = f(2) + f(2) = 2$. -/
+@[category test, AMS 11]
+theorem erdos_422.test.f3 : ∀ f : ℕ+ → ℕ+, IsHofstadterQ f → f 3 = 2 := by
+  intro f ⟨h1, h2, h⟩
+  obtain ⟨-, -, h3⟩ := h 3 (by decide)
+  simp only [h3, show (3 : ℕ+) - 1 = 2 from rfl, show (3 : ℕ+) - 2 = 1 from rfl, h1, h2]
+  rfl
+
+/-- The fourth term of Hofstadter's $Q$-sequence is $f(4) = f(2) + f(3) = 3$. -/
+@[category test, AMS 11]
+theorem erdos_422.test.f4 : ∀ f : ℕ+ → ℕ+, IsHofstadterQ f → f 4 = 3 := by
+  intro f hf
+  have h3 := erdos_422.test.f3 f hf
+  obtain ⟨h1, h2, h⟩ := hf
+  obtain ⟨-, -, h4⟩ := h 4 (by decide)
+  simp only [h4, show (4 : ℕ+) - 1 = 3 from rfl, show (4 : ℕ+) - 2 = 2 from rfl, h2, h3]
+  rfl
+
+/--
 Let $f(1) = f(2) = 1$ and for $n > 2$
 $$
 f(n) = f(n - f(n - 1)) + f(n - f(n - 2)).
 $$
-
-Note: It is not known whether $f(n)$ is well-defined for all $n$.
--/
-partial def f : ℕ+ → ℕ+
-  | 1 => 1
-  | 2 => 1
-  | n => f (n - f (n - 1)) + f (n - f (n - 2))
-
-/--
 Does $f(n)$ miss infinitely many integers?
 -/
 @[category research open, AMS 11]
-theorem erdos_422 : answer(sorry) ↔ Set.Infinite {n | ∀ x, f x ≠ n} := by
+theorem erdos_422 : answer(sorry) ↔
+    ∀ f : ℕ+ → ℕ+, IsHofstadterQ f → Set.Infinite {n | ∀ x, f x ≠ n} := by
   sorry
 
 /--
 Is $f$ surjective?
 -/
 @[category research open, AMS 11]
-theorem erdos_422.variants.surjective : answer(sorry) ↔ f.Surjective := by
+theorem erdos_422.variants.surjective : answer(sorry) ↔
+    ∀ f : ℕ+ → ℕ+, IsHofstadterQ f → f.Surjective := by
   sorry
 
 /--
@@ -59,6 +89,7 @@ How does $f$ grow?
 -/
 @[category research open, AMS 11]
 theorem erdos_422.variants.growth_rate :
+    ∀ f : ℕ+ → ℕ+, IsHofstadterQ f →
     (fun n ↦ (f n : ℝ)) =O[atTop] (answer(sorry) : ℕ+ → ℝ) := by
   sorry
 
@@ -66,7 +97,8 @@ theorem erdos_422.variants.growth_rate :
 Does $f$ become stationary at some point?
 -/
 @[category research open, AMS 11]
-theorem erdos_422.variants.eventually_const : answer(sorry) ↔ EventuallyConst f atTop := by
+theorem erdos_422.variants.eventually_const : answer(sorry) ↔
+    ∀ f : ℕ+ → ℕ+, IsHofstadterQ f → EventuallyConst f atTop := by
   sorry
 
 end Erdos422


### PR DESCRIPTION
`Erdos422.f` was a `partial def`. Lean elaborates this as an opaque constant `ℕ+ → ℕ+` with no equation lemmas, so the four statements in the file referred to a function that the logic never identified with Hofstadter's $Q$-sequence: neither $f(1) = f(2) = 1$ nor the recurrence $f(n) = f(n - f(n-1)) + f(n - f(n-2))$ was available.

**Change**

- Replace `partial def f` by the predicate `IsHofstadterQ (f : ℕ+ → ℕ+)`: $f(1) = f(2) = 1$ and, for every $n > 2$, $f(n-1) < n$, $f(n-2) < n$ and $f(n) = f(n - f(n-1)) + f(n - f(n-2))$. The two inequalities are the conditions that make both arguments positive integers; at most one function satisfies the predicate, and one does exactly when the sequence is well-defined for all $n$ (the source notes this is not known).
- Quantify `erdos_422`, `erdos_422.variants.surjective`, `erdos_422.variants.growth_rate` and `erdos_422.variants.eventually_const` over `f` with `IsHofstadterQ f`, keeping `answer(sorry)` before the quantifier.
- Add test lemmas `erdos_422.test.f3` ($f(3) = 2$) and `erdos_422.test.f4` ($f(4) = 3$), and cite OEIS A005185 in the module docstring.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«422»` builds successfully.

Fixes #5649
