### PR TITLE
ErdosProblems/219: link formal proof

### DIFF
--- a/FormalConjectures/ErdosProblems/219.lean
+++ b/FormalConjectures/ErdosProblems/219.lean
@@ -72,7 +72,8 @@ Solution: yes.
 Ref: Green, Ben and Tao, Terence, _The primes contain arbitrarily long arithmetic progressions_
 -/
 
-@[category research solved, AMS 5 11]
+@[category research solved, AMS 5 11,
+  formal_proof using lean4 at "https://github.com/plby/lean-proofs/blob/1268917deaaaa0d674f651287027baa26cea9920/src/latest/ErdosProblems/Erdos219.lean"]
 theorem erdos_219 : answer(True) ↔ ∀ N : ℕ, ∃ l ∈ primeArithmeticProgressions, N ≤ ENat.card l := by
   sorry
 


### PR DESCRIPTION
Fixes #5394.

## Summary

- link the external Lean proof of Erdős Problem 219 at a pinned commit
- keep the existing `research solved` category and in-repository statement unchanged

The linked proof establishes the same claim that there are arbitrarily long arithmetic progressions of primes. Its `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.

## Checks

- `git diff --check`
- `lake --wfail build 'FormalConjectures.ErdosProblems.«219»'`