### PR TITLE
fix(ErdosProblems/282): use distinct denominators; scope Graham answer

### DIFF
--- a/FormalConjectures/ErdosProblems/282.lean
+++ b/FormalConjectures/ErdosProblems/282.lean
@@ -27,21 +27,22 @@ open Filter Real
 namespace Erdos282
 
 /-- Let $A\subseteq \mathbb{N}$ be an infinite set and consider the following
-greedy algorithm for a rational $x$: choose the minimal $n\in A$ such
+greedy algorithm for a rational $x$: choose the minimal $n\in A$ not used so far such
 that $n\geq 1/x$ and repeat with $x$ replaced by $x-\frac{1}{n}$.
 
 This process of subtracting unit fractions is modelled in `greedyUnitFractionRem`.
 At each step `t : ℕ`, the function `greedyUnitFractionRem A x t` returns the remainder
-of `x` with respect to the first `t + 1` unit fractions, with denominators taken from `A`.
-If this process ever reaches `0` then it terminates. This corresponds to producing a
-representation of `x` as the sum of distinct unit fractions with denominators from `A`,
-however this function does not return this representation. -/
-noncomputable def greedyUnitFractionRem (A : Set ℕ) (x : ℚ) : ℕ → ℚ
-  | 0 => x - 1 / sInf { n | n ∈ A ∧ 1 / x ≤ n }
-  | t + 1 =>
-    let prev := greedyUnitFractionRem A x t
-    if prev ≤ 0 then 0 else
-      prev - 1 / sInf { n | n ∈ A ∧ 1 / prev ≤ n }
+of `x` with respect to the first `t + 1` unit fractions, with distinct denominators taken
+from `A`. Once the remainder reaches `0` it stays `0`, and the process terminates. This
+corresponds to producing a representation of `x` as the sum of distinct unit fractions with
+denominators from `A`, however this function does not return this representation. -/
+noncomputable def greedyUnitFractionRem (A : Set ℕ) (x : ℚ) (t : ℕ) : ℚ :=
+  if x ≤ 0 then 0 else
+    let n := sInf { n | n ∈ A ∧ 1 / x ≤ n }
+    let rem := x - 1 / n
+    match t with
+    | 0 => rem
+    | t + 1 => greedyUnitFractionRem (A \ {n}) rem t
 
 @[category test, AMS 5]
 theorem greedyUnitFractionRem_zero (n : ℕ) : greedyUnitFractionRem .univ (1 / n) 0 = 0 := by
@@ -49,12 +50,11 @@ theorem greedyUnitFractionRem_zero (n : ℕ) : greedyUnitFractionRem .univ (1 / 
 
 @[category test, AMS 5]
 theorem greedyUnitFractionRem_one (n : ℕ) : greedyUnitFractionRem .univ (1 / n) 1 = 0 := by
-  rw [greedyUnitFractionRem, greedyUnitFractionRem_zero]
-  simp
+  simp [greedyUnitFractionRem, Set.Ici_def]
 
 /-- Let $A\subseteq \mathbb{N}$ be an infinite set and consider the following
-greedy algorithm for a rational $x\in (0,1)$: choose the minimal $n\in A$ such
-that $n\geq 1/x$ and repeat with $x$ replaced by $x-\frac{1}{n}$. If this
+greedy algorithm for a rational $x\in (0,1)$: choose the minimal $n\in A$ not used
+so far such that $n\geq 1/x$ and repeat with $x$ replaced by $x-\frac{1}{n}$. If this
 terminates after finitely many steps then this produces a representation of
 $x$ as the sum of distinct unit fractions with denominators from $A$.
 
@@ -85,9 +85,10 @@ Does the greedy algorithm always
 terminate in such cases?
 -/
 @[category research open, AMS 5]
-theorem erdos_282.variants.graham {x : ℚ} (hx : x ∈ Set.Ioo 0 1) {a d : ℕ} (hd : 1 < d)
-    (h : (x.den / x.den.gcd (a.gcd d)).gcd (d / a.gcd d) = 1) :
-    (greedyUnitFractionRem { n | n ≡ a [MOD d] } x =ᶠ[atTop] 0) ↔ answer(sorry) := by
+theorem erdos_282.variants.graham :
+    answer(sorry) ↔ ∀ x : ℚ, x ∈ Set.Ioo 0 1 → ∀ a d : ℕ, 1 < d →
+      (x.den / x.den.gcd (a.gcd d)).gcd (d / a.gcd d) = 1 →
+      greedyUnitFractionRem { n | n ≡ a [MOD d] } x =ᶠ[atTop] 0 := by
   sorry
 
 @[category test, AMS 5]


### PR DESCRIPTION
`Erdos282.greedyUnitFractionRem` picked each next denominator from all of `A`, without excluding denominators already used, so it could subtract the same unit fraction twice (e.g. over the odd numbers it gives `2/3 = 1/3 + 1/3`, and over `{4, 16, 64, …}` it "terminates" on `1/2` although no sum of distinct such unit fractions equals `1/2`). The source's greedy algorithm (Erdős–Graham 1980, p. 30; confirmed by T. Bloom in the erdosproblems.com/282 comments) chooses at each step the largest unit fraction not yet used with denominator in `A`, and produces a sum of *distinct* unit fractions. Separately, `erdos_282.variants.graham` had `x`, `a`, `d` and their hypotheses outside `answer(sorry)`, so a single fixed answer was asserted for every instance rather than for the universal question "does the greedy algorithm always terminate in such cases?".

**Change**
- `greedyUnitFractionRem` now removes each chosen denominator from `A` before recursing (`A \ {n}`), and treats a remainder `≤ 0` as absorbing (so reaching `0` means termination). Docstrings updated to say "not used so far" / "distinct denominators". The `greedyUnitFractionRem_one` test proof was adjusted to the new unfolding.
- `erdos_282.variants.graham` is now `answer(sorry) ↔ ∀ x, x ∈ Ioo 0 1 → ∀ a d, 1 < d → (gcd condition) → termination`, matching the style of `erdos_282.variants.sq`.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«282»'` — builds with no warnings.

Fixes #5634
