### PR TITLE
fix(ErdosProblems/40): erdos_40 asks for the class of admissible g

### DIFF
--- a/FormalConjectures/ErdosProblems/40.lean
+++ b/FormalConjectures/ErdosProblems/40.lean
@@ -42,14 +42,24 @@ def Erdos40For (g : ℕ → ℝ) : Prop :=
 For what functions $g(N) → \infty$ is it true that
 $$\lvert A\cap \{1,\ldots,N\}\rvert \gg \frac{N^{1/2}}{g(N)}$$
 implies $\limsup 1_A\ast 1_A(n)=\infty$?
+-/
+@[category research open, AMS 11]
+theorem erdos_40 :
+    {g : ℕ → ℝ | Tendsto g atTop atTop ∧ Erdos40For g} = answer(sorry) := by
+  sorry
 
-Asked here in decision form: is there any such $g$ at all? Establishing the
-implication for even one $g(N) → \infty$ already answers Erdős Problem 28
+/--
+Is there any function $g(N) → \infty$ such that
+$$\lvert A\cap \{1,\ldots,N\}\rvert \gg \frac{N^{1/2}}{g(N)}$$
+implies $\limsup 1_A\ast 1_A(n)=\infty$?
+
+This is a weaker form of Erdős Problem 40, which asks for all such $g$. Establishing
+the implication for even one $g(N) → \infty$ already answers Erdős Problem 28
 positively, because a basis of order $2$ satisfies
 $\lvert A\cap \{1,\ldots,N\}\rvert \gg N^{1/2}$.
 -/
 @[category research open, AMS 11]
-theorem erdos_40 :
+theorem erdos_40.variants.weaker :
     answer(sorry) ↔ ∃ g : ℕ → ℝ, Tendsto g atTop atTop ∧ Erdos40For g := by
   sorry
 


### PR DESCRIPTION
[erdosproblems.com/40](https://www.erdosproblems.com/40) asks: *for what functions* $g(N)\to\infty$ does $\lvert A\cap\{1,\ldots,N\}\rvert \gg N^{1/2}/g(N)$ imply $\limsup 1_A\ast 1_A(n)=\infty$? Since #4993 the headline `erdos_40` asked only whether *some* such $g$ exists (`answer(sorry) ↔ ∃ g, Tendsto g atTop atTop ∧ Erdos40For g`). That is a strictly weaker decision question: a positive answer leaves the set of admissible growth rates undetermined, and `answer(sorry)` should carry exactly the information the problem asks to determine.

**Change**

- `erdos_40` now states the classification: `{g : ℕ → ℝ | Tendsto g atTop atTop ∧ Erdos40For g} = answer(sorry)`, the shape used for "for what values" questions elsewhere in the collection (e.g. Erdős 349) and in CONTRIBUTING.md.
- The existence question from #4993 is kept, unchanged, as `erdos_40.variants.weaker`, with its docstring recording that one admissible $g$ already implies Erdős Problem 28.
- `Erdos40For` and `erdos_40.variants.implies_erdos_28` are untouched.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«40»'` — Build completed successfully.

Fixes #5646
