### PR TITLE
fix(Wikipedia/WallSunSun): fix the Lucas parameters before p varies

### DIFF
--- a/FormalConjectures/Wikipedia/WallSunSun.lean
+++ b/FormalConjectures/Wikipedia/WallSunSun.lean
@@ -138,15 +138,17 @@ theorem infinite_isWallSunSunPrime : {p : ℕ | IsWallSunSunPrime p}.Infinite :=
 A Lucas–Wieferich prime associated with $(a,b)$ is an odd prime $p$, not dividing $a^2 - 4b$, such
 that $U_{p-\varepsilon}(a,b) \equiv 0 \pmod{p^2}$ where $U(a,b)$ is the Lucas sequence of the first
 kind and $\varepsilon$ is the Legendre symbol $\left({\tfrac {a^2-4b}{p}}\right)$.
-The discriminant of this number is the quantity $a^2 - 4b$. It is conjectured that there are
-infinitely many Lucas–Wieferich primes of any given non-one fundamental discriminant.
+The discriminant of this number is the quantity $a^2 - 4b$. It is conjectured that for every
+Lucas sequence $U(a,b)$ whose discriminant $D = a^2 - 4b$ is a non-one fundamental discriminant,
+there are infinitely many Lucas–Wieferich primes associated with $(a,b)$. Here the parameters
+$(a,b)$ are fixed and only the prime $p$ varies.
 
 TODO: Source this conjecture
 -/
 @[category research open, AMS 11]
-theorem infinite_isWallSunSunPrime_of_disc_eq {D : ℤ} (hD : IsFundamentalDiscr D)
-    (hD₁ : D ≠ 1) :
-    {p : ℕ | ∃ a b, a ^ 2 - 4 * b = D ∧ IsLucasWieferichPrime a b p}.Infinite := by
+theorem infinite_isWallSunSunPrime_of_disc_eq {D a b : ℤ} (hD : IsFundamentalDiscr D)
+    (hD₁ : D ≠ 1) (hab : a ^ 2 - 4 * b = D) :
+    {p : ℕ | IsLucasWieferichPrime a b p}.Infinite := by
   sorry
 
 end WallSunSun


### PR DESCRIPTION
`infinite_isWallSunSunPrime_of_disc_eq` stated that the set `{p | ∃ a b, a ^ 2 - 4 * b = D ∧ IsLucasWieferichPrime a b p}` is infinite for every non-one fundamental discriminant `D`. Because `(a, b)` are chosen inside the set, a different Lucas sequence may be used for every prime `p`; taking `p² ∣ a` (and `b = (a² - D)/4`) makes every odd prime not dividing `D` a member, so the statement was elementary (see #5015 for a compiled proof). The source conjectures infinitely many Wall–Sun–Sun primes with discriminant `D` for a *fixed* Lucas sequence `U(a, b)` with `a² - 4b = D`.

**Change**: `a` and `b` are now fixed parameters with hypothesis `hab : a ^ 2 - 4 * b = D`, and the set is `{p : ℕ | IsLucasWieferichPrime a b p}`. The docstring is updated to say that `(a, b)` are fixed and only `p` varies. The statement stays `research open` with `by sorry`; the Fibonacci case `(a, b) = (1, -1)`, `D = 5` is `infinite_isWallSunSunPrime`.

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.WallSunSun` (Build completed successfully, no warnings).

Overlaps with #5550, which keeps the elementary statement as `research solved` and adds a separate open declaration; this PR instead replaces the defective statement in place.

Fixes #5015
