### PR TITLE
fix(ErdosProblems/326): state the minimal-basis question from the source

### DIFF
--- a/FormalConjectures/ErdosProblems/326.lean
+++ b/FormalConjectures/ErdosProblems/326.lean
@@ -19,7 +19,12 @@ import FormalConjecturesUtil
 /-!
 # Erdős Problem 326
 
-*Reference:* [erdosproblems.com/326](https://www.erdosproblems.com/326)
+*References:*
+- [erdosproblems.com/326](https://www.erdosproblems.com/326)
+- [ErGr80] Erdős, P. and Graham, R. L., *Old and new problems and results in combinatorial number
+  theory*. Monographies de L'Enseignement Mathématique (1980), p. 47.
+- [Ca57] Cassels, J. W. S., *Über Basen der natürlichen Zahlenreihe*.
+  Abh. Math. Sem. Univ. Hamburg (1957), 247-257.
 -/
 
 open Filter
@@ -29,19 +34,26 @@ open scoped Topology
 namespace Erdos326
 
 /--
-Let $A \subset \mathbb{N}$ be an additive basis of order 2.
+Does there exist $A = \{a_1 < a_2 < \cdots\} \subset \mathbb{N}$ which is a minimal basis of
+order $2$ (i.e. every large integer is the sum of $2$ elements from $A$, and no proper subset of
+$A$ has this property), such that
+$$\lim_{k\to\infty} \frac{a_k}{k^2} = c$$
+for some $c \neq 0$?
 
-Must there exist $B = \{b_1 < b_2 < \dots\} \subseteq A$ which is also a basis such that
-$\lim_{k\to\infty} \frac{b_k}{k^2}$ does not exist?
+Erdős and Graham conjectured a negative answer to this question [ErGr80].
+
+"Minimal basis of order $2$" is formalised as `Minimal` for the predicate
+`Set.IsAsymptoticAddBasisOfOrder · 2` on sets of naturals ordered by inclusion.
 -/
 @[category research open, AMS 5 11]
-theorem erdos_326 : answer(sorry) ↔ ∀ (A : Set ℕ), A.IsAddBasisOfOrder 2 →
-    ∃ (b : ℕ → ℕ), StrictMono b ∧ ∀ n, b n ∈ A ∧ (Set.range b).IsAddBasis ∧
-      ∀ (x : ℝ), ¬ Tendsto (fun n ↦ (b n : ℝ) / n ^ 2) atTop (𝓝 x) := by
+theorem erdos_326 : answer(sorry) ↔ ∃ (a : ℕ → ℕ), StrictMono a ∧
+    Minimal (fun A : Set ℕ ↦ A.IsAsymptoticAddBasisOfOrder 2) (Set.range a) ∧
+      ∃ (c : ℝ), c ≠ 0 ∧ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 c) := by
   sorry
 
 /--
-Erdős originally asked whether this was true with `A = B`, but this was disproved by Cassels.
+Erdős originally asked this for any basis (not necessarily minimal); such a basis was constructed
+by Cassels [Ca57].
 -/
 -- Formalisation note: This is trivially true for `x = 0` by taking `a = id`. Cassels' proof
 -- shows it for `0 < x` which is more interesting.


### PR DESCRIPTION
`erdos_326` formalised the previous wording of [erdosproblems.com/326](https://www.erdosproblems.com/326): for every additive basis `A` of order 2, a subbasis `b` of *some* order (`IsAddBasis`) with `b n / n ^ 2` converging to no real limit, zero included. The source (revised 17 April 2026) asks instead whether there is a minimal asymptotic additive basis of order 2, `A = {a_1 < a_2 < ⋯}`, with `a_k / k^2 → c` for some `c ≠ 0`; Erdős originally asked this for any basis, which Cassels constructed, and Erdős–Graham conjecture a negative answer.

**Change**: restate `erdos_326` as `∃ a, StrictMono a ∧ Minimal (fun A : Set ℕ ↦ A.IsAsymptoticAddBasisOfOrder 2) (Set.range a) ∧ ∃ c : ℝ, c ≠ 0 ∧ Tendsto (fun n ↦ (a n : ℝ) / n ^ 2) atTop (𝓝 c)`, so the basis has order exactly 2, is minimal under inclusion (no proper subset is an asymptotic basis of order 2), and the limit is nonzero. Docstrings and the module references ([ErGr80], [Ca57]) are updated to match the source; the Cassels variant `erdos_326.variants.eq` is unchanged apart from its docstring.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«326»'` completes successfully with no warnings.

Fixes #5639
