### PR TITLE
fix(ErdosProblems/145): Huxley's moment asymptotic holds for α < 11/3

### DIFF
--- a/FormalConjectures/ErdosProblems/145.lean
+++ b/FormalConjectures/ErdosProblems/145.lean
@@ -72,13 +72,14 @@ theorem erdos_145.variants.le_three {α : ℝ} (hα : α ∈ Set.Icc 0 3) :
   sorry
 
 /--
-Greaves, Harman, and Huxley [GHH97] showed that this is true for $0 \leq \alpha\leq 11/3$.
+Greaves, Harman, and Huxley showed (in Chapter 11 of [GHH97]) that this is true for
+$0 \leq \alpha < 11/3$.
 
 [GHH97] Greaves, G. R. H. and Harman, G. and Huxley, M. N., Sieve Methods, Exponential Sums, and
   their Applications in Number Theory. (1997).
 -/
 @[category research solved, AMS 11]
-theorem erdos_145.variants.le_eleven_thirds {α : ℝ} (hα : α ∈ Set.Icc 0 (11 / 3)) :
+theorem erdos_145.variants.lt_eleven_thirds {α : ℝ} (hα : α ∈ Set.Ico 0 (11 / 3)) :
     ∃ β : ℝ,
       atTop.Tendsto (fun x : ℝ ↦ 1 / x * ∑ n ∈ A x, (s (n + 1) - s n : ℝ) ^ α) (𝓝 β) := by
   sorry


### PR DESCRIPTION
`Erdos145.erdos_145.variants.le_eleven_thirds` assumed `α ∈ Set.Icc 0 (11 / 3)`, i.e. it claimed the moment asymptotic for the endpoint α = 11/3 as well. The cited result (Huxley, *Moments of differences between square-free numbers*, Chapter 11 of [GHH97]) proves the asymptotic for k-free numbers when γ < 2k − 1 + 2/(k+1), which for squarefree numbers is exactly the open range 0 ≤ α < 11/3 (see also the history recounted in Chan, arXiv:2310.08448, and the zbMATH review of Huxley's chapter). The endpoint is not covered by the source.

**Change**: the hypothesis becomes `α ∈ Set.Ico 0 (11 / 3)`, the theorem is renamed `erdos_145.variants.lt_eleven_thirds`, and the docstring now states the range as $0 \leq \alpha < 11/3$ (with the erdosproblems.com wording pointing to Chapter 11 of [GHH97]).

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«145»` — Build completed successfully, no warnings.

Fixes #5630
