### PR TITLE
feat(ErdosProblems): formalise Erdős Problem 1032

### DIFF
--- a/FormalConjectures/ErdosProblems/1032.lean
+++ b/FormalConjectures/ErdosProblems/1032.lean
@@ -1,0 +1,50 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 1032
+
+*Reference:* [erdosproblems.com/1032](https://www.erdosproblems.com/1032)
+-/
+
+namespace Erdos1032
+
+open SimpleGraph
+
+/--
+A graph is $4$-chromatic critical if it has chromatic number $4$, and removing any edge decreases
+the chromatic number to $3$.
+-/
+def IsFourChromaticCritical {V : Type*} (G : SimpleGraph V) : Prop :=
+  G.chromaticNumber = 4 ∧ ∀ e ∈ G.edgeSet, (G.deleteEdges {e}).chromaticNumber = 3
+
+open scoped Classical in
+/--
+We say that a graph is $4$-chromatic critical if it has chromatic number $4$, and removing any
+edge decreases the chromatic number to $3$.
+
+Is there, for arbitrarily large $n$, a $4$-chromatic critical graph on $n$ vertices with minimum
+degree $\gg n$?
+-/
+@[category research open, AMS 5]
+theorem erdos_1032 : answer(sorry) ↔
+    ∃ c > (0 : ℝ), ∀ N : ℕ, ∃ n ≥ N, ∃ G : SimpleGraph (Fin n),
+      IsFourChromaticCritical G ∧ c * n ≤ G.minDegree := by
+  sorry
+
+end Erdos1032


### PR DESCRIPTION
Fixes #1083.

Adds a statement-only formalisation of [Erdős Problem 1032](https://www.erdosproblems.com/1032): whether there are 4-chromatic critical graphs on arbitrarily large `n` vertices with minimum degree `≫ n`. The problem is open.

Formalisation notes:
- A graph is 4-chromatic critical when `χ(G) = 4` and deleting any edge drops the chromatic number to 3, matching the boxed definition (edge-critical, not the vertex-critical `IsCritical` already in `FormalConjecturesForMathlib`).
- `≫ n` is a positive linear lower bound on `minDegree`, for some `c > 0` independent of `n`, for infinitely many `n`.
- Graphs are `SimpleGraph (Fin n)`. `open scoped Classical` supplies the `DecidableRel` instance required by `minDegree`.

Checked with:
```
lake --wfail build 'FormalConjectures.ErdosProblems.«1032»'
```
This completed successfully.