### PR TITLE
fix(ErdosProblems/522): use counting measure as Kac coefficient reference

### DIFF
--- a/FormalConjectures/ErdosProblems/522.lean
+++ b/FormalConjectures/ErdosProblems/522.lean
@@ -29,7 +29,9 @@ namespace Erdos522
 
 /--
 A sequence of *Kac coefficients* over a subset `S` of a field `k` is a countably infinite sequence
-of independent random variables, each uniformly distributed over `S`.
+of independent random variables, each uniformly distributed over `S` with respect to the reference
+measure `μ`. The default reference measure is the counting measure, so that for a finite set `S`
+each coefficient takes every value of `S` with probability `1 / |S|`.
 
 Such a sequence determines a *Kac polynomial* of degree `n` for each `n`, which is the random
 polynomial given by `KacCoefficients.polynomial`.
@@ -37,13 +39,13 @@ polynomial given by `KacCoefficients.polynomial`.
 @[ext]
 structure KacCoefficients
     {k : Type*} [Field k] [MeasurableSpace k] (S : Set k)
-    (Ω : Type*) [MeasureSpace Ω] (μ : Measure k := by volume_tac) where
+    (Ω : Type*) [MeasureSpace Ω] (μ : Measure k := Measure.count) where
   toFun : ℕ → Ω → k
   h_indep : ProbabilityTheory.iIndepFun toFun ℙ
   h_unif : ∀ i, MeasureTheory.pdf.IsUniform (toFun i) S ℙ μ
 
 variable {k : Type*} [Field k] [MeasurableSpace k] (S : Set k)
-    (Ω : Type*) [MeasureSpace Ω] (μ : Measure k := by volume_tac)
+    (Ω : Type*) [MeasureSpace Ω] (μ : Measure k := Measure.count)
 
 /--
 We can always view a Kac polynomial as a random variable on `ℕ`.


### PR DESCRIPTION
`Erdos522.KacCoefficients` took `volume` as the default reference measure `μ`, and `erdos_522`, `variants.zero_one`, `variants.number_real_roots` and `variants.yakir_solution` all used this default on the two-point sets `{-1, 1}` or `{0, 1}`. These sets have Lebesgue measure zero, so `h_unif : pdf.IsUniform (toFun i) S ℙ μ` (which unfolds to `map (toFun i) ℙ = cond μ S`) forced the law of each coefficient to be the zero measure, not the fair `±1` (resp. `{0, 1}`) coefficients of [erdosproblems.com/522](https://www.erdosproblems.com/522).

**Change**: the default reference measure of `KacCoefficients` is now `Measure.count`, and the docstring explains that for a finite `S` each coefficient is then uniform on `S`. With this default, `cond Measure.count {-1, 1} = 2⁻¹ • (dirac (-1) + dirac 1)` is exactly the intended Rademacher law (checked in a scratch file). No theorem statements needed to change since they all use the default.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«522»'` builds successfully with no warnings.

Fixes #5658
