### PR TITLE
fix(ErdosProblems/274): state erdos_274 as the source's existence question

### DIFF
--- a/FormalConjectures/ErdosProblems/274.lean
+++ b/FormalConjectures/ErdosProblems/274.lean
@@ -57,10 +57,9 @@ The conjectured answer is no: in every such exact covering, two of the subgroups
 the same cardinality.
 -/
 @[category research open, AMS 20]
-theorem erdos_274 : answer(sorry) ↔ ∀ (G : Type*) [Group G],
-    1 < ENat.card G → ∀ (ι : Type*) [Fintype ι],
-    ∀ (P : Group.ExactCovering G ι), 1 < Fintype.card ι →
-    ∃ i j, i ≠ j ∧ #(P.parts i) = #(P.parts j) := by
+theorem erdos_274 : answer(sorry) ↔ ∃ (G : Type*) (_ : Group G),
+    1 < ENat.card G ∧ ∃ (ι : Type*) (_ : Fintype ι) (P : Group.ExactCovering G ι),
+    1 < Fintype.card ι ∧ ∀ i j, i ≠ j → #(P.parts i) ≠ #(P.parts j) := by
   sorry
 
 /--


### PR DESCRIPTION
[erdosproblems.com/274](https://www.erdosproblems.com/274) asks: *can there exist an exact covering of a group `G` by more than one coset of different sizes?* The Lean statement `erdos_274` had `answer(sorry) ↔ ∀ G …, ∃ i j, i ≠ j ∧ #(P.parts i) = #(P.parts j)`, i.e. the right-hand side was the *negation* of the source's question, so `answer(True)` would have encoded the source's negative answer.

**Change**: restate the right-hand side of `erdos_274` as the existence of a nontrivial group `G` and an exact covering `P : Group.ExactCovering G ι` with more than one part whose parts have pairwise distinct cardinalities (`∀ i j, i ≠ j → #(P.parts i) ≠ #(P.parts j)`). Now `answer(True)`/`answer(False)` line up with a yes/no answer to the source question (the conjectured answer being no, as the docstring already says). Docstring, attributes and the other theorems in the file are unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«274»` — Build completed successfully.

Fixes #5633
