### PR TITLE
fix(ErdosProblems/700): state part (a) as a set-level characterization

### DIFF
--- a/FormalConjectures/ErdosProblems/700.lean
+++ b/FormalConjectures/ErdosProblems/700.lean
@@ -66,10 +66,10 @@ dividing $n$.
 
 Erdős–Szekeres [ErSz78] note that $f(n) = n/P(n)$ when $n$ is a product of two primes
 (`erdos_700.variants.prime_mul`), with $n = 30$ a further example. The characterisation itself is
-open; we state it as the (unknown) predicate that is equivalent to being such an `n`. -/
+open; we state it as the (unknown) set of all composite `n` with `f n = n / P n`. -/
 @[category research open, AMS 11]
-theorem erdos_700.parts.i (n : ℕ) (hn : ¬ n.Prime) (hn1 : 1 < n) :
-    f n = n / P n ↔ answer(sorry) := by
+theorem erdos_700.parts.i :
+    {n : ℕ | ¬ n.Prime ∧ 1 < n ∧ f n = n / P n} = answer(sorry) := by
   sorry
 
 /-- Let $f(n) = \min_{1 < k \le n/2} \gcd(n, \binom{n}{k})$.


### PR DESCRIPTION
Part (a) of [Erdős Problem 700](https://www.erdosproblems.com/700) asks to characterise the composite integers `n` with `f(n) = n/P(n)`. The Lean statement bound `n`, `¬ n.Prime` and `1 < n` before `answer(sorry)`, so `answer(f n = n / P n)` proved the theorem for every admissible `n` without giving any characterisation.

**Change:** restate `erdos_700.parts.i` as the set equality `{n : ℕ | ¬ n.Prime ∧ 1 < n ∧ f n = n / P n} = answer(sorry)`, so a single unknown set is asked for; the docstring is updated accordingly. Nothing else in the file changes.

**Checked:** `lake --wfail build FormalConjectures.ErdosProblems.«700»` (Build completed successfully, no warnings).

Overlaps with open PR #5212, which proposes the same restatement.

Fixes #5211
