### PR TITLE
fix(ErdosProblems/325): use Wooley's exponent 0.91709477 in the k = 3 bound

### DIFF
--- a/FormalConjectures/ErdosProblems/325.lean
+++ b/FormalConjectures/ErdosProblems/325.lean
@@ -53,12 +53,15 @@ theorem erdos_325.variants.weaker :
   sorry
 
 /--
-For $k = 3$, the best known is due to Wooley [Wo15]
+For $k = 3$, the best known is due to Wooley [Wo15], who proved
+$f_{3, 3}(x) \gg x^{0.91709477}$.
+
 [Wo15] Wooley, Trevor D., Sums of three cubes, II. Acta Arith. (2015), 73-100.
 -/
 @[category research solved, AMS 11]
 theorem erdos_325.variants.wooley :
-    (fun x : ℕ => (x : ℝ) ^ (0.917 : ℝ)) =O[atTop] (fun x => (cardIsSumThreePowerBelow 3 x : ℝ)) := by
+    (fun x : ℕ => (x : ℝ) ^ (0.91709477 : ℝ)) =O[atTop]
+      (fun x => (cardIsSumThreePowerBelow 3 x : ℝ)) := by
   sorry
 
 end Erdos325


### PR DESCRIPTION
`erdos_325.variants.wooley` stated the lower bound `x ^ 0.917 = O(f_{3,3}(x))` for the number of integers up to `x` that are sums of three cubes, while the cited result (Wooley, *Sums of three cubes, II*, Acta Arith. 170 (2015), Theorem 1.1) gives `f_{3,3}(x) ≫ x^β` with `β = 0.91709477`. The Lean statement was therefore strictly weaker than the best-known bound its docstring advertises (the two rates differ by the unbounded factor `x ^ 0.00009477`).

**Change**: replace the exponent `0.917` by `0.91709477` in `erdos_325.variants.wooley` and state the bound explicitly in the docstring. Attributes and the `sorry` proof are unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«325»` — `Build completed successfully`, no warnings.

Fixes #5638
