### PR TITLE
fix(ErdosProblems/1000): exclude denominators dividing an earlier term

### DIFF
--- a/FormalConjectures/ErdosProblems/1000.lean
+++ b/FormalConjectures/ErdosProblems/1000.lean
@@ -33,15 +33,16 @@ open Filter Topology
 namespace Erdos1000
 
 /--
-Given an infinite sequence of integers $A = \{n_1 < n_2 < \cdots\}$, `phiSeq n k` is
-$\phi_A(k)$: the number of $1\leq m\leq n_k$ such that
+Given an infinite sequence of positive integers $A = \{n_1 < n_2 < \cdots\}$, `phiSeq n k` is
+$\phi_A(k)$: the number of $1\leq m\leq n_k$ such that $\frac{m}{n_k}$ cannot be written as
+$\frac{b}{n_j}$ for any integer $b$ and any $1\leq j<k$; equivalently,
 $$
-\frac{n_k}{(m,n_k)}\neq n_j
+\frac{n_k}{(m,n_k)}\nmid n_j
 $$
 for all $1\leq j<k$.
 -/
 def phiSeq (n : ℕ → ℕ) (k : ℕ) : ℕ :=
-  ((Finset.Icc 1 (n k)).filter fun m => ∀ j < k, n k / Nat.gcd m (n k) ≠ n j).card
+  ((Finset.Icc 1 (n k)).filter fun m => ∀ j < k, ¬ (n k / Nat.gcd m (n k)) ∣ n j).card
 
 /--
 The average $\frac{1}{N}\sum_{k\leq N}\frac{\phi_A(k)}{n_k}$.
@@ -50,11 +51,11 @@ noncomputable def phiAvg (n : ℕ → ℕ) (N : ℕ) : ℝ :=
   (∑ k ∈ Finset.range N, (phiSeq n k : ℝ) / (n k : ℝ)) / (N : ℝ)
 
 /--
-Let $A=\{n_1<n_2<\cdots\}$ be an infinite sequence of integers, and let $\phi_A(k)$ count the
-number of $1\leq m\leq n_k$ such that the fraction $\frac{m}{n_k}$ does not have denominator $n_j$
-for $j<k$ when written in lowest form; equivalently,
+Let $A=\{n_1<n_2<\cdots\}$ be an infinite sequence of positive integers, and let $\phi_A(k)$
+count the number of $1\leq m\leq n_k$ such that the fraction $\frac{m}{n_k}$ cannot be written
+as $\frac{b}{n_j}$ for any integer $b$ and any $j<k$; equivalently,
 $$
-\frac{n_k}{(m,n_k)}\neq n_j
+\frac{n_k}{(m,n_k)}\nmid n_j
 $$
 for all $1\leq j<k$.
 
@@ -76,7 +77,8 @@ theorem erdos_1000 : answer(True) ↔
 It is trivial that $\phi_A(k)\geq \phi(n_k)$, where $\phi$ is the Euler totient function.
 -/
 @[category research solved, AMS 11]
-theorem erdos_1000.variants.totient_le (n : ℕ → ℕ) (hn : StrictMono n) (k : ℕ) :
+theorem erdos_1000.variants.totient_le (n : ℕ → ℕ) (hn : StrictMono n) (hn0 : 0 < n 0)
+    (k : ℕ) :
     (n k).totient ≤ phiSeq n k := by
   sorry
 


### PR DESCRIPTION
`Erdos1000.phiSeq` counted the `1 ≤ m ≤ n_k` whose reduced denominator `n_k/(m,n_k)` is *not equal to* any earlier term `n_j`. The primary source, Erdős [Er64b] (Compositio Math. 16, p. 59), defines `φ(n_1,…,n_{k−1}; n_k)` as the number of `1 ≤ a ≤ n_k` with `a/n_k ≠ b/n_j` for every `j < k` and every integer `b`. Since `a/n_k = b/n_j` is solvable in `b` exactly when the reduced denominator of `a/n_k` *divides* `n_j`, the correct condition is `n_k/(m,n_k) ∤ n_j`. The two definitions differ (e.g. for `n_k = 2k`, `phiSeq n 5 = 7` before and `4` after: `4/12 = 2/6` was wrongly counted) and the discrepancy is not asymptotically harmless (for `n_k = 4k+2` the liminf of `φ_A(k)/n_k` is `0` under the source definition but `1/2` under the old one). Erdős's own argument on p. 60 uses the divisibility form. The "equivalently, `n_k/(m,n_k) ≠ n_j`" clause on erdosproblems.com is inaccurate and was the origin of the error.

**Change**
- `phiSeq` now filters by `∀ j < k, ¬ (n k / Nat.gcd m (n k)) ∣ n j`.
- Docstrings say the fraction `m/n_k` cannot be written as `b/n_j` for any `b` and `j < k`; the sequence is described as consisting of positive integers, as the theorems assume.
- `erdos_1000.variants.totient_le` gains `hn0 : 0 < n 0` (already present in the other variants): every positive `d` divides `0`, so the bound fails if `n 0 = 0`.
- The `formal_proof` attribute is kept: the corrected count is bounded above by the old one, so the linked proof of the existence statement still implies the corrected statement.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«1000»` (passes); also verified by `decide` that the corrected `phiSeq (fun k => 2*(k+1)) 5 = 4` and that `phiSeq (fun k => k+1) 12 = Nat.totient 12`.

Fixes #5613
