### PR TITLE
fix(GreensOpenProblems/16,24,35,37): answer slots depend on binders

### DIFF
--- a/FormalConjectures/GreensOpenProblems/16.lean
+++ b/FormalConjectures/GreensOpenProblems/16.lean
@@ -44,7 +44,7 @@ noncomputable def f (N : ℕ) : ℕ :=
 @[category research open, AMS 5 11]
 theorem green_16 (N : ℕ) :
     ∃ A : Finset ℕ, A ⊆ Icc 1 N ∧ SolutionFree A ∧
-      A.card = answer(sorry) ∧
+      A.card = (answer(sorry) : ℕ → ℕ) N ∧
       MaximalFor (fun B => B ⊆ Icc 1 N ∧ SolutionFree B) Finset.card A := by
   sorry
 

--- a/FormalConjectures/GreensOpenProblems/24.lean
+++ b/FormalConjectures/GreensOpenProblems/24.lean
@@ -50,7 +50,7 @@ $\lbrace 0,1,3 \rbrace$ that $A$ can contain?
 Conjectured in [Aa19] p.579: $\left(\frac{1}{3} + o(1)\right) n^2$.
 -/
 @[category research open, AMS 5 11]
-theorem green_24 : ∀ n, max013AffineTranslates n = answer(sorry) := by
+theorem green_24 : ∀ n, max013AffineTranslates n = (answer(sorry) : ℕ → ℕ) n := by
   sorry
 
 /-  A collection of associated bounds and conjectured values. -/

