### PR TITLE
fix(ErdosProblems/363): fix the number of blocks and their sizes

### DIFF
--- a/FormalConjectures/ErdosProblems/363.lean
+++ b/FormalConjectures/ErdosProblems/363.lean
@@ -49,13 +49,20 @@ def IsValidCollection (S : List (Finset ℕ)) : Prop :=
   IsSquare ((S.map (fun I => ∏ m ∈ I, m)).prod)
 
 /--
-Is it true that there are only finitely many collections of disjoint intervals $I_1,\ldots,I_n$ of size $\lvert I_i\rvert \geq 4$ for $1\leq i\leq n$ such that$$\prod_{1\leq i\leq n}\prod_{m\in I_i}m$$is a square?
+Is it true that, for each fixed $n$ and fixed sizes $k_1,\ldots,k_n \geq 4$, there are only finitely
+many collections of disjoint intervals $I_1,\ldots,I_n$ of size $\lvert I_i\rvert = k_i$ for
+$1\leq i\leq n$ such that$$\prod_{1\leq i\leq n}\prod_{m\in I_i}m$$is a square?
 
-This is false: Ulas [Ul05] constructed infinitely many such collections.
+The number of intervals and their sizes are fixed: the list `ks` of sizes determines both. Without
+this restriction, finiteness fails for a trivial reason (Skałba, see [Ul05]).
+
+This is false: Ulas [Ul05] constructed infinitely many such collections with $n = 4$ and
+$k_1 = \cdots = k_4 = 4$.
 -/
 @[category research solved, AMS 11,
   formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/main/src/v4.29.1/ErdosProblems/Erdos363.lean"]
-theorem erdos_363 : answer(False) ↔ {S : List (Finset ℕ) | IsValidCollection S}.Finite := by
+theorem erdos_363 : answer(False) ↔ ∀ ks : List ℕ,
+    {S : List (Finset ℕ) | IsValidCollection S ∧ S.map Finset.card = ks}.Finite := by
   sorry
 
 end Erdos363


### PR DESCRIPTION
`erdos_363` applied `.Finite` to the set of all valid collections `S` with the number of blocks and the block sizes left free, so `answer(False)` only asserted that the union over every parameter choice is infinite. The sources keep the parameters fixed: Ulas [Ul05, p. 332] states the conjecture for "each fixed k" and separately notes Skałba's observation that "if we allow k to vary, the above conjecture is not true"; Bennett–Van Luijk [BeVL12, §1] ask for finitely many solutions "for fixed r ≥ 1 and {k₁, …, k_r} with k_j ≥ 4". So the previous free-parameter statement was true for a cheap reason and did not capture the problem.

**Change:** the statement now reads `answer(False) ↔ ∀ ks : List ℕ, {S | IsValidCollection S ∧ S.map Finset.card = ks}.Finite`, so the list `ks` fixes both the number of blocks and their sizes. The docstring says so and records Ulas's counterexample family (`n = 4`, all sizes `4`). The `formal_proof` link is kept: the linked construction uses four blocks of length `4` (`Icc (x + 1) (x + 4)`) with an injective parametrisation, which gives infinitely many solutions for the fixed `ks = [4, 4, 4, 4]`.

**Checked:** `lake --wfail build 'FormalConjectures.ErdosProblems.«363»'` — Build completed successfully.

Fixes #5643
