### PR TITLE
fix(Wikipedia/Koethe): drop unused nil-ideal binders, fix docstring

### DIFF
--- a/FormalConjectures/Wikipedia/Koethe.lean
+++ b/FormalConjectures/Wikipedia/Koethe.lean
@@ -72,10 +72,10 @@ theorem KotherConjecture.variants.two_by_two_matrix {I : TwoSidedIdeal R} (hI : 
   sorry
 
 open scoped Classical in
-/-- The **Köthe conjecture**: for any positive integer `n`, the Köthe radical of `R` is the matrix ideal `M_2(Nil*(R))`. -/
+/-- The **Köthe conjecture**: for any finite index type `n`, the Köthe radical of the matrix
+ring `M_n(R)` is the ideal `M_n(Nil*(R))` of matrices with entries in the Köthe radical of `R`. -/
 @[category research open, AMS 16]
-theorem KotherConjecture.variants.matrixOver_KotherRadical
-    {I : TwoSidedIdeal R} (hI : IsNil I) (n : Type*) [Fintype n] :
+theorem KotherConjecture.variants.matrixOver_KotherRadical (n : Type*) [Fintype n] :
     matrix n (Nil* R) = Nil* (Matrix n n R) := by
   sorry
 


### PR DESCRIPTION
`Koethe.KotherConjecture.variants.matrixOver_KotherRadical` took hypotheses `{I : TwoSidedIdeal R} (hI : IsNil I)` that do not occur in its conclusion `matrix n (Nil* R) = Nil* (Matrix n n R)`, and its docstring said "the Köthe radical of `R` is the matrix ideal `M_2(Nil*(R))`". The Lean statement itself is Wikipedia's equivalent formulation 6 (the upper nilradical of `M_n(R)` is the set of matrices with entries in the upper nilradical of `R`, for every `n`), so the docstring named the wrong ring and fixed the size.

**Change**: remove the two unused binders and reword the docstring to describe the statement as written (Köthe radical of `M_n(R)` equals `M_n(Nil*(R))` for any finite index type `n`). No change to the statement's meaning or attributes.

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.Koethe` — Build completed successfully.

Fixes #5002
