### PR TITLE
fix(Wikipedia/UnionClosed): state tightness as a maximum, not for every element

### DIFF
--- a/FormalConjectures/Wikipedia/UnionClosed.lean
+++ b/FormalConjectures/Wikipedia/UnionClosed.lean
@@ -199,14 +199,21 @@ theorem union_closed.variants.sharpness [Fintype n] (c : ℝ) (hc : 1 / 2 < c) :
   simp at this
 
 /--
-If the UC conjecture is tight for some family `A` then $|A| = 2^k$ for some $k$.
+The union-closed sets conjecture is tight for a union-closed family `A` if the largest number of
+sets in `A` containing a common element is exactly half of the sets in `A`, that is,
+$\max_i |\{X \in A : i \in X\}| = |A| / 2$.
+
+If the union-closed sets conjecture is tight for some family `A` then $|A| = 2^k$ for some $k$.
 
 Reference: Conjecture 3 in https://www.nieuwarchief.nl/serie5/pdf/naw5-2023-24-4-225.pdf.
 -/
 @[category research open, AMS 5]
 theorem union_closed.variants.cardinality_even_of_union_closed_tight
-    [Nonempty n] (hA : A ≠ {∅} ∧ A ≠ ∅) (hA : IsUnionClosed A)
-    (UCC_tight : ∀ i, #{x ∈ A | i ∈ x} = (1 / 2 : ℝ) * #A) :
+    [Nonempty n]
+    (h_ne_singleton_empty : A ≠ {∅})
+    (h_ne_empty : A ≠ ∅)
+    (h_union_closed : IsUnionClosed A)
+    (h_tight : IsGreatest (Set.range fun i : n => (#{x ∈ A | i ∈ x} : ℚ)) ((1 / 2 : ℚ) * #A)) :
     ∃ k, #A = 2 ^ k := by
   sorry
 


### PR DESCRIPTION
`union_closed.variants.cardinality_even_of_union_closed_tight` assumed `∀ i, #{x ∈ A | i ∈ x} = #A / 2`, i.e. every element of the ambient type lies in exactly half of the members of `A`. Conjecture 3 of the cited NAW article (Roos, 2023) only assumes that Frankl's conjecture is *tight* for `A`, which the article uses to mean that the largest number of members containing a common element equals `#A / 2` (Theorem 2: "the largest number of ones per column equals …, which is tight for the UCC if and only if …"). The `∀ i` form is strictly stronger (it also forces every element of `n` to lie in some member, hence `n` finite), so the Lean theorem was strictly weaker than the source. The binder `hA` was also used twice.

**Change**
- Replace the hypothesis by `IsGreatest (Set.range fun i : n => (#{x ∈ A | i ∈ x} : ℚ)) ((1 / 2 : ℚ) * #A)`, using `ℚ` as in the file's statement of the conjecture.
- Split `hA : A ≠ {∅} ∧ A ≠ ∅` / `hA : IsUnionClosed A` into `h_ne_singleton_empty`, `h_ne_empty`, `h_union_closed`, matching the sibling declarations. `A ≠ ∅` is kept since the empty family is tight in this sense but has cardinality `0`.
- Docstring now defines tightness.

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.UnionClosed` — Build completed successfully.

Fixes #5001
