### PR TITLE
fix(ErdosProblems/319): remove the tautological isBigO and isLittleO variants

### DIFF
--- a/FormalConjectures/ErdosProblems/319.lean
+++ b/FormalConjectures/ErdosProblems/319.lean
@@ -47,11 +47,7 @@ theorem erdos_319 (N : ℕ) : IsGreatest
   sorry
 
 -- Formalisation note: it's possible that solution to `erdos_319` needs to be
--- expressed asymptotically. To handle this we include `IsTheta`, `IsBigO`
--- and `IsLittleO` variants below. Since a solution is not known this necessitates
--- the use of an `answer(sorry)` placeholder. Trivial or sub-optimal solutions
--- will therefore exist to the asymptotic formalisations. A true solution to
--- the asymptotic variants should have a degree of optimality or non-triviality to it.
+-- expressed asymptotically. To handle this we include an `IsTheta` variant below.
 /-- Let $c(N)$ be the size of the largest $A\subseteq\{1, \dots, N\}$ such that there is a function
 $\delta : A \to \{-1, 1\}$ such that
 $$
@@ -69,44 +65,6 @@ theorem erdos_319.variants.isTheta (N : ℕ) (c : ℕ → ℝ)
       (_ : ∃ δ : ℕ → ℤˣ, ∑ n ∈ A, (δ n : ℚ) / n = 0 ∧
         ∀ A' ⊂ A, A'.Nonempty → ∑ n ∈ A', (δ n : ℚ) / n ≠ 0) } (c N)) :
     c =Θ[atTop] (answer(sorry) : ℕ → ℝ) := by
-  sorry
-
-/-- Let $c(N)$ be the size of the largest $A\subseteq\{1, \dots, N\}$ such that there is a function
-$\delta : A \to \{-1, 1\}$ such that
-$$
-  \sum_{n\in A} \frac{\delta n}{n} = 0
-$$
-and
-$$
-  \sum_{n\in A'}\frac{\delta n}{n} \neq 0
-$$
-for all non-empty $A'\subsetneq A$. Find the simplest $g(N)$ such that $c(N) = O(g(N))$. -/
-@[category research open, AMS 5]
-theorem erdos_319.variants.isBigO (N : ℕ) (c : ℕ → ℝ)
-    (h : ∀ N, IsGreatest
-    { (#A : ℝ) | (A) (_ : A ⊆ Finset.Icc 1 N)
-      (_ : ∃ δ : ℕ → ℤˣ, ∑ n ∈ A, (δ n : ℚ) / n = 0 ∧
-        ∀ A' ⊂ A, A'.Nonempty → ∑ n ∈ A', (δ n : ℚ) / n ≠ 0) } (c N)) :
-    c =O[atTop] (answer(sorry) : ℕ → ℝ) := by
-  sorry
-
-/-- Let $c(N)$ be the size of the largest $A\subseteq\{1, \dots, N\}$ such that there is a function
-$\delta : A \to \{-1, 1\}$ such that
-$$
-  \sum_{n\in A} \frac{\delta n}{n} = 0
-$$
-and
-$$
-  \sum_{n\in A'}\frac{\delta n}{n} \neq 0
-$$
-for all non-empty $A'\subsetneq A$. Find the simplest $g(N)$ such that $c(N) = o(g(N))$. -/
-@[category research open, AMS 5]
-theorem erdos_319.variants.isLittleO (N : ℕ) (c : ℕ → ℝ)
-    (h : ∀ N, IsGreatest
-    { (#A : ℝ) | (A) (_ : A ⊆ Finset.Icc 1 N)
-      (_ : ∃ δ : ℕ → ℤˣ, ∑ n ∈ A, (δ n : ℚ) / n = 0 ∧
-        ∀ A' ⊂ A, A'.Nonempty → ∑ n ∈ A', (δ n : ℚ) / n ≠ 0) } (c N)) :
-    c =o[atTop] (answer(sorry) : ℕ → ℝ) := by
   sorry
 
 /-- Adenwalla has observed that a lower bound (on the maximum size of $A$) of


### PR DESCRIPTION
`erdos_319.variants.isBigO` asked for "the simplest $g(N)$ such that $c(N) = O(g(N))$", but the Lean statement only required the answer to be some upper bound of $c$. Since every admissible $A$ satisfies $A \subseteq \{1, \dots, N\}$, the answer $g(N) = N$ closes it without using the unit-fraction condition (see #4890). The source only asks for the size of the largest $A$; it does not ask for an $O$- or $o$-bound.

**Change**

Remove `erdos_319.variants.isBigO` and `erdos_319.variants.isLittleO`, and shorten the formalisation note accordingly. Adding a matching lower bound to `isBigO` makes it identical to the existing `erdos_319.variants.isTheta`, which already pins the growth rate up to constants. The `isLittleO` variant has the same defect ($c(N) = o(N^2)$ trivially) and admits no optimal answer, since $c(N) \neq o(N)$ by the Croot lower bound. `erdos_319`, `isTheta` and `lb` are unchanged.

**Checked**: `lake --wfail build FormalConjectures.ErdosProblems.«319»`

Fixes #4892
