### PR TITLE
fix(ErdosProblems/1085): use (p-1)/(2p) in the odd-d upper bound

### DIFF
--- a/FormalConjectures/ErdosProblems/1085.lean
+++ b/FormalConjectures/ErdosProblems/1085.lean
@@ -76,13 +76,13 @@ theorem erdos_1085.variants.upper_d4_erdos (hd : 4 ≤ d) :
   sorry
 
 /-- Erdős and Pach showed that, for $d \ge 5$ odd, there exist constants $c_1(d), c_2(d) > 0$
-such that $\frac{p - 1}{2p} n^2 - c_1 n^{4/3} ≤ f_d(n) \le \frac{p - 1}{2p} n^2 + c_2 n^{4/3}$ where
+such that $\frac{p - 1}{2p} n^2 + c_1 n^{4/3} \le f_d(n) \le \frac{p - 1}{2p} n^2 + c_2 n^{4/3}$ where
 $p = \lfloor\frac d2\rfloor$. -/
 @[category research solved, AMS 52]
 theorem erdos_1085.variants.upper_lower_d5_odd (hd : 5 ≤ d) (hd_odd : Odd d) :
     ∃ c₁ > (0 : ℝ), ∃ c₂ : ℝ, ∀ᶠ n in atTop,
       ↑(d / 2 - 1) / (2 * ↑(d / 2)) * n ^ 2 + c₁ * n ^ (4 / 3 : ℝ) ≤ f d n ∧
-      f d n ≤ ↑(d / 2 - 1) / ↑(d / 2) * n ^ 2 + c₂ * n ^ (4 / 3 : ℝ) := by
+      f d n ≤ ↑(d / 2 - 1) / (2 * ↑(d / 2)) * n ^ 2 + c₂ * n ^ (4 / 3 : ℝ) := by
   sorry
 
 end Erdos1085


### PR DESCRIPTION
`Erdos1085.erdos_1085.variants.upper_lower_d5_odd` bounded `f d n` above by `(p-1)/p · n² + c₂ n^{4/3}` (with `p = d/2`), while [erdosproblems.com/1085](https://www.erdosproblems.com/1085) states the Erdős–Pach result for odd `d ≥ 5` as `(p-1)/(2p) n² + c₁ n^{4/3} ≤ f_d(n) ≤ (p-1)/(2p) n² + c₂ n^{4/3}`. With coefficient `(p-1)/p` the upper conjunct is weaker than the trivial bound `f_d(n) ≤ C(n,2)`.

**Change:** the upper conjunct now uses `↑(d / 2 - 1) / (2 * ↑(d / 2))`, matching the lower conjunct and the source. The docstring's `- c_1 n^{4/3}` is corrected to `+ c_1 n^{4/3}`, agreeing with the statement and the source.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«1085»` — Build completed successfully.

Fixes #5618
