### PR TITLE
fix(Wikipedia/HardyLittlewood): state the asymptotic, require distinct offsets

### DIFF
--- a/FormalConjectures/Wikipedia/HardyLittlewood.lean
+++ b/FormalConjectures/Wikipedia/HardyLittlewood.lean
@@ -22,7 +22,7 @@ import FormalConjecturesUtil
 *Reference:* [Wikipedia](https://en.wikipedia.org/wiki/First_Hardy%E2%80%93Littlewood_conjecture)
 -/
 
-open Filter
+open Asymptotics Filter
 
 open scoped Nat.Prime
 
@@ -58,15 +58,23 @@ noncomputable def Nat.primeTupleCounting {k : ℕ} (m : Fin k.succ → ℕ) (n :
   open scoped Classical in
   Nat.count (IsAdmissiblePrimeConstellation m) n.succ
 
+/--
+The first Hardy–Littlewood conjecture for the tuple $(m_0, m_1, \dots, m_k)$: if $m_0 = 0$ and
+the $m_i$ are pairwise distinct, then
+$$
+  \pi_P(n)\sim C_P\int_2^n\frac{dt}{\log^{k+1}t}.
+$$
+-/
 def FirstHardyLittlewoodConjectureFor {k : ℕ} (m : Fin k.succ → ℕ) : Prop :=
-  let C : ℝ :=
+  m 0 = 0 → Function.Injective m →
+    let C : ℝ :=
       2 ^ k * ∏' (q : { q : ℕ // q.Prime ∧ 3 ≤ q}),
         (1 - (Nat.numResidues q m : ℝ) / q) / (1 - 1 / q) ^ k.succ
     let π_P : ℕ → ℝ := fun n => (Nat.primeTupleCounting m n : ℝ)
-    π_P =O[atTop] fun n => C * ∫ t in (2)..n, 1 / t.log ^ k.succ
+    π_P ~[atTop] fun n => C * ∫ t in (2)..n, 1 / t.log ^ k.succ
 
 /--
-Let $P = (m_1, \dots, m_k)$ be a tuple of positive even integers. Let
+Let $P = (m_1, \dots, m_k)$ be a tuple of distinct positive even integers. Let
 $\pi_P(n)$ denote the number of primes $p\leq n$ such that $(p, p + m_1, \dots, p + m_k)$
 forms an admissible prime constellation. Let $w(q; m_1, \dots, m_k)$ denote the
 number of distinct residues of $0, m_1, \dots, m_k$ modulo $q$, and let


### PR DESCRIPTION
`FirstHardyLittlewoodConjectureFor m` stated `π_P =O[atTop] fun n => C_P * ∫ t in (2)..n, 1 / t.log ^ k.succ`, a one-sided bound with an arbitrary implied constant. For distinct admissible offsets this bound is a classical sieve theorem (Brun–Selberg), so the declaration did not express an open problem, while Wikipedia (and the file's own docstring) state the asymptotic `π_P(n) ∼ C_P ∫_2^n dt / log^{k+1} t`. Independently, nothing required the offsets `m i` to be distinct: at `m = ![0, 1, 1]` the Euler product diverges, Mathlib's `∏'` returns its junk value `1`, and the resulting bound `π₂(n) =O n / (log n)^3` contradicts the conjecture itself.

**Change**
- `FirstHardyLittlewoodConjectureFor` now assumes `m 0 = 0` and `Function.Injective m` (so the offsets `2 * m i`, `i ≠ 0`, are distinct positive even integers) and states `π_P ~[atTop] fun n => C * ∫ t in (2)..n, 1 / t.log ^ k.succ` using `Asymptotics.IsEquivalent`. The hypotheses live inside the predicate so that `not_first_and_secondHardyLittlewoodConjecture` (Richards) still quantifies over the full conjecture; with the `∼` reading its antecedent now implies the prime `k`-tuples conjecture, as Richards' argument needs.
- Docstrings updated: the offsets are distinct, and the predicate documents the asymptotic it states.

**Reviewer notes**
- The Euler product is kept as `∏'`: with distinct offsets `w(q) = k + 1` for every prime `q` larger than all `m i`, so the factor is `1 + O(1/q²)` and the product converges absolutely (unlike the Bateman–Horn constant of #5828, which is only conditionally convergent). If some odd prime `q` has `w(q) = q` then the product is `0` and `π_P ≡ 0`, so the statement is trivially `0 ~ 0`, matching the source's restriction to admissible tuples.
- `m 0 = 0` is needed alongside injectivity: without it `IsPrimeConstellation m p` never holds, `π_P ≡ 0`, and `0 ~ C_P ∫ …` would be false for `C_P ≠ 0`.

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.HardyLittlewood` — Build completed successfully.

Fixes #4996
