### PR TITLE
fix(ErdosProblems/289): require the intervals to be non-adjacent

### DIFF
--- a/FormalConjectures/ErdosProblems/289.lean
+++ b/FormalConjectures/ErdosProblems/289.lean
@@ -25,17 +25,20 @@ open Asymptotics Filter Finset
 
 namespace Erdos289
 
-/-- Is it true that, for all sufficiently large $k$, there exists finite intervals
-$I_1, \dotsc, I_k \subset \mathbb{N}$ with $|I_i| \geq 2$ for $1 \leq i \leq k$ such that
+/-- Is it true that, for all sufficiently large $k$, there exist finite intervals
+$I_1, \dotsc, I_k \subset \mathbb{N}$, distinct, not overlapping or adjacent, with
+$|I_i| \geq 2$ for $1 \leq i \leq k$ such that
 $$
-1 = \sum_{i=1}^k \sum_{n \in I_i} \frac{1}{n}.
+1 = \sum_{i=1}^k \sum_{n \in I_i} \frac{1}{n}?
 $$
+Here two intervals are adjacent if their union is again an interval, so any two of the
+$I_i$ must be separated by at least one integer.
 -/
 @[category research open, AMS 11]
 theorem erdos_289 : answer(sorry) ↔
     (∀ᶠ k : ℕ in atTop, ∃ I : Fin k → ℕ × ℕ,
     (∀ i, (I i).1 < (I i).2) ∧
-    (∀ i j, i ≠ j → (I i).2 < (I j).1 ∨ (I j).2 < (I i).1) ∧
+    (∀ i j, i ≠ j → (I i).2 + 1 < (I j).1 ∨ (I j).2 + 1 < (I i).1) ∧
     ∑ i, ∑ n ∈ .Icc (I i).1 (I i).2, (n⁻¹ : ℚ) = 1) := by
   sorry
 


### PR DESCRIPTION
[erdosproblems.com/289](https://www.erdosproblems.com/289) asks for finite intervals $I_1, \dotsc, I_k \subset \mathbb{N}$ that are "distinct, not overlapping or adjacent" (the page notes that without this restriction the problem is easy, by Kovač's argument). `erdos_289` only required the intervals to be pairwise disjoint, so adjacent intervals such as $[2,3]$ and $[4,5]$ counted as two separate intervals.

**Change:** replace the disjointness condition `(I i).2 < (I j).1 ∨ (I j).2 < (I i).1` by the separation condition `(I i).2 + 1 < (I j).1 ∨ (I j).2 + 1 < (I i).1`, so that any two intervals are separated by at least one integer, and state the restriction in the docstring.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«289»` builds successfully.

Fixes #5636
