### PR TITLE
fix(ErdosProblems/348): keep repeated terms in the completeness checks

### DIFF
--- a/FormalConjectures/ErdosProblems/348.lean
+++ b/FormalConjectures/ErdosProblems/348.lean
@@ -35,8 +35,8 @@ $A = \{a_1 \leq a_2 \leq \cdots\}$ of integers such that
 @[category research open, AMS 11]
 theorem erdos_348 :
     { (m, n) | (m) (n) (_ : m < n) (a : ℕ → ℕ) (_ : Monotone a)
-      (_ : ∀ s, s.card = m → IsAddComplete (Set.range (Function.updateFinset a s 0)))
-        (_ : ∀ t, t.card = n → ¬IsAddComplete (Set.range (Function.updateFinset a t 0))) } =
+      (_ : ∀ s, s.card = m → IsAddCompleteNatSeq' (Function.updateFinset a s 0))
+        (_ : ∀ t, t.card = n → ¬IsAddCompleteNatSeq' (Function.updateFinset a t 0)) } =
     answer(sorry) := by
   sorry
 


### PR DESCRIPTION
Erdős #348 asks, for a nondecreasing (possibly repeating) sequence `a_1 ≤ a_2 ≤ ⋯`, whether it remains complete after removing any `m` terms but not after removing any `n` terms. The Lean statement applied `IsAddComplete` to `Set.range (Function.updateFinset a s 0)`, which collapses repeated terms into a single set element: the constant sequence `1, 1, 1, …` is complete as a sequence, but its range `{1}` is not complete as a set, and deleting one position of a repeated value wrongly removes every occurrence.

**Change**: both completeness clauses now use the indexed predicate `IsAddCompleteNatSeq'` on the modified sequence `Function.updateFinset a s 0` (resp. `t`), so each remaining indexed term stays available (a deleted term becomes `0`, which contributes nothing to any sum). The "all sufficiently large integers" meaning, the docstring, the open status and the unknown answer are unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«348»` — Build completed successfully, no warnings.

Note: open PR #5363 proposes the same statement change together with a test file; this PR is the minimal statement fix.

Fixes #5362
