### PR TITLE
feat(ErdosProblems): formalise Erdős Problem 863

### DIFF
--- a/FormalConjectures/ErdosProblems/863.lean
+++ b/FormalConjectures/ErdosProblems/863.lean
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -/
+
 import FormalConjecturesUtil
 
 /-!
@@ -23,66 +24,75 @@ import FormalConjecturesUtil
 - [erdosproblems.com/30](https://www.erdosproblems.com/30)
 -/
 
-open Filter
+open Asymptotics Filter Finset
+
+open scoped Topology
 
 namespace Erdos863
 
-/-- A set `A ⊆ ℕ` is said to be a `B₂[g]` set if for all `n`, the equation
-`a + a' = n, a ≤ a', a, a' ∈ A` has at most `g` solutions. -/
-def B2 (g : ℕ) (A : Set ℕ) : Prop :=
-  ∀ n, {x : ℕ × ℕ | x.1 + x.2 = n ∧ x.1 ≤ x.2 ∧ x.1 ∈ A ∧ x.2 ∈ A}.encard ≤ g
-
-/-- A set `A ⊆ ℕ` has at most `r` solutions to `n = a - b` for any `n`. -/
-def Diff (r : ℕ) (A : Set ℕ) : Prop :=
-  ∀ n ≥ 1, {x : ℕ × ℕ | x.1 = x.2 + n ∧ x.1 ∈ A ∧ x.2 ∈ A}.encard ≤ r
-
-/-- The maximum size of a `B₂[r]` subset of `{1, …, N}`. -/
-noncomputable def maxA (r N : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ B2 r A ∧ A.card = k}
-
-/-- The maximum size of a subset of `{1, …, N}` with at most `r` solutions to `n = a - b`
-for any `n`. -/
-noncomputable def maxB (r N : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ Diff r A ∧ A.card = k}
+/--
+A set `A` is a $B_2[r]$ set if for every `n` there are at most `r` solutions of `n = a + b`
+with `a ≤ b` and `a, b ∈ A`.
+-/
+def IsB2 (r : ℕ) (A : Set ℕ) : Prop :=
+  ∀ n, {x : ℕ × ℕ | x.1 + x.2 = n ∧ x.1 ≤ x.2 ∧ x.1 ∈ A ∧ x.2 ∈ A}.encard ≤ r
 
 /--
-Let $r\geq 2$ and let $A\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a+b$ with $a\leq b$ for any $n$. (That is, $A$ is a $B_2[r]$ set.)
+A set `A` has at most `r` difference representations of every positive `n`, i.e. at most `r`
+solutions of `n = a - b` with `a, b ∈ A`.
+-/
+def IsDiffBounded (r : ℕ) (A : Set ℕ) : Prop :=
+  ∀ n > 0, {x : ℕ × ℕ | x.1 ∈ A ∧ x.2 ∈ A ∧ x.1 = x.2 + n}.encard ≤ r
 
-Similarly, let $B\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a-b$ for any $n$.
+/-- Maximum size of a $B_2[r]$ subset of `{1, …, N}`. -/
+noncomputable def maxB2 (r N : ℕ) : ℕ :=
+  sSup ((·.card) '' {A : Finset ℕ | A ⊆ Icc 1 N ∧ IsB2 r (A : Set ℕ)})
 
-If $\lvert A\rvert\sim c_r N^{1/2}$ as $N\to \infty$ and $\lvert B\rvert \sim c_r' N^{1/2}$ as $N\to \infty$ then is it true that $c_r\neq c_r'$ for $r\geq 2$?
+/-- Maximum size of a subset of `{1, …, N}` with at most `r` difference representations. -/
+noncomputable def maxDiff (r N : ℕ) : ℕ :=
+  sSup ((·.card) '' {A : Finset ℕ | A ⊆ Icc 1 N ∧ IsDiffBounded r (A : Set ℕ)})
+
+/-- Normalised size `max / N^{1/2}`. -/
+noncomputable def normalised (f : ℕ → ℕ) (N : ℕ) : ℝ :=
+  (f N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)
+
+/--
+Let $r\geq 2$ and let $A\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at
+most $r$ solutions to $n=a+b$ with $a\leq b$ for any $n$. (That is, $A$ is a $B_2[r]$ set.)
+
+Similarly, let $B\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most
+$r$ solutions to $n=a-b$ for any $n$.
+
+If $\lvert A\rvert\sim c_rN^{1/2}$ as $N\to \infty$ and $\lvert B\rvert \sim c_r'N^{1/2}$ as
+$N\to \infty$ then is it true that $c_r\neq c_r'$ for $r\geq 2$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_863.parts.i : answer(sorry) ↔
     ∀ r ≥ 2, ∀ c c' : ℝ,
-      Tendsto (fun N => (maxA r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c) →
-      Tendsto (fun N => (maxB r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c') →
+      Tendsto (normalised (maxB2 r)) atTop (nhds c) →
+      Tendsto (normalised (maxDiff r)) atTop (nhds c') →
       c ≠ c' := by
   sorry
 
 /--
-Let $r\geq 2$ and let $A\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a+b$ with $a\leq b$ for any $n$. (That is, $A$ is a $B_2[r]$ set.)
-
-Similarly, let $B\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a-b$ for any $n$.
-
-If $\lvert A\rvert\sim c_r N^{1/2}$ as $N\to \infty$ and $\lvert B\rvert \sim c_r' N^{1/2}$ as $N\to \infty$ then is it true that $c_r'<c_r$?
+Is it true that $c_r'<c_r$?
 -/
 @[category research open, AMS 5 11]
 theorem erdos_863.parts.ii : answer(sorry) ↔
     ∀ r ≥ 2, ∀ c c' : ℝ,
-      Tendsto (fun N => (maxA r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c) →
-      Tendsto (fun N => (maxB r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c') →
+      Tendsto (normalised (maxB2 r)) atTop (nhds c) →
+      Tendsto (normalised (maxDiff r)) atTop (nhds c') →
       c' < c := by
   sorry
 
 /--
-It is true that $c_1=c_1'$, and the classical bound on the size of Sidon sets (see [30]) implies $c_1=c_1'=1$.
+It is true that $c_1=c_1'$, and the classical bound on the size of Sidon sets implies
+$c_1=c_1'=1$.
 -/
 @[category research solved, AMS 5 11]
 theorem erdos_863.variants.r_one :
-    Tendsto (fun N => (Finset.maxSidonSubsetCard (Finset.Icc 1 N) : ℝ) /
-      (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds 1) ∧
-    Tendsto (fun N => (maxB 1 N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds 1) := by
+    Tendsto (normalised (maxB2 1)) atTop (nhds 1) ∧
+      Tendsto (normalised (maxDiff 1)) atTop (nhds 1) := by
   sorry
 
 end Erdos863

--- a/FormalConjectures/ErdosProblems/863.lean
+++ b/FormalConjectures/ErdosProblems/863.lean
@@ -1,0 +1,88 @@
+/-
+Copyright 2026 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 863
+
+*References:*
+- [erdosproblems.com/863](https://www.erdosproblems.com/863)
+- [erdosproblems.com/30](https://www.erdosproblems.com/30)
+-/
+
+open Filter
+
+namespace Erdos863
+
+/-- A set `A ⊆ ℕ` is said to be a `B₂[g]` set if for all `n`, the equation
+`a + a' = n, a ≤ a', a, a' ∈ A` has at most `g` solutions. -/
+def B2 (g : ℕ) (A : Set ℕ) : Prop :=
+  ∀ n, {x : ℕ × ℕ | x.1 + x.2 = n ∧ x.1 ≤ x.2 ∧ x.1 ∈ A ∧ x.2 ∈ A}.encard ≤ g
+
+/-- A set `A ⊆ ℕ` has at most `r` solutions to `n = a - b` for any `n`. -/
+def Diff (r : ℕ) (A : Set ℕ) : Prop :=
+  ∀ n ≥ 1, {x : ℕ × ℕ | x.1 = x.2 + n ∧ x.1 ∈ A ∧ x.2 ∈ A}.encard ≤ r
+
+/-- The maximum size of a `B₂[r]` subset of `{1, …, N}`. -/
+noncomputable def maxA (r N : ℕ) : ℕ :=
+  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ B2 r A ∧ A.card = k}
+
+/-- The maximum size of a subset of `{1, …, N}` with at most `r` solutions to `n = a - b`
+for any `n`. -/
+noncomputable def maxB (r N : ℕ) : ℕ :=
+  sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ Diff r A ∧ A.card = k}
+
+/--
+Let $r\geq 2$ and let $A\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a+b$ with $a\leq b$ for any $n$. (That is, $A$ is a $B_2[r]$ set.)
+
+Similarly, let $B\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a-b$ for any $n$.
+
+If $\lvert A\rvert\sim c_r N^{1/2}$ as $N\to \infty$ and $\lvert B\rvert \sim c_r' N^{1/2}$ as $N\to \infty$ then is it true that $c_r\neq c_r'$ for $r\geq 2$?
+-/
+@[category research open, AMS 5 11]
+theorem erdos_863.parts.i : answer(sorry) ↔
+    ∀ r ≥ 2, ∀ c c' : ℝ,
+      Tendsto (fun N => (maxA r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c) →
+      Tendsto (fun N => (maxB r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c') →
+      c ≠ c' := by
+  sorry
+
+/--
+Let $r\geq 2$ and let $A\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a+b$ with $a\leq b$ for any $n$. (That is, $A$ is a $B_2[r]$ set.)
+
+Similarly, let $B\subseteq \{1,\ldots,N\}$ be a set of maximal size such that there are at most $r$ solutions to $n=a-b$ for any $n$.
+
+If $\lvert A\rvert\sim c_r N^{1/2}$ as $N\to \infty$ and $\lvert B\rvert \sim c_r' N^{1/2}$ as $N\to \infty$ then is it true that $c_r'<c_r$?
+-/
+@[category research open, AMS 5 11]
+theorem erdos_863.parts.ii : answer(sorry) ↔
+    ∀ r ≥ 2, ∀ c c' : ℝ,
+      Tendsto (fun N => (maxA r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c) →
+      Tendsto (fun N => (maxB r N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds c') →
+      c' < c := by
+  sorry
+
+/--
+It is true that $c_1=c_1'$, and the classical bound on the size of Sidon sets (see [30]) implies $c_1=c_1'=1$.
+-/
+@[category research solved, AMS 5 11]
+theorem erdos_863.variants.r_one :
+    Tendsto (fun N => (Finset.maxSidonSubsetCard (Finset.Icc 1 N) : ℝ) /
+      (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds 1) ∧
+    Tendsto (fun N => (maxB 1 N : ℝ) / (N : ℝ) ^ (1 / 2 : ℝ)) atTop (nhds 1) := by
+  sorry
+
+end Erdos863


### PR DESCRIPTION
## Summary
Statement-only Lean 4 formalisation of [Erdős Problem 863](https://www.erdosproblems.com/863).

Fixes #987.

## Check
`lake --wfail build 'FormalConjectures.ErdosProblems.«863»'`

Lake and elan were not on PATH locally, so this target was not built on this machine.