### PR TITLE
fix(ErdosProblems/321): require positive iterated logs in upper bound

### DIFF
--- a/FormalConjectures/ErdosProblems/321.lean
+++ b/FormalConjectures/ErdosProblems/321.lean
@@ -101,11 +101,15 @@ R(N) \le \frac{1}{\log 2} \log_r N \left( \frac{N}{\log N} \prod_{i=3}^{r} \log_
 $$
 valid for any $k \ge 4$ with $\log_k N \ge k$ and any $r \ge 1$ with $\log_{2r} N \ge 1$. (In these bounds $\log_i n$ denotes the $i$-fold iterated logarithm.)
 
+Since `Real.log` is defined on all of $\mathbb{R}$, the condition $\log_{2r} N \ge 1$ is
+formalised as $\log_i N \ge 1$ for all $i \le 2r$, which is equivalent to it for the
+genuine iterated logarithm and ensures that every intermediate iterate is positive.
+
 [BlEr75] Bleicher, M. N. and Erdős, P., _The number of distinct subsums of $\sum \sb{1}\spN\,1/i$_. Math. Comp. (1975), 29-42.
 [BlEr76b] Bleicher, Michael N. and Erdős, Paul, _Denominators of Egyptian fractions. II_. Illinois J. Math. (1976), 598-613.
 -/
 @[category research solved, AMS 11]
-theorem erdos_321.variants.upper (N r : ℕ) (hr : 1 ≤ r) (hrN : 1 ≤ log^[2 * r] N) :
+theorem erdos_321.variants.upper (N r : ℕ) (hr : 1 ≤ r) (hrN : ∀ i ≤ 2 * r, 1 ≤ log^[i] N) :
     R N ≤ 1 / log 2 * log^[r] N * N / log N * ∏ i ∈ Finset.Icc 3 r, (log^[i] N) := by
   sorry
 


### PR DESCRIPTION
`erdos_321.variants.upper` assumed only `1 ≤ log^[2 * r] N`. Because Mathlib's `Real.log x = log |x|`, intermediate iterates can be negative while this hypothesis still holds: for `N = 13`, `r = 4` one gets `log^[8] 13 ≈ 1.21 ≥ 1` but `log^[3] 13 < 0` and `log^[4] 13 < 0`, so the asserted bound on `R 13` is about `-3.47` and the statement is false. The source (Bleicher–Erdős, as quoted on erdosproblems.com/321) presupposes that every iterated logarithm `log_i N` is positive, which is automatic there since `log_{2r} N ≥ 1` forces `log_i N ≥ 1` for all `i ≤ 2r`.

**Change**: the hypothesis is now `∀ i ≤ 2 * r, 1 ≤ log^[i] N`, which is equivalent to `log_{2r} N ≥ 1` for the genuine iterated logarithm and guarantees all intermediate iterates are positive. The docstring explains this. Statement, attributes and proof placeholder are otherwise unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«321»'` — Build completed successfully.

Fixes #5637
