### PR TITLE
fix(ErdosProblems/851): bound the lower density instead of the density

### DIFF
--- a/FormalConjectures/ErdosProblems/851.lean
+++ b/FormalConjectures/ErdosProblems/851.lean
@@ -49,8 +49,8 @@ form $2^k+n$, where $k \geq 0$ and $n$ has at most $r$ prime divisors, is at lea
 This was proved affirmatively by Price and GPT-5.2 Pro [Pr26].
 -/
 @[category research solved, AMS 11]
-theorem erdos_851 (ε : ℝ) (hε : ε ∈ Set.Ioo 0 1) : ∃ r d,
-    (TwoPowAddSet r).HasDensity d ∧ 1 - ε ≤ d := by
+theorem erdos_851 (ε : ℝ) (hε : ε ∈ Set.Ioo 0 1) : ∃ r,
+    1 - ε ≤ (TwoPowAddSet r).lowerDensity := by
   sorry
 
 end Erdos851


### PR DESCRIPTION
[erdosproblems.com/851](https://www.erdosproblems.com/851) asks whether, for every $\epsilon > 0$, there is some $r \ll_\epsilon 1$ such that the density of integers of the form $2^k + n$ ($n$ with at most $r$ prime divisors) is at least $1 - \epsilon$. The Lean statement `erdos_851` required the natural density to exist and be at least $1 - \epsilon$ (`∃ r d, (TwoPowAddSet r).HasDensity d ∧ 1 - ε ≤ d`), which is stronger than the source: "density is at least" is a bound on the lower density, and the existence of the natural density is not part of the problem or its proof.

**Change**: state the conclusion as `∃ r, 1 - ε ≤ (TwoPowAddSet r).lowerDensity`, matching the reading used for the same phrase elsewhere in the repository (Erdős 10, 26). Docstring, attributes and the Romanoff variant are unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«851»'` — Build completed successfully, no warnings.

Same fix as the open PR #5364.

Fixes #4973
