### PR TITLE
fix(ErdosProblems/688): state "estimate ε_n" as a single Theta bound

### DIFF
--- a/FormalConjectures/ErdosProblems/688.lean
+++ b/FormalConjectures/ErdosProblems/688.lean
@@ -40,19 +40,11 @@ def Erdos688Prop (n : ℕ) (ε : ℝ) : Prop :=
 noncomputable def epsilonFunction (n : ℕ) : ℝ := sSup {ε : ℝ | Erdos688Prop n ε}
 
 /--
-Estimate $\epsilon_n$ - lower bound.
+Estimate $\epsilon_n$.
 -/
 @[category research open, AMS 11]
-theorem erdos_688.parts.i.lower_bound :
-    (answer(sorry) : ℕ → ℝ) =O[atTop] epsilonFunction := by
-  sorry
-
-/--
-Estimate $\epsilon_n$ - upper bound.
--/
-@[category research open, AMS 11]
-theorem erdos_688.parts.i.upper_bound :
-    epsilonFunction =O[atTop] (answer(sorry) : ℕ → ℝ) := by
+theorem erdos_688.parts.i :
+    epsilonFunction =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 /--


### PR DESCRIPTION
Part (i) of [Erdős Problem 688](https://www.erdosproblems.com/688) asks to "estimate $\epsilon_n$". The file stated this as two one-sided Big-O bounds against an `answer(sorry)` comparison function, `epsilonFunction =O[atTop] answer(sorry)` and `answer(sorry) =O[atTop] epsilonFunction`. Neither half constrains the answer: since `0 ≤ epsilonFunction n ≤ 1` for `n ≥ 2` the constant `1` satisfies the upper bound, and the constant `0` satisfies the lower bound (`0 =O f` always holds).

**Change**: replace both halves with a single `erdos_688.parts.i : epsilonFunction =Θ[atTop] (answer(sorry) : ℕ → ℝ)`, the idiom the repository already uses for "estimate $f(n)$" (e.g. 142, 319, 321, 357, 539, 609, 789). The answer must now match the true order of $\epsilon_n$ in both directions. Part (ii) (`ε_n = o(1)?`) and the `research solved` lower-bound variant are unchanged.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«688»'` completes with no warnings or errors.

Fixes #4919
