### PR TITLE
fix(ErdosProblems/418): state positive lower density for nonaliquots

### DIFF
--- a/FormalConjectures/ErdosProblems/418.lean
+++ b/FormalConjectures/ErdosProblems/418.lean
@@ -109,16 +109,14 @@ theorem erdos_418.variants.seven_mem_cototient :
 Erdős [Er73b] has shown that a positive density set of natural numbers cannot be written as
 $\sigma(n)-n$ (numbers not of this form are called nonaliquot, or sometimes untouchable).
 
-The density sits in an existential, so `HasPosDensity` is the *stronger* reading: the witness
-`S` is ours to choose, and weakening it to positive lower density would claim less rather than
-more. That is the opposite of the usual situation for Erdős' "positive density", where the
-density is a hypothesis or a claim about a fixed set. Whether the nonaliquot numbers themselves
-have a density is a separate question and is not what this states.
+Here "positive density" means positive lower density: Banks and Luca [BaLu05] proved that the
+set of nonaliquots has lower density at least $1/48$, Chen and Zhao [ChZh11] improved this to
+$0.06$, and it is not known whether the natural density of the nonaliquots exists (Pollack and
+Pomerance [PoPo16] give a heuristic predicting its value).
 -/
 @[category research solved, AMS 11]
 theorem erdos_418.variants.sigma :
-    ∃ (S : Set ℕ) (hS : S.HasPosDensity),
-      S ⊆ { (σ 1 n - n : ℕ) | n }ᶜ := by
+    0 < { (σ 1 n - n : ℕ) | n }ᶜ.lowerDensity := by
   sorry
 
 /--
@@ -131,11 +129,11 @@ theorem erdos_418.variants.soln :
   sorry
 
 /--
-It is open whether the set of non-cototients has positive density.
+It is open whether the set of non-cototients has positive (lower) density.
 -/
 @[category research open, AMS 11]
 theorem erdos_418.variants.density :
-    answer(sorry) ↔ ∃ (S : Set ℕ) (hS : S.HasPosDensity), S ⊆ { (n - n.totient : ℕ) | n }ᶜ := by
+    answer(sorry) ↔ 0 < { (n - n.totient : ℕ) | n }ᶜ.lowerDensity := by
   sorry
 
 end Erdos418


### PR DESCRIPTION
`erdos_418.variants.sigma` and `erdos_418.variants.density` required, via `HasPosDensity`, a subset of the nonaliquots (resp. the non-cototients) whose natural density exists and is positive. The sources only give positive *lower* density for the nonaliquots (Erdős [Er73b]; Banks–Luca [BaLu05] lower density ≥ 1/48; Chen–Zhao [ChZh11] ≥ 0.06; Pollack–Pomerance [PoPo16] only give a heuristic for the exact density), and the open question on erdosproblems.com/418 asks whether the non-cototients have positive density in the same sense. Positive lower density is strictly weaker: e.g. `⋃ₖ (4ᵏ, 2·4ᵏ]` has lower density 1/3 but contains no subset of positive natural density. So the `research solved` statement claimed more than is known.

**Change**: both statements now read `0 < Sᶜ.lowerDensity` (the convention used in e.g. ErdosProblems/424 and 822), and the docstrings are updated accordingly; the earlier docstring note defending `HasPosDensity` is removed.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«418»'` passes.

Fixes #5648
