### PR TITLE
fix(ErdosProblems/377): state the almost-all variant with density one

### DIFF
--- a/FormalConjectures/ErdosProblems/377.lean
+++ b/FormalConjectures/ErdosProblems/377.lean
@@ -103,14 +103,14 @@ and
 $$
   \gamma_0 = \sum_{k = 2}^{\infty} \frac{\log k}{2^k}
 $$
-then for almost all integers $f(m) = \gamma_0 + o(1)$.
+then for almost all integers $f(m) = \gamma_0 + o(1)$, i.e. for every $\varepsilon > 0$ the set of
+$n$ with $|f(n) - \gamma_0| < \varepsilon$ has natural density one.
 
 [EGRS75] Erdős, P. and Graham, R. L. and Ruzsa, I. Z. and Straus, E. G., _On the prime factors of $\binom{2n}{n}$_. Math. Comp. (1975), 83-92.
 -/
 @[category research solved, AMS 11]
 theorem erdos_377.variants.ae (γ₀ : ℝ) (hγ₀ : γ₀ = ∑' (k : ℕ), (k + 2 : ℝ).log / 2 ^ (k + 2)) :
-    ∃ (o : ℕ → ℝ) (_ : Tendsto o atTop (𝓝 0)),
-      ∀ᶠ n in cofinite, sumInvPrimesNotDvdCentralBinom n = γ₀ + o n := by
+    ∀ ε > (0 : ℝ), {n : ℕ | |sumInvPrimesNotDvdCentralBinom n - γ₀| < ε}.HasDensity 1 := by
   sorry
 
 /--


### PR DESCRIPTION
`erdos_377.variants.ae` concluded with `∀ᶠ n in cofinite, f n = γ₀ + o n` for some `o → 0`, which (via `Nat.cofinite_eq_atTop`) says `f(n) → γ₀` as `n → ∞`. The source ([erdosproblems.com/377](https://www.erdosproblems.com/377), [EGRS75]) only states `f(m) = γ₀ + o(1)` for *almost all* integers, i.e. on a set of natural density one. Ordinary convergence is false, and would in any case make the open question `erdos_377` (boundedness of `f`) trivial.

**Change**: restate the variant as `∀ ε > 0, {n | |f n - γ₀| < ε}.HasDensity 1` (using `Set.HasDensity` from `FormalConjecturesForMathlib`), and add the density-one gloss to the docstring. Attributes unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«377»` — Build completed successfully, no warnings.

Fixes #5645
