### PR TITLE
fix(ErdosProblems/1036): forbid ordinary balanced bicliques in G and Gᶜ

### DIFF
--- a/FormalConjectures/ErdosProblems/1036.lean
+++ b/FormalConjectures/ErdosProblems/1036.lean
@@ -42,14 +42,14 @@ def HasManyNonIsomorphicInducedSubgraphs {V : Type*} (G : SimpleGraph V) (k : �
     k ≤ (𝒮.ncard : ℝ)
 
 /--
-`G` contains no complete bipartite graph, and no complement of a complete bipartite graph, on
-more than `m` vertices as an induced subgraph.
+Neither `G` nor its complement contains a balanced complete bipartite graph $K_{k,k}$ on more
+than `m` vertices as a (not necessarily induced) subgraph. That is, there are no two disjoint
+sets of `k` vertices with $2k > m$ such that every pair of vertices from different sets is
+adjacent in `G`, or every such pair is non-adjacent in `G`.
 -/
-def NoLargeInducedBipartite {V : Type*} (G : SimpleGraph V) (m : ℝ) : Prop :=
-  ∀ (s : Set V) (a b : ℕ),
-    (Nonempty (G.induce s ≃g completeBipartiteGraph (Fin a) (Fin b)) ∨
-      Nonempty (G.induce s ≃g (completeBipartiteGraph (Fin a) (Fin b))ᶜ)) →
-    (s.ncard : ℝ) ≤ m
+def NoLargeBiclique {V : Type*} (G : SimpleGraph V) (m : ℝ) : Prop :=
+  ∀ k : ℕ, ((completeBipartiteGraph (Fin k) (Fin k)).IsContained G ∨
+    (completeBipartiteGraph (Fin k) (Fin k)).IsContained Gᶜ) → (2 * k : ℝ) ≤ m
 
 /--
 Let $G$ be a graph on $n$ vertices which does not contain a trivial (empty or complete) graph on
@@ -79,14 +79,14 @@ theorem erdos_1036.variants.alon_hajnal :
   sorry
 
 /--
-Erdős and Hajnal [ErHa89b] proved that if $G$ does not contain a complete bipartite graph or its
-complement on more than $c\log n$ vertices then $G$ contains at least $2^{\Omega_c(n)}$ many
-non-isomorphic induced subgraphs.
+Erdős and Hajnal [ErHa89b] proved that if neither $G$ nor its complement contains a balanced
+complete bipartite graph $K_{k,k}$ on more than $c\log n$ vertices (as a not necessarily induced
+subgraph) then $G$ contains at least $2^{\Omega_c(n)}$ many non-isomorphic induced subgraphs.
 -/
 @[category research solved, AMS 5]
 theorem erdos_1036.variants.erdos_hajnal :
     ∀ c : ℝ, 0 < c → ∃ δ : ℝ, 0 < δ ∧ ∀ᶠ n : ℕ in atTop, ∀ G : SimpleGraph (Fin n),
-      NoLargeInducedBipartite G (c * Real.log (n : ℝ)) →
+      NoLargeBiclique G (c * Real.log (n : ℝ)) →
         HasManyNonIsomorphicInducedSubgraphs G ((2 : ℝ) ^ (δ * (n : ℝ))) := by
   sorry
 


### PR DESCRIPTION
`erdos_1036.variants.erdos_hajnal` assumed `NoLargeInducedBipartite G (c * log n)`, which only forbids *induced* copies of $K_{a,b}$ and of its complement (so the two parts must be independent sets or cliques). Erdős–Hajnal [ErHa89b, Theorem 2, p. 154] instead assume $K_{c\log n,\,c\log n} \not\subseteq G, \bar G$, i.e. neither $G$ nor $\bar G$ contains a balanced biclique as an ordinary (not necessarily induced) subgraph, with edges inside the two parts unrestricted. The Lean hypothesis was therefore satisfied by graphs the source excludes (e.g. joins of two Ramsey graphs).

**Change**: replace `NoLargeInducedBipartite` by `NoLargeBiclique G m`, which says that for every `k`, if `completeBipartiteGraph (Fin k) (Fin k)` is contained (`SimpleGraph.IsContained`) in `G` or in `Gᶜ` then `2 * k ≤ m`; update the docstrings accordingly. Only balanced bicliques are forbidden, as in the source (forbidding all unbalanced $K_{a,b}$ as ordinary subgraphs would be impossible for large $n$ because of stars). The `2k` vs `k` and strict/non-strict conventions are absorbed by the universally quantified `c`.

**Checked**: `cd WORKTREE && lake --wfail build FormalConjectures.ErdosProblems.«1036»` — `Build completed successfully`, no warnings.

Fixes #5614
