### PR TITLE
feat(ErdosProblems): formalise Erdős Problem 1145

### DIFF
--- a/FormalConjectures/ErdosProblems/1145.lean
+++ b/FormalConjectures/ErdosProblems/1145.lean
@@ -21,45 +21,65 @@ import FormalConjectures.ErdosProblems.«28»
 # Erdős Problem 1145
 
 *References:*
-- [erdosproblems.com/28](https://www.erdosproblems.com/28)
 - [erdosproblems.com/1145](https://www.erdosproblems.com/1145)
+- [erdosproblems.com/28](https://www.erdosproblems.com/28)
+- [erdosproblems.com/331](https://www.erdosproblems.com/331)
 -/
 
 open Set Filter Pointwise Topology AdditiveCombinatorics
 
 namespace Erdos1145
 
+/-- Ordered representations of `n` as `a + b` with `a ∈ A` and `b ∈ B`.
+This is the two-set analogue of `sumRep`. -/
+noncomputable def sumRepAB (A B : Set ℕ) : ℕ → ℕ := (𝟙_A ∗ 𝟙_B : ℕ → ℕ)
+
+/-- Integers whose binary expansion is supported only on even bit positions. -/
+def evenBinaryDigits : Set ℕ := {n | ∀ k, n.testBit (2 * k + 1) = false}
+
+/-- Integers whose binary expansion is supported only on odd bit positions. -/
+def oddBinaryDigits : Set ℕ := {n | ∀ k, n.testBit (2 * k) = false}
+
 /--
-Let $A=\{1\leq a_1 < a_2 < \cdots\}$ and $B=\{1\leq b_1 < b_2 < \cdots\}$ be sets of integers with
-$a_n/b_n\to 1$.
+Let $A=\{1\leq a_1 < a_2 < \cdots\}$ and $B=\{1\leq b_1 < b_2 < \cdots\}$ be sets of integers
+with $a_n/b_n\to 1$.
 
 If $A+B$ contains all sufficiently large positive integers then is it true that
-$\limsup 1_A\ast 1_B(n)=\infty$?
+$$\limsup 1_A\ast 1_B(n)=\infty?$$
 
-Formalization note: There's some discussion in the comments of [erdosproblems.com/28] and
-[erdosproblems.com/1145] about whether or not $0$ should be included in $A$ or $B$ and has been
-left purposely ambiguous. Problem 1145 was originally written as $A + B = \mathbb{N}$, which
-would imply that $0$ would need to exist in $A$ or $B$ to include $1$ in $A + B$. However, it's been
-made more general and rewritten as "sufficiently large positive integers". The formalization below
-is the version that includes $0$.
+The enumerations $a_n$ and $b_n$ are the increasing enumerations of $A$ and $B$
+(`Nat.nth`). The source writes $1\le a_1$; we work with `Set ℕ`, so `0` is allowed.
 -/
 def Erdos1145Prop : Prop :=
   ∀ ⦃A B : Set ℕ⦄ (_ : A.Infinite) (_ : B.Infinite),
     Tendsto (fun n ↦ (Nat.nth (· ∈ A) n : ℝ) / (Nat.nth (· ∈ B) n : ℝ)) atTop (𝓝 1) →
     (∀ᶠ n in atTop, n ∈ A + B) →
-    limsup (fun n => ↑(((𝟙_A ∗ 𝟙_B) : ℕ → ℕ) n)) atTop = (⊤ : ℕ∞)
+    limsup (fun n ↦ (sumRepAB A B n : ℕ∞)) atTop = ⊤
 
 /--
-Let $A=\{1\leq a_1 < a_2 < \cdots\}$ and $B=\{1\leq b_1 < b_2 < \cdots\}$ be sets of integers with
-$a_n/b_n\to 1$.
+Let $A=\{1\leq a_1 < a_2 < \cdots\}$ and $B=\{1\leq b_1 < b_2 < \cdots\}$ be sets of integers
+with $a_n/b_n\to 1$.
 
 If $A+B$ contains all sufficiently large positive integers then is it true that
-$\limsup 1_A\ast 1_B(n)=\infty$?
+$$\limsup 1_A\ast 1_B(n)=\infty?$$
 
-A conjecture of Erdős and Sárközy.
+A conjecture of Erdős and Sárközy. This is a stronger form of [erdosproblems.com/28].
+See also [erdosproblems.com/331].
 -/
-@[category research open, AMS 5]
+@[category research open, AMS 11]
 theorem erdos_1145 : answer(sorry) ↔ Erdos1145Prop := by
+  sorry
+
+/--
+Some condition relating $A$ and $B$ is necessary: if $A$ is the set of integers with only
+even binary digits and $B$ is the set of integers with only odd binary digits, then
+$$1_A\ast 1_B(n)=1$$
+for all $n$.
+-/
+@[category research solved, AMS 11]
+theorem erdos_1145.variants.even_odd_binary_digits :
+    (∀ n, sumRepAB evenBinaryDigits oddBinaryDigits n = 1) ∧
+      evenBinaryDigits + oddBinaryDigits = univ := by
   sorry
 
 /--
@@ -67,7 +87,7 @@ A stronger form of [erdosproblems.com/28].
 -/
 @[category test, AMS 11]
 theorem erdos_1145.test_implies_erdos_28 : Erdos1145Prop → type_of% Erdos28.erdos_28 := by
-  delta sumRep
+  delta sumRep sumRepAB
   intro h1145 s hs
   rcases hs.exists_le with ⟨m, hm⟩
   by_cases hfin : s.Finite


### PR DESCRIPTION
## Summary
Statement-only Lean 4 formalisation of [Erdős Problem 1145](https://www.erdosproblems.com/1145): if $A=\{a_1<a_2<\cdots\}$ and $B=\{b_1<b_2<\cdots\}$ satisfy $a_n/b_n\to 1$ and $A+B$ contains all large integers, is $\limsup 1_A\ast 1_B(n)=\infty$?

The boxed conjecture was already present on `main` ([#1904](https://github.com/google-deepmind/formal-conjectures/pull/1904)). This PR keeps that statement and:

- tags the conjecture `AMS 11`, matching [28](https://www.erdosproblems.com/28) and [40](https://www.erdosproblems.com/40)
- introduces `sumRepAB`, the two-set analogue of `AdditiveCombinatorics.sumRep`
- records the even/odd binary-digit example from the remarks (a relation between $A$ and $B$ is necessary)
- uses `$$ $$` display math

There is no open GitHub issue titled Erdős Problem 1145 (`#1978` is closed).

## Check
`lake --wfail build 'FormalConjectures.ErdosProblems.«1145»'`