### PR TITLE
fix(ErdosProblems/36): White's 2022 lower bound is non-strict

### DIFF
--- a/FormalConjectures/ErdosProblems/36.lean
+++ b/FormalConjectures/ErdosProblems/36.lean
@@ -295,12 +295,13 @@ theorem minimum_overlap.variants.lower.haugland_1996 :
   sorry
 
 /--
-A lower bound of $0.379005$.
+A lower bound of $0.379005$: the minimum overlap constant is at least $0.379005$.
 See [Erdős' minimum overlap problem](https://arxiv.org/abs/2201.05704)
 by *Ethan Patrick White*, 2022
 -/
 @[category research solved, AMS 5 11]
-theorem minimum_overlap.variants.lower.white_2022 : 0.379005 < atTop.liminf MinOverlapQuotient := by
+theorem minimum_overlap.variants.lower.white_2022 :
+    0.379005 ≤ atTop.liminf MinOverlapQuotient := by
   sorry
 
 /--


### PR DESCRIPTION
`Erdos36.minimum_overlap.variants.lower.white_2022` stated the strict inequality `0.379005 < atTop.liminf MinOverlapQuotient`. The cited source, White's *Erdős' minimum overlap problem* (arXiv:2201.05704), proves in Theorem 1 only that the minimum overlap constant μ is lower bounded by 0.379005, i.e. μ ≥ 0.379005; the paper does not establish strictness (its certificate only verifies the dual objective is at least 0.379005), so the Lean statement claimed more than the source.

**Change**: state the bound as `0.379005 ≤ atTop.liminf MinOverlapQuotient` (line broken to match the neighbouring lower-bound theorems) and make the docstring say "at least 0.379005". Category/AMS attributes unchanged; proof remains `sorry`.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«36»` — Build completed successfully, no warnings.

Fixes #5642
