### PR TITLE
fix(ErdosProblems/137): answer(True) means a powerful product exists

### DIFF
--- a/FormalConjectures/ErdosProblems/137.lean
+++ b/FormalConjectures/ErdosProblems/137.lean
@@ -26,11 +26,12 @@ import FormalConjecturesUtil
 namespace Erdos137
 
 /--
-Let $k\geq 3$. Can the product of any $k$ consecutive integers $N$ ever be powerful? That is,
-must there always exist a prime $p\mid N$ such that $p^2\nmid N$?
+We say that $N$ is powerful if whenever $p\mid N$ we also have $p^2\mid N$.
+
+Let $k\geq 3$. Can the product of any $k$ consecutive positive integers ever be powerful?
 -/
 @[category research open, AMS 11]
-theorem erdos_137 : answer(sorry) ↔ ∀ k ≥ 3, ∀ n, ¬ (∏ x ∈ Finset.Ioc n (n + k), x).Powerful := by
+theorem erdos_137 : answer(sorry) ↔ ∃ k ≥ 3, ∃ n, (∏ x ∈ Finset.Ioc n (n + k), x).Powerful := by
   sorry
 
 /--


### PR DESCRIPTION
[erdosproblems.com/137](https://www.erdosproblems.com/137) asks: "Let $k\geq 3$. Can the product of any $k$ consecutive positive integers ever be powerful?" The Lean statement `erdos_137` identified `answer(sorry)` with `∀ k ≥ 3, ∀ n, ¬ (∏ x ∈ Finset.Ioc n (n + k), x).Powerful`, so `answer(True)` asserted a *negative* answer to the source's question (the opposite polarity), and the docstring's "That is, must there always exist a prime $p\mid N$ with $p^2\nmid N$?" restated the negated question.

**Change**: the statement is now `answer(sorry) ↔ ∃ k ≥ 3, ∃ n, (∏ x ∈ Finset.Ioc n (n + k), x).Powerful`, so `answer(True)` states that a powerful product of at least three consecutive positive integers exists, as the source asks. The docstring is rewritten to follow the source wording (including the definition of powerful) and no longer switches polarity. Attributes and the variants are unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«137»` — Build completed successfully.

Fixes #5627
