### PR TITLE
fix(Wikipedia/MovingSofa): apply the translation before the rotation

### DIFF
--- a/FormalConjectures/Wikipedia/MovingSofa.lean
+++ b/FormalConjectures/Wikipedia/MovingSofa.lean
@@ -115,8 +115,13 @@ The rigid motion that translates by $p$ and then rotates counterclockwise by $\a
 Note that [Ge92] used this definition while [Ro18] used rotation first and then translation.
 -/
 def rotateTranslate (α : Real.Angle) (p : ℝ²) : E(2) :=
-  (EuclideanGeometry.o.rotation α).toAffineIsometryEquiv
-    |>.trans (AffineIsometryEquiv.vaddConst ℝ p)
+  (AffineIsometryEquiv.vaddConst ℝ p).trans
+    (EuclideanGeometry.o.rotation α).toAffineIsometryEquiv
+
+/-- `rotateTranslate α p` sends $q$ to $R_\alpha(q + p)$: the translation is applied first. -/
+@[category test, AMS 49]
+theorem rotateTranslate_apply (α : Real.Angle) (p q : ℝ²) :
+    rotateTranslate α p q = EuclideanGeometry.o.rotation α (q + p) := rfl
 
 /--
 The sofa according to a rotation path $p : [0, \pi/2] \to \mathbb{R}^2$ as in [Ge92] is the


### PR DESCRIPTION
`MovingSofa.rotateTranslate α p` is documented as the rigid motion that translates by `p` and then rotates by `α` (Gerver's convention, `q ↦ R_α (q + p)`), with the note that [Ro18] uses the opposite order. But `AffineIsometryEquiv.trans` composes left-to-right, so `rotation.trans (vaddConst p)` computes `q ↦ R_α q + p`, i.e. Romik's order. The Gerver path `GerversSofa.p` in this file satisfies `x_Romik(t) = R_t p(t)` (checked numerically phase by phase against Romik's Table 1), so only the documented translate-then-rotate order makes `sofaOfRotateTranslatePath p` equal Romik's hallway family `⋂ (x(t) + R_t L)`; the current order places the hallways wrongly (e.g. at `t = π/2` it translates by `(0, 1.23)` instead of `(-1.23, 0)`).

**Change**: reverse the composition in `rotateTranslate` to `(vaddConst ℝ p).trans (rotation α)`, and add the `rfl` regression theorem `rotateTranslate_apply : rotateTranslate α p q = rotation α (q + p)` (`category test`) pinning the convention. Docstrings and the path formulas are unchanged.

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.MovingSofa` (Build completed successfully, no warnings).

Note: this is the same change as the draft PR #5333 by the issue reporter, which was awaiting confirmation of the intended convention; the numerical check above confirms it.

Fixes #5270
