### PR TITLE
fix(ErdosProblems/124): require positive exponents in melfi_construction

### DIFF
--- a/FormalConjectures/ErdosProblems/124.lean
+++ b/FormalConjectures/ErdosProblems/124.lean
@@ -89,18 +89,21 @@ lemma erdos124.converse {D : Finset ℕ} (hD₃ : ∀ d ∈ D, 3 ≤ d)
 
 /--
 For any $\varepsilon > 0$, there exists an infinite sequence $2 \le d_0 < d_1 < \dots$ such
-that all sufficiently large integers can be written as $\sum_{i \in I} a_i$ for some finite
-set $I$, where each $a_i$ has only the digits $0, 1$ when written in base $d_i$,
-and the series $\sum_{i=0}^{\infty} \frac{1}{d_i - 1}$ converges to a value at most
-$\varepsilon$.
+that the series $\sum_{i=0}^{\infty} \frac{1}{d_i - 1}$ converges to a value at most
+$\varepsilon$, and yet for every $k \ne 0$ all sufficiently large integers can be written as
+$\sum_{i \in I} a_i$ for some finite set $I$, where each $a_i$ is divisible by $d_i^k$ and has
+only the digits $0, 1$ when written in base $d_i$.
 
-Proved by Melfi [Me04]
+The restriction $k \ne 0$ excludes the degenerate representation of $n$ as a sum of $n$ copies
+of $1 = d_i^0$ taken from $n$ distinct bases.
+
+Proved by Melfi [Me04, Proposition 1]
 -/
 @[category research solved, AMS 11]
 lemma erdos124.melfi_construction {ε : ℝ} (hε : 0 < ε) :
     ∃ d : ℕ → ℕ, StrictMono d ∧ 2 ≤ d 0 ∧
-      Summable (fun i ↦ (d i - 1 : ℝ)⁻¹) ∧ ∑' i, (d i - 1 : ℝ)⁻¹ ≤ ε ∧ ∀ᶠ n in atTop,
-      ∃ (I : Finset ℕ) (a : ℕ → ℕ), (∀ i ∈ I, a i ∈ sumsOfDistinctPowers (d i) 0) ∧
+      Summable (fun i ↦ (d i - 1 : ℝ)⁻¹) ∧ ∑' i, (d i - 1 : ℝ)⁻¹ ≤ ε ∧ ∀ k ≠ 0, ∀ᶠ n in atTop,
+      ∃ (I : Finset ℕ) (a : ℕ → ℕ), (∀ i ∈ I, a i ∈ sumsOfDistinctPowers (d i) k) ∧
         ∑ i ∈ I, a i = n := by
   sorry
 


### PR DESCRIPTION
`erdos124.melfi_construction` used the exponent cutoff `sumsOfDistinctPowers (d i) 0`. For an infinite base sequence this makes the representability clause vacuous: every `n` is the sum of `n` copies of `1 = d_i ^ 0` taken from `n` distinct bases, so the lemma was provable by junk (even after the `2 ≤ d 0` / summability hypotheses of #5540). Melfi's actual result ([Me04], Proposition 1, arXiv:math/0404555) constructs a set `A` of integers `≥ 2` with `∑ 1/(a-1) < ε` such that the powers `a ^ j` with `j ≥ k` form a complete sequence for **every** `k ≥ 1`.

**Change**
- Quantify the representability clause over `k ≠ 0` and use `sumsOfDistinctPowers (d i) k`, in the same style as `erdos124.ne_zero` in this file.
- Docstring updated to state the positive-exponent condition and why `k = 0` is degenerate.
- Includes the `2 ≤ d 0` and `Summable` hypotheses from #5540 (the branch was cut before that PR landed; if it shows a conflict, main's version of these lines is what this branch contains).

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«124»` — Build completed successfully, no warnings.

Fixes #5626, fixes #5536
