### PR TITLE
fix(ErdosProblems/195): range over one-sided permutations ℕ ≃ ℤ

### DIFF
--- a/FormalConjectures/ErdosProblems/195.lean
+++ b/FormalConjectures/ErdosProblems/195.lean
@@ -32,10 +32,15 @@ namespace Erdos195
 /--
 What is the largest $k$ such that in any permutation of $\mathbb{Z}$ there must exist a
 monotone $k$-term arithmetic progression $x_1 < \cdots < x_k$?
+
+Here a permutation of $\mathbb{Z}$ is a one-sided arrangement $a_1, a_2, a_3, \ldots$ of the
+integers, i.e. a bijection $\mathbb{N} \to \mathbb{Z}$, and a monotone $k$-term arithmetic
+progression is a subsequence $a_{i_1}, \ldots, a_{i_k}$ with $i_1 < \cdots < i_k$ forming an
+increasing or decreasing arithmetic progression.
 -/
 @[category research open, AMS 5]
 theorem erdos_195 :
-    answer(sorry) = sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by
+    answer(sorry) = sSup {k : ℕ | ∀ f : ℕ ≃ ℤ, HasMonotoneAP f k} := by
   sorry
 
 /--
@@ -43,7 +48,7 @@ Geneson [Ge19] proved that k ≤ 5.
 -/
 @[category research solved, AMS 5]
 theorem erdos_195.variants.leq_5_bound :
-    5 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by
+    5 ≥ sSup {k : ℕ | ∀ f : ℕ ≃ ℤ, HasMonotoneAP f k} := by
   sorry
 
 /--
@@ -51,7 +56,7 @@ Adenwalla [Ad22] proved that k ≤ 4.
 -/
 @[category research solved, AMS 5]
 theorem erdos_195.variants.leq_4_bound :
-    4 ≥ sSup {k : ℕ | ∀ f : ℤ ≃ ℤ, HasMonotoneAP f k} := by
+    4 ≥ sSup {k : ℕ | ∀ f : ℕ ≃ ℤ, HasMonotoneAP f k} := by
   sorry
 
 end Erdos195


### PR DESCRIPTION
`erdos_195` and its two variants took the supremum over all `f : ℤ ≃ ℤ`, i.e. over doubly infinite arrangements `…, a₋₁, a₀, a₁, …` of the integers. In the source literature ([erdosproblems.com/195](https://www.erdosproblems.com/195) and the cited papers of Geneson and Adenwalla, following Davis–Entringer–Graham–Simmons) a *permutation of ℤ* is a one-sided sequence `a₁, a₂, a₃, …` enumerating ℤ; Geneson's `k ≤ 5` and Adenwalla's `k ≤ 4` are constructions of such one-sided permutations, and Adenwalla treats the doubly infinite case as a separate open question. The two problems are genuinely different (a one-sided `k`-AP-free permutation yields a doubly infinite one, but not conversely).

**Change**: quantify over `f : ℕ ≃ ℤ` in `erdos_195`, `erdos_195.variants.leq_5_bound` and `erdos_195.variants.leq_4_bound` (matching `ErdosProblems/196`, which uses `ℕ ≃ ℕ`), and state in the docstring that a permutation of ℤ means a one-sided arrangement / bijection ℕ → ℤ and what a monotone `k`-term AP is.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«195»` — Build completed successfully.

Fixes #5631
