### PR TITLE
fix(ErdosProblems/1047): drop root-count restriction from Goodman's maximum

### DIFF
--- a/FormalConjectures/ErdosProblems/1047.lean
+++ b/FormalConjectures/ErdosProblems/1047.lean
@@ -117,14 +117,14 @@ theorem erdos_1047.variants.referee :
   sorry
 
 /--
-Goodman raises the question of the maximum number of non-convex components that are possible as
-a function of the degree of $f$.
+Goodman raises the question of the maximum number of non-convex components of
+$\{ z: \lvert f(z)\rvert < c\}$ that are possible as a function of the degree of $f$, where
+$f$ ranges over all monic polynomials of degree $n$ and $c$ over all positive constants.
 -/
 @[category research open, AMS 30 52]
 theorem erdos_1047.variants.max_non_convex_components (n : ℕ) :
     IsGreatest {k : ℕ | ∃ (f : ℂ[X]) (c : ℝ), f.Monic ∧ f.natDegree = n ∧ 0 < c ∧
-      (componentsIn (sublevelSet f c)).ncard = (f.rootSet ℂ).ncard ∧
-      {t ∈ componentsIn (sublevelSet f c) | ¬ Convex ℝ t}.ncard = k} answer(sorry) := by
+      {t ∈ componentsIn (strictSublevelSet f c) | ¬ Convex ℝ t}.ncard = k} answer(sorry) := by
   sorry
 
 end Erdos1047


### PR DESCRIPTION
`Erdos1047.erdos_1047.variants.max_non_convex_components` maximised the number of non-convex components only over sublevel sets `sublevelSet f c` whose component count equals `(f.rootSet ℂ).ncard`. Goodman [Go66, §4] asks to "determine the maximum number of nonconvex components of E(c) as a function of n, the degree of the polynomial", where `E(c) = {z : |f(z)| < c}`, with no component-count hypothesis (he reintroduces "Suppose again that ... E(c) has m components" only for the separate starlikeness question). The erdosproblems.com entry states the question unqualified as well. The extra restriction changes the answer already in degree 2 (`z² − 1` at level `9/8` has a single non-convex component but is excluded).

**Change**: remove the conjunct `(componentsIn (sublevelSet f c)).ncard = (f.rootSet ℂ).ncard` and take the components of the open sublevel set `strictSublevelSet f c`, matching Goodman's `E(c)` (as the other Goodman variants in the file already do); docstring updated accordingly.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«1047»` — Build completed successfully.

Fixes #5615
