### PR TITLE
fix(ErdosProblems/346): variants.example uses ratio liminf, strict monotone

### DIFF
--- a/FormalConjectures/ErdosProblems/346.lean
+++ b/FormalConjectures/ErdosProblems/346.lean
@@ -95,11 +95,13 @@ theorem erdos_346.variants.gt_goldenRatio_not_IsAddComplete {A : ℕ → ℕ}
   sorry
 
 /-- Erdős and Graham [ErGr80] also say that it is not hard to construct very irregular sequences
-satisfying the aforementioned properties. -/
+satisfying the aforementioned properties: there is a strictly increasing sequence `A` that is
+strongly complete and not complete whenever infinitely many terms are removed from it, but with
+$\liminf_n A(n+1)/A(n) = 1$ and $\limsup_n A(n+1)/A(n) = \infty$. -/
 @[category research solved, AMS 11]
-theorem erdos_346.variants.example : ∃ A : ℕ → ℕ, IsAddStronglyCompleteNatSeq A ∧
+theorem erdos_346.variants.example : ∃ A : ℕ → ℕ, StrictMono A ∧ IsAddStronglyCompleteNatSeq A ∧
     (∀ B : Set ℕ, B ⊆ range A → B.Infinite → ¬ IsAddComplete (range A \ B)) ∧
-    liminf (fun n => A (n + 1) / (2 : ℝ)) atTop = 1 ∧
+    liminf (fun n => A (n + 1) / (A n : ℝ)) atTop = 1 ∧
     limsup (fun n => A (n + 1) / (A n : ENNReal)) atTop = ⊤ := by
   sorry
 


### PR DESCRIPTION
`erdos_346.variants.example` formalises the remark in [ErGr80, p. 57] that there are very irregular sequences (with $\liminf a_{n+1}/a_n = 1$ and $\limsup a_{n+1}/a_n = \infty$) which are strongly complete and cease to be complete after deleting any infinite subsequence. The Lean statement had two defects: the lower-limit clause was `liminf (fun n => A (n + 1) / (2 : ℝ)) atTop = 1`, which divides by `2` rather than by `A n` (and equals `0` for any unbounded `A`), and deletions were modelled as infinite sets of values `B ⊆ range A` with no monotonicity hypothesis on `A`, whereas the source deletes infinitely many terms of a strictly increasing sequence `a_1 < a_2 < ⋯`, so repeated values could make the value-based conditions vacuous.

**Change**: replace the denominator `(2 : ℝ)` by `(A n : ℝ)`, and add `StrictMono A` to the existential, matching the source's `1 ≤ a_1 < a_2 < ⋯`; under `StrictMono A` the existing range-based formulation of completeness and of infinite deletions (shared with the other declarations in the file) agrees with the term-based one. The docstring now states the two limit conditions. Other declarations are untouched.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«346»'` (Build completed successfully, no warnings).

Note: open PR #5571 changes the answer/status of the main theorem `erdos_346` and does not touch `variants.example`, so the two changes are independent.

Fixes #5640
