### PR TITLE
fix(Arxiv/2504.17644/Margulis): embed F[t] into F((t⁻¹)) via t ↦ X⁻¹

### DIFF
--- a/FormalConjectures/Arxiv/2504.17644/Margulis.lean
+++ b/FormalConjectures/Arxiv/2504.17644/Margulis.lean
@@ -66,9 +66,11 @@ section FunctionFieldDiagonalOrbit
 
 variable (F : Type u) [Field F] [Fintype F]
 
-/-- The natural inclusion `F[t] →+* F((t⁻¹))`. -/
+/-- The natural inclusion `F[t] →+* F((t⁻¹))`. The field `F((t⁻¹))` is modelled by the Laurent
+series field `F⸨X⸩`, whose variable `X` plays the role of `t⁻¹`, so the polynomial variable `t`
+is sent to `X⁻¹`. -/
 noncomputable def polyToLaurent : F[X] →+* F⸨X⸩ :=
-  (HahnSeries.ofPowerSeries ℤ F).comp Polynomial.coeToPowerSeries.ringHom
+  Polynomial.eval₂RingHom HahnSeries.C (HahnSeries.single (-1 : ℤ) 1)
 
 -- The `SetLike.GradeZero` instances for `Semiring`/`CommSemiring`/`Ring`/`CommRing`/`Monoid`/
 -- `Algebra` on a grade-zero piece are stated for an arbitrary graded family and unify with
@@ -79,7 +81,8 @@ attribute [-instance] SetLike.GradeZero.instMonoid SetLike.GradeZero.instSemirin
 /-- **Huang–Shi, Theorem 1.2**
 
 Let `F` be a finite field of characteristic `p ∈ {3, 5, 7, 11}`, and set
-`K = F((t⁻¹))`, `A = F[t]`. Let
+`K = F((t⁻¹))`, `A = F[t]`. Here `K` is modelled by the Laurent series field `F⸨X⸩` with
+`X = t⁻¹`, so that `A` is embedded via `t ↦ X⁻¹`. Let
 
 * `D` be the diagonal subgroup of `SL₄(K)`,
 * `Γ = SL₄(A)` the lattice subgroup embedded into `SL₄(K)` via the natural inclusion `A →+* K`.


### PR DESCRIPTION
`Margulis.polyToLaurent` sent the polynomial variable `t` to the Laurent series variable `X`, i.e. it embedded `F[t]` into `F((X))` by `t ↦ X`. Mathlib's `F⸨X⸩` carries the `X`-adic topology, so this lands `F[t]` inside the compact valuation ring `F[[X]]`, and `huang_shi_theorem_1_2` was quotienting `SL₄(F((X)))` by the compact open subgroup `SL₄(F[X])`, where no relatively compact full diagonal orbits exist. Huang–Shi, Theorem 1.2 concerns `SL₄(F((t⁻¹)))/SL₄(F[t])`, where `|t| > 1`.

**Change**: `polyToLaurent` is now `Polynomial.eval₂RingHom HahnSeries.C (HahnSeries.single (-1 : ℤ) 1)`, so the Laurent series variable `X` models `t⁻¹` and `t ↦ X⁻¹`. The docstrings of `polyToLaurent` and `huang_shi_theorem_1_2` state this convention. The statement of `huang_shi_theorem_1_2` is otherwise unchanged (it uses the corrected embedding through `(Matrix.SpecialLinearGroup.map (polyToLaurent F)).range`).

**Checked**: `lake --wfail build 'FormalConjectures.Arxiv.«2504.17644».Margulis'` completes successfully with no warnings.

Fixes #5612
