### PR TITLE
fix(ErdosProblems/1110): ask for pairwise coprime non-representables

### DIFF
--- a/FormalConjectures/ErdosProblems/1110.lean
+++ b/FormalConjectures/ErdosProblems/1110.lean
@@ -40,13 +40,15 @@ Let $p>q\geq 2$ be two coprime integers. We call $n$ representable if it is the 
 integers of the form $p^kq^l$, none of which divide each other.
 
 If $\{p,q\}\neq \{2,3\}$ then what can be said about the density of non-representable
-numbers? Are there infinitely many coprime non-representable numbers?
+numbers? Are there infinitely many coprime non-representable numbers, that is, an infinite
+family of pairwise coprime non-representable integers?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_1110 :
     answer(sorry) ↔ ∀ (p q : ℕ), q < p → 2 ≤ q →
       Nat.Coprime p q → ¬(p = 3 ∧ q = 2) →
-      Set.Infinite {n : ℕ | Nat.Coprime n (p * q) ∧ ¬Representable p q n} := by
+      ∃ A : Set ℕ, A.Infinite ∧ A.Pairwise Nat.Coprime ∧
+        ∀ n ∈ A, ¬Representable p q n := by
   sorry
 
 end Erdos1110


### PR DESCRIPTION
`Erdos1110.erdos_1110` concluded `Set.Infinite {n | Nat.Coprime n (p * q) ∧ ¬Representable p q n}`, i.e. infinitely many non-representable numbers each coprime to `p * q`. The source (Erdős–Lewin, *d-complete sequences of integers*, Math. Comp. 65 (1996), p. 840: "Are there infinitely many coprime nonrepresentables?", repeated verbatim on erdosproblems.com/1110 and in Yu–Chen, J. Number Theory 238 (2022), Corollary 1.2) asks for infinitely many coprime non-representable numbers, i.e. an infinite family of pairwise coprime non-representable integers. The Lean statement imposed no coprimality between the non-representable numbers themselves.

**Change**: replace the conclusion by `∃ A : Set ℕ, A.Infinite ∧ A.Pairwise Nat.Coprime ∧ ∀ n ∈ A, ¬Representable p q n` (base hypotheses unchanged) and update the docstring accordingly. This reading is the stronger one: an infinite pairwise coprime family has at most two members not coprime to `p * q`, so it implies the previous statement.

**Checked**: `lake --wfail build 'FormalConjectures.ErdosProblems.«1110»'`

Fixes #5623
