### PR TITLE
fix(ErdosProblems/12): Schoen and Baier bounds hold for infinitely many N

### DIFF
--- a/FormalConjectures/ErdosProblems/12.lean
+++ b/FormalConjectures/ErdosProblems/12.lean
@@ -119,20 +119,23 @@ theorem erdos_12.variants.example (A : Set ℕ)
 Let $A$ be a set of natural numbers with the property that there are no distinct $a,b,c \in A$ such
 that $a \mid (b+c)$ and $b,c > a$. If all elements in $A$ are pairwise coprime then
 $$\lvert A\cap\{1,\ldots,N\}\rvert \ll N^{2/3}$$
+for infinitely many $N$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_12.variants.schoen (A : Set ℕ) (hA : IsGood A) (hA' : A.Pairwise Nat.Coprime) :
-    (fun N ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =O[atTop] (fun N ↦ (N : ℝ) ^ (2 / 3 : ℝ)) := by
+    ∃ C > (0 : ℝ), {N : ℕ | (A ∩ Icc 1 N).ncard ≤ C * (N : ℝ) ^ (2 / 3 : ℝ)}.Infinite := by
   sorry
 
 /--
 Let $A$ be a set of natural numbers with the property that there are no distinct $a,b,c \in A$ such
 that $a \mid (b+c)$ and $b,c > a$. If all elements in $A$ are pairwise coprime then
 $$\lvert A\cap\{1,\ldots,N\}\rvert \ll N^{2/3}/\log N$$
+for infinitely many $N$.
 -/
 @[category research solved, AMS 11]
 theorem erdos_12.variants.baier (A : Set ℕ) (hA : IsGood A) (hA' : A.Pairwise Nat.Coprime) :
-    (fun N ↦ ((A ∩ Icc 1 N).ncard : ℝ)) =O[atTop] (fun N ↦ (N : ℝ) ^ (2 / 3 : ℝ) / (N : ℝ).log) := by
+    ∃ C > (0 : ℝ),
+      {N : ℕ | (A ∩ Icc 1 N).ncard ≤ C * (N : ℝ) ^ (2 / 3 : ℝ) / (N : ℝ).log}.Infinite := by
   sorry
 
 end Erdos12


### PR DESCRIPTION
`Erdos12.erdos_12.variants.schoen` and `Erdos12.erdos_12.variants.baier` concluded with `=O[atTop]`, i.e. `|A ∩ [1,N]| ≤ C·N^{2/3}` (resp. `C·N^{2/3}/log N`) for **all** sufficiently large `N`. [erdosproblems.com/12](https://www.erdosproblems.com/12) states Schoen's result and Baier's improvement only **for infinitely many `N`**, so the Lean statements were strictly stronger than the cited theorems.

**Change**: restate both variants as `∃ C > (0 : ℝ), {N : ℕ | (A ∩ Icc 1 N).ncard ≤ C * N^(2/3) [/ log N]}.Infinite`, following the "infinitely many `N`" style already used by `erdos_12.parts.ii` in the same file. Docstrings now say "for infinitely many $N$". Hypotheses, categories and AMS tags are unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«12»'` — Build completed successfully, no warnings.

Fixes #5625
