### PR TITLE
fix(ErdosProblems/11): Granville–Soundararajan gives non-Wieferich primes

### DIFF
--- a/FormalConjectures/ErdosProblems/11.lean
+++ b/FormalConjectures/ErdosProblems/11.lean
@@ -66,13 +66,14 @@ theorem erdos_11.variants.finite_bound2 (n : ℕ) (hn : Odd n) (h : n < 2^50) (h
   sorry
 
 /--
-Suppose that every odd $n$ is the sum of a squarefree number and a power of 2. Then the set of primes
-$p$ such that $2 ^ p ≡ 2 \mod p ^ 2$ is infinite. This is Theorem 1 in [GrSo98].
+Suppose that every odd $n > 1$ is the sum of a squarefree number and a power of 2. Then the set of
+primes $p$ such that $2^p \not\equiv 2 \pmod{p^2}$ (the non-Wieferich primes) is infinite.
+This is Theorem 1 in [GrSo98].
 [GrSo98] Granville, A. and Soundararajan, K., A Binary Additive Problem of Erdős and the Order of $2$ mod $p^2$. The Ramanujan Journal (1998), 283-298.
 -/
 @[category research solved, AMS 11]
 theorem erdos_11.variants.granville_soundararajan (H : type_of% erdos_11) :
-    {p : ℕ | p.Prime ∧ 2 ^ p ≡ 2 [MOD p ^ 2]}.Infinite := by
+    {p : ℕ | p.Prime ∧ ¬ 2 ^ p ≡ 2 [MOD p ^ 2]}.Infinite := by
   sorry
 
 end Erdos11


### PR DESCRIPTION
`erdos_11.variants.granville_soundararajan` concluded that the set of primes `p` with `2 ^ p ≡ 2 [MOD p ^ 2]` (the Wieferich primes) is infinite. Theorem 1 of Granville–Soundararajan, *A Binary Additive Problem of Erdős and the Order of 2 mod p²* (1998), says the opposite: if every odd `n > 1` is the sum of a squarefree number and a power of 2, then there are infinitely many primes with `2^p ≢ 2 (mod p^2)`, i.e. non-Wieferich primes (erdosproblems.com/11 summarises this as "a positive proportion of primes are non-Wieferich primes"). The docstring repeated the same error.

**Change**: add the missing negation, `¬ 2 ^ p ≡ 2 [MOD p ^ 2]`, to the conclusion and rewrite the docstring to say non-Wieferich primes (and `n > 1`, matching the hypothesis `type_of% erdos_11`).

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«11»` builds successfully with no warnings.

Fixes #5620