--- a/FormalConjectures/GreensOpenProblems/35.lean
+++ b/FormalConjectures/GreensOpenProblems/35.lean
@@ -35,6 +35,12 @@ supported on `[0,1]`, and has total integral `1`.
 - [MV10](https://arxiv.org/abs/0907.1379)
   M. Matolcsi and C. Vinuesa, *Improved bounds on the supremum of autoconvolutions*,
   J. Math. Anal. Appl. 372 (2010), 439-447.
+- [AE25](https://arxiv.org/abs/2506.13131)
+  A. Novikov et al., *AlphaEvolve: A coding agent for scientific and algorithmic discovery*,
+  arXiv:2506.13131 (2025), Appendix B.1.
+
+The constants of [CS17], [MV10] and [AE25] are stated for functions supported on
+$[-1/4, 1/4]$; rescaling to $[0, 1]$ halves them.
 -/
 
 namespace Green35
@@ -50,19 +56,21 @@ def IsUnitIntervalDensity (f : ℝ → ℝ) : Prop :=
 noncomputable def c (p : ℝ≥0∞) : ℝ≥0∞ :=
   sInf { r | ∃ f, IsUnitIntervalDensity f ∧ r = eLpNorm (f ⋆ f) p }
 
-/-- Lower bound for $c(p)$ for $1 < p \le \infty$, improving the known value at $p = 2$ or $p = \infty$. -/
+/-- Lower bound for $c(p)$ for $1 < p \le \infty$, improving the known value $\sqrt{4/7}$ at
+$p = 2$ or the known value $0.64$ at $p = \infty$. -/
 @[category research open, AMS 26 28 42]
 theorem green_35.lower :
     let lb : ℝ≥0∞ → ℝ≥0∞ := answer(sorry)
     (∀ p, 1 < p → lb p ≤ c p) ∧
-      (ENNReal.ofReal (Real.sqrt (4 / 7)) < c 2 ∨ 0.64 < c ∞) := by
+      (ENNReal.ofReal (Real.sqrt (4 / 7)) < lb 2 ∨ 0.64 < lb ∞) := by
   sorry
 
-/-- Upper bound for $c(p)$ for $1 < p \le \infty$, improving the best-known value at $p = \infty$. -/
+/-- Upper bound for $c(p)$ for $1 < p \le \infty$, improving the best-known value $0.75265$ at
+$p = \infty$. -/
 @[category research open, AMS 26 28 42]
 theorem green_35.upper :
     let ub : ℝ≥0∞ → ℝ≥0∞ := answer(sorry)
-    (∀ p, 1 < p → c p ≤ ub p) ∧ ub ∞ < 0.7505 := by
+    (∀ p, 1 < p → c p ≤ ub p) ∧ ub ∞ < 0.75265 := by
   sorry
 
 /-  Known bounds and comparisons. -/
@@ -78,9 +86,17 @@ theorem c_2_lower : ENNReal.ofReal (Real.sqrt (4 / 7)) ≤ c 2 := by
 theorem c_inf_lower : 0.64 ≤ c ∞ := by
   sorry
 
-/-- Best-known upper bound for $c(\infty)$ due to Matolcsi and Vinuesa ([MV10]). -/
+/-- Upper bound for $c(\infty)$ due to Matolcsi and Vinuesa ([MV10]); their step function has
+autoconvolution supremum $1.50972\ldots$, which rescales to $0.75486\ldots$. -/
 @[category research solved, AMS 26 28 42]
-theorem c_inf_upper : c ∞ ≤ 0.7505 := by
+theorem c_inf_upper : c ∞ ≤ 0.7549 := by
+  sorry
+
+/-- Best-known upper bound for $c(\infty)$, found by AlphaEvolve ([AE25]) and recorded in Green's
+2025 update; the step function there has autoconvolution supremum at most $1.5053$, which
+rescales to $0.75265$. -/
+@[category research solved, AMS 26 28 42]
+theorem c_inf_upper_ae25 : c ∞ ≤ 0.75265 := by
   sorry
 
 /-- A comparison bound from Young's inequality. -/

--- a/FormalConjectures/GreensOpenProblems/37.lean
+++ b/FormalConjectures/GreensOpenProblems/37.lean
@@ -46,22 +46,24 @@ an arithmetic progression of length `k` with common difference `d`.
 -/
 @[category research open, AMS 5 11]
 theorem green_37 (N k : ℕ) :
-    IsLeast { m | ∃ A : Finset ℕ, A.card = m ∧ IsAPCover (A : Set ℕ) N k } (answer(sorry)) := by
+    IsLeast { m | ∃ A : Finset ℕ, A.card = m ∧ IsAPCover (A : Set ℕ) N k }
+      ((answer(sorry) : ℕ → ℕ → ℕ) N k) := by
   sorry
 
 /--
 Asymptotic version: determine the asymptotic behavior of `m(N, k)` as `N` grows.
-The solver should determine what function `f : ℕ → ℝ` eventually equals `(fun N ↦ (m N k : ℝ))`.
+The solver should determine a function `f : ℕ → ℕ → ℝ` such that, for each `k`,
+`f k` eventually equals `(fun N ↦ (m N k : ℝ))`.
 -/
 @[category research open, AMS 5 11]
 theorem green_37_asymptotic (k : ℕ) :
-    ∀ᶠ N in atTop, (m N k : ℝ) = (answer(sorry) : ℕ → ℝ) N := by
+    ∀ᶠ N in atTop, (m N k : ℝ) = (answer(sorry) : ℕ → ℕ → ℝ) k N := by
   sorry
 
-/-- Determine the asymptotic equivalence class (theta) of `m(N, k)`. -/
+/-- Determine, for each `k`, the asymptotic equivalence class (theta) of `m(N, k)` as `N` grows. -/
 @[category research open, AMS 5 11]
 theorem green_37_theta (k : ℕ) :
-    (fun N ↦ (m N k : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
+    (fun N ↦ (m N k : ℝ)) =Θ[atTop] (answer(sorry) : ℕ → ℕ → ℝ) k := by
   sorry
 
 /-- Determine an upper bound (big O) for `m(N, k)`. -/


### PR DESCRIPTION
Several `answer(sorry)` slots in `GreensOpenProblems` were closed terms placed under a quantifier whose value they must depend on. Under the `with_auxiliary` reading (the answer is a top-level constant) each such statement is false: `green_24` asserts that `max013AffineTranslates` is constant, `green_16` that the maximal solution-free size is independent of `N`, `green_37` that the least cover size is independent of `N` and `k`, and `green_37_asymptotic` / `green_37_theta` that one function of `N` serves every `k` (`m N 0 = 0` while `m N 1 = 1`). In `35.lean` the slots were inert: the improvement conjuncts spoke about `c`, not the answer.

**Change** (per file)

- `24.lean`: `green_24` asks for a function `ℕ → ℕ`, applied to `n`.
- `16.lean`: `green_16` asks for a function `ℕ → ℕ`, applied to `N`.
- `37.lean`: `green_37` asks for `ℕ → ℕ → ℕ` applied to `N k`; `green_37_asymptotic` and `green_37_theta` ask for `ℕ → ℕ → ℝ` applied to `k` (docstrings updated). `green_37_bigO` / `green_37_littleO` are untouched; they admit a closed answer and are handled in #4943.
- `35.lean`: `green_35.lower` now requires the answer `lb` (not `c`) to beat the known values at `p = 2` or `p = ∞`; `green_35.upper` now asks to beat the best-known `0.75265`. The `c(∞)` upper bounds are corrected: the cited sources state their constants for functions supported on `[-1/4, 1/4]`, and rescaling to `[0, 1]` halves them (as Green notes for [CS17]: `1.28 → 0.64`). [MV10] proves `1.50972…`, i.e. `c ∞ ≤ 0.7549`, not `0.7505` (Green's `0.75049…` is a misprint of `0.7549…`); `variants.c_inf_upper` is corrected accordingly. The AlphaEvolve bound from Green's 2025 update ([AE25], `1.5053`, i.e. `c ∞ ≤ 0.75265`; Green's `0.75026` is likewise a misprint) is added as `variants.c_inf_upper_ae25` and used as the threshold in `green_35.upper`, which therefore stays open.
- `41.lean`: not changed here; `green_41` is covered by #5757 (branch `fix/issue-5680`).

**Checked**: `lake --wfail build FormalConjectures.GreensOpenProblems.«16» FormalConjectures.GreensOpenProblems.«24» FormalConjectures.GreensOpenProblems.«35» FormalConjectures.GreensOpenProblems.«37»` — `Build completed successfully`, no warnings.

Related open PRs on these files: #4943 (`37.lean`, bigO/littleO), #5757 and #5553 (`41.lean`).

Fixes #5005
