### PR TITLE
fix(Erdos/142): ask for asymptotic formula; order of magnitude variant

### DIFF
--- a/FormalConjectures/ErdosProblems/142.lean
+++ b/FormalConjectures/ErdosProblems/142.lean
@@ -22,8 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [erdosproblems.com/142](https://www.erdosproblems.com/142)
 -/
 
-open Filter
-
+open Asymptotics Filter
 
 namespace Erdos142
 
@@ -32,9 +31,10 @@ noncomputable abbrev r := Set.IsAPOfLengthFree.maxCard
 /--
 Prove an asymptotic formula for $r_k(N)$, the largest possible size of a subset
 of $\{1, \dots, N\}$ that does not contain any non-trivial $k$-term arithmetic progression.
+That is, find $f_k$ with $r_k(N) / f_k(N) \to 1$ as $N \to \infty$.
 -/
 @[category research open, AMS 11]
-theorem erdos_142 (k : ℕ) : (fun N => (r k N : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
+theorem erdos_142 (k : ℕ) : (fun N => (r k N : ℝ)) ~[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 /--
@@ -48,12 +48,13 @@ theorem erdos_142.variants.lower (k : ℕ) (hk : 1 < k) :
 
 
 /--
-Find functions $f_k$, such that $r_k(N) = O_k(f_k)$, where $r_k(N)$ the largest possible size of a
-subset of $\{1, \dots, N\}$ that does not contain any non-trivial $k$-term arithmetic progression.
+Determine the order of magnitude of $r_k(N)$, the largest possible size of a subset
+of $\{1, \dots, N\}$ that does not contain any non-trivial $k$-term arithmetic progression.
+That is, find $f_k$ with $r_k(N) \asymp_k f_k(N)$.
 -/
 @[category research open, AMS 11]
-theorem erdos_142.variants.upper (k : ℕ) :
-    (fun N => (r k N : ℝ)) =O[atTop] (answer(sorry) : ℕ → ℝ) := by
+theorem erdos_142.variants.isTheta (k : ℕ) :
+    (fun N => (r k N : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 
@@ -62,9 +63,10 @@ theorem erdos_142.variants.upper (k : ℕ) :
 /--
 Prove an asymptotic formula for $r_3(N)$, the largest possible size of a subset
 of $\{1, \dots, N\}$ that does not contain any non-trivial $3$-term arithmetic progression.
+That is, find $f$ with $r_3(N) / f(N) \to 1$ as $N \to \infty$.
 -/
 @[category research open, AMS 11]
-theorem erdos_142.variants.three : (fun N => (r 3 N : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
+theorem erdos_142.variants.three : (fun N => (r 3 N : ℝ)) ~[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 end Erdos142


### PR DESCRIPTION
`erdos_142` and `erdos_142.variants.three` related $r_k(N)$ to the answer by `=Θ[atTop]`, which only fixes the order of growth (it is satisfied by `2 * r k` as well as by `r k`), whereas [erdosproblems.com/142](https://www.erdosproblems.com/142) asks for an asymptotic formula, i.e. a function whose ratio to $r_k(N)$ tends to $1$. Separately, `erdos_142.variants.upper` asked for an arbitrary function $f_k$ with $r_k(N) = O_k(f_k(N))$, which the trivial bound $f_k(N) = N$ satisfies (#4922).

**Change**
- `erdos_142` and `erdos_142.variants.three` now use `~[atTop]` (`Asymptotics.IsEquivalent`), matching the asymptotic-formula question and the convention used in `ErdosProblems/272.lean` and `507.lean`.
- `erdos_142.variants.upper` is replaced by `erdos_142.variants.isTheta`, which asks for the order of magnitude of $r_k(N)$ (`=Θ[atTop]`) — the question the source attributes to [Er80] and [Va99]. The trivial linear bound no longer works, since $r_k(N) = o(N)$.
- Docstrings updated to spell out the intended relation in each case.

Reviewer note: as with every `answer(sorry) : ℕ → ℝ` statement in the repository (e.g. #272, #507), the tautological answer `r k` itself still closes these; per CONTRIBUTING.md that is out of scope.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«142»'` — build completed successfully, no warnings.

Fixes #5628, fixes #4922
