### PR TITLE
fix(ErdosProblems/1104): state the (1-o(1)) and (2+o(1)) bounds

### DIFF
--- a/FormalConjectures/ErdosProblems/1104.lean
+++ b/FormalConjectures/ErdosProblems/1104.lean
@@ -34,36 +34,32 @@ noncomputable def triangleFreeMaxChromatic (n : ℕ) : ℕ :=
 
 /--
 Lower bound (Hefty–Horn–King–Pfender 2025).
-There exists a constant $c_1 \in (0,1]$ such that, for sufficiently large $n$,
 $$
-c_1 \sqrt{\frac{n}{\log n}} \le f(n),
+(1 - o(1)) \sqrt{\frac{n}{\log n}} \le f(n),
 $$
 where $f(n)$ denotes the maximum chromatic number of a triangle-free graph on
 $n$ vertices, formalized as `triangleFreeMaxChromatic n`.
 -/
 @[category research solved, AMS 5]
 theorem erdos_1104.variants.lower :
-    ∃ c₁ : ℝ, 0 < c₁ ∧ c₁ ≤ 1 ∧
-      (∀ᶠ n : ℕ in atTop,
-        c₁ * Real.sqrt (n : ℝ) / Real.sqrt (Real.log (n : ℝ))
-          ≤ (triangleFreeMaxChromatic n : ℝ)) := by
+    ∀ ε > (0 : ℝ), ∀ᶠ n : ℕ in atTop,
+      (1 - ε) * Real.sqrt (n : ℝ) / Real.sqrt (Real.log (n : ℝ))
+        ≤ (triangleFreeMaxChromatic n : ℝ) := by
   sorry
 
 /--
 Upper bound (Davies–Illingworth 2022).
-There exists a constant $c_2 \ge 2$ such that, for sufficiently large $n$,
 $$
-f(n) \le c_2 \sqrt{\frac{n}{\log n}},
+f(n) \le (2 + o(1)) \sqrt{\frac{n}{\log n}},
 $$
 where $f(n)$ denotes the maximum chromatic number of a triangle-free graph on
 $n$ vertices, formalized as `triangleFreeMaxChromatic n`.
 -/
 @[category research solved, AMS 5]
 theorem erdos_1104.variants.upper :
-    ∃ c₂ : ℝ, 2 ≤ c₂ ∧
-      (∀ᶠ n : ℕ in atTop,
-        (triangleFreeMaxChromatic n : ℝ)
-          ≤ c₂ * Real.sqrt (n : ℝ) / Real.sqrt (Real.log (n : ℝ))) := by
+    ∀ ε > (0 : ℝ), ∀ᶠ n : ℕ in atTop,
+      (triangleFreeMaxChromatic n : ℝ)
+        ≤ (2 + ε) * Real.sqrt (n : ℝ) / Real.sqrt (Real.log (n : ℝ)) := by
   sorry
 
 end Erdos1104


### PR DESCRIPTION
`Erdos1104.erdos_1104.variants.lower` and `.upper` asserted `c₁ √(n / log n) ≤ f(n)` and `f(n) ≤ c₂ √(n / log n)` for some unspecified constants `c₁ ≤ 1` and `c₂ ≥ 2`. The source states the sharper asymptotic bounds `(1 - o(1)) √(n / log n) ≤ f(n) ≤ (2 + o(1)) √(n / log n)` (Hefty–Horn–King–Pfender; Davies–Illingworth), so the Lean statements were strictly weaker corollaries.

**Change:** both theorems now quantify over every `ε > 0` and assert, for sufficiently large `n`, `(1 - ε) √n / √(log n) ≤ f(n)` and `f(n) ≤ (2 + ε) √n / √(log n)`. Docstrings updated to match.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«1104»` — Build completed successfully.

Fixes #5621
