### PR TITLE
fix(Paper/VoronovskajaTypeFormula): make the answer depend on α, f, x

### DIFF
--- a/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
+++ b/FormalConjectures/Paper/VoronovskajaTypeFormula.lean
@@ -120,8 +120,9 @@ with shape parameter $\alpha > 0$, $\alpha \neq 1$.
 The source asks for sufficiently smooth functions. This concrete version uses
 `ContDiffOn ℝ 2 f I` as a readable baseline regularity assumption; since the
 domain is the compact interval $[0,1]$, this also explains why no separate
-boundedness assumption is included here. The variants below record the unknown
-smoothness threshold more explicitly.
+boundedness assumption is included here. The limit is sought as an explicit
+expression in $\alpha$, $f$ and $x$, so the answer is a function of these.
+The variants below record the unknown smoothness threshold more explicitly.
 -/
 @[category research open, AMS 26 40 47]
 theorem voronovskaja_theorem.bezier_bernstein_operators
@@ -129,7 +130,7 @@ theorem voronovskaja_theorem.bezier_bernstein_operators
     (f : ℝ → ℝ) (x : ℝ) (hx : x ∈ I)
     (hf : ContDiffOn ℝ 2 f I) :
     Tendsto (fun n : ℕ => Real.sqrt n * (bezierBernstein n α f x - f x)) atTop
-      (𝓝 answer(sorry)) := by
+      (𝓝 ((answer(sorry) : ℝ → (ℝ → ℝ) → ℝ → ℝ) α f x)) := by
   sorry
 
 /--
@@ -140,7 +141,7 @@ $C^m$ function on $[0,1]$ should have the asserted asymptotic formula.
 @[category research open, AMS 26 40 47]
 theorem voronovskaja_theorem.bezier_bernstein_operators.variants.eventually_smooth
     (α : ℝ) (hα_pos : 0 < α) (hα : α ≠ 1) :
-    let limitFormula : (ℝ → ℝ) → ℝ → ℝ := answer(sorry)
+    let limitFormula : (ℝ → ℝ) → ℝ → ℝ := (answer(sorry) : ℝ → (ℝ → ℝ) → ℝ → ℝ) α
     ∀ᶠ m : ℕ in atTop,
       ∀ (f : ℝ → ℝ) (x : ℝ), x ∈ I → ContDiffOn ℝ m f I →
         Tendsto (fun n : ℕ => Real.sqrt n * (bezierBernstein n α f x - f x)) atTop
@@ -164,13 +165,13 @@ theorem voronovskaja_theorem.bezier_bernstein_operators.variants.eventually_smoo
 
 /--
 Variant of the Bézier-Bernstein Voronovskaja problem with the required smoothness order itself
-left as an answer. Replacing `(answer(sorry) : ℕ × ((ℝ → ℝ) → ℝ → ℝ))` by a concrete value lets one
-state the conjecture for a chosen regularity threshold.
+left as an answer. Replacing `(answer(sorry) : ℝ → ℕ × ((ℝ → ℝ) → ℝ → ℝ))` by a concrete function
+of $\alpha$ lets one state the conjecture for a chosen regularity threshold.
 -/
 @[category research open, AMS 26 40 47]
 theorem voronovskaja_theorem.bezier_bernstein_operators.variants.answer_smoothness
     (α : ℝ) (hα_pos : 0 < α) (hα : α ≠ 1) :
-    let p : ℕ × ((ℝ → ℝ) → ℝ → ℝ) := answer(sorry)
+    let p : ℕ × ((ℝ → ℝ) → ℝ → ℝ) := (answer(sorry) : ℝ → ℕ × ((ℝ → ℝ) → ℝ → ℝ)) α
     let m := p.1
     let limitFormula := p.2
     ∀ (f : ℝ → ℝ) (x : ℝ), x ∈ I → ContDiffOn ℝ m f I →


### PR DESCRIPTION
In `voronovskaja_theorem.bezier_bernstein_operators` the `answer(sorry)` slot sat inside the binders `α`, `f`, `x`, so a closed answer had to be a single real number valid for every admissible `α`, `f` and `x`. For a constant function the Bézier–Bernstein weights telescope to `1`, so the scaled sequence is identically `0` and the answer is forced to `0`, which then asserts a zero limit for every `C²` function. The source (Abel, Sozopol 2010) asks for the limit as an explicit expression in `f`, `x` and `α`. The `variants.eventually_smooth` and `variants.answer_smoothness` slots had the same defect with respect to `α`.

**Change**: the three answer slots are now function-typed and applied to the binders: `(answer(sorry) : ℝ → (ℝ → ℝ) → ℝ → ℝ) α f x` in the main statement, `(answer(sorry) : ℝ → (ℝ → ℝ) → ℝ → ℝ) α` in `eventually_smooth`, and `(answer(sorry) : ℝ → ℕ × ((ℝ → ℝ) → ℝ → ℝ)) α` in `answer_smoothness`. Docstrings updated accordingly. Categories and AMS tags are unchanged; `limit_exists` was already correctly formed and is untouched.

**Checked**: `lake --wfail build FormalConjectures.Paper.VoronovskajaTypeFormula` (build completed successfully, no warnings).

Note: open PRs #4646 and #4432 touch the same declaration; whichever lands second will need a trivial rebase on the answer slot.

Fixes #5008
