### PR TITLE
fix(Wikipedia/SparseRuler): state Wichmann's conjecture for large rulers

### DIFF
--- a/FormalConjectures/Wikipedia/SparseRuler.lean
+++ b/FormalConjectures/Wikipedia/SparseRuler.lean
@@ -26,9 +26,9 @@ A distance $k \in \mathbb{N}$ can be measured if there are $i, j \in \{1, \dots,
 $k = a_j - a_i$.
 
 One question concerns the structure of *optimal* rulers. Wichmann [Wi63] gave a
-parametric family of sparse rulers and conjectured that, beyond a small number of exceptions,
-every optimal ruler is of his type. The known exceptions occur at lengths $1, 13, 17, 23, 58$;
-the largest of these has $13$ segments, which motivates the bound below.
+parametric family of sparse rulers and speculated that every sufficiently large optimal ruler
+is of his type. The known exceptions occur at lengths $1, 13, 17, 23, 58$, and no further
+exceptions exist up to length $213$.
 
 The asymptotic growth of the minimal number of marks of an optimal ruler of length $L$ — i.e.
 the limit of $l(n)^2 / n$, conjectured to lie in $[2.434\ldots, 3]$ — is the subject of
@@ -90,13 +90,14 @@ lemma wichmannGaps_sum (r s : ℕ) :
     smul_eq_mul]
   ring
 
-/-- **Wichmann's conjecture on optimal rulers.** Every optimal ruler with more than $13$
-segments is a Wichmann ruler $W(r, s)$ (up to reflection, i.e. reversing the segment list).
-Posed by Wichmann [Wi63]; the finitely many known exceptions all have at most $13$ segments
-(lengths $1, 13, 17, 23, 58$), and no further exceptions are known up to length $213$. -/
+/-- **Wichmann's conjecture on optimal rulers.** Every optimal ruler of sufficiently large
+length is a Wichmann ruler $W(r, s)$ (up to reflection, i.e. reversing the segment list).
+Posed by Wichmann [Wi63]; the known exceptions have lengths $1, 13, 17, 23, 58$, and no
+further exceptions exist up to length $213$. -/
 @[category research open, AMS 5]
-theorem wichmann_conjecture {g : List ℕ} (hopt : IsOptimal g) (hseg : 13 < g.length) :
-    ∃ r s : ℕ, g = wichmannGaps r s ∨ g = (wichmannGaps r s).reverse := by
+theorem wichmann_conjecture :
+    ∃ N : ℕ, ∀ g : List ℕ, IsOptimal g → N < g.sum →
+      ∃ r s : ℕ, g = wichmannGaps r s ∨ g = (wichmannGaps r s).reverse := by
   sorry
 
 end SparseRuler


### PR DESCRIPTION
`SparseRuler.wichmann_conjecture` asserted that every optimal ruler with more than 13 segments is a Wichmann ruler. The cited source (Wikipedia, *Sparse ruler*) only records Wichmann's speculation that all **sufficiently large** optimal rulers are of this type; no specific threshold is claimed there (or in [Wi63]), and the exceptions are catalogued by length (1, 13, 17, 23, 58), with none up to length 213. The docstring's justification for `13` also mixed marks and segments: the length-58 exception has 13 marks, i.e. 12 segments.

**Change**
- Restate the theorem as an eventual claim: `∃ N : ℕ, ∀ g, IsOptimal g → N < g.sum → ∃ r s, g = wichmannGaps r s ∨ g = (wichmannGaps r s).reverse`. The bound is on the ruler length `g.sum`, matching the source's wording; for optimal rulers this is equivalent to a bound on the number of segments.
- Update the module and theorem docstrings to describe the exceptions by length only and drop the unsupported segment count.

**Checked**: `lake --wfail build FormalConjectures.Wikipedia.SparseRuler`

Fixes #5000
