### PR TITLE
fix(ErdosProblems/409): ask for the density and assume σ-termination

### DIFF
--- a/FormalConjectures/ErdosProblems/409.lean
+++ b/FormalConjectures/ErdosProblems/409.lean
@@ -111,18 +111,19 @@ theorem erdos_409.parts.ii :
 What is the density of $n$ which reach any fixed prime under the iteration $n\mapsto\phi(n) + 1$?
 -/
 @[category research open, AMS 11]
-theorem erdos_409.parts.iii (p : ℕ) (h : p.Prime) (α : ℝ)
-    (hα : { n | ∃ i, (φ · + 1)^[i] n = p }.HasDensity α) :
-    α = answer(sorry) := by
+theorem erdos_409.parts.iii (p : ℕ) (h : p.Prime) :
+    { n | ∃ i, (φ · + 1)^[i] n = p }.HasDensity answer(sorry) := by
   sorry
 
 /--
-How many iterations of $n\mapsto\sigma(n) - 1$ are needed before a prime is reached?
+If the iteration $n\mapsto\sigma(n) - 1$ starting at $n > 1$ reaches a prime, how many
+iterations are needed before a prime is reached?
 -/
--- Formalisation note: non-termination of this sequence is less clear since
--- it is strictly increasing except at primes.
+-- Formalisation note: termination of this sequence is not known in general since
+-- it is strictly increasing except at primes, so it is assumed as a hypothesis.
 @[category research open, AMS 11]
-theorem erdos_409.variants.sigma (n : ℕ) (hn : n > 1) :
+theorem erdos_409.variants.sigma (n : ℕ) (hn : n > 1)
+    (hterm : ∃ i, (σ 1 · - 1)^[i] n |>.Prime) :
     IsLeast { i | (σ 1 · - 1)^[i] n |>.Prime } answer(sorry) := by
   sorry
 


### PR DESCRIPTION
`erdos_409.parts.iii` took a real `α` and `hα : S_p.HasDensity α` as hypotheses and concluded `α = answer(sorry)`. This is closed by `rfl` with `answer(α)` (noted in #4923), and it holds for every real answer whenever `S_p` has no natural density. The source asks for the density itself. `erdos_409.variants.sigma` asked for a natural-number least prime-hitting time of `n ↦ σ(n) - 1` with no termination hypothesis; since `IsLeast` requires membership, any answer forces termination for every `n > 1`, while the source poses the count only conditionally ("do iterates of this always reach a prime? If so, how soon?").

**Change**
- `parts.iii` now states `{ n | ∃ i, (φ · + 1)^[i] n = p }.HasDensity answer(sorry)` for a prime `p`, following the pattern of `erdos_1074.parts.ii`.
- `variants.sigma` gains the hypothesis `hterm : ∃ i, (σ 1 · - 1)^[i] n |>.Prime`; its docstring and formalisation note now say the count is conditional on termination. The separate yes/no question `sigma_prime_termination` is unchanged.

**Checked** `lake --wfail build 'FormalConjectures.ErdosProblems.«409»'` — builds with no warnings.

Fixes #5647
