### PR TITLE
fix(ErdosProblems/272): ask for the exact maximum, not an asymptotic

### DIFF
--- a/FormalConjectures/ErdosProblems/272.lean
+++ b/FormalConjectures/ErdosProblems/272.lean
@@ -46,7 +46,7 @@ arithmetic progression for all $i\neq j$?
 -/
 @[category research open, AMS 5]
 theorem erdos_272 :
-    (fun N ↦ (maxArithInterCard N : ℝ)) ~[atTop] (answer(sorry) : ℕ → ℝ) := by
+    ∀ N ≥ 1, maxArithInterCard N = (answer(sorry) : ℕ → ℕ) N := by
   sorry
 
 /--


### PR DESCRIPTION
[erdosproblems.com/272](https://www.erdosproblems.com/272) asks: "Let $N \geq 1$. What is the largest $t$ such that there are $A_1, \ldots, A_t \subseteq \{1, \ldots, N\}$ with $A_i \cap A_j$ a non-empty arithmetic progression for all $i \neq j$?" The headline `erdos_272` only asked for a function asymptotically equivalent to `maxArithInterCard` under `~[atTop]`. That asymptotic question is already resolved by Szabo ($N^2/2$, recorded in `erdos_272.variants.szabo`), and the `~[atTop]` form says nothing about any fixed $N$ (e.g. `fun N => N^2/2` gives $1/2$ at $N = 1$ while `maxArithInterCard 1 = 1`).

**Change**: restate the headline as the exact value for every $N \geq 1$:
`∀ N ≥ 1, maxArithInterCard N = (answer(sorry) : ℕ → ℕ) N`. Docstring, category and variants are unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«272»'` — Build completed successfully.

Note: this conflicts with #5556, which fills the `~[atTop]` headline with `N^2/2` and marks it solved; that asymptotic is already covered by `erdos_272.variants.szabo`, while the open question on the source is the exact maximum.

Fixes #5632
