### PR TITLE
fix(Wikipedia/BatemanHorn): define the constant via ordered partial products

### DIFF
--- a/FormalConjectures/Wikipedia/BatemanHornConjecture.lean
+++ b/FormalConjectures/Wikipedia/BatemanHornConjecture.lean
@@ -40,15 +40,16 @@ def DegreesProduct (polys : Finset ℤ[X]) : ℕ :=
   polys.prod (fun f => f.natDegree)
 
 /--
-The Bateman-Horn constant of a set of polynomials `S`. This is defined as the infinite product over all primes:
-$$\frac{1}{D} \prod_p (1 - \frac{1}{p})^{-|S|} (1 - \frac{\omega_p(S)}{p})$$
-where $D = \prod_{f \in S} \deg(f)$ is the product of degrees and $\omega_p(S)$ is the number of residue classes mod $p$
-where at least one polynomial in $S$ vanishes.
+The partial Euler product of the Bateman-Horn constant of a set of polynomials `S`, taken over the
+primes $p < N$:
+$$\prod_{p < N} (1 - \frac{1}{p})^{-|S|} (1 - \frac{\omega_p(S)}{p})$$
+where $\omega_p(S)$ is the number of residue classes mod $p$ where at least one polynomial in $S$
+vanishes. The Bateman-Horn constant is the limit of these partial products as $N \to \infty$;
+the product is only conditionally convergent, so the order of the factors matters.
 -/
-noncomputable def BatemanHornConstant (polys : Finset ℤ[X]) : ℝ :=
-  (1 : ℝ) / (DegreesProduct polys) *
-  ∏' p : {p : ℕ // p.Prime},
-    (1 - (1 : ℝ) / p.val) ^ (-polys.card : ℤ) * (1 - (OmegaP polys p.val : ℝ) / p.val)
+noncomputable def BatemanHornPartialProduct (polys : Finset ℤ[X]) (N : ℕ) : ℝ :=
+  ∏ p ∈ Nat.primesBelow N,
+    (1 - (1 : ℝ) / p) ^ (-polys.card : ℤ) * (1 - (OmegaP polys p : ℝ) / p)
 
 /-- `CountSimultaneousPrimes S x` counts the number of `n ≤ x` at which all polynomials in `S` attain a prime value. -/
 noncomputable def CountSimultaneousPrimes (polys : Finset ℤ[X]) (x : ℝ) : ℕ :=
@@ -60,14 +61,18 @@ noncomputable def CountSimultaneousPrimes (polys : Finset ℤ[X]) (x : ℝ) : �
 **The Bateman-Horn Conjecture**
 Given a finite collection of distinct irreducible polynomials non-constant $f_1, f_2, \dots, f_k \in \mathbb{Z}[x]$
 with positive leading coefficients that satisfy the Schinzel condition, the number
-of positive integers n ≤ x for which all polynomials $f_i$ are simultaneously prime is asymptotic to:
-$$C(f_1, f_2, \dots, f_k) x / (log x)^k$$
-where $C$ is the Bateman-Horn constant given by the convergent infinite product:
-$$C = \frac{1}{D}\prod_{p\in\mathbb{P}} (1 - 1/p)^(-k) · (1 - \omega_p/p)$$
-Here $\omega_p/p$ is the number of residue classes modulo $p$ for which at least one polynomial vanishes.
+of positive integers $n \leq x$ for which all polynomials $f_i$ are simultaneously prime is
+asymptotic to:
+$$\frac{C}{D} \frac{x}{(\log x)^k}$$
+where $D = \prod_i \deg(f_i)$ and $C$ is the Bateman-Horn constant given by the convergent
+infinite product:
+$$C = \prod_{p\in\mathbb{P}} (1 - 1/p)^{-k} (1 - \omega_p/p)$$
+Here $\omega_p$ is the number of residue classes modulo $p$ for which at least one polynomial
+vanishes. The product is only conditionally convergent: it is the limit as $N \to \infty$ of the
+partial products over the primes $p < N$.
 
 The Schinzel condition ensures that for each prime $p$, there exists some integer $n$
-such that $p$ does not divide the product $f_(n) f_2(n) \dotsb f_(n)$, which guarantees the
+such that $p$ does not divide the product $f_1(n) f_2(n) \dotsb f_k(n)$, which guarantees the
 infinite product converges to a positive value.
 -/
 @[category research open, AMS 11 12]
@@ -76,8 +81,9 @@ theorem bateman_horn_conjecture
     (h_nonempty : polys.Nonempty)
     (h_irreducible : ∀ f ∈ polys, BunyakovskyCondition f)
     (h_compat : SchinzelCondition polys) :
-    (fun x : ℝ => (CountSimultaneousPrimes polys x : ℝ)) ~[atTop]
-    (fun x : ℝ => BatemanHornConstant polys * x / (Real.log x) ^ polys.card) := by
+    ∃ C : ℝ, 0 < C ∧ Tendsto (BatemanHornPartialProduct polys) atTop (𝓝 C) ∧
+      (fun x : ℝ => (CountSimultaneousPrimes polys x : ℝ)) ~[atTop]
+        (fun x : ℝ => C / DegreesProduct polys * x / (Real.log x) ^ polys.card) := by
   sorry
 
 end BatemanHornConjecture


### PR DESCRIPTION
`BatemanHornConstant` was defined with `∏'` (Mathlib's unconditional `tprod`) over all primes. The Bateman–Horn Euler product `∏_p (1 - 1/p)^{-k} (1 - ω_p/p)` is only conditionally convergent (in increasing order of primes): for a single irreducible quadratic the log of the local factor is `±1/p + O(1/p²)` and `∑ 1/p` diverges, so the family is not `Multipliable` and the `tprod` returns the junk value `1`. This made the statement disprovable (`X² + 1` vs `4X² + 1` get the same constant `1/2` but their counts satisfy `Count{f}(2N) = Count{g}(N) + 1`). [Wikipedia](https://en.wikipedia.org/wiki/Bateman%E2%80%93Horn_conjecture) defines `C` as the ordered product over primes and states `P(x) ~ (C/D) ∫₂ˣ dt/(log t)^m`.

**Change**: replace `BatemanHornConstant` by `BatemanHornPartialProduct polys N`, the product over the primes `p < N` (`Nat.primesBelow N`), and state the conjecture as: there is `C > 0` such that the partial products tend to `C` and `CountSimultaneousPrimes polys x ~ C / D · x / (log x)^k`. Docstrings updated to match (the `1/D` factor is now written explicitly in the asymptotic rather than folded into `C`, as in the source).

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.BatemanHornConjecture` (build completed successfully, no warnings).

Fixes #5255
